### PR TITLE
ci: GitHub Actions CI workflow + Firefox 128+ min version (#92 #93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+# Run tests on every pull request to main and on every push to main
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -77,6 +77,13 @@
     ]
   },
 
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "muga@yocreoquesi.github.io",
+      "strict_min_version": "128.0"
+    }
+  },
+
   "content_security_policy": "script-src 'self'; object-src 'self'",
 
   "icons": {


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` — runs `npm ci` + `npm test` on every PR to `main` and every push to `main`
- Set `strict_min_version: "128.0"` in `manifest.v2.json` — Firefox 128+ is required for `declarativeNetRequest` `queryTransform` support

## Test plan
- [ ] Verify CI workflow runs on this PR
- [ ] Confirm `npm test` passes (112 tests, 0 fail)
- [ ] Confirm `manifest.v2.json` has correct gecko min version

Closes #92, closes #93