### PR TITLE
fix: UX and quality improvements — disabled state, Amazon path, export, i18n, a11y

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -178,7 +178,6 @@ chrome.contextMenus.onClicked.addListener(async (info) => {
     for (const match of matches) {
       const rawUrl = match[0];
       const candidate = rawUrl.replace(/[.,;:!?)\]]+$/, "");
-      if (!candidate.includes("?")) continue;
       const cleaned = await handleProcessUrl(candidate, { skipNotify: true });
       if (cleaned.cleanUrl !== candidate) {
         result = result.replace(candidate, cleaned.cleanUrl);

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -83,10 +83,6 @@
     const matches = [...trimmed.matchAll(URL_RE)];
     if (matches.length === 0) return;
 
-    // Check at least one URL actually has query params worth cleaning
-    const hasQueryParams = matches.some(m => m[0].includes("?"));
-    if (!hasQueryParams) return;
-
     e.preventDefault();
 
     try {
@@ -96,7 +92,6 @@
         const rawUrl = match[0];
         // Strip trailing punctuation that is unlikely to be part of the URL
         const cleanCandidate = rawUrl.replace(/[.,;:!?)\]]+$/, "");
-        if (!cleanCandidate.includes("?")) continue;
 
         const response = await chrome.runtime.sendMessage({
           type: "PROCESS_URL",
@@ -142,9 +137,6 @@
       return;
     }
     if (!["http:", "https:"].includes(url.protocol)) return;
-
-    // No query string means nothing to clean
-    if (!url.search) return;
 
     // Preserve Ctrl/Cmd/Shift+click and target="_blank" (open in new tab/window)
     const opensNewTab = e.ctrlKey || e.metaKey || e.shiftKey ||

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -65,7 +65,7 @@ export const TRANSLATIONS = {
   wl_hint:  { en: "Format: <code>domain::param::value</code>. That creator's affiliate tag is never modified.", es: "Formato: <code>dominio::parámetro::valor</code>. El afiliado de ese creador nunca se toca." },
   add_btn:  { en: "+ Add", es: "+ Añadir" },
   empty_list: { en: "No entries yet.", es: "Sin entradas todavía." },
-  privacy_link: { en: "Privacy policy", es: "Política de privacidad" },
+  muga_disabled: { en: "MUGA is disabled", es: "MUGA está desactivado" },
   section_language: { en: "Language", es: "Idioma" },
   lang_label:  { en: "Display language", es: "Idioma de la interfaz" },
   lang_hint:   { en: "Affects the popup and settings page. Does not affect URL processing.", es: "Afecta al popup y a esta página. No afecta al procesamiento de URLs." },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -38,6 +38,10 @@
       left: 3px; top: 3px; background: white; border-radius: 50%; transition: transform .2s; }
     .toggle input:checked + .slider { background: var(--accent); }
     .toggle input:checked + .slider::before { transform: translateX(16px); }
+    .toggle input:focus-visible + .slider {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
     .list-section { padding: 12px 16px; }
     .list-items { margin-bottom: 10px; min-height: 20px; }
     .list-item { display: flex; align-items: center; justify-content: space-between;
@@ -89,7 +93,7 @@
   </style>
 </head>
 <body>
-  <h1>MUGA</h1>
+  <h1 data-i18n="opts_title">Advanced settings</h1>
   <p class="subtitle" data-i18n="opts_subtitle">Make URLs Great Again</p>
 
   <section>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -118,6 +118,7 @@ function initLanguageSelect() {
     applyTranslations(currentLang);
     // Re-render dynamic lists with new language
     const prefs = await chrome.storage.sync.get(PREF_DEFAULTS);
+    renderList("custom-params-items", prefs.customParams || [], "customParams");
     renderList("blacklist-items", prefs.blacklist, "blacklist");
     renderList("whitelist-items", prefs.whitelist, "whitelist");
   });
@@ -172,6 +173,7 @@ function initExportImport() {
       version: chrome.runtime.getManifest().version,
       blacklist: prefs.blacklist,
       whitelist: prefs.whitelist,
+      customParams: prefs.customParams,
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -194,16 +196,17 @@ function initExportImport() {
     try {
       const text = await file.text();
       const data = JSON.parse(text);
-      if (!data.muga || !Array.isArray(data.blacklist) || !Array.isArray(data.whitelist)) {
+      if (!data.muga || !Array.isArray(data.blacklist) || !Array.isArray(data.whitelist) || !Array.isArray(data.customParams)) {
         throw new Error("invalid");
       }
       const isValidEntry = e => typeof e === "string" && e.length > 0 && e.length < 500;
-      if (!data.blacklist.every(isValidEntry) || !data.whitelist.every(isValidEntry)) {
+      if (!data.blacklist.every(isValidEntry) || !data.whitelist.every(isValidEntry) || !data.customParams.every(isValidEntry)) {
         throw new Error("invalid");
       }
-      await chrome.storage.sync.set({ blacklist: data.blacklist, whitelist: data.whitelist });
+      await chrome.storage.sync.set({ blacklist: data.blacklist, whitelist: data.whitelist, customParams: data.customParams });
       renderList("blacklist-items", data.blacklist, "blacklist");
       renderList("whitelist-items", data.whitelist, "whitelist");
+      renderList("custom-params-items", data.customParams, "customParams");
       alert(t("import_success", currentLang));
     } catch {
       alert(t("import_error", currentLang));

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -155,6 +155,11 @@ header {
 .toggle input:checked + .slider::before { transform: translateX(16px); }
 .toggle.sm input:checked + .slider::before { transform: translateX(13px); }
 
+.toggle input:focus-visible + .slider {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* URL preview */
 .preview {
   padding: 8px 14px 10px;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,6 +10,7 @@
   <header>
     <div class="logo">MUGA</div>
     <div class="toggle-wrap">
+      <span class="toggle-label" data-i18n="toggle_enabled" style="display:none">Enable MUGA</span>
       <label class="toggle" title="Enable / disable MUGA">
         <input type="checkbox" id="enabled-toggle">
         <span class="slider"></span>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -66,8 +66,10 @@ async function showUrlPreview(prefs, lang) {
   section.hidden = false;
 
   if (prefs.enabled === false) {
-    document.getElementById("preview-clean").hidden = false;
-    document.getElementById("preview-clean").textContent = url;
+    const previewClean = document.getElementById("preview-clean");
+    previewClean.hidden = false;
+    previewClean.textContent = t("muga_disabled", lang);
+    previewClean.style.color = "var(--text2)";
     return;
   }
 

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -49,12 +49,13 @@ describe("Scenario A — tracking parameter removal", () => {
   });
 
   test("strips all major UTM params at once", () => {
-    const { removedTracking, cleanUrl } = processUrl(
+    const { removedTracking, cleanUrl, junkRemoved } = processUrl(
       "https://example.com/?utm_source=fb&utm_medium=cpc&utm_campaign=spring&utm_content=banner&utm_term=shoes",
       PREFS
     );
     assert.equal(removedTracking.length, 5);
     assert.equal(cleanUrl, "https://example.com/");
+    assert.equal(junkRemoved, 5);
   });
 
   test("strips fbclid", () => {
@@ -336,7 +337,7 @@ describe("Scenario A (extended) — new tracking params (#17)", () => {
 describe("Amazon — affiliate param preserved", () => {
 
   test("amazon.es: tag= is preserved, UTM is stripped", () => {
-    const { cleanUrl, removedTracking } = processUrl(
+    const { cleanUrl, removedTracking, junkRemoved } = processUrl(
       "https://www.amazon.es/dp/B08N5WRWNW?tag=someaffiliate-21&utm_source=email&utm_medium=cpc",
       PREFS
     );
@@ -344,6 +345,7 @@ describe("Amazon — affiliate param preserved", () => {
     assert.equal(clean.searchParams.get("tag"), "someaffiliate-21");
     assert.ok(removedTracking.includes("utm_source"));
     assert.ok(removedTracking.includes("utm_medium"));
+    assert.equal(junkRemoved, 2);
   });
 
   test("amazon.com: tag= is preserved when no tracking present", () => {
@@ -354,13 +356,14 @@ describe("Amazon — affiliate param preserved", () => {
   });
 
   test("amazon internal noise params are stripped", () => {
-    const { removedTracking } = processUrl(
+    const { removedTracking, junkRemoved } = processUrl(
       "https://www.amazon.es/dp/B08N5WRWNW?tag=someaffiliate-21&psc=1&pd_rd_r=abc&linkCode=ll1",
       PREFS
     );
     assert.ok(removedTracking.includes("psc"));
     assert.ok(removedTracking.includes("pd_rd_r"));
     assert.ok(removedTracking.includes("linkCode"));
+    assert.equal(junkRemoved, 3);
   });
 
 });
@@ -631,8 +634,9 @@ describe("Amazon — real-world URL cleaning", () => {
 
   test("full real URL 2 from issue #1", () => {
     const raw = "https://www.amazon.es/edihome-Puff/dp/B0GQ4N9N33/ref=zg_bsnr_c_kitchen_d_sccl_3/258-3201434-8228601?content-id=amzn1.sym.8303e4e0&pd_rd_i=B0GQ4N9N33&th=1";
-    const { cleanUrl } = processUrl(raw, PREFS);
+    const { cleanUrl, junkRemoved } = processUrl(raw, PREFS);
     assert.equal(new URL(cleanUrl).href, "https://www.amazon.es/edihome-Puff/dp/B0GQ4N9N33/");
+    assert.equal(junkRemoved, 4);
   });
 
 });


### PR DESCRIPTION
Closes #63

## Summary

- **BUG-07**: Popup preview when MUGA is disabled now shows "MUGA is disabled" in `--text2` grey instead of the raw URL in green (misleading)
- **BUG-08**: Removed `!url.search` and `!includes("?")` guards from the click handler, copy handler (content/cleaner.js), and selection context menu handler (service-worker.js) — Amazon path-only URLs are now cleaned on click and copy, not just in the popup preview
- **BUG-09**: Removed the duplicate `privacy_link` key (line 68) from `src/lib/i18n.js`
- **CQ-09**: Wired `data-i18n="opts_title"` to `<h1>` in options.html; added hidden `toggle_enabled` span in popup.html toggle-wrap; added `muga_disabled` key to TRANSLATIONS
- **CQ-12**: Export now includes `customParams`; import validates it with `Array.isArray` + `every(isValidEntry)` and writes it to storage
- **CQ-13**: Language change handler now also calls `renderList("custom-params-items", ...)` so the custom params list re-renders on language switch
- **UX-05**: Added `focus-visible` outline rule for toggle switches in `popup.css` and the inline `<style>` block in `options.html`
- **TEST-02**: Added `assert.equal(result.junkRemoved, N)` to 4 existing tests (UTM strip ×5, Amazon UTM strip ×2, Amazon noise params ×3, full real URL 2 ×4)

## Test plan

- [x] `npm test` — 83 tests, 0 failures, 3 todo (unchanged todo count)