### PR TITLE
fix: strip /ref= from any path position on Amazon URLs (closes #7)

### DIFF
--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -41,7 +41,8 @@ function cleanAmazonPath(hostname, pathname) {
   if (!/amazon\.[a-z.]+$/.test(hostname)) return pathname;
   return pathname
     .replace(/(\/dp\/[A-Z0-9]{10})\/.+/, "$1/")
-    .replace(/(\/gp\/product\/[A-Z0-9]{10})\/.+/, "$1/");
+    .replace(/(\/gp\/product\/[A-Z0-9]{10})\/.+/, "$1/")
+    .replace(/\/ref=[^/?#]*/g, "") || "/";
 }
 
 /**

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -569,3 +569,37 @@ describe("stripAllAffiliates — strip all affiliate params", () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// Amazon root-level /ref= path cleaning (closes #7)
+// ---------------------------------------------------------------------------
+describe("Amazon — root-level /ref= path tracking", () => {
+
+  test("strips /ref=nav_logo from homepage URL", () => {
+    const { cleanUrl } = processUrl("https://www.amazon.es/ref=nav_logo", PREFS);
+    assert.equal(new URL(cleanUrl).pathname, "/");
+  });
+
+  test("strips /ref= mid-path, preserves real path segments", () => {
+    const { cleanUrl } = processUrl(
+      "https://www.amazon.es/s/ref=nb_sb_noss?k=iphone", PREFS
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.pathname, "/s");
+    assert.equal(u.searchParams.get("k"), "iphone");
+  });
+
+  test("strips /ref= at end of deep path", () => {
+    const { cleanUrl } = processUrl(
+      "https://www.amazon.es/gp/cart/view.html/ref=nav_cart", PREFS
+    );
+    assert.equal(new URL(cleanUrl).pathname, "/gp/cart/view.html");
+  });
+
+  test("does not modify /ref= paths on non-Amazon sites", () => {
+    const raw = "https://www.example.com/blog/ref=social";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    assert.equal(new URL(cleanUrl).pathname, "/blog/ref=social");
+  });
+
+});


### PR DESCRIPTION
Extends `cleanAmazonPath()` to strip `/ref=value` at any path position, not just after the ASIN. 57 tests · 54 pass · 0 fail.