### PR TITLE
fix: Amazon locale params, ie=UTF8, product slug cleaning (#65)

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -121,6 +121,20 @@
   /**
    * Intercepts link clicks before navigation.
    * The service worker handles processing and responds with the clean URL.
+   *
+   * ARCHITECTURE NOTE — navigation interception scope:
+   *   MUGA intercepts clicks on <a> elements within pages where this content
+   *   script is already running (injected via manifest content_scripts rules).
+   *   The following navigation types CANNOT be intercepted in MV3:
+   *     - Typing or pasting a URL directly into the address bar
+   *     - Opening a bookmark
+   *     - External apps (e.g. clicking a link in an email client or Slack)
+   *     - Google Search result clicks that navigate the top-level frame to Amazon
+   *       before the content script has loaded on that tab
+   *   Cleaning these would require declarativeNetRequest (DNR) rules, which must
+   *   be declared statically and cannot be generated dynamically from user prefs.
+   *   The popup preview always reflects what WOULD be cleaned if the URL were
+   *   processed; actual cleaning only happens on in-page link clicks.
    */
   document.addEventListener("click", async (e) => {
     const anchor = e.target.closest("a[href]");

--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -54,6 +54,11 @@ export const TRACKING_PARAMS = [
   "linkcode", "linkid",
   "ascsubtag", "asc_contentid", "asc_contenttype", "asc_campaign",
   "th", "_encoding", "content-id", "ref_",
+  // Amazon — locale/keyboard layout selector (appears in ES, DE, FR, IT storefronts).
+  // Stored lowercase — cleaner.js compares param.toLowerCase() against this list.
+  "__mk_es_es", "__mk_de_de", "__mk_fr_fr", "__mk_it_it",
+  // Amazon — legacy encoding indicator (ie=UTF8 on browse/search pages)
+  "ie",
 
   // eBay
   "mkevt", "mkcid", "mkrid", "campid", "toolid", "customid",

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -40,6 +40,8 @@ function domainMatches(hostname, entryDomain) {
 function cleanAmazonPath(hostname, pathname) {
   if (!/amazon\.[a-z.]+$/.test(hostname)) return pathname;
   return pathname
+    // Strip product-name slug that precedes /dp/ASIN (e.g. /UGREEN-Adaptador/dp/B0B9N3QSL3/)
+    .replace(/\/[^/]+\/dp\/([A-Z0-9]{10})/, "/dp/$1")
     .replace(/(\/dp\/[A-Z0-9]{10})\/.+/, "$1/")
     .replace(/(\/gp\/product\/[A-Z0-9]{10})\/.+/, "$1/")
     .replace(/\/ref=[^/?#]*/g, "") || "/";

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -626,16 +626,23 @@ describe("Amazon — real-world URL cleaning", () => {
     assert.ok(u.pathname.includes("/ref=tracking"), "non-Amazon path must not be modified");
   });
 
-  test("full real URL 1 from issue #1", () => {
+  test("full real URL 1 from issue #1 — slug now stripped by FIX-A3", () => {
+    // FIX-A3: product name slug before /dp/ is now stripped, so the expected path
+    // is /dp/ASIN/ rather than /Emergencia-Homologada/dp/ASIN/
     const raw = "https://www.amazon.es/Emergencia-Homologada/dp/B0GF8C2S62/?_encoding=UTF8&content-id=amzn1.sym.0a1e4d50&ref_=pd_hp_d_atf_unk&th=1";
     const { cleanUrl } = processUrl(raw, PREFS);
-    assert.equal(new URL(cleanUrl).href, "https://www.amazon.es/Emergencia-Homologada/dp/B0GF8C2S62/");
+    const u = new URL(cleanUrl);
+    assert.equal(u.pathname, "/dp/B0GF8C2S62/", "slug must be stripped, ASIN path preserved");
+    assert.equal(u.search, "");
   });
 
-  test("full real URL 2 from issue #1", () => {
+  test("full real URL 2 from issue #1 — slug now stripped by FIX-A3", () => {
+    // FIX-A3: product name slug before /dp/ is now stripped
     const raw = "https://www.amazon.es/edihome-Puff/dp/B0GQ4N9N33/ref=zg_bsnr_c_kitchen_d_sccl_3/258-3201434-8228601?content-id=amzn1.sym.8303e4e0&pd_rd_i=B0GQ4N9N33&th=1";
     const { cleanUrl, junkRemoved } = processUrl(raw, PREFS);
-    assert.equal(new URL(cleanUrl).href, "https://www.amazon.es/edihome-Puff/dp/B0GQ4N9N33/");
+    const u = new URL(cleanUrl);
+    assert.equal(u.pathname, "/dp/B0GQ4N9N33/", "slug must be stripped, ASIN path preserved");
+    assert.equal(u.search, "");
     assert.equal(junkRemoved, 4);
   });
 
@@ -861,6 +868,68 @@ describe("affiliate param / tracking param collision", () => {
     const clean = new URL(cleanUrl);
     assert.equal(clean.searchParams.get("ref"), "creator-21",
       "whitelisted ref= must be preserved on pccomponentes");
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// Amazon extended cleaning (FIX-A1/A2/A3)
+// ---------------------------------------------------------------------------
+describe("Amazon extended cleaning", () => {
+
+  test("product slug + ASIN path is cleaned: /UGREEN-Adaptador/dp/B0B9N3QSL3/ref=sr_1_7 → /dp/B0B9N3QSL3/", () => {
+    const raw = "https://www.amazon.es/UGREEN-Adaptador/dp/B0B9N3QSL3/ref=sr_1_7";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.equal(u.pathname, "/dp/B0B9N3QSL3/",
+      "slug before /dp/ must be removed and /ref= after ASIN must be removed");
+  });
+
+  test("path without slug still cleaned correctly: /dp/B0B9N3QSL3/ref=sr_1_7 → /dp/B0B9N3QSL3", () => {
+    const raw = "https://www.amazon.es/dp/B0B9N3QSL3/ref=sr_1_7";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.equal(u.pathname, "/dp/B0B9N3QSL3/",
+      "/dp/ASIN path without slug must still have trailing /ref= stripped");
+  });
+
+  test("__mk_es_ES is stripped from an Amazon URL", () => {
+    const raw = "https://www.amazon.es/s?k=usb+hub&__mk_es_ES=%C3%85M%C3%85%C5%BD%C3%95%C3%91&crid=abc";
+    const { cleanUrl, removedTracking } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("__mk_es_ES"), null, "__mk_es_ES must be stripped");
+    assert.ok(removedTracking.includes("__mk_es_ES"), "__mk_es_ES must appear in removedTracking");
+    assert.equal(u.searchParams.get("k"), "usb hub", "functional k= param must be preserved (+ decoded as space)");
+  });
+
+  test("ie=UTF8 is stripped from an Amazon browse URL", () => {
+    const raw = "https://www.amazon.es/s?k=laptop&ie=UTF8&index=electronics";
+    const { cleanUrl, removedTracking } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("ie"), null, "ie= must be stripped");
+    assert.ok(removedTracking.includes("ie"), "ie must appear in removedTracking");
+    assert.equal(u.searchParams.get("k"), "laptop", "k= must be preserved");
+  });
+
+  test("node= is NOT stripped from an Amazon browse URL (functional category param)", () => {
+    const raw = "https://www.amazon.es/s?k=laptop&node=938005031";
+    const { cleanUrl } = processUrl(raw, PREFS);
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("node"), "938005031",
+      "node= is a functional category filter and must NOT be stripped");
+  });
+
+  test("ref=sr_1_7 in path is not treated as a detected_foreign action", () => {
+    // ref= is in TRACKING_PARAMS generically, but on amazon.es the affiliate param
+    // is tag=, not ref=. Path-based /ref= is cleaned by cleanAmazonPath, not flagged
+    // as a foreign affiliate. This confirms no spurious detected_foreign is raised.
+    const raw = "https://www.amazon.es/UGREEN-Adaptador/dp/B0B9N3QSL3/ref=sr_1_7?psc=1";
+    const { action } = processUrl(raw, {
+      ...PREFS,
+      notifyForeignAffiliate: true,
+    });
+    assert.notEqual(action, "detected_foreign",
+      "path-based /ref= must not trigger foreign affiliate detection");
   });
 
 });


### PR DESCRIPTION
## Summary

- **FIX-A1** — Add `__mk_es_ES`, `__mk_de_DE`, `__mk_fr_FR`, `__mk_it_IT` to `TRACKING_PARAMS`. These Amazon keyboard/locale selector params appear in Spanish/German/French/Italian storefront URLs and are pure noise.
- **FIX-A2** — Add `ie` to `TRACKING_PARAMS`. The `ie=UTF8` legacy encoding param appears on Amazon browse/search pages and carries no functional meaning.
- **FIX-A3** — `cleanAmazonPath` now strips product-name slugs before `/dp/ASIN` (e.g. `/UGREEN-Adaptador/dp/B0B9N3QSL3/` → `/dp/B0B9N3QSL3/`). Amazon search results include the product name in the path; it is cosmetic noise.
- **FIX-A4** — Added a detailed architecture comment in `src/content/cleaner.js` explaining that MV3 content scripts can only intercept in-page `<a>` clicks, not address-bar / bookmark / external-app navigation, and why declarativeNetRequest would be required for the latter.
- **Tests** — New `"Amazon extended cleaning"` describe block with 6 cases covering slug stripping, `__mk_es_ES` removal, `ie` removal, `node=` preservation, and no spurious `detected_foreign` from path-based `/ref=`. Two pre-existing "full real URL" tests updated to reflect the new slug-stripping behaviour.

## Test plan
- [x] `npm test` — 89 tests, 0 failures, 3 TODO skips