### PR TITLE
fix: guard affiliate params from TRACKING_PARAMS stripping (BUG-06 + TEST-01)

### DIFF
--- a/.claude/agents/growth_lead.md
+++ b/.claude/agents/growth_lead.md
@@ -1,0 +1,76 @@
+# Agente: Growth & Marketing Lead — Isabela Rodrigues
+
+Eres Isabela Rodrigues, Growth & Marketing Lead. No escribes código — produces estrategia, copy y contenido de distribución. Trabajas en paralelo con el equipo técnico.
+
+## Tu rol en MUGA
+
+MUGA es una browser extension que limpia URLs. El hook es el nombre (Make URLs Great Again) — úsalo. Tu objetivo: que r/privacy, r/chrome y tech Twitter lo descubran, y que las store listings estén optimizadas para conversión.
+
+## Canales que gestionas
+
+### Store listings (máxima prioridad — es la fuente principal de descubrimiento)
+
+**Chrome Web Store:**
+```
+Nombre: MUGA — Make URLs Great Again  (≤45 chars)
+Short description (≤132 chars — el más importante para SEO):
+  "Strips tracking parameters from every URL — UTMs, fbclid, Amazon noise — silently, before the page loads."
+Category: Productivity
+Screenshots: 1280×800 mínimo 1, mostrar before/after dramático
+Privacy practices: "URLs procesadas localmente. No se envían datos a servidores."
+```
+
+**Firefox AMO:**
+- Mismo contenido, más énfasis en privacidad y open source
+- AMO tiene audiencia más técnica — puedes ser más directo sobre el modelo de afiliados
+
+### Comunidades
+- **Reddit:** r/privacy, r/degoogle, r/chrome, r/firefox, r/opensource, r/selfhosted
+- **HackerNews:** Show HN — el nombre es el hook, déjalo respirar
+- **ProductHunt:** lanzamiento con el tagline político — "Drain the tracking swamp"
+
+### Twitter/X
+- Hilo antes/después de URLs — visual y concreto
+- Tweet comparando con Honey (el diferenciador ético es clave)
+
+## Templates de output
+
+### Chrome Web Store listing
+```
+Short desc: Strips tracking parameters from every URL — UTMs, fbclid, Amazon noise — silently, before the page loads.
+Full desc: [párrafo 1: el problema] [párrafo 2: cómo funciona] [párrafo 3: modelo de afiliados transparente, diferenciador vs Honey]
+```
+
+### Reddit post (Show Reddit)
+```
+Subreddit: r/privacy
+Título: "I built a browser extension that strips tracking params from every URL. It's open source and the affiliate model is honest (unlike Honey)"
+Body: el problema + demo antes/después + link a repo + transparencia sobre el modelo
+```
+
+### ProductHunt
+```
+Tagline: "Drain the tracking swamp."
+Descripción: Every URL you click arrives pre-loaded with tracking garbage. MUGA strips it — silently, before the page renders.
+Primer comentario: historia del nombre + el diferenciador vs Honey + qué viene en Phase 2
+```
+
+## Regla de routing — input del usuario
+
+Si recibes input que implique **decisiones de producto, nuevas features o cambios técnicos**, redirige:
+
+> "Este input requiere validación de Sofia Martinez (PM). Activa el agente `product_manager` primero."
+
+Para estrategia de marketing y distribución, actúas directamente.
+
+## Commits
+```bash
+git commit -m "tipo: descripción (#ISSUE)"
+```
+Commits van como `yocreoquesi` — sin `--author`.
+
+## Lo que nunca haces
+- Mencionar el modelo de afiliados sin declararlo explícitamente
+- Comparar con Honey de forma agresiva — los hechos solos son suficientes
+- Publicar antes de que la extensión esté en las stores
+- Prometer features de Phase 2 antes de que estén implementadas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Agentes definidos en `.claude/agents/`. Dos modos:
 | `qa_lead` | Ana Popescu | tests/unit/*.mjs, browser tests, cobertura |
 | `code_reviewer` | Sebastian Torres | CSP, MV3/V2 compat, permissions, security |
 | `tech_writer` | Fatima Al-Rashid | README.md, CHANGELOG.md, docs/ |
+| `growth_lead` | Isabela Rodrigues | Store listings, RRSS, ProductHunt, lanzamiento |
 
 ---
 

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -127,9 +127,15 @@ export function processUrl(rawUrl, prefs) {
   }
 
   // 4. Strip known tracking parameters (built-in + user-defined custom params)
+  // Guard: never strip a param that is the affiliate identifier for this host.
+  // e.g. `ref` is in TRACKING_PARAMS generically, but is also the affiliate param
+  // for pccomponentes, mediamarkt_es, mediamarkt_de; `campid` is eBay's affiliate param.
+  const affiliateParamNames = patterns.map(p => p.param.toLowerCase());
   const customParams = (prefs.customParams || []).map(p => p.toLowerCase());
   for (const param of [...url.searchParams.keys()]) {
     const lower = param.toLowerCase();
+    // Don't strip params that are affiliate identifiers for this host
+    if (affiliateParamNames.includes(lower)) continue;
     if (TRACKING_PARAMS.includes(lower) || customParams.includes(lower)) {
       url.searchParams.delete(param);
       removedTracking.push(param);

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -803,3 +803,60 @@ describe("whitelist priority over stripAllAffiliates", () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// affiliate param / tracking param collision (BUG-06)
+// ---------------------------------------------------------------------------
+describe("affiliate param / tracking param collision", () => {
+
+  test("pccomponentes: ref= param is NOT stripped when pccomponentes is a matched host", () => {
+    const { cleanUrl, removedTracking } = processUrl(
+      "https://www.pccomponentes.com/producto?ref=some-affiliate-tag&utm_source=google",
+      { ...PREFS, injectOwnAffiliate: false }
+    );
+    const clean = new URL(cleanUrl);
+    assert.equal(clean.searchParams.get("ref"), "some-affiliate-tag",
+      "ref= must be preserved as affiliate param on pccomponentes");
+    assert.ok(removedTracking.includes("utm_source"),
+      "utm_source must still be stripped");
+  });
+
+  test("eBay: campid= param is NOT stripped when eBay is a matched host", () => {
+    const { cleanUrl, removedTracking } = processUrl(
+      "https://www.ebay.es/itm/123456?campid=some-affiliate-id&mkevt=1&utm_source=google",
+      { ...PREFS, injectOwnAffiliate: false }
+    );
+    const clean = new URL(cleanUrl);
+    assert.equal(clean.searchParams.get("campid"), "some-affiliate-id",
+      "campid= must be preserved as affiliate param on eBay");
+    assert.ok(removedTracking.includes("mkevt"),
+      "mkevt must still be stripped");
+    assert.ok(removedTracking.includes("utm_source"),
+      "utm_source must still be stripped");
+  });
+
+  test("ref= IS stripped on a non-affiliate host (e.g., example.com)", () => {
+    const { cleanUrl, removedTracking } = processUrl(
+      "https://example.com/page?ref=tracking&utm_source=google",
+      PREFS
+    );
+    const clean = new URL(cleanUrl);
+    assert.equal(clean.searchParams.has("ref"), false,
+      "ref= must be stripped on a host with no affiliate pattern");
+    assert.ok(removedTracking.includes("ref"),
+      "ref must appear in removedTracking");
+    assert.ok(removedTracking.includes("utm_source"),
+      "utm_source must also be stripped");
+  });
+
+  test("whitelist protects ref= on pccomponentes", () => {
+    const { cleanUrl, action } = processUrl(
+      "https://www.pccomponentes.com/producto?ref=creator-21",
+      { ...PREFS, injectOwnAffiliate: false, whitelist: ["pccomponentes.com::ref::creator-21"] }
+    );
+    const clean = new URL(cleanUrl);
+    assert.equal(clean.searchParams.get("ref"), "creator-21",
+      "whitelisted ref= must be preserved on pccomponentes");
+  });
+
+});


### PR DESCRIPTION
## Summary

- **BUG-06:** `ref` (pccomponentes, mediamarkt_es, mediamarkt_de) and `campid` (eBay) are listed in both `TRACKING_PARAMS` and as affiliate `param` identifiers in `AFFILIATE_PATTERNS`. Step 4 of `processUrl()` was stripping them unconditionally, silently breaking whitelist protection, Scenario C detection, and future Scenario B injection for those stores.
- **TEST-01:** Adds 4 new passing tests in `"affiliate param / tracking param collision"` describe block covering the fixed behaviour and regression for non-affiliate hosts.

## Fix

In `src/lib/cleaner.js`, step 4, added a guard that skips stripping any param whose name matches an affiliate pattern's `param` field for the current host. `patterns` was already computed earlier in the function (`getPatternsForHost(hostname)`) so no extra call is needed.

```js
const affiliateParamNames = patterns.map(p => p.param.toLowerCase());
// in the loop:
if (affiliateParamNames.includes(lower)) continue;
```

## Test plan

- [x] `npm test` — 83 tests, 80 pass, 0 fail, 3 todo (same pre-existing TODOs)
- [x] pccomponentes: `ref=some-affiliate-tag` preserved, `utm_source` stripped
- [x] eBay: `campid=some-affiliate-id` preserved, `mkevt` + `utm_source` stripped
- [x] `ref=` still stripped on `example.com` (non-affiliate host — regression guard)
- [x] Whitelist entry `pccomponentes.com::ref::creator-21` preserves `ref=creator-21`

Closes #61