### PR TITLE
fix: whitelist overrides stripAllAffiliates (closes #8)

### DIFF
--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -128,9 +128,11 @@ export function processUrl(rawUrl, prefs) {
   if (removedTracking.length > 0 && action === "untouched") action = "cleaned";
 
   // 4b. Strip all affiliate params when user opted out of all affiliates
+  // Whitelist entries are respected — specific beats general.
   if (prefs.stripAllAffiliates) {
     for (const pattern of patterns) {
-      if (url.searchParams.has(pattern.param)) {
+      const val = url.searchParams.get(pattern.param);
+      if (val && !whitelistedValues.has(`${pattern.param}::${val}`)) {
         url.searchParams.delete(pattern.param);
         if (action === "untouched") action = "cleaned";
       }

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -603,3 +603,36 @@ describe("Amazon — root-level /ref= path tracking", () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// Whitelist priority over stripAllAffiliates (closes #8)
+// ---------------------------------------------------------------------------
+describe("whitelist priority over stripAllAffiliates", () => {
+
+  test("whitelisted affiliate is preserved even when stripAllAffiliates is on", () => {
+    const prefs = {
+      ...PREFS,
+      stripAllAffiliates: true,
+      whitelist: ["amazon.es::tag::trusted-21"],
+    };
+    const { cleanUrl } = processUrl(
+      "https://www.amazon.es/dp/B08?tag=trusted-21", prefs
+    );
+    assert.equal(new URL(cleanUrl).searchParams.get("tag"), "trusted-21",
+      "whitelisted tag must survive stripAllAffiliates");
+  });
+
+  test("non-whitelisted affiliate is stripped when stripAllAffiliates is on", () => {
+    const prefs = {
+      ...PREFS,
+      stripAllAffiliates: true,
+      whitelist: ["amazon.es::tag::trusted-21"],
+    };
+    const { cleanUrl } = processUrl(
+      "https://www.amazon.es/dp/B08?tag=other-99", prefs
+    );
+    assert.equal(new URL(cleanUrl).searchParams.get("tag"), null,
+      "non-whitelisted tag must be stripped");
+  });
+
+});


### PR DESCRIPTION
Step 4b now checks `whitelistedValues` before stripping. A whitelisted affiliate is always preserved regardless of `stripAllAffiliates`. Priority order documented in issue. 59 tests · 56 pass · 0 fail.