### PR TITLE
fix: DNR redirect action requires redirect.transform.queryTransform structure

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -39,7 +39,7 @@ async function syncCustomParamsDNR(customParams) {
       priority: 1,
       action: {
         type: "redirect",
-        redirect: { queryTransform: { removeParams: normalized } },
+        redirect: { transform: { queryTransform: { removeParams: normalized } } },
       },
       condition: { urlFilter: "||*", resourceTypes: ["main_frame"] },
     }],

--- a/src/rules/tracking-params.json
+++ b/src/rules/tracking-params.json
@@ -5,8 +5,9 @@
     "action": {
       "type": "redirect",
       "redirect": {
-        "queryTransform": {
-          "removeParams": [
+        "transform": {
+          "queryTransform": {
+            "removeParams": [
             "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
             "utm_id", "utm_source_platform", "utm_creative_format", "utm_marketing_tactic",
             "fbclid", "gclid", "gclsrc", "dclid", "gbraid", "wbraid",
@@ -36,6 +37,7 @@
             "srsltid", "wickedid"
           ]
         }
+      }
       }
     },
     "condition": {


### PR DESCRIPTION
Chrome DNR API requires `action.redirect.transform.queryTransform.removeParams`, not `action.redirect.queryTransform.removeParams`. Fixed in both the static rules file and the dynamic rule generated in service-worker.js for custom params.