### PR TITLE
feat: add Temu, Zalando, SHEIN, Fnac, MediaMarkt as affiliate stores (#13)

### DIFF
--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -161,6 +161,70 @@ export const AFFILIATE_PATTERNS = [
     type: "affiliate",
     ourTag: "",
   },
+  {
+    id: "temu",
+    name: "Temu",
+    domains: ["temu.com", "www.temu.com"],
+    param: "aff_id",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your Temu affiliate ID
+  },
+  {
+    id: "zalando_es",
+    name: "Zalando ES",
+    domains: ["zalando.es", "www.zalando.es"],
+    param: "wt_mc",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your Zalando affiliate marketing code
+  },
+  {
+    id: "zalando_de",
+    name: "Zalando DE",
+    domains: ["zalando.de", "www.zalando.de"],
+    param: "wt_mc",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your Zalando DE affiliate marketing code
+  },
+  {
+    id: "shein",
+    name: "SHEIN",
+    domains: ["shein.com", "www.shein.com", "es.shein.com", "fr.shein.com", "de.shein.com"],
+    param: "url_from",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your SHEIN affiliate ID
+  },
+  {
+    id: "fnac_es",
+    name: "Fnac ES",
+    domains: ["fnac.es", "www.fnac.es"],
+    param: "oref",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your Fnac affiliate origin ref
+  },
+  {
+    id: "fnac_fr",
+    name: "Fnac FR",
+    domains: ["fnac.com", "www.fnac.com"],
+    param: "oref",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your Fnac FR affiliate origin ref
+  },
+  {
+    id: "mediamarkt_es",
+    name: "MediaMarkt ES",
+    domains: ["mediamarkt.es", "www.mediamarkt.es"],
+    param: "ref",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your MediaMarkt affiliate ref (Impact Radius)
+  },
+  {
+    id: "mediamarkt_de",
+    name: "MediaMarkt DE",
+    domains: ["mediamarkt.de", "www.mediamarkt.de"],
+    param: "ref",
+    type: "affiliate",
+    ourTag: "",  // TODO: fill in your MediaMarkt DE affiliate ref
+  },
 ];
 
 /**

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -3,6 +3,7 @@
  */
 
 import { applyTranslations, getStoredLang, t, SUPPORTED_LANGS } from "../lib/i18n.js";
+import { getSupportedStores } from "../lib/affiliates.js";
 
 const DEFAULTS = {
   injectOwnAffiliate: true,
@@ -71,22 +72,10 @@ function bindListButtons() {
 }
 
 function renderStores() {
-  const STORES = [
-    { name: "Amazon ES", param: "tag", ourTag: "" },
-    { name: "Amazon DE", param: "tag", ourTag: "" },
-    { name: "Amazon FR", param: "tag", ourTag: "" },
-    { name: "Amazon IT", param: "tag", ourTag: "" },
-    { name: "Amazon UK", param: "tag", ourTag: "" },
-    { name: "Amazon US", param: "tag", ourTag: "" },
-    { name: "Booking.com", param: "aid", ourTag: "" },
-    { name: "AliExpress", param: "aff_fcid", ourTag: "" },
-    { name: "PcComponentes", param: "ref", ourTag: "" },
-    { name: "El Corte Inglés", param: "affiliateId", ourTag: "" },
-    { name: "eBay", param: "campid", ourTag: "" },
-  ];
+  const stores = getSupportedStores();
 
   const grid = document.getElementById("stores-grid");
-  grid.innerHTML = STORES.map(s => `
+  grid.innerHTML = stores.map(s => `
     <div class="store-chip">
       <div class="store-dot ${s.ourTag ? "active" : ""}"></div>
       <div>
@@ -97,7 +86,7 @@ function renderStores() {
   `).join("");
 
   const countEl = document.getElementById("stores-count");
-  if (countEl) countEl.textContent = `(${STORES.length})`;
+  if (countEl) countEl.textContent = `(${stores.length})`;
 }
 
 function initLanguageSelect() {


### PR DESCRIPTION
## Summary
- Adds **8 new affiliate store patterns**: Temu, Zalando ES/DE, SHEIN, Fnac ES/FR, MediaMarkt ES/DE
- All have empty `ourTag` pending affiliate account registration
- `renderStores()` in options.js now reads from `getSupportedStores()` instead of a hardcoded array — future stores appear in the UI automatically without touching the options page code

## Store details
| Store | Domains | Param |
|-------|---------|-------|
| Temu | temu.com | `aff_id` |
| Zalando ES/DE | zalando.es, zalando.de | `wt_mc` |
| SHEIN | shein.com + regional | `url_from` |
| Fnac ES/FR | fnac.es, fnac.com | `oref` |
| MediaMarkt ES/DE | mediamarkt.es, mediamarkt.de | `ref` |

## Test plan
- [x] `npm test` — all 56 tests pass, 0 fail
- [ ] Open options page → Supported stores section shows 20 stores (up from 11)
- [ ] Green/grey dots display correctly for active vs pending stores

Closes #13