### PR TITLE
fix: remove declarativeNetRequest permission, add MV2 CSP (#53)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,6 @@
     "storage",
     "tabs",
     "contextMenus",
-    "declarativeNetRequest",
     "clipboardWrite"
   ],
 

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -55,6 +55,8 @@
     "privacy/privacy.html"
   ],
 
+  "content_security_policy": "script-src 'self'; object-src 'self'",
+
   "icons": {
     "16": "icons/16.png",
     "48": "icons/48.png",


### PR DESCRIPTION
CQ-07: remove unused declarativeNetRequest from src/manifest.json permissions.
CQ-08: add content_security_policy to src/manifest.v2.json.
