### PR TITLE
feat: redesign counters, nudge banner, report issue link (closes #3)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -35,15 +35,21 @@ async function handleProcessUrl(rawUrl, { skipInject = false } = {}) {
 
   const result = processUrl(rawUrl, effectivePrefs);
 
-  // Update stats
-  if (result.removedTracking.length > 0) {
-    await incrementStat("trackingRemoved");
+  // Record first use timestamp for nudge threshold
+  const stored = await chrome.storage.sync.get({ firstUsed: null });
+  if (!stored.firstUsed) {
+    await chrome.storage.sync.set({ firstUsed: Date.now() });
   }
-  if (result.action === "injected") {
-    await incrementStat("affiliatesInjected");
+
+  // Update stats
+  if (result.action !== "untouched") {
+    await incrementStat("urlsCleaned");
+  }
+  if (result.junkRemoved > 0) {
+    await incrementStat("junkRemoved", result.junkRemoved);
   }
   if (result.action === "detected_foreign") {
-    await incrementStat("foreignDetected");
+    await incrementStat("referralsSpotted");
     // If the user has "replace foreign affiliate" enabled, build the URL with our tag
     if (prefs.allowReplaceAffiliate && result.detectedAffiliate?.pattern?.ourTag) {
       const url = new URL(result.cleanUrl);

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -68,7 +68,9 @@ export function processUrl(rawUrl, prefs) {
   }
 
   const hostname = url.hostname;
+  const originalPathname = url.pathname;
   url.pathname = cleanAmazonPath(hostname, url.pathname);
+  const pathCleaned = url.pathname !== originalPathname;
   const blacklist = prefs.blacklist || [];
   const whitelist = prefs.whitelist || [];
 
@@ -121,7 +123,9 @@ export function processUrl(rawUrl, prefs) {
       removedTracking.push(param);
     }
   }
+  if (pathCleaned && action === "untouched") action = "cleaned";
   if (removedTracking.length > 0 && action === "untouched") action = "cleaned";
+  const junkRemoved = removedTracking.length + (pathCleaned ? 1 : 0);
 
   // 5. Strip specific blacklisted affiliate values
   for (const entry of parsedBlacklist) {
@@ -160,6 +164,7 @@ export function processUrl(rawUrl, prefs) {
     cleanUrl: url.toString(),
     action,
     removedTracking,
+    junkRemoved,
     detectedAffiliate,
   };
 }

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -21,9 +21,13 @@ export const SUPPORTED_LANGS = [
 
 export const TRANSLATIONS = {
   // ── Popup ────────────────────────────────────────────────────────────────
-  stat_tracking:   { en: "tracking removed",   es: "tracking eliminado" },
-  stat_injected:   { en: "affiliate links",     es: "afiliados activos" },
-  stat_foreign:    { en: "referrals detected",  es: "referidos detectados" },
+  stat_urls:       { en: "URLs cleaned",      es: "URLs limpias" },
+  stat_junk:       { en: "junk removed",      es: "basura eliminada" },
+  stat_referrals:  { en: "referrals spotted", es: "referidos detectados" },
+  nudge_text:      { en: "You've quietly cleaned {n} URLs. Enjoying MUGA?", es: "Has limpiado {n} URLs sin esfuerzo. ¿Te gusta MUGA?" },
+  nudge_review:    { en: "⭐ Leave a review", es: "⭐ Deja una reseña" },
+  nudge_kofi:      { en: "☕ Ko-fi",          es: "☕ Ko-fi" },
+  nudge_dismiss:   { en: "✕",                 es: "✕" },
   toggle_enabled:  { en: "Enable MUGA",         es: "Activar MUGA" },
   opt_inject_label: { en: "Inject our affiliate when none is present", es: "Inyectar nuestro afiliado si no hay ninguno" },
   opt_inject_hint:  { en: "Only on stores where we have an active account", es: "Solo en tiendas donde tenemos cuenta activa" },
@@ -46,6 +50,8 @@ export const TRANSLATIONS = {
   stores_hint:       { en: "Green dot = affiliate account active and configured. Grey = account pending registration.", es: "Punto verde = cuenta de afiliado activa. Gris = cuenta pendiente de registro." },
   section_blacklist: { en: "Blacklist — these affiliates are always stripped", es: "Blacklist — estos afiliados se eliminan siempre" },
   section_whitelist: { en: "Whitelist — these affiliates are trusted and never touched", es: "Whitelist — estos afiliados son de confianza, no se tocan" },
+  privacy_link:    { en: "Privacy policy",                       es: "Política de privacidad" },
+  report_issue:    { en: "Report a bug or suggest a feature",    es: "Reportar un error o sugerir mejora" },
   bl_placeholder: { en: "amazon.es  or  amazon.es::tag::youtuber-21", es: "amazon.es  o  amazon.es::tag::youtuber-21" },
   wl_placeholder: { en: "amazon.es::tag::creator-i-support", es: "amazon.es::tag::creador-que-apoyo" },
   bl_hint:  { en: "Domain only (e.g. <code>amazon.es</code>) — blocks all affiliate activity on that site.<br>Domain::param::value (e.g. <code>amazon.es::tag::youtuber-21</code>) — blocks one specific affiliate.", es: "Solo dominio (ej: <code>amazon.es</code>) para bloquear toda actividad en esa web.<br>Dominio::param::valor (ej: <code>amazon.es::tag::youtuber-21</code>) para bloquear un afiliado concreto." },

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -12,10 +12,12 @@ const DEFAULTS = {
   blacklist: [],   // e.g. ["amazon.es", "booking.com::aid::123456"]
   whitelist: [],   // e.g. ["amazon.es::tag::youtuber-21"]
   stats: {
-    trackingRemoved: 0,
-    affiliatesInjected: 0,
-    foreignDetected: 0,
+    urlsCleaned: 0,
+    junkRemoved: 0,
+    referralsSpotted: 0,
   },
+  firstUsed: null,
+  nudgeDismissed: false,
 };
 
 export async function getPrefs() {
@@ -56,10 +58,10 @@ export async function removeFromWhitelist(entry) {
   await setPrefs({ whitelist: prefs.whitelist.filter(e => e !== entry) });
 }
 
-export async function incrementStat(key) {
+export async function incrementStat(key, amount = 1) {
   const prefs = await getPrefs();
   const stats = prefs.stats || DEFAULTS.stats;
-  stats[key] = (stats[key] || 0) + 1;
+  stats[key] = (stats[key] || 0) + amount;
   await setPrefs({ stats });
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -163,6 +163,8 @@
 
   <div class="footer-links">
     <a href="../privacy/privacy.html" target="_blank" data-i18n="privacy_link">Privacy policy</a>
+    &nbsp;·&nbsp;
+    <a href="https://github.com/yocreoquesi/muga/issues/new" target="_blank" data-i18n="report_issue">Report a bug or suggest a feature</a>
   </div>
 
   <script type="module" src="options.js"></script>

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -155,6 +155,52 @@ header {
 .toggle input:checked + .slider::before { transform: translateX(16px); }
 .toggle.sm input:checked + .slider::before { transform: translateX(13px); }
 
+/* Nudge banner */
+.nudge {
+  padding: 10px 14px;
+  background: var(--bg2);
+  border-bottom: 0.5px solid var(--border);
+}
+
+.nudge-text {
+  font-size: 11.5px;
+  color: var(--text);
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.nudge-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.nudge-btn {
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 5px;
+  border: 0.5px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.nudge-btn.primary {
+  background: var(--accent);
+  color: white;
+  border-color: transparent;
+}
+
+.nudge-btn.dismiss {
+  margin-left: auto;
+  padding: 4px 7px;
+  color: var(--text2);
+}
+
+.nudge-btn:hover { opacity: 0.85; }
+
 footer {
   display: flex;
   justify-content: space-between;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -19,18 +19,27 @@
 
   <section class="stats">
     <div class="stat">
-      <span class="stat-value" id="stat-tracking">0</span>
-      <span class="stat-label" data-i18n="stat_tracking">tracking removed</span>
+      <span class="stat-value" id="stat-urls">0</span>
+      <span class="stat-label" data-i18n="stat_urls">URLs cleaned</span>
     </div>
     <div class="stat">
-      <span class="stat-value" id="stat-injected">0</span>
-      <span class="stat-label" data-i18n="stat_injected">affiliate links</span>
+      <span class="stat-value" id="stat-junk">0</span>
+      <span class="stat-label" data-i18n="stat_junk">junk removed</span>
     </div>
     <div class="stat">
-      <span class="stat-value" id="stat-foreign">0</span>
-      <span class="stat-label" data-i18n="stat_foreign">referrals detected</span>
+      <span class="stat-value" id="stat-referrals">0</span>
+      <span class="stat-label" data-i18n="stat_referrals">referrals spotted</span>
     </div>
   </section>
+
+  <div class="nudge" id="nudge" hidden>
+    <p class="nudge-text" id="nudge-text"></p>
+    <div class="nudge-actions">
+      <a class="nudge-btn primary" id="nudge-review" href="#" target="_blank" data-i18n="nudge_review">⭐ Leave a review</a>
+      <a class="nudge-btn" href="https://ko-fi.com/yocreoquesi" target="_blank" data-i18n="nudge_kofi">☕ Ko-fi</a>
+      <button class="nudge-btn dismiss" id="nudge-dismiss" data-i18n="nudge_dismiss">✕</button>
+    </div>
+  </div>
 
   <section class="options">
     <label class="option-row">

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -3,7 +3,11 @@
  * Loads preferences, displays stats, and manages the toggle switches.
  */
 
-import { applyTranslations, getStoredLang } from "../lib/i18n.js";
+import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
+
+const NUDGE_URL_THRESHOLD = 150;
+const NUDGE_DAY_THRESHOLD = 10;
+const MS_PER_DAY          = 86_400_000;
 
 async function init() {
   const lang = await getStoredLang();
@@ -13,15 +17,17 @@ async function init() {
     enabled: true,
     injectOwnAffiliate: true,
     notifyForeignAffiliate: false,
-    stats: { trackingRemoved: 0, affiliatesInjected: 0, foreignDetected: 0 },
+    stats: { urlsCleaned: 0, junkRemoved: 0, referralsSpotted: 0 },
+    firstUsed: null,
+    nudgeDismissed: false,
   });
 
-  document.getElementById("stat-tracking").textContent =
-    formatStat(prefs.stats?.trackingRemoved ?? 0);
-  document.getElementById("stat-injected").textContent =
-    formatStat(prefs.stats?.affiliatesInjected ?? 0);
-  document.getElementById("stat-foreign").textContent =
-    formatStat(prefs.stats?.foreignDetected ?? 0);
+  document.getElementById("stat-urls").textContent =
+    formatStat(prefs.stats?.urlsCleaned ?? 0);
+  document.getElementById("stat-junk").textContent =
+    formatStat(prefs.stats?.junkRemoved ?? 0);
+  document.getElementById("stat-referrals").textContent =
+    formatStat(prefs.stats?.referralsSpotted ?? 0);
 
   const enabledToggle = document.getElementById("enabled-toggle");
   const injectToggle  = document.getElementById("inject-toggle");
@@ -42,9 +48,37 @@ async function init() {
     e.preventDefault();
     chrome.runtime.openOptionsPage();
   });
+
+  maybeShowNudge(prefs, lang);
+}
+
+function maybeShowNudge(prefs, lang) {
+  if (prefs.nudgeDismissed) return;
+  const urlsCleaned   = prefs.stats?.urlsCleaned ?? 0;
+  const firstUsed     = prefs.firstUsed;
+  if (!firstUsed) return;
+  const daysInstalled = (Date.now() - firstUsed) / MS_PER_DAY;
+  if (urlsCleaned < NUDGE_URL_THRESHOLD || daysInstalled < NUDGE_DAY_THRESHOLD) return;
+
+  const nudge = document.getElementById("nudge");
+  document.getElementById("nudge-text").textContent =
+    t("nudge_text", lang).replace("{n}", formatStat(urlsCleaned));
+
+  const reviewUrl = typeof browser !== "undefined"
+    ? "https://addons.mozilla.org/firefox/addon/muga-make-urls-great-again/"
+    : "https://chromewebstore.google.com/detail/muga-make-urls-great-again/";
+  document.getElementById("nudge-review").href = reviewUrl;
+
+  nudge.hidden = false;
+
+  document.getElementById("nudge-dismiss").addEventListener("click", () => {
+    nudge.hidden = true;
+    chrome.storage.sync.set({ nudgeDismissed: true });
+  });
 }
 
 function formatStat(n) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
   return String(n);
 }


### PR DESCRIPTION
## Changes

### Counters (popup)
- **URLs cleaned** — URLs where MUGA made any change
- **Junk removed** — tracking query params + path segments stripped
- **Referrals spotted** — foreign affiliate tags detected
- Dropped 'affiliate links' counter (confusing, kept in onboarding for transparency)

### Stats tracking
- `incrementStat` now accepts an `amount` parameter
- Path cleanings counted toward `junkRemoved`
- `firstUsed` timestamp recorded on first URL processed

### Nudge banner
- Appears in popup once: `urlsCleaned >= 150` AND `daysInstalled >= 10`
- Links: ⭐ Leave a review (Chrome/Firefox store auto-detected) · ☕ Ko-fi
- Dismissed permanently, stored in `chrome.storage.sync`
- Never appears during browsing — popup only — ToS compliant

### Options page
- Footer now includes "Report a bug or suggest a feature → GitHub Issues"

### i18n
- All new keys translated EN + ES