### PR TITLE
perf: cache pre-parsed blacklist/whitelist in service worker (#84)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -4,7 +4,7 @@
  * and maintains extension state.
  */
 
-import { processUrl } from "../lib/cleaner.js";
+import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getPrefs, incrementStat, getStats, setStats, migrateStatsToLocal } from "../lib/storage.js";
 
 // Run migration once on startup (no-op if already done)
@@ -15,7 +15,12 @@ migrateStatsToLocal();
 let cachedPrefs = null;
 
 async function getPrefsWithCache() {
-  if (!cachedPrefs) cachedPrefs = await getPrefs();
+  if (!cachedPrefs) {
+    cachedPrefs = await getPrefs();
+    // Pre-parse blacklist/whitelist once so processUrl doesn't re-parse on every call
+    cachedPrefs._parsedBlacklist = (cachedPrefs.blacklist || []).map(parseListEntry);
+    cachedPrefs._parsedWhitelist = (cachedPrefs.whitelist || []).map(parseListEntry);
+  }
   return cachedPrefs;
 }
 

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -14,7 +14,7 @@ import { TRACKING_PARAMS, getPatternsForHost } from "./affiliates.js";
  * @param {string} entry
  * @returns {{ domain: string, param: string|null, value: string|null }}
  */
-function parseListEntry(entry) {
+export function parseListEntry(entry) {
   const parts = entry.split("::");
   return {
     domain: parts[0]?.trim().replace(/^www\./, "") || "",
@@ -74,9 +74,9 @@ export function processUrl(rawUrl, prefs) {
   const blacklist = prefs.blacklist || [];
   const whitelist = prefs.whitelist || [];
 
-  // Parse all list entries upfront
-  const parsedBlacklist = blacklist.map(parseListEntry);
-  const parsedWhitelist = whitelist.map(parseListEntry);
+  // Use pre-parsed lists from the caller (service worker cache) when available
+  const parsedBlacklist = prefs._parsedBlacklist || blacklist.map(parseListEntry);
+  const parsedWhitelist = prefs._parsedWhitelist || whitelist.map(parseListEntry);
 
   // 0. Per-domain disable — user wants MUGA to do nothing on this domain
   const domainDisabled = parsedBlacklist.some(


### PR DESCRIPTION
## Summary
- Export `parseListEntry` from `src/lib/cleaner.js`
- Pre-parse `blacklist` and `whitelist` when building the prefs cache in the service worker — stored as `_parsedBlacklist` / `_parsedWhitelist`
- `processUrl` uses pre-parsed lists when provided, falling back to inline parsing for callers that don't supply them (content scripts, popup)

Avoids redundant `Array.map(parseListEntry)` on every URL processed.

## Test plan
- [ ] `npm test` passes (112 tests, 0 fail)

Closes #84