### PR TITLE
feat: auto-detect browser language on first run (#41)

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -126,11 +126,27 @@ export function applyTranslations(lang) {
 }
 
 /**
- * Reads the stored language preference, defaulting to "en".
+ * Reads the stored language preference.
+ * On first run (no preference saved), falls back to the browser's UI language
+ * via chrome.i18n.getUILanguage() — no extra permissions required.
+ * Unsupported languages fall back to "en".
  * @returns {Promise<string>}
  */
 export async function getStoredLang() {
+  const supported = new Set(SUPPORTED_LANGS.map(l => l.code));
+
+  // Resolve the browser language once, clamped to supported list
+  function browserLang() {
+    const raw = (typeof chrome !== "undefined" && chrome.i18n?.getUILanguage?.())
+      || navigator.language
+      || "en";
+    const code = raw.split("-")[0].toLowerCase();
+    return supported.has(code) ? code : "en";
+  }
+
   return new Promise(resolve => {
-    chrome.storage.sync.get({ language: "en" }, r => resolve(r.language));
+    chrome.storage.sync.get({ language: null }, r => {
+      resolve(r.language ?? browserLang());
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Uses `chrome.i18n.getUILanguage()` (no extra permissions) as fallback default when no language preference is stored
- Unsupported browser languages gracefully fall back to `"en"`
- Manual language selection in settings is always respected

## Test plan
- [ ] Fresh install with browser set to Spanish → popup shows in Spanish automatically
- [ ] Change browser language to unsupported locale → falls back to English
- [ ] User who previously saved a preference → no change in behaviour

Closes #41