### PR TITLE
feat: per-domain disable mode via domain::disabled (#19)

### DIFF
--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -69,15 +69,24 @@ export function processUrl(rawUrl, prefs) {
   }
 
   const hostname = url.hostname;
-  const originalPathname = url.pathname;
-  url.pathname = cleanAmazonPath(hostname, url.pathname);
-  const pathCleaned = url.pathname !== originalPathname;
   const blacklist = prefs.blacklist || [];
   const whitelist = prefs.whitelist || [];
 
   // Parse all list entries upfront
   const parsedBlacklist = blacklist.map(parseListEntry);
   const parsedWhitelist = whitelist.map(parseListEntry);
+
+  // 0. Per-domain disable — user wants MUGA to do nothing on this domain
+  const domainDisabled = parsedBlacklist.some(
+    e => e.param === "disabled" && !e.value && domainMatches(hostname, e.domain)
+  );
+  if (domainDisabled) {
+    return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
+  }
+
+  const originalPathname = url.pathname;
+  url.pathname = cleanAmazonPath(hostname, url.pathname);
+  const pathCleaned = url.pathname !== originalPathname;
 
   // 1. Scenario D — domain is fully blacklisted: strip everything, no injection
   const domainBlacklisted = parsedBlacklist.some(

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -55,7 +55,7 @@ export const TRANSLATIONS = {
   report_issue:    { en: "Report a bug or suggest a feature",    es: "Reportar un error o sugerir mejora" },
   bl_placeholder: { en: "amazon.es  or  amazon.es::tag::youtuber-21", es: "amazon.es  o  amazon.es::tag::youtuber-21" },
   wl_placeholder: { en: "amazon.es::tag::creator-i-support", es: "amazon.es::tag::creador-que-apoyo" },
-  bl_hint:  { en: "Domain only (e.g. <code>amazon.es</code>) — blocks all affiliate activity on that site.<br>Domain::param::value (e.g. <code>amazon.es::tag::youtuber-21</code>) — blocks one specific affiliate.", es: "Solo dominio (ej: <code>amazon.es</code>) para bloquear toda actividad en esa web.<br>Dominio::param::valor (ej: <code>amazon.es::tag::youtuber-21</code>) para bloquear un afiliado concreto." },
+  bl_hint:  { en: "Domain only (e.g. <code>amazon.es</code>) — strips all params on that site.<br>Domain::param::value (e.g. <code>amazon.es::tag::youtuber-21</code>) — strips one specific affiliate.<br><code>amazon.es::disabled</code> — MUGA does nothing on that domain.", es: "Solo dominio (ej: <code>amazon.es</code>) — elimina todos los parámetros en esa web.<br>Dominio::param::valor (ej: <code>amazon.es::tag::youtuber-21</code>) — elimina un afiliado concreto.<br><code>amazon.es::disabled</code> — MUGA no toca nada en ese dominio." },
   wl_hint:  { en: "Format: <code>domain::param::value</code>. That creator's affiliate tag is never modified.", es: "Formato: <code>dominio::parámetro::valor</code>. El afiliado de ese creador nunca se toca." },
   add_btn:  { en: "+ Add", es: "+ Añadir" },
   empty_list: { en: "No entries yet.", es: "Sin entradas todavía." },

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -605,6 +605,64 @@ describe("Amazon — root-level /ref= path tracking", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Per-domain disable (issue #19)
+// ---------------------------------------------------------------------------
+describe("per-domain disable — domain::disabled blacklist entry", () => {
+
+  test("disabled domain returns URL completely untouched", () => {
+    const raw = "https://www.amazon.es/dp/B08?tag=affiliate-21&utm_source=email";
+    const { action, cleanUrl } = processUrl(raw, {
+      ...PREFS,
+      blacklist: ["amazon.es::disabled"],
+    });
+    assert.equal(action, "untouched");
+    assert.equal(cleanUrl, raw);
+  });
+
+  test("disabled domain does not strip tracking params", () => {
+    const raw = "https://example.com/page?utm_source=google&fbclid=abc";
+    const { action, cleanUrl, removedTracking } = processUrl(raw, {
+      ...PREFS,
+      blacklist: ["example.com::disabled"],
+    });
+    assert.equal(action, "untouched");
+    assert.equal(cleanUrl, raw);
+    assert.deepEqual(removedTracking, []);
+  });
+
+  test("disabled domain does not inject affiliate", () => {
+    const raw = "https://www.amazon.es/dp/B08";
+    const { action } = processUrl(raw, {
+      ...PREFS,
+      injectOwnAffiliate: true,
+      blacklist: ["amazon.es::disabled"],
+    });
+    assert.notEqual(action, "injected");
+  });
+
+  test("disabled domain takes priority over regular domain blacklist", () => {
+    const raw = "https://www.amazon.es/dp/B08?tag=x";
+    const { action, cleanUrl } = processUrl(raw, {
+      ...PREFS,
+      blacklist: ["amazon.es::disabled", "amazon.es"],
+    });
+    // ::disabled fires first — URL unchanged
+    assert.equal(action, "untouched");
+    assert.equal(cleanUrl, raw);
+  });
+
+  test("non-disabled domain is still processed normally", () => {
+    const raw = "https://www.amazon.es/dp/B08?utm_source=email";
+    const { action } = processUrl(raw, {
+      ...PREFS,
+      blacklist: ["booking.com::disabled"],
+    });
+    assert.equal(action, "cleaned");
+  });
+
+});
+
+// ---------------------------------------------------------------------------
 // Whitelist priority over stripAllAffiliates (closes #8)
 // ---------------------------------------------------------------------------
 describe("whitelist priority over stripAllAffiliates", () => {


### PR DESCRIPTION
## Summary
- New blacklist format: `amazon.es::disabled` — MUGA returns the URL **completely untouched** for that domain
- Different from `amazon.es` (domain-only entry) which strips all params
- `::disabled` is checked first in `processUrl()`, before any cleaning or path modification
- Blacklist input hint updated to document all three formats

## Blacklist format reference
| Entry | Effect |
|-------|--------|
| `amazon.es` | Strips all params (nuclear clean) |
| `amazon.es::tag::youtuber-21` | Strips only that specific affiliate |
| `amazon.es::disabled` | MUGA does nothing on this domain |

## Test plan
- [x] `npm test` — 61 tests pass, 0 fail (5 new tests for this feature)
- [ ] Add `amazon.es::disabled` to blacklist → tracking params preserved on Amazon pages
- [ ] Remove entry → cleaning resumes normally

Closes #19