### PR TITLE
fix: amp-redirect.js and redirect-unwrap.js were never injected — missing from manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,16 @@
       "matches": ["<all_urls>"],
       "js": ["lib/browser-polyfill.min.js", "content/cleaner.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["lib/browser-polyfill.min.js", "content/amp-redirect.js"],
+      "run_at": "document_end"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["lib/browser-polyfill.min.js", "content/redirect-unwrap.js"],
+      "run_at": "document_end"
     }
   ],
 

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -24,6 +24,16 @@
       "matches": ["<all_urls>"],
       "js": ["lib/browser-polyfill.min.js", "content/cleaner.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["lib/browser-polyfill.min.js", "content/amp-redirect.js"],
+      "run_at": "document_end"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["lib/browser-polyfill.min.js", "content/redirect-unwrap.js"],
+      "run_at": "document_end"
     }
   ],
 


### PR DESCRIPTION
Critical bug: both content scripts existed in src/content/ but were not registered in manifest.json or manifest.v2.json. They were never executed in any browser. Added as document_end content scripts in both manifests. Closes #102.