### PR TITLE
fix: XSS in toast, invalid JSON comment, Firefox MV2 ES modules (#118 #112 #143)

### DIFF
--- a/src/background/background.html
+++ b/src/background/background.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../lib/browser-polyfill.min.js"></script>
+    <script type="module" src="service-worker.js"></script>
+  </head>
+</html>

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -235,7 +235,7 @@
     notice.innerHTML = `
       <div style="font-weight:500;margin-bottom:6px;font-size:12px;color:#aaa">${s.toast_title}</div>
       <div style="margin-bottom:10px;font-size:12px;color:#ddd">
-        ${domain} ${s.toast_tag_msg} <code style="${codeStyle}">${escHtml(affiliate.param)}=${escHtml(affiliate.value)}</code>
+        ${escHtml(domain)} ${s.toast_tag_msg} <code style="${codeStyle}">${escHtml(affiliate.param)}=${escHtml(affiliate.value)}</code>
       </div>
       <div style="display:flex;gap:6px;flex-wrap:wrap">
         <button data-choice="original" style="${btnStyle}">${s.toast_keep}</button>

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -15,7 +15,7 @@
   ],
 
   "background": {
-    "scripts": ["lib/browser-polyfill.min.js", "background/service-worker.js"],
+    "page": "background/background.html",
     "persistent": false
   },
 
@@ -66,7 +66,6 @@
     "privacy/privacy.html"
   ],
 
-  // Requires Firefox 128+ for queryTransform support
   "declarative_net_request": {
     "rule_resources": [
       {


### PR DESCRIPTION
## Summary
- **#118** Fix XSS: `domain` hostname was interpolated unescaped into toast `innerHTML` — now wrapped with `escHtml()`
- **#112** Remove `//` comment from `manifest.v2.json` — JavaScript comments are invalid JSON, breaks AMO validator and `JSON.parse()`
- **#143** Fix Firefox MV2 background: replace `scripts` array with `background.html` page that loads `service-worker.js` via `<script type="module">` — the scripts array loads files as classic scripts which do not support ES module `import` statements

## Test plan
- [ ] `npm test` passes (112 tests)
- [ ] `node -e "JSON.parse(require('fs').readFileSync('src/manifest.v2.json','utf8'))"` — valid

Closes #118, closes #112, closes #143