### PR TITLE
feat: options UI toggles for new privacy/redirect prefs

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -71,6 +71,18 @@ export const TRANSLATIONS = {
   lang_label:  { en: "Display language", es: "Idioma de la interfaz" },
   lang_hint:   { en: "Affects the popup and settings page. Does not affect URL processing.", es: "Afecta al popup y a esta página. No afecta al procesamiento de URLs." },
 
+  section_url_cleaning:  { en: "URL Cleaning",                       es: "Limpieza de URLs" },
+  row_dnr_label:         { en: "Strip tracking parameters before navigation", es: "Eliminar parámetros de rastreo antes de navegar" },
+  row_dnr_hint:          { en: "Uses browser-native rules to clean URLs from the address bar, bookmarks, and external apps", es: "Usa reglas nativas del navegador para limpiar URLs desde la barra de direcciones, marcadores y apps externas" },
+  section_privacy:       { en: "Privacy",                            es: "Privacidad" },
+  row_pings_label:       { en: "Block <a ping> tracking beacons",    es: "Bloquear balizas de rastreo <a ping>" },
+  row_pings_hint:        { en: "Removes ping attributes from links so the browser doesn't send tracking beacons on click", es: "Elimina atributos ping para que el navegador no envíe balizas al hacer clic" },
+  section_redirects:     { en: "Redirect handling",                  es: "Gestión de redirecciones" },
+  row_amp_label:         { en: "Redirect AMP pages to canonical URL", es: "Redirigir páginas AMP a la URL canónica" },
+  row_amp_hint:          { en: "Replaces Google AMP links with the original article URL", es: "Reemplaza los enlaces AMP de Google con la URL original del artículo" },
+  row_unwrap_label:      { en: "Unwrap redirect-wrapper URLs",        es: "Desenvolver URLs de redirección" },
+  row_unwrap_hint:       { en: "Extracts the real destination from Facebook, Reddit, Google, Steam and similar redirect wrappers", es: "Extrae el destino real de redireccionadores de Facebook, Reddit, Google, Steam y similares" },
+
   section_stats:         { en: "Statistics",                                                                        es: "Estadísticas" },
   stats_reset_btn:       { en: "Reset stats",                                                                       es: "Reiniciar stats" },
   stats_reset_confirm:   { en: "Are you sure? This will clear all counters.",                                       es: "¿Seguro? Se borrarán todos los contadores." },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -130,6 +130,52 @@
   </section>
 
   <section>
+    <h2 data-i18n="section_url_cleaning">URL Cleaning</h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="row_dnr_label">Strip tracking parameters before navigation</strong>
+          <small data-i18n="row_dnr_hint">Uses browser-native rules to clean URLs from the address bar, bookmarks, and external apps</small>
+        </div>
+        <label class="toggle"><input type="checkbox" id="dnr-enabled"><span class="slider"></span></label>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 data-i18n="section_privacy">Privacy</h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="row_pings_label">Block &lt;a ping&gt; tracking beacons</strong>
+          <small data-i18n="row_pings_hint">Removes ping attributes from links so the browser doesn't send tracking beacons on click</small>
+        </div>
+        <label class="toggle"><input type="checkbox" id="block-pings"><span class="slider"></span></label>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 data-i18n="section_redirects">Redirect handling</h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="row_amp_label">Redirect AMP pages to canonical URL</strong>
+          <small data-i18n="row_amp_hint">Replaces Google AMP links with the original article URL</small>
+        </div>
+        <label class="toggle"><input type="checkbox" id="amp-redirect"><span class="slider"></span></label>
+      </div>
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="row_unwrap_label">Unwrap redirect-wrapper URLs</strong>
+          <small data-i18n="row_unwrap_hint">Extracts the real destination from Facebook, Reddit, Google, Steam and similar redirect wrappers</small>
+        </div>
+        <label class="toggle"><input type="checkbox" id="unwrap-redirects"><span class="slider"></span></label>
+      </div>
+    </div>
+  </section>
+
+  <section>
     <div class="card">
       <details class="stores-details">
         <summary class="stores-summary">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -18,6 +18,10 @@ async function init() {
   bindToggle("notify", "notifyForeignAffiliate", prefs);
   bindToggle("replace", "allowReplaceAffiliate", prefs);
   bindToggle("strip-affiliates", "stripAllAffiliates", prefs);
+  bindToggle("dnr-enabled", "dnrEnabled", prefs);
+  bindToggle("block-pings", "blockPings", prefs);
+  bindToggle("amp-redirect", "ampRedirect", prefs);
+  bindToggle("unwrap-redirects", "unwrapRedirects", prefs);
 
   renderList("custom-params-items", prefs.customParams, "customParams");
   renderList("blacklist-items", prefs.blacklist, "blacklist");


### PR DESCRIPTION
## Summary

Exposes the 4 new pref keys from the DNR + privacy PR as user-facing toggles in the Advanced Settings page.

## New sections

| Section | Toggle | Pref key | Default |
|---|---|---|---|
| URL Cleaning | Strip tracking parameters before navigation | `dnrEnabled` | ON |
| Privacy | Block `<a ping>` tracking beacons | `blockPings` | ON |
| Redirect handling | Redirect AMP pages to canonical URL | `ampRedirect` | ON |
| Redirect handling | Unwrap redirect-wrapper URLs | `unwrapRedirects` | ON |

## Changed files

- `src/lib/i18n.js` — 11 new keys (EN + ES): section headers + row labels + hints
- `src/options/options.html` — 3 new `<section>` cards with 4 toggle rows
- `src/options/options.js` — 4 new `bindToggle()` calls

## Test plan

- [x] `npm test` → 86 pass, 0 fail
- [ ] Load unpacked in Chrome → options page shows 3 new sections with correct labels
- [ ] Toggle each switch → confirmed saved in `chrome.storage.sync`
- [ ] Switch language to ES → sections re-render in Spanish

Closes #73