### PR TITLE
feat: export / import settings (blacklist + whitelist) (#15)

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -66,11 +66,16 @@ export const TRANSLATIONS = {
   lang_label:  { en: "Display language", es: "Idioma de la interfaz" },
   lang_hint:   { en: "Affects the popup and settings page. Does not affect URL processing.", es: "Afecta al popup y a esta página. No afecta al procesamiento de URLs." },
 
-  section_stats:       { en: "Statistics",                                     es: "Estadísticas" },
-  stats_reset_btn:     { en: "Reset stats",                                    es: "Reiniciar stats" },
-  stats_reset_confirm: { en: "Are you sure? This will clear all counters.",    es: "¿Seguro? Se borrarán todos los contadores." },
-  stats_reset_done:    { en: "Stats cleared.",                                 es: "Stats borrados." },
-  stats_version:       { en: "Version",                                        es: "Versión" },
+  section_stats:         { en: "Statistics",                                                                        es: "Estadísticas" },
+  stats_reset_btn:       { en: "Reset stats",                                                                       es: "Reiniciar stats" },
+  stats_reset_confirm:   { en: "Are you sure? This will clear all counters.",                                       es: "¿Seguro? Se borrarán todos los contadores." },
+  stats_reset_done:      { en: "Stats cleared.",                                                                    es: "Stats borrados." },
+  stats_version:         { en: "Version",                                                                           es: "Versión" },
+  section_data:          { en: "Import / Export",                                                                   es: "Importar / Exportar" },
+  export_btn:            { en: "Export settings",                                                                   es: "Exportar ajustes" },
+  import_btn:            { en: "Import settings",                                                                   es: "Importar ajustes" },
+  import_success:        { en: "Settings imported successfully.",                                                   es: "Ajustes importados correctamente." },
+  import_error:          { en: "Invalid file. Make sure it is a MUGA settings export.",                            es: "Archivo inválido. Asegúrate de que es una exportación de MUGA." },
 
   // ── Content script toast ──────────────────────────────────────────────────
   toast_title:   { en: "MUGA detected an affiliate", es: "MUGA detectó un referido" },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -197,6 +197,25 @@
     </div>
   </section>
 
+  <section>
+    <h2 data-i18n="section_data">Import / Export</h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="export_btn">Export settings</strong>
+        </div>
+        <button class="add-btn" id="export-btn" data-i18n="export_btn">Export settings</button>
+      </div>
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="import_btn">Import settings</strong>
+        </div>
+        <button class="add-btn" id="import-btn" data-i18n="import_btn">Import settings</button>
+        <input type="file" id="import-file" accept=".json" style="display:none">
+      </div>
+    </div>
+  </section>
+
   <div class="footer-links">
     <a href="../privacy/privacy.html" target="_blank" data-i18n="privacy_link">Privacy policy</a>
     &nbsp;·&nbsp;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -33,6 +33,7 @@ async function init() {
   initLanguageSelect();
   bindListButtons();
   initStatsSection();
+  initExportImport();
 }
 
 function bindToggle(id, key, prefs) {
@@ -141,6 +142,50 @@ function initStatsSection() {
       nudgeDismissed: false,
     });
     alert(t("stats_reset_done", currentLang));
+  });
+}
+
+function initExportImport() {
+  document.getElementById("export-btn").addEventListener("click", async () => {
+    const prefs = await chrome.storage.sync.get(DEFAULTS);
+    const payload = {
+      muga: true,
+      version: chrome.runtime.getManifest().version,
+      blacklist: prefs.blacklist,
+      whitelist: prefs.whitelist,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "muga-settings.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  const fileInput = document.getElementById("import-file");
+
+  document.getElementById("import-btn").addEventListener("click", () => {
+    fileInput.click();
+  });
+
+  fileInput.addEventListener("change", async () => {
+    const file = fileInput.files[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      if (!data.muga || !Array.isArray(data.blacklist) || !Array.isArray(data.whitelist)) {
+        throw new Error("invalid");
+      }
+      await chrome.storage.sync.set({ blacklist: data.blacklist, whitelist: data.whitelist });
+      renderList("blacklist-items", data.blacklist, "blacklist");
+      renderList("whitelist-items", data.whitelist, "whitelist");
+      alert(t("import_success", currentLang));
+    } catch {
+      alert(t("import_error", currentLang));
+    }
+    fileInput.value = "";
   });
 }
 


### PR DESCRIPTION
## Summary
- New **Import / Export** section at the bottom of the options page
- **Export**: generates `muga-settings.json` with current blacklist and whitelist, triggers browser download
- **Import**: opens a file picker for `.json` files, validates the MUGA format (`muga: true`, array types), applies settings and re-renders lists
- Exported file includes version number for future compatibility checks
- Error shown if file is invalid or not a MUGA export

## File format
```json
{
  "muga": true,
  "version": "1.0.6",
  "blacklist": ["amazon.es", "booking.com::aid::12345"],
  "whitelist": ["amazon.es::tag::creator-i-support-21"]
}
```

## Test plan
- [x] `npm test` — all 56 tests pass, 0 fail
- [ ] Click Export → `muga-settings.json` downloads with correct content
- [ ] Click Import → select valid file → lists update, success alert
- [ ] Click Import → select non-MUGA file → error alert shown

Closes #15