### PR TITLE
feat: migrate renderStores() to DOM construction and add import integration tests

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -79,15 +79,31 @@ function renderStores() {
   const stores = getSupportedStores();
 
   const grid = document.getElementById("stores-grid");
-  grid.innerHTML = stores.map(s => `
-    <div class="store-chip">
-      <div class="store-dot ${s.ourTag ? "active" : ""}"></div>
-      <div>
-        <div class="store-name">${s.name}</div>
-        <div class="store-param">${s.param}=</div>
-      </div>
-    </div>
-  `).join("");
+  grid.innerHTML = "";
+
+  stores.forEach(s => {
+    const chip = document.createElement("div");
+    chip.className = "store-chip";
+
+    const dot = document.createElement("div");
+    dot.className = "store-dot" + (s.ourTag ? " active" : "");
+
+    const info = document.createElement("div");
+
+    const nameEl = document.createElement("div");
+    nameEl.className = "store-name";
+    nameEl.textContent = s.name;
+
+    const paramEl = document.createElement("div");
+    paramEl.className = "store-param";
+    paramEl.textContent = s.param + "=";
+
+    info.appendChild(nameEl);
+    info.appendChild(paramEl);
+    chip.appendChild(dot);
+    chip.appendChild(info);
+    grid.appendChild(chip);
+  });
 
   const countEl = document.getElementById("stores-count");
   if (countEl) countEl.textContent = `(${stores.length})`;

--- a/tests/unit/imports.test.mjs
+++ b/tests/unit/imports.test.mjs
@@ -1,0 +1,65 @@
+/**
+ * MUGA — Integration tests for UI-layer ES module imports
+ *
+ * Verifies that named exports from src/lib/ resolve correctly at the Node.js
+ * level, catching typos like the PREF_PREF_DEFAULTS regression.
+ *
+ * Run with: npm test
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// ---------------------------------------------------------------------------
+// Chrome mock — storage.js uses chrome.storage.* inside function bodies.
+// The mock must exist before the module is imported so Node.js does not throw
+// a ReferenceError if the engine evaluates any top-level expressions.
+// ---------------------------------------------------------------------------
+globalThis.chrome = {
+  storage: {
+    sync: {
+      get: (defaults, cb) => cb && cb({}),
+      set: (_data, cb) => cb && cb(),
+      remove: (_keys, cb) => cb && cb(),
+    },
+    local: {
+      get: (defaults, cb) => cb && cb({}),
+      set: (_data, cb) => cb && cb(),
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Test 1 — PREF_DEFAULTS is exported from storage.js and is an object
+// ---------------------------------------------------------------------------
+test("PREF_DEFAULTS is exported from storage.js and is an object with key 'enabled'", async () => {
+  const { PREF_DEFAULTS } = await import("../../src/lib/storage.js");
+  assert.notEqual(PREF_DEFAULTS, undefined, "PREF_DEFAULTS must not be undefined");
+  assert.equal(typeof PREF_DEFAULTS, "object", "PREF_DEFAULTS must be an object");
+  assert.ok("enabled" in PREF_DEFAULTS, "PREF_DEFAULTS must have key 'enabled'");
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — getPrefs is exported from storage.js and is a function
+// ---------------------------------------------------------------------------
+test("getPrefs is exported from storage.js and is a function", async () => {
+  const { getPrefs } = await import("../../src/lib/storage.js");
+  assert.equal(typeof getPrefs, "function", "getPrefs must be a function");
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — getSupportedStores is exported from affiliates.js and returns an array
+// ---------------------------------------------------------------------------
+test("getSupportedStores is exported from affiliates.js and returns an array", async () => {
+  const { getSupportedStores } = await import("../../src/lib/affiliates.js");
+  assert.equal(typeof getSupportedStores, "function", "getSupportedStores must be a function");
+  assert.ok(Array.isArray(getSupportedStores()), "getSupportedStores() must return an array");
+});
+
+// ---------------------------------------------------------------------------
+// Test 4 — processUrl is exported from lib/cleaner.js and is a function
+// ---------------------------------------------------------------------------
+test("processUrl is exported from lib/cleaner.js and is a function", async () => {
+  const { processUrl } = await import("../../src/lib/cleaner.js");
+  assert.equal(typeof processUrl, "function", "processUrl must be a function");
+});


### PR DESCRIPTION
## Summary

- **Task 1 (Sam — frontend_dev):** Replace `innerHTML` template literal in `renderStores()` (`src/options/options.js`) with `document.createElement` + `textContent` DOM construction, following the same CSP-safe pattern as `renderList()`. Visual output is identical — same CSS classes (`store-chip`, `store-dot`, `store-name`, `store-param`) and same active/inactive dot logic based on `s.ourTag`.
- **Task 2 (Ana — qa_lead):** Add `tests/unit/imports.test.mjs` with 4 `node:test` integration tests that verify named exports (`PREF_DEFAULTS`, `getPrefs`, `getSupportedStores`, `processUrl`) resolve correctly at the Node.js level, catching import-typo regressions like `PREF_PREF_DEFAULTS`.

Closes #59

## Test plan

- [x] `npm test` passes: 79 tests, 76 pass, 0 fail, 3 todo (unchanged todo count)
- [x] All 4 new import tests pass individually
- [x] `renderStores()` produces identical DOM structure with no `innerHTML` usage
- [x] Chrome mock in `imports.test.mjs` covers `chrome.storage.sync` and `chrome.storage.local`