### PR TITLE
docs: CONTRIBUTING.md, storage schema, processUrl JSDoc (#98 #99 #90)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to MUGA
+
+Thanks for your interest in contributing! This document covers how to set up the project, run tests, and submit changes.
+
+## Development setup
+
+**Requirements:** Node.js 20+, npm, git
+
+```bash
+git clone https://github.com/yocreoquesi/muga.git
+cd muga
+npm install
+```
+
+## Running tests
+
+```bash
+npm test
+```
+
+Uses the Node.js built-in test runner. All tests live in `tests/unit/*.mjs`.
+
+## Project structure
+
+```
+src/
+├── manifest.json          Chrome MV3
+├── manifest.v2.json       Firefox MV2
+├── background/
+│   └── service-worker.js  URL processing, message handling
+├── content/
+│   ├── cleaner.js         Click interceptor (document_start)
+│   ├── amp-redirect.js    AMP → canonical redirect (document_end)
+│   └── redirect-unwrap.js Tracking redirect unwrapper (document_end)
+├── lib/
+│   ├── cleaner.js         Core URL processing logic (pure, testable)
+│   ├── affiliates.js      Affiliate patterns + tracking params
+│   ├── storage.js         chrome.storage helpers + PREF_DEFAULTS
+│   └── i18n.js            EN/ES translations
+├── popup/                 Browser action popup
+└── options/               Full options page
+tests/unit/                Node.js test runner tests
+```
+
+## Workflow
+
+**Never commit directly to `main`.** Always:
+
+1. Create an issue: `gh issue create --title "..." --label bug|enhancement`
+2. Create a branch: `git checkout -b fix/name` or `feat/name`
+3. Implement + write/update tests
+4. `npm test` must pass
+5. `git push origin branch-name`
+6. `gh pr create --fill`
+7. `gh pr merge --squash`
+8. `git checkout main && git pull origin main`
+
+## Security rules
+
+- No `eval()`, inline scripts, or remote code — violates CSP
+- No external network requests — all processing is local (Phase 1)
+- Minimal permissions in manifests — only what is strictly needed
+- Content scripts must be explicitly listed in `manifest.json` and `manifest.v2.json`
+
+## Commit message format
+
+```
+type: short description (#ISSUE)
+```
+
+Types: `feat`, `fix`, `test`, `docs`, `ci`, `refactor`
+
+## Building the extension
+
+```bash
+npm run build
+```
+
+Output goes to `dist/`. Uses `web-ext` (Mozilla). The build generates both MV3 (Chrome) and MV2 (Firefox) packages.
+
+## Browser compatibility
+
+- Chrome: Manifest V3, `declarativeNetRequest`
+- Firefox: Manifest V2, requires Firefox 128+ for `queryTransform` support in DNR rules
+
+## Adding tracking parameters
+
+Edit `src/lib/affiliates.js` — add to the `TRACKING_PARAMS` array. Parameters are stripped by both the DNR static rule (`src/rules/tracking-params.json`) and the content script cleaner. Keep both in sync.
+
+## Adding affiliate stores
+
+Edit `src/lib/affiliates.js` — add an entry to `AFFILIATE_PATTERNS`:
+
+```js
+{
+  id: "store_id",
+  name: "Store Name",
+  domains: ["store.com", "store.co.uk"],
+  param: "affiliate_param",
+  type: "affiliate",
+  ourTag: "",   // filled in by the extension owner
+}
+```
+
+Leave `ourTag` empty — it is filled in privately by the repository owner.

--- a/docs/data_architect.md
+++ b/docs/data_architect.md
@@ -1,0 +1,81 @@
+# MUGA — Storage Schema
+
+Reference document for all data stored by the extension.
+
+## chrome.storage.sync — User preferences
+
+Synced across devices. ~100 KB quota.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `true` | Master on/off switch for all URL cleaning |
+| `injectOwnAffiliate` | boolean | `true` | Scenario B — inject ourTag when no affiliate present |
+| `notifyForeignAffiliate` | boolean | `false` | Scenario C — show toast when foreign affiliate detected |
+| `allowReplaceAffiliate` | boolean | `false` | Scenario C — allow replacing foreign tag with ours (requires notifyForeignAffiliate) |
+| `stripAllAffiliates` | boolean | `false` | Strip ALL affiliate params, never inject |
+| `dnrEnabled` | boolean | `true` | Enable static DNR rule (declarativeNetRequest) for tracking param stripping |
+| `blockPings` | boolean | `true` | Block `<a ping>` and `navigator.sendBeacon` calls |
+| `ampRedirect` | boolean | `true` | Redirect AMP pages to canonical URL |
+| `unwrapRedirects` | boolean | `true` | Unwrap tracking redirect URLs (e.g. ?url=, ?redirect=) |
+| `blacklist` | string[] | `[]` | Domain/param/value entries to always strip. Format: `"domain"` or `"domain::param::value"` |
+| `whitelist` | string[] | `[]` | Affiliate values to never touch. Format: `"domain::param::value"` |
+| `customParams` | string[] | `[]` | Extra tracking param names to strip beyond built-in list |
+| `language` | string | `"en"` | UI language. Supported: `"en"`, `"es"` |
+| `onboardingDone` | boolean | `false` | Whether the user has completed onboarding |
+
+### List entry format
+
+```
+"amazon.es"                      → strip all params on amazon.es
+"amazon.es::tag::youtuber-21"    → strip/protect specific affiliate value
+```
+
+### Defaults source of truth
+
+`src/lib/storage.js` — `PREF_DEFAULTS` object.
+
+---
+
+## chrome.storage.local — Stats and ephemeral state
+
+Device-only. ~10 MB quota.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `stats.urlsCleaned` | number | `0` | Total URLs cleaned since install |
+| `stats.junkRemoved` | number | `0` | Total tracking params stripped |
+| `stats.referralsSpotted` | number | `0` | Total foreign affiliates detected |
+| `firstUsed` | number\|null | `null` | Unix timestamp (ms) of first use — used for nudge timing |
+| `nudgeDismissed` | boolean | `false` | Whether the user dismissed the review nudge |
+
+---
+
+## chrome.storage.session — Per-session state
+
+Cleared when the browser closes. No quota concerns.
+
+| Key | Type | Description |
+|---|---|---|
+| `history` | Array<{original, clean}> | Recent URL clean events (shown in popup history section) |
+| `tab_{tabId}` | number | Count of URLs cleaned for a specific tab (shown as tab badge in popup) |
+
+---
+
+## processUrl return shape
+
+The core `processUrl(rawUrl, prefs)` function in `src/lib/cleaner.js` returns:
+
+```js
+{
+  cleanUrl: string,           // The cleaned URL (equals rawUrl if no changes)
+  action: string,             // "untouched" | "blacklisted" | "cleaned" | "error"
+  removedTracking: string[],  // Names of tracking params removed
+  junkRemoved: number,        // Count of params removed + path segments cleaned
+  detectedAffiliate: {        // null if no foreign affiliate detected
+    param: string,
+    value: string,
+    id: string,
+    name: string,
+  } | null,
+}
+```

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -60,7 +60,7 @@ function cleanAmazonPath(hostname, pathname) {
  *
  * @param {string} rawUrl - The original URL to process.
  * @param {object} prefs  - User preferences from chrome.storage.sync.
- * @returns {{ cleanUrl: string, action: string, removedTracking: string[], detectedAffiliate: object|null }}
+ * @returns {{ cleanUrl: string, action: string, removedTracking: string[], junkRemoved: number, detectedAffiliate: object|null }}
  */
 export function processUrl(rawUrl, prefs) {
   let url;


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` — setup, workflow, security rules, project structure
- Add `docs/data_architect.md` — full storage schema (sync/local/session) + processUrl return shape
- Fix `@returns` JSDoc for `processUrl` to include `junkRemoved: number`

## Test plan
- [ ] `npm test` passes (112 tests, 0 fail)

Closes #98, closes #99, closes #90