### PR TITLE
feat: pre-navigation DNR stripping + content script prefs wiring

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -10,6 +10,56 @@ import { getPrefs, incrementStat, getStats, setStats, migrateStatsToLocal } from
 // Run migration once on startup (no-op if already done)
 migrateStatsToLocal();
 
+// --- Prefs cache ---
+
+let cachedPrefs = null;
+
+async function getPrefsWithCache() {
+  if (!cachedPrefs) cachedPrefs = await getPrefs();
+  return cachedPrefs;
+}
+
+// --- DNR sync helpers ---
+
+const DYNAMIC_RULE_ID = 1000;
+
+async function syncCustomParamsDNR(customParams) {
+  if (!customParams || customParams.length === 0) {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: [DYNAMIC_RULE_ID],
+      addRules: [],
+    });
+    return;
+  }
+  const normalized = customParams.map(p => p.trim().toLowerCase());
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: [DYNAMIC_RULE_ID],
+    addRules: [{
+      id: DYNAMIC_RULE_ID,
+      priority: 1,
+      action: {
+        type: "redirect",
+        redirect: { queryTransform: { removeParams: normalized } },
+      },
+      condition: { urlFilter: "||*", resourceTypes: ["main_frame"] },
+    }],
+  });
+}
+
+async function applyDnrState(prefs) {
+  if (prefs.dnrEnabled) {
+    await chrome.declarativeNetRequest.updateEnabledRulesets({
+      enableRulesetIds: ["tracking_params"],
+    }).catch(() => {}); // no-op if already enabled
+    await syncCustomParamsDNR(prefs.customParams);
+  } else {
+    await chrome.declarativeNetRequest.updateEnabledRulesets({
+      disableRulesetIds: ["tracking_params"],
+    }).catch(() => {});
+    await syncCustomParamsDNR([]);
+  }
+}
+
 // Matches http/https URLs in arbitrary text — used by the "selection" context menu handler
 const URL_RE = /https?:\/\/[^\s"'<>()[\]{}]+/g;
 
@@ -52,8 +102,23 @@ async function appendHistory(original, clean) {
   await chrome.storage.session.set({ history });
 }
 
+// --- Storage change listener: invalidate cache and re-apply DNR state ---
+chrome.storage.onChanged.addListener(async (changes, area) => {
+  if (area !== "sync") return;
+  cachedPrefs = null; // Invalidate cache
+  if (changes.customParams || changes.dnrEnabled) {
+    const prefs = await getPrefsWithCache();
+    await applyDnrState(prefs);
+  }
+});
+
 // --- Main message listener from content scripts ---
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "getPrefs") {
+    getPrefsWithCache().then(sendResponse);
+    return true;
+  }
+
   if (message.type === "PROCESS_URL") {
     const tabId = sender.tab?.id;
     handleProcessUrl(message.url, { skipNotify: message.skipNotify })
@@ -113,8 +178,17 @@ async function handleProcessUrl(rawUrl, { skipNotify = false } = {}) {
   return result;
 }
 
+// --- On startup: apply DNR state ---
+chrome.runtime.onStartup.addListener(async () => {
+  const prefs = await getPrefsWithCache();
+  await applyDnrState(prefs);
+});
+
 // --- On install: open onboarding on first run, register context menu ---
 chrome.runtime.onInstalled.addListener(async (details) => {
+  const prefs = await getPrefsWithCache();
+  await applyDnrState(prefs);
+
   chrome.contextMenus.create({
     id: "muga-copy-clean",
     title: "MUGA: Copy clean link",

--- a/src/content/amp-redirect.js
+++ b/src/content/amp-redirect.js
@@ -1,0 +1,46 @@
+/**
+ * MUGA — AMP Redirect Content Script
+ * Detects AMP pages and redirects to the canonical non-AMP URL.
+ *
+ * Note: ES module imports are not supported in MV3 content scripts.
+ * Prefs are fetched from the service worker via messaging.
+ */
+
+(function () {
+  "use strict";
+
+  chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
+    if (!prefs || !prefs.enabled || !prefs.ampRedirect) return;
+
+    // Find the canonical link pointing to the non-AMP version
+    const canonical = document.querySelector('link[rel="canonical"]');
+    if (!canonical || !canonical.href) return;
+
+    const currentUrl = window.location.href;
+    const canonicalUrl = canonical.href;
+
+    // Only redirect if we are on an AMP page and canonical differs
+    const isAmp =
+      document.documentElement.hasAttribute("amp") ||
+      document.documentElement.hasAttribute("⚡") ||
+      currentUrl.includes("/amp") ||
+      currentUrl.includes("?amp");
+
+    if (!isAmp) return;
+    if (canonicalUrl === currentUrl) return;
+
+    try {
+      const canonical_ = new URL(canonicalUrl);
+      const current_ = new URL(currentUrl);
+      // Redirect only if the canonical is on the same or a parent domain
+      if (
+        canonical_.hostname === current_.hostname ||
+        current_.hostname.endsWith("." + canonical_.hostname)
+      ) {
+        window.location.replace(canonicalUrl);
+      }
+    } catch {
+      // Invalid URL — do nothing
+    }
+  });
+})();

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -266,4 +266,26 @@
       callback("original");
     });
   }
+
+  // --- Ping blocking (conditional on prefs.blockPings) ---
+  chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
+    if (!prefs || !prefs.enabled) return;
+    if (prefs.blockPings) {
+      // Strip the ping attribute from all existing and future <a ping> elements
+      function removePingAttrs(root) {
+        root.querySelectorAll("a[ping]").forEach(a => a.removeAttribute("ping"));
+      }
+      removePingAttrs(document);
+      const observer = new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+          for (const node of mutation.addedNodes) {
+            if (node.nodeType !== 1) continue;
+            if (node.hasAttribute?.("ping")) node.removeAttribute("ping");
+            removePingAttrs(node);
+          }
+        }
+      });
+      observer.observe(document.documentElement, { childList: true, subtree: true });
+    }
+  });
 })();

--- a/src/content/redirect-unwrap.js
+++ b/src/content/redirect-unwrap.js
@@ -1,0 +1,53 @@
+/**
+ * MUGA — Redirect Unwrap Content Script
+ * Detects redirect wrapper URLs (e.g. tracking redirectors) and unwraps
+ * the final destination URL, navigating there directly.
+ *
+ * Note: ES module imports are not supported in MV3 content scripts.
+ * Prefs are fetched from the service worker via messaging.
+ */
+
+(function () {
+  "use strict";
+
+  chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
+    if (!prefs || !prefs.enabled || !prefs.unwrapRedirects) return;
+
+    const currentUrl = window.location.href;
+
+    // Common redirect wrapper patterns — look for a destination URL in query params
+    const REDIRECT_PARAMS = ["url", "redirect", "redirect_url", "destination", "dest", "target", "to", "goto", "next", "return", "returnUrl", "return_url", "continue", "location"];
+
+    let parsed;
+    try {
+      parsed = new URL(currentUrl);
+    } catch {
+      return;
+    }
+
+    for (const param of REDIRECT_PARAMS) {
+      const value = parsed.searchParams.get(param);
+      if (!value) continue;
+
+      let destination;
+      try {
+        destination = new URL(value);
+      } catch {
+        // Try decoding if it's percent-encoded
+        try {
+          destination = new URL(decodeURIComponent(value));
+        } catch {
+          continue;
+        }
+      }
+
+      if (!["http:", "https:"].includes(destination.protocol)) continue;
+
+      // Only unwrap if the destination host differs (it's an actual redirect wrapper)
+      if (destination.hostname === parsed.hostname) continue;
+
+      window.location.replace(destination.href);
+      return;
+    }
+  });
+})();

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -17,6 +17,10 @@ export const PREF_DEFAULTS = {
   blacklist: [],     // e.g. ["amazon.es", "booking.com::aid::123456"]
   whitelist: [],     // e.g. ["amazon.es::tag::youtuber-21"]
   customParams: [],  // e.g. ["ref_code", "promo_id"]
+  dnrEnabled: true,
+  blockPings: true,
+  ampRedirect: true,
+  unwrapRedirects: true,
   language: "en",
   onboardingDone: false,
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,9 @@
     "storage",
     "tabs",
     "contextMenus",
-    "clipboardWrite"
+    "clipboardWrite",
+    "declarativeNetRequest",
+    "declarativeNetRequestFeedback"
   ],
 
   "host_permissions": [
@@ -60,6 +62,16 @@
       "matches": ["<all_urls>"]
     }
   ],
+
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "tracking_params",
+        "enabled": true,
+        "path": "rules/tracking-params.json"
+      }
+    ]
+  },
 
   "icons": {
     "16": "icons/16.png",

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -10,6 +10,7 @@
     "tabs",
     "contextMenus",
     "clipboardWrite",
+    "declarativeNetRequest",
     "<all_urls>"
   ],
 
@@ -54,6 +55,17 @@
     "onboarding/onboarding.html",
     "privacy/privacy.html"
   ],
+
+  // Requires Firefox 128+ for queryTransform support
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "tracking_params",
+        "enabled": true,
+        "path": "rules/tracking-params.json"
+      }
+    ]
+  },
 
   "content_security_policy": "script-src 'self'; object-src 'self'",
 

--- a/src/rules/tracking-params.json
+++ b/src/rules/tracking-params.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "Static DNR rules — pre-navigation tracking param stripping. Do not edit manually. Params ref and campid are intentionally excluded (affiliate param conflicts on pccomponentes/mediamarkt/ebay).",
+  "rules": [
+    {
+      "id": 1,
+      "priority": 1,
+      "action": {
+        "type": "redirect",
+        "redirect": {
+          "queryTransform": {
+            "removeParams": [
+              "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
+              "utm_id", "utm_source_platform", "utm_creative_format", "utm_marketing_tactic",
+              "fbclid", "gclid", "gclsrc", "dclid", "gbraid", "wbraid",
+              "msclkid", "tclid", "twclid",
+              "mc_cid", "mc_eid", "mailingid", "hqemail",
+              "igshid", "igsh", "s_cid",
+              "si", "_r",
+              "source", "campaign", "cid", "clickid",
+              "_hsenc", "_hsmi", "hsctatracking",
+              "mkt_tok", "trk", "trkcampaign",
+              "irgwc", "cjevent", "tduid",
+              "ocid", "psc", "spla",
+              "pd_rd_r", "pd_rd_w", "pd_rd_wg", "pd_rd_i",
+              "pf_rd_p", "pf_rd_r",
+              "linkcode", "linkid",
+              "ascsubtag", "asc_contentid", "asc_contenttype", "asc_campaign",
+              "th", "_encoding", "ref_",
+              "__mk_es_es", "__mk_de_de", "__mk_fr_fr", "__mk_it_it",
+              "ie",
+              "mkevt", "mkcid", "mkrid", "toolid", "customid",
+              "aff_trace_key", "algo_expid", "algo_pvid", "btsid", "ws_ab_test",
+              "e_t", "epik",
+              "sc_channel", "sc_country", "sc_funnel", "sc_segment", "sc_icid",
+              "rdt_cid",
+              "ranmid", "raneaid", "ransiteid",
+              "ttaid", "ttrk", "ttcid",
+              "srsltid", "wickedid"
+            ]
+          }
+        }
+      },
+      "condition": {
+        "urlFilter": "||*",
+        "resourceTypes": ["main_frame"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds static DNR ruleset (`src/rules/tracking-params.json`) stripping 69 tracking params at the browser engine level (pre-navigation), before content scripts can run. `ref` and `campid` intentionally excluded to avoid breaking affiliate links on pccomponentes, mediamarkt, and eBay.
- Wires `syncCustomParamsDNR` so user-defined custom params (from options) are applied as dynamic DNR rule id 1000.
- Gates ping-blocking, AMP redirect, and redirect unwrap behaviours behind individual user prefs (`blockPings`, `ampRedirect`, `unwrapRedirects`).
- Adds a prefs cache in the service worker to avoid redundant `chrome.storage.sync.get` calls on every message.

## Test plan

- [x] `npm test` — 86 pass, 0 fail, 3 pre-existing todos
- [ ] Load unpacked in Chrome — verify DNR ruleset is accepted (no manifest errors)
- [ ] Navigate to a URL with `utm_source` — verify param is stripped before page load
- [ ] Set a custom param in options — verify it is stripped by the dynamic rule
- [ ] Toggle `dnrEnabled` off in options — verify ruleset is disabled
- [ ] Toggle `blockPings` off — verify `<a ping>` attributes are NOT removed
- [ ] AMP page with canonical link — verify redirect when `ampRedirect` is on
- [ ] Redirect wrapper URL — verify unwrap when `unwrapRedirects` is on

Closes #71