### PR TITLE
feat: stats reset button and version number in options (#16)

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -64,6 +64,12 @@ export const TRANSLATIONS = {
   lang_label:  { en: "Display language", es: "Idioma de la interfaz" },
   lang_hint:   { en: "Affects the popup and settings page. Does not affect URL processing.", es: "Afecta al popup y a esta página. No afecta al procesamiento de URLs." },
 
+  section_stats:       { en: "Statistics",                                     es: "Estadísticas" },
+  stats_reset_btn:     { en: "Reset stats",                                    es: "Reiniciar stats" },
+  stats_reset_confirm: { en: "Are you sure? This will clear all counters.",    es: "¿Seguro? Se borrarán todos los contadores." },
+  stats_reset_done:    { en: "Stats cleared.",                                 es: "Stats borrados." },
+  stats_version:       { en: "Version",                                        es: "Versión" },
+
   // ── Content script toast ──────────────────────────────────────────────────
   toast_title:   { en: "MUGA detected an affiliate", es: "MUGA detectó un referido" },
   toast_tag_msg: { en: "carries the tag", es: "lleva el tag" },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -184,6 +184,19 @@
     </div>
   </section>
 
+  <section>
+    <h2 data-i18n="section_stats">Statistics</h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="stats_version">Version</strong>
+          <small id="version-number"></small>
+        </div>
+        <button class="add-btn" id="reset-stats-btn" data-i18n="stats_reset_btn">Reset stats</button>
+      </div>
+    </div>
+  </section>
+
   <div class="footer-links">
     <a href="../privacy/privacy.html" target="_blank" data-i18n="privacy_link">Privacy policy</a>
     &nbsp;·&nbsp;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -31,6 +31,7 @@ async function init() {
   renderStores();
   initLanguageSelect();
   bindListButtons();
+  initStatsSection();
 }
 
 function bindToggle(id, key, prefs) {
@@ -135,6 +136,23 @@ async function removeEntry(listKey, index) {
   list.splice(index, 1);
   await chrome.storage.sync.set({ [listKey]: list });
   renderList(containerId, list, listKey);
+}
+
+function initStatsSection() {
+  const versionEl = document.getElementById("version-number");
+  if (versionEl) {
+    versionEl.textContent = chrome.runtime.getManifest().version;
+  }
+
+  document.getElementById("reset-stats-btn").addEventListener("click", async () => {
+    if (!confirm(t("stats_reset_confirm", currentLang))) return;
+    await chrome.storage.local.set({
+      stats: { urlsCleaned: 0, junkRemoved: 0, referralsSpotted: 0 },
+      firstUsed: null,
+      nudgeDismissed: false,
+    });
+    alert(t("stats_reset_done", currentLang));
+  });
 }
 
 document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## Summary
- Adds a **Statistics** section to the options page
- Shows the current extension version (read from `chrome.runtime.getManifest().version`) — no hardcoding
- Adds a **Reset Stats** button that clears all local counters with a confirmation dialog
- Fully translated in EN and ES

## Test plan
- [x] `npm test` — all 56 tests pass, 0 fail
- [ ] Open options page and verify version number appears
- [ ] Click Reset Stats — confirm dialog appears, counters clear, popup shows 0 after refresh

Closes #16