### PR TITLE
fix: ux and logic improvements — injection on copy, popup prefs, toast timeout, frame targets (#55)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -56,7 +56,7 @@ async function appendHistory(original, clean) {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "PROCESS_URL") {
     const tabId = sender.tab?.id;
-    handleProcessUrl(message.url, { skipInject: message.skipInject })
+    handleProcessUrl(message.url, { skipNotify: message.skipInject })
       .then(result => {
         updateTabBadge(tabId, result.junkRemoved ?? 0);
         sendResponse(result);
@@ -70,17 +70,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-async function handleProcessUrl(rawUrl, { skipInject = false } = {}) {
+async function handleProcessUrl(rawUrl, { skipNotify = false } = {}) {
   const prefs = await getPrefs();
 
   if (!prefs.enabled) {
     return { cleanUrl: rawUrl, action: "untouched" };
   }
 
-  // On copy: respect the user's affiliate injection setting but suppress the toast
-  // (same behaviour as the context menu handler)
-  const effectivePrefs = skipInject
-    ? { ...prefs, notifyForeignAffiliate: false }
+  // On copy: suppress the toast and affiliate injection — user didn't navigate,
+  // they just copied a link, so we should not inject our tag either.
+  const effectivePrefs = skipNotify
+    ? { ...prefs, notifyForeignAffiliate: false, injectOwnAffiliate: false }
     : prefs;
 
   const result = processUrl(rawUrl, effectivePrefs);
@@ -143,7 +143,7 @@ chrome.commands.onCommand.addListener(async (command) => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab?.url || !tab?.id) return;
 
-  const result = await handleProcessUrl(tab.url, { skipInject: true });
+  const result = await handleProcessUrl(tab.url, { skipNotify: true });
   chrome.tabs.sendMessage(tab.id, {
     type: "COPY_TO_CLIPBOARD",
     text: result.cleanUrl,
@@ -155,8 +155,8 @@ chrome.contextMenus.onClicked.addListener(async (info) => {
 
   if (info.menuItemId === "muga-copy-clean") {
     // Route through handleProcessUrl so stats are incremented correctly.
-    // skipInject: true suppresses the foreign-affiliate toast (not relevant on copy).
-    const result = await handleProcessUrl(info.linkUrl, { skipInject: true });
+    // skipNotify: true suppresses the foreign-affiliate toast and injection (not relevant on copy).
+    const result = await handleProcessUrl(info.linkUrl, { skipNotify: true });
 
     // Copy to clipboard via content script (service worker has no direct clipboard access)
     if (tab?.id) {
@@ -179,7 +179,7 @@ chrome.contextMenus.onClicked.addListener(async (info) => {
       const rawUrl = match[0];
       const candidate = rawUrl.replace(/[.,;:!?)\]]+$/, "");
       if (!candidate.includes("?")) continue;
-      const cleaned = await handleProcessUrl(candidate, { skipInject: true });
+      const cleaned = await handleProcessUrl(candidate, { skipNotify: true });
       if (cleaned.cleanUrl !== candidate) {
         result = result.replace(candidate, cleaned.cleanUrl);
       }

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -148,7 +148,7 @@
 
     // Preserve Ctrl/Cmd/Shift+click and target="_blank" (open in new tab/window)
     const opensNewTab = e.ctrlKey || e.metaKey || e.shiftKey ||
-      (anchor.target && anchor.target !== "_self" && anchor.target !== "_top" && anchor.target !== "_parent");
+      anchor.target === "_blank";
 
     e.preventDefault();
 
@@ -243,7 +243,7 @@
 
     const timer = setTimeout(() => {
       notice.remove();
-      callback("original");
+      callback("clean");
     }, 5000);
 
     notice.querySelectorAll("button[data-choice]").forEach(btn => {

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -94,7 +94,7 @@ export function processUrl(rawUrl, prefs) {
   );
   if (domainBlacklisted) {
     url.search = "";
-    return { cleanUrl: url.toString(), action: "blacklisted", removedTracking: [], detectedAffiliate: null };
+    return { cleanUrl: url.toString(), action: "blacklisted", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
   }
 
   const patterns = getPatternsForHost(hostname);

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -8,7 +8,7 @@
 
 // ── Sync: user preferences ──────────────────────────────────────────────────
 
-const PREF_DEFAULTS = {
+export const PREF_DEFAULTS = {
   enabled: true,
   injectOwnAffiliate: true,
   notifyForeignAffiliate: false,

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -4,16 +4,7 @@
 
 import { applyTranslations, getStoredLang, t, SUPPORTED_LANGS } from "../lib/i18n.js";
 import { getSupportedStores } from "../lib/affiliates.js";
-
-const DEFAULTS = {
-  injectOwnAffiliate: true,
-  notifyForeignAffiliate: false,
-  allowReplaceAffiliate: false,
-  stripAllAffiliates: false,
-  blacklist: [],
-  whitelist: [],
-  customParams: [],
-};
+import { PREF_PREF_DEFAULTS } from "../lib/storage.js";
 
 let currentLang = "en";
 
@@ -21,7 +12,7 @@ async function init() {
   currentLang = await getStoredLang();
   applyTranslations(currentLang);
 
-  const prefs = await chrome.storage.sync.get(DEFAULTS);
+  const prefs = await chrome.storage.sync.get(PREF_DEFAULTS);
 
   bindToggle("inject", "injectOwnAffiliate", prefs);
   bindToggle("notify", "notifyForeignAffiliate", prefs);
@@ -110,7 +101,7 @@ function initLanguageSelect() {
     await chrome.storage.sync.set({ language: currentLang });
     applyTranslations(currentLang);
     // Re-render dynamic lists with new language
-    const prefs = await chrome.storage.sync.get(DEFAULTS);
+    const prefs = await chrome.storage.sync.get(PREF_DEFAULTS);
     renderList("blacklist-items", prefs.blacklist, "blacklist");
     renderList("whitelist-items", prefs.whitelist, "whitelist");
   });
@@ -159,7 +150,7 @@ function initStatsSection() {
 
 function initExportImport() {
   document.getElementById("export-btn").addEventListener("click", async () => {
-    const prefs = await chrome.storage.sync.get(DEFAULTS);
+    const prefs = await chrome.storage.sync.get(PREF_DEFAULTS);
     const payload = {
       muga: true,
       version: chrome.runtime.getManifest().version,

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -5,6 +5,7 @@
 
 import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
 import { processUrl } from "../lib/cleaner.js";
+import { getPrefs } from "../lib/storage.js";
 
 const NUDGE_URL_THRESHOLD = 150;
 const NUDGE_DAY_THRESHOLD = 10;
@@ -15,11 +16,7 @@ async function init() {
   applyTranslations(lang);
 
   const [prefs, local] = await Promise.all([
-    chrome.storage.sync.get({
-      enabled: true,
-      injectOwnAffiliate: true,
-      notifyForeignAffiliate: false,
-    }),
+    getPrefs(),
     chrome.storage.local.get({
       stats: { urlsCleaned: 0, junkRemoved: 0, referralsSpotted: 0 },
       firstUsed: null,
@@ -65,10 +62,16 @@ async function showUrlPreview(prefs, lang) {
   const url = tab?.url;
   if (!url || url.startsWith("chrome://") || url.startsWith("about:") || url.startsWith("moz-extension://") || url.startsWith("chrome-extension://")) return;
 
-  const result = processUrl(url, { ...prefs, notifyForeignAffiliate: false });
-
   const section = document.getElementById("preview");
   section.hidden = false;
+
+  if (prefs.enabled === false) {
+    document.getElementById("preview-clean").hidden = false;
+    document.getElementById("preview-clean").textContent = url;
+    return;
+  }
+
+  const result = processUrl(url, { ...prefs, notifyForeignAffiliate: false });
 
   if (result.cleanUrl === url && result.action === "untouched") {
     document.getElementById("preview-clean").hidden = false;


### PR DESCRIPTION
- BUG-01 (cleaner.js): add junkRemoved: 0 to blacklisted early-return for consistent return shape
- BUG-02 (service-worker.js): skipInject renamed to skipNotify; effectivePrefs now also sets injectOwnAffiliate: false on copy so no tag is injected when user copies a link
- UX-01 + CQ-01 (popup.js): replace raw chrome.storage.sync.get() with getPrefs() from storage.js; preview shows original URL when MUGA is disabled
- CQ-02 (storage.js, options.js): export PREF_DEFAULTS from storage.js; options.js imports and uses it instead of duplicated local DEFAULTS object
- UX-03 (content/cleaner.js): toast auto-dismiss now navigates to clean URL instead of original (safer privacy default)
- UX-04 (content/cleaner.js): opensNewTab check now uses anchor.target === "_blank" only, not all named frame targets
