### PR TITLE
fix: context menu copy now increments stats (closes #11)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -81,8 +81,10 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
 chrome.contextMenus.onClicked.addListener(async (info) => {
   if (info.menuItemId !== "muga-copy-clean") return;
-  const prefs = await getPrefs();
-  const result = processUrl(info.linkUrl, { ...prefs, notifyForeignAffiliate: false });
+
+  // Route through handleProcessUrl so stats are incremented correctly.
+  // skipInject: true suppresses the foreign-affiliate toast (not relevant on copy).
+  const result = await handleProcessUrl(info.linkUrl, { skipInject: true });
 
   // Copy to clipboard via content script (service worker has no direct clipboard access)
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });


### PR DESCRIPTION
Routes context menu handler through `handleProcessUrl()` so `urlsCleaned` and `junkRemoved` are correctly counted when using right-click → Copy clean link. No logic change — only stat tracking was missing.