### PR TITLE
fix: strip Amazon path tracking and missing query params (closes #1)

### DIFF
--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -48,12 +48,12 @@ export const TRACKING_PARAMS = [
   "ocid",
 
   // Amazon — internal / referral noise (not the affiliate tag)
-  "psc", "spLa",
-  "pd_rd_r", "pd_rd_w", "pd_rd_wg",
+  "psc", "spla",
+  "pd_rd_r", "pd_rd_w", "pd_rd_wg", "pd_rd_i",
   "pf_rd_p", "pf_rd_r",
   "linkcode", "linkid",
   "ascsubtag", "asc_contentid", "asc_contenttype", "asc_campaign",
-  "th",
+  "th", "_encoding", "content-id", "ref_",
 
   // eBay
   "mkevt", "mkcid", "mkrid", "campid", "toolid", "customid",

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -32,6 +32,19 @@ function domainMatches(hostname, entryDomain) {
 }
 
 /**
+ * Strips Amazon path-based tracking segments that appear after the ASIN.
+ * Amazon embeds referral tokens and session IDs directly in the path, e.g.:
+ *   /dp/B0GQ4N9N33/ref=zg_bsnr_c_kitchen_d_sccl_3/258-3201434-8228601
+ * The clean form is: /dp/B0GQ4N9N33/
+ */
+function cleanAmazonPath(hostname, pathname) {
+  if (!/amazon\.[a-z.]+$/.test(hostname)) return pathname;
+  return pathname
+    .replace(/(\/dp\/[A-Z0-9]{10})\/.+/, "$1/")
+    .replace(/(\/gp\/product\/[A-Z0-9]{10})\/.+/, "$1/");
+}
+
+/**
  * Processes a URL according to user preferences and blacklist/whitelist rules.
  *
  * Logic order:
@@ -55,6 +68,7 @@ export function processUrl(rawUrl, prefs) {
   }
 
   const hostname = url.hostname;
+  url.pathname = cleanAmazonPath(hostname, url.pathname);
   const blacklist = prefs.blacklist || [];
   const whitelist = prefs.whitelist || [];
 

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -472,3 +472,58 @@ describe("result shape", () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// Amazon — missing query params and path-based tracking (closes #1)
+// ---------------------------------------------------------------------------
+describe("Amazon — real-world URL cleaning", () => {
+
+  test("strips _encoding, content-id, ref_ from product URL", () => {
+    const raw = "https://www.amazon.es/Emergencia/dp/B0GF8C2S62/?_encoding=UTF8&content-id=amzn1.sym.abc&ref_=pd_hp_d_atf_unk&th=1";
+    const { cleanUrl, action } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("_encoding"), null);
+    assert.equal(u.searchParams.get("content-id"), null);
+    assert.equal(u.searchParams.get("ref_"), null);
+    assert.equal(u.searchParams.get("th"), null);
+    assert.equal(u.search, "");
+    assert.equal(action, "cleaned");
+  });
+
+  test("strips pd_rd_i and content-id from product URL", () => {
+    const raw = "https://www.amazon.es/edihome/dp/B0GQ4N9N33/?content-id=amzn1.sym.def&pd_rd_i=B0GQ4N9N33&th=1";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("pd_rd_i"), null);
+    assert.equal(u.searchParams.get("content-id"), null);
+    assert.equal(u.search, "");
+  });
+
+  test("strips path-based /ref= tracking after ASIN", () => {
+    const raw = "https://www.amazon.es/edihome/dp/B0GQ4N9N33/ref=zg_bsnr_c_kitchen_d_sccl_3/258-3201434-8228601?content-id=x&pd_rd_i=B0GQ4N9N33&th=1";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.ok(u.pathname.endsWith("/dp/B0GQ4N9N33/"), `path should end with /dp/ASIN/, got: ${u.pathname}`);
+    assert.equal(u.search, "");
+  });
+
+  test("does not modify non-Amazon path", () => {
+    const raw = "https://www.example.com/product/ref=tracking?utm_source=x";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.ok(u.pathname.includes("/ref=tracking"), "non-Amazon path must not be modified");
+  });
+
+  test("full real URL 1 from issue #1", () => {
+    const raw = "https://www.amazon.es/Emergencia-Homologada/dp/B0GF8C2S62/?_encoding=UTF8&content-id=amzn1.sym.0a1e4d50&ref_=pd_hp_d_atf_unk&th=1";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    assert.equal(new URL(cleanUrl).href, "https://www.amazon.es/Emergencia-Homologada/dp/B0GF8C2S62/");
+  });
+
+  test("full real URL 2 from issue #1", () => {
+    const raw = "https://www.amazon.es/edihome-Puff/dp/B0GQ4N9N33/ref=zg_bsnr_c_kitchen_d_sccl_3/258-3201434-8228601?content-id=amzn1.sym.8303e4e0&pd_rd_i=B0GQ4N9N33&th=1";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    assert.equal(new URL(cleanUrl).href, "https://www.amazon.es/edihome-Puff/dp/B0GQ4N9N33/");
+  });
+
+});


### PR DESCRIPTION
## Changes

### `src/lib/affiliates.js`
Added missing Amazon tracking params:
- `_encoding` — charset hint embedded in most Amazon URLs
- `content-id` — homepage/placement section tracker
- `ref_` — Amazon referral (distinct from the generic `ref`, has trailing underscore)
- `pd_rd_i` — personalized deal row ASIN tracker

### `src/lib/cleaner.js`
Added `cleanAmazonPath()` — strips tracking segments embedded in the URL **path** after the ASIN:
```
/dp/B0GQ4N9N33/ref=zg_bsnr_c_kitchen_d_sccl_3/258-3201434-8228601
→ /dp/B0GQ4N9N33/
```
Also handles `/gp/product/ASIN/` pattern. Non-Amazon paths are untouched.

### `tests/unit/cleaner.test.mjs`
6 new tests including the two exact real-world URLs from the issue report.

## Test results
49 tests · 46 pass · 0 fail · 3 todo (pending affiliate tags)

Closes #1