### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to MUGA will be documented in this file.
 
+## [1.3.0] — 2026-03-21
+
+### Added
+- **Pre-navigation DNR stripping** — browser-native `declarativeNetRequest` rules strip 69 tracking parameters *before* the page loads, covering address-bar navigation, bookmarks, and external app links. Togglable via Settings → URL Cleaning.
+- **Block `<a ping>` tracking beacons** — removes `ping` attributes from links so the browser doesn't send a background tracking request on click. Enabled by default; Settings → Privacy.
+- **AMP redirect** — detects Google AMP pages and silently redirects to the canonical article URL. Enabled by default; Settings → Redirect handling.
+- **Redirect-wrapper unwrapping** — unwraps common redirect intermediaries (Reddit `out.reddit.com`, Steam `linkfilter/`, and generic `?redirect=`, `?destination=`, `?url=`, `?to=` patterns). Enabled by default; Settings → Redirect handling.
+- **Batch URL cleaner** — new "Batch" tab in the popup: paste a block of text with multiple URLs and clean them all at once with a "Copy all" button.
+- **Options page — new sections**: URL Cleaning, Privacy, and Redirect handling with individual toggles for all four new features.
+- **Amazon extended cleaning** — strips product slug from URLs (`/ProductName/dp/ASIN/` → `/dp/ASIN/`) and locale params (`__mk_es_ES`, `__mk_de_DE`, `__mk_fr_FR`, `__mk_it_IT`, `ie`).
+
+### Fixed
+- `declarativeNetRequestFeedback` permission removed from manifest (was declared but never used).
+- AMP redirect now requires canonical URL to be `https:` before redirecting (prevents accidental http downgrade).
+- `tracking-params.json` corrected to top-level JSON array (Chrome DNR requirement).
+- DNR `action.redirect` structure corrected: `queryTransform` must nest under `transform`.
+- Inactive affiliate stores no longer shown in options page or popup when no `ourTag` is configured.
+- Copy-clean (Ctrl+C and context menu) no longer injects our affiliate tag into copied URLs.
+- Toast auto-dismiss navigates to clean URL instead of original.
+
+### Security
+- Toast rendering hardened with `escHtml()` to prevent XSS via malicious affiliate param values.
+- Options page list rendering migrated from `innerHTML` to `createElement` + `textContent`.
+
+---
+
 ## [1.0.1] - 2026-03-19
 
 ### Fixed
@@ -109,7 +135,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/yocreoquesi/muga/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/yocreoquesi/muga/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/yocreoquesi/muga/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/yocreoquesi/muga/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![MUGA — Make URLs Great Again](docs/assets/promo-marquee-1400x560.png)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.2.0-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-83_pass-brightgreen)](#development)
+[![Version](https://img.shields.io/badge/version-1.3.0-blue)](#)
+[![Tests](https://img.shields.io/badge/tests-105_pass-brightgreen)](#development)
 [![Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-coming_soon-lightgrey)](#installation)
 [![Firefox Add-ons](https://img.shields.io/badge/Firefox_Add--ons-coming_soon-lightgrey)](#installation)
 
@@ -54,8 +54,13 @@ After:  https://www.ebay.es/itm/123456789
 
 | Feature | Default |
 |---|---|
-| Strip 65+ tracking params (UTMs, fbclid, gclid, YouTube `si`, Pinterest, Snapchat, Reddit…) | **Always on** |
-| Strip Amazon path noise (`/ref=nav_logo`, session IDs after ASIN) | **Always on** |
+| Strip 89 tracking params before navigation (DNR — covers address bar, bookmarks, external apps) | On — opt-out |
+| Strip tracking params on in-page clicks (UTMs, fbclid, gclid, YouTube `si`, Pinterest, Snapchat, Reddit…) | **Always on** |
+| Strip Amazon path noise (`/ref=nav_logo`, session IDs after ASIN, product slug) | **Always on** |
+| Block `<a ping>` tracking beacons | On — opt-out |
+| Redirect AMP pages to canonical URL | On — opt-out |
+| Unwrap redirect wrappers (Reddit, Steam, generic `?redirect=`, `?url=`…) | On — opt-out |
+| **Batch cleaner** — paste multiple URLs, clean all at once | **Always on** |
 | Right-click any link → **Copy clean link** | **Always on** |
 | **Alt+Shift+C** — copy clean URL of current tab | **Always on** |
 | Badge counter — items cleaned on current tab | **Always on** |
@@ -135,7 +140,7 @@ Load unpacked from `chrome://extensions` (Developer mode) or `about:debugging` i
 ## Development
 
 ```bash
-npm test               # 83 unit tests
+npm test               # 105 unit tests
 npm run build:chrome
 npm run build:firefox
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Make URLs Great Again — clean URLs, no tracking, no unwanted referrals.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Clean URLs, no tracking, no unwanted referrals. You decide what happens to each link.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Clean URLs, no tracking, no unwanted referrals. You decide what happens to each link.",
 
   "permissions": [


### PR DESCRIPTION
Bumps version to 1.3.0 and documents the full v1.3.0 feature set.

## Changed files
- `package.json`, `src/manifest.json`, `src/manifest.v2.json` — version 1.2.0 → 1.3.0
- `CHANGELOG.md` — new [1.3.0] entry with Added / Fixed / Security sections
- `README.md` — version badge updated, tests badge 83 → 105, feature table updated with 7 new rows (DNR, ping blocking, AMP redirect, redirect unwrap, batch cleaner)

Closes #79