### PR TITLE
feat: hide inactive affiliate stores in options and popup (#67)

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -52,6 +52,7 @@ export const TRANSLATIONS = {
   row_strip_affiliates_label: { en: "Strip all affiliate parameters",                      es: "Eliminar todos los parámetros de afiliado" },
   section_stores:    { en: "Supported stores", es: "Tiendas soportadas" },
   stores_hint:       { en: "Green dot = affiliate account active and configured. Grey = account pending registration.", es: "Punto verde = cuenta de afiliado activa. Gris = cuenta pendiente de registro." },
+  no_active_stores:  { en: "No affiliate accounts configured yet.", es: "No hay cuentas de afiliado configuradas aún." },
   section_custom_params:    { en: "Custom tracking params — always stripped everywhere", es: "Parámetros personalizados — siempre eliminados" },
   cp_placeholder:           { en: "ref_code  or  promo_id",                              es: "ref_codigo  o  promo_id" },
   cp_hint:                  { en: "One param name per entry. Stripped on every site, case-insensitive.", es: "Un nombre de parámetro por entrada. Eliminado en todas las webs, sin distinción de mayúsculas." },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -138,7 +138,7 @@
         </summary>
         <div class="stores-grid" id="stores-grid"></div>
         <div style="padding: 4px 16px 12px">
-          <p class="hint" data-i18n="stores_hint">Green dot = affiliate account active. Grey = pending registration.</p>
+          <p class="hint" id="stores-hint" data-i18n="stores_hint">Green dot = affiliate account active. Grey = pending registration.</p>
         </div>
       </details>
     </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -76,17 +76,37 @@ function bindListButtons() {
 }
 
 function renderStores() {
-  const stores = getSupportedStores();
+  const allStores = getSupportedStores();
+  // Only show stores where an affiliate tag has been configured.
+  const activeStores = allStores.filter(s => s.ourTag && s.ourTag.trim() !== "");
 
   const grid = document.getElementById("stores-grid");
+  const hintEl = document.getElementById("stores-hint");
   grid.innerHTML = "";
 
-  stores.forEach(s => {
+  if (activeStores.length === 0) {
+    // Hide the stores grid and hint; show a placeholder message instead.
+    grid.hidden = true;
+    if (hintEl) hintEl.hidden = true;
+    const placeholder = document.createElement("p");
+    placeholder.className = "empty";
+    placeholder.style.cssText = "padding:8px 16px 12px";
+    placeholder.textContent = t("no_active_stores", currentLang);
+    grid.parentNode.insertBefore(placeholder, grid);
+    const countEl = document.getElementById("stores-count");
+    if (countEl) countEl.textContent = "";
+    return;
+  }
+
+  grid.hidden = false;
+  if (hintEl) hintEl.hidden = false;
+
+  activeStores.forEach(s => {
     const chip = document.createElement("div");
     chip.className = "store-chip";
 
     const dot = document.createElement("div");
-    dot.className = "store-dot" + (s.ourTag ? " active" : "");
+    dot.className = "store-dot active";
 
     const info = document.createElement("div");
 
@@ -106,7 +126,7 @@ function renderStores() {
   });
 
   const countEl = document.getElementById("stores-count");
-  if (countEl) countEl.textContent = `(${stores.length})`;
+  if (countEl) countEl.textContent = `(${activeStores.length})`;
 }
 
 function initLanguageSelect() {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -6,6 +6,7 @@
 import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
 import { processUrl } from "../lib/cleaner.js";
 import { getPrefs } from "../lib/storage.js";
+import { getSupportedStores } from "../lib/affiliates.js";
 
 const NUDGE_URL_THRESHOLD = 150;
 const NUDGE_DAY_THRESHOLD = 10;
@@ -45,6 +46,15 @@ async function init() {
     chrome.storage.sync.set({ injectOwnAffiliate: injectToggle.checked }));
   notifyToggle.addEventListener("change", () =>
     chrome.storage.sync.set({ notifyForeignAffiliate: notifyToggle.checked }));
+
+  // Hide the inject toggle row when no affiliate accounts are active.
+  // The feature does nothing without a configured ourTag, so showing it
+  // only adds confusion.
+  const hasActiveStores = getSupportedStores().some(s => s.ourTag && s.ourTag.trim() !== "");
+  if (!hasActiveStores) {
+    const injectRow = injectToggle.closest("label.option-row");
+    if (injectRow) injectRow.hidden = true;
+  }
 
   document.getElementById("open-options").addEventListener("click", (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary

- **`renderStores()` filtered** — only stores where `ourTag` is non-empty are shown in the options grid. With zero active stores the grid and the "Green dot = …" hint are hidden, replaced by a placeholder: "No affiliate accounts configured yet."
- **i18n** — new `no_active_stores` key added in EN and ES.
- **`options.html`** — added `id="stores-hint"` to the hint paragraph so JS can toggle it.
- **Popup inject toggle** — when no stores have an active `ourTag`, the inject toggle row is hidden in the popup. The feature is inert without a configured tag; hiding it avoids user confusion.

## Test plan
- [x] `npm test` — 89 tests, 0 failures, 3 TODO skips