### PR TITLE
feat: batch URL cleaner tab in popup

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -82,6 +82,14 @@ export const TRANSLATIONS = {
   import_success:        { en: "Settings imported successfully.",                                                   es: "Ajustes importados correctamente." },
   import_error:          { en: "Invalid file. Make sure it is a MUGA settings export.",                            es: "Archivo inválido. Asegúrate de que es una exportación de MUGA." },
 
+  // ── Batch cleaner tab ────────────────────────────────────────────────────
+  tab_current:       { en: "Current page",                    es: "Página actual" },
+  tab_batch:         { en: "Batch",                           es: "Lote" },
+  batch_placeholder: { en: "Paste URLs here, one per line...", es: "Pega URLs aquí, una por línea..." },
+  batch_clean_btn:   { en: "Clean",                           es: "Limpiar" },
+  batch_copy_all:    { en: "Copy all",                        es: "Copiar todo" },
+  batch_result_count: { en: "URLs cleaned",                   es: "URLs limpias" },
+
   // ── Content script toast ──────────────────────────────────────────────────
   toast_title:   { en: "MUGA detected an affiliate", es: "MUGA detectó un referido" },
   toast_tag_msg: { en: "carries the tag", es: "lleva el tag" },

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -292,3 +292,111 @@ footer a {
 }
 
 footer a:hover { color: var(--accent); }
+
+/* Tab bar */
+.tab-bar {
+  display: flex;
+  border-bottom: 0.5px solid var(--border);
+  background: var(--bg);
+  padding: 0;
+  gap: 0;
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 8px 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text2);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  font-family: inherit;
+}
+
+.tab-btn:hover { color: var(--text); }
+
+.tab-btn.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Batch panel */
+.batch-body {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.batch-textarea {
+  width: 100%;
+  height: 90px;
+  resize: vertical;
+  padding: 8px;
+  font-size: 11px;
+  font-family: monospace;
+  color: var(--text);
+  background: var(--bg2);
+  border: 0.5px solid var(--border);
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+.batch-textarea:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.batch-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.batch-btn {
+  padding: 5px 14px;
+  font-size: 12px;
+  font-family: inherit;
+  border-radius: 6px;
+  border: 0.5px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.batch-btn.primary {
+  background: var(--accent);
+  color: white;
+  border-color: transparent;
+}
+
+.batch-btn:hover { opacity: 0.85; }
+
+.batch-result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.batch-count {
+  font-size: 11px;
+  color: var(--text2);
+}
+
+.batch-output {
+  width: 100%;
+  max-height: 120px;
+  overflow-y: auto;
+  resize: none;
+  padding: 8px;
+  font-size: 11px;
+  font-family: monospace;
+  color: var(--accent);
+  background: var(--bg2);
+  border: 0.5px solid var(--border);
+  border-radius: 6px;
+  box-sizing: border-box;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -18,6 +18,13 @@
     </div>
   </header>
 
+  <nav class="tab-bar" role="tablist">
+    <button class="tab-btn active" id="tab-current" role="tab" aria-selected="true" aria-controls="current-panel" data-i18n="tab_current">Current page</button>
+    <button class="tab-btn" id="tab-batch" role="tab" aria-selected="false" aria-controls="batch-panel" data-i18n="tab_batch">Batch</button>
+  </nav>
+
+  <div id="current-panel" role="tabpanel">
+
   <section class="stats">
     <div class="stat">
       <span class="stat-value" id="stat-urls">0</span>
@@ -82,6 +89,24 @@
     <a href="#" id="open-options" data-i18n="link_advanced">Advanced settings →</a>
     <a href="https://ko-fi.com/yocreoquesi" target="_blank" id="donate-link" data-i18n="link_donate">Support the project</a>
   </footer>
+
+  </div><!-- /#current-panel -->
+
+  <div id="batch-panel" role="tabpanel" hidden>
+    <div class="batch-body">
+      <textarea id="batch-input" class="batch-textarea" data-i18n-placeholder="batch_placeholder" spellcheck="false"></textarea>
+      <div class="batch-actions">
+        <button id="batch-clean-btn" class="batch-btn primary" data-i18n="batch_clean_btn">Clean</button>
+      </div>
+      <div id="batch-results" hidden>
+        <div class="batch-result-header">
+          <span id="batch-count" class="batch-count"></span>
+          <button id="batch-copy-all" class="batch-btn" data-i18n="batch_copy_all">Copy all</button>
+        </div>
+        <textarea id="batch-output" class="batch-output" readonly></textarea>
+      </div>
+    </div>
+  </div><!-- /#batch-panel -->
 
   <script type="module" src="popup.js"></script>
 </body>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -64,6 +64,7 @@ async function init() {
   maybeShowNudge({ ...prefs, ...local }, lang);
   await showUrlPreview(prefs, lang);
   await showHistory();
+  initTabs(lang);
 }
 
 async function showUrlPreview(prefs, lang) {
@@ -149,6 +150,73 @@ async function showHistory() {
     entryDiv.appendChild(beforeDiv);
     entryDiv.appendChild(afterDiv);
     list.appendChild(entryDiv);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tab switching
+// ---------------------------------------------------------------------------
+function initTabs(lang) {
+  const tabCurrent = document.getElementById("tab-current");
+  const tabBatch   = document.getElementById("tab-batch");
+  const panelCurrent = document.getElementById("current-panel");
+  const panelBatch   = document.getElementById("batch-panel");
+
+  function switchTab(active) {
+    const isBatch = active === "batch";
+    tabCurrent.classList.toggle("active", !isBatch);
+    tabBatch.classList.toggle("active", isBatch);
+    tabCurrent.setAttribute("aria-selected", String(!isBatch));
+    tabBatch.setAttribute("aria-selected", String(isBatch));
+    panelCurrent.hidden = isBatch;
+    panelBatch.hidden   = !isBatch;
+  }
+
+  tabCurrent.addEventListener("click", () => switchTab("current"));
+  tabBatch.addEventListener("click",   () => switchTab("batch"));
+  initBatchPanel(lang);
+}
+
+// ---------------------------------------------------------------------------
+// Batch URL cleaner
+// ---------------------------------------------------------------------------
+async function batchClean(rawText) {
+  const lines = rawText.split("\n").map(l => l.trim()).filter(l => l.length > 0);
+  const prefs = await getPrefs();
+  const results = lines.map(line => {
+    try {
+      const r = processUrl(line, { ...prefs, notifyForeignAffiliate: false, injectOwnAffiliate: false });
+      return r.cleanUrl || line;
+    } catch (e) {
+      return line; // Return original if parsing fails
+    }
+  });
+  return results;
+}
+
+function initBatchPanel(lang) {
+  const cleanBtn  = document.getElementById("batch-clean-btn");
+  const copyBtn   = document.getElementById("batch-copy-all");
+  const inputArea = document.getElementById("batch-input");
+  const outputArea = document.getElementById("batch-output");
+  const resultsDiv = document.getElementById("batch-results");
+  const countSpan  = document.getElementById("batch-count");
+
+  cleanBtn.addEventListener("click", async () => {
+    const raw = inputArea.value;
+    if (!raw.trim()) return;
+    const cleaned = await batchClean(raw);
+    outputArea.value = cleaned.join("\n");
+    countSpan.textContent = `${cleaned.length} ${t("batch_result_count", lang)}`;
+    resultsDiv.hidden = false;
+  });
+
+  copyBtn.addEventListener("click", () => {
+    if (!outputArea.value) return;
+    navigator.clipboard.writeText(outputArea.value).catch(() => {
+      outputArea.select();
+      document.execCommand("copy");
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- Adds a **tab bar** (Current page | Batch) to the popup header, below the logo/toggle row. Tabs switch panels in-place with proper `role="tab"` / `aria-selected` attributes.
- **Batch panel** contains:
  - A `<textarea>` (placeholder: "Paste URLs here, one per line…") 
  - A "Clean" button that processes each non-empty line through `processUrl()` with `notifyForeignAffiliate: false` and `injectOwnAffiliate: false` — only tracking params are stripped
  - A results area (`<textarea readonly>`) showing cleaned URLs, capped at 120px height with `overflow-y: auto`
  - A counter ("X URLs cleaned") and a "Copy all" button
- `i18n.js`: added `tab_current`, `tab_batch`, `batch_placeholder`, `batch_clean_btn`, `batch_copy_all`, `batch_result_count` keys (EN + ES)
- Styling uses existing popup design tokens; no new CSS variables introduced

## Test plan

- [x] `npm test` passes — 89 tests, 0 failures (86 pass + 3 pre-existing TODO stubs)
- [x] Existing Scenario A tests confirm `processUrl` with `injectOwnAffiliate: false` strips tracking params correctly — covers the batch clean code path
- [ ] Manual: open popup → "Batch" tab → paste a URL with `?utm_source=google` → click Clean → result should be clean URL
- [ ] Manual: "Copy all" copies the cleaned results to clipboard
- [ ] Manual: switching between tabs preserves each panel's state
- [ ] Manual: EN/ES language toggle localises all batch UI labels