### PR TITLE
feat: session history in popup — last 5 cleaned URLs (#35)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -37,6 +37,18 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   chrome.storage.session.remove(`tab_${tabId}`);
 });
 
+// --- Session history helpers ---
+
+const HISTORY_MAX = 5;
+
+async function appendHistory(original, clean) {
+  if (original === clean) return;
+  const data = await chrome.storage.session.get({ history: [] });
+  const entry = { original, clean, ts: Date.now() };
+  const history = [entry, ...data.history].slice(0, HISTORY_MAX);
+  await chrome.storage.session.set({ history });
+}
+
 // --- Main message listener from content scripts ---
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "PROCESS_URL") {
@@ -76,9 +88,10 @@ async function handleProcessUrl(rawUrl, { skipInject = false } = {}) {
     await setStats({ firstUsed: Date.now() });
   }
 
-  // Update stats
+  // Update stats and session history
   if (result.action !== "untouched") {
     await incrementStat("urlsCleaned");
+    await appendHistory(rawUrl, result.cleanUrl);
   }
   if (result.junkRemoved > 0) {
     await incrementStat("junkRemoved", result.junkRemoved);

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -30,6 +30,7 @@ export const TRANSLATIONS = {
   nudge_dismiss:   { en: "✕",                 es: "✕" },
   preview_clean:   { en: "✓ This page is already clean",  es: "✓ Esta página ya está limpia" },
   preview_label:   { en: "This page",                     es: "Esta página" },
+  history_label:   { en: "Recent",                        es: "Recientes" },
   toggle_enabled:  { en: "Enable MUGA",                   es: "Activar MUGA" },
   opt_inject_label: { en: "Inject our affiliate when none is present", es: "Inyectar nuestro afiliado si no hay ninguno" },
   opt_inject_hint:  { en: "Only on stores where we have an active account", es: "Solo en tiendas donde tenemos cuenta activa" },

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -239,6 +239,41 @@ header {
 
 .nudge-btn:hover { opacity: 0.85; }
 
+/* Session history */
+.history { border-top: 0.5px solid var(--border); }
+
+.history-summary {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--text2);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.history-summary::-webkit-details-marker { display: none; }
+.history-summary::after { content: ' ›'; margin-left: auto; }
+
+.history-entry {
+  padding: 4px 16px 5px;
+  border-top: 0.5px solid var(--border);
+}
+
+.history-url {
+  font-size: 10.5px;
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.6;
+}
+
+.history-url.before { color: var(--text2); text-decoration: line-through; }
+.history-url.after  { color: var(--accent); }
+
 footer {
   display: flex;
   justify-content: space-between;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -72,6 +72,11 @@
     </label>
   </section>
 
+  <details class="history" id="history" hidden>
+    <summary class="history-summary" data-i18n="history_label">Recent</summary>
+    <div id="history-list"></div>
+  </details>
+
   <footer>
     <a href="#" id="open-options" data-i18n="link_advanced">Advanced settings →</a>
     <a href="https://ko-fi.com/yocreoquesi" target="_blank" id="donate-link" data-i18n="link_donate">Support the project</a>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -56,6 +56,7 @@ async function init() {
 
   maybeShowNudge({ ...prefs, ...local }, lang);
   await showUrlPreview(prefs, lang);
+  await showHistory();
 }
 
 async function showUrlPreview(prefs, lang) {
@@ -107,6 +108,23 @@ function formatStat(n) {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
   return String(n);
+}
+
+async function showHistory() {
+  const data = await chrome.storage.session.get({ history: [] });
+  const history = data.history;
+  if (!history.length) return;
+
+  const section = document.getElementById("history");
+  const list = document.getElementById("history-list");
+  section.hidden = false;
+
+  list.innerHTML = history.map(entry => `
+    <div class="history-entry">
+      <div class="history-url before">${entry.original}</div>
+      <div class="history-url after">${entry.clean}</div>
+    </div>
+  `).join("");
 }
 
 document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## Summary
- Service worker appends a `{ original, clean, ts }` entry to `chrome.storage.session` (max 5, newest first) after each URL is cleaned
- Popup shows a collapsible **Recent** section at the bottom with before (strikethrough) → after (accent) pairs
- Section stays hidden if history is empty (fresh session)
- History clears automatically when the browser closes (session storage)

## Test plan
- [x] `npm test` — 68 tests pass
- [ ] Click a few tracking-heavy links → open popup → Recent section appears with entries
- [ ] Close and reopen browser → Recent section gone
- [ ] More than 5 entries → only 5 most recent shown

Closes #35