### PR TITLE
fix: DNR urlFilter "||*" is invalid — use "*" for match-all

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -41,7 +41,7 @@ async function syncCustomParamsDNR(customParams) {
         type: "redirect",
         redirect: { transform: { queryTransform: { removeParams: normalized } } },
       },
-      condition: { urlFilter: "||*", resourceTypes: ["main_frame"] },
+      condition: { urlFilter: "*", resourceTypes: ["main_frame"] },
     }],
   });
 }

--- a/src/rules/tracking-params.json
+++ b/src/rules/tracking-params.json
@@ -41,7 +41,7 @@
       }
     },
     "condition": {
-      "urlFilter": "||*",
+      "urlFilter": "*",
       "resourceTypes": ["main_frame"]
     }
   }


### PR DESCRIPTION
Chrome DNR rejects `||*` as urlFilter. The correct match-all pattern is `*`. Fixed in both the static rules file and the dynamic rule in service-worker.js.