### PR TITLE
fix: toast referido, export/import all prefs, cache race, junkRemoved, dead handler (#111 #115 #116 #124 #114)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -13,15 +13,21 @@ migrateStatsToLocal();
 // --- Prefs cache ---
 
 let cachedPrefs = null;
+let prefsFetchPromise = null;
 
-async function getPrefsWithCache() {
-  if (!cachedPrefs) {
-    cachedPrefs = await getPrefs();
-    // Pre-parse blacklist/whitelist once so processUrl doesn't re-parse on every call
-    cachedPrefs._parsedBlacklist = (cachedPrefs.blacklist || []).map(parseListEntry);
-    cachedPrefs._parsedWhitelist = (cachedPrefs.whitelist || []).map(parseListEntry);
+function getPrefsWithCache() {
+  if (cachedPrefs) return Promise.resolve(cachedPrefs);
+  if (!prefsFetchPromise) {
+    prefsFetchPromise = getPrefs().then(prefs => {
+      // Pre-parse blacklist/whitelist once so processUrl doesn't re-parse on every call
+      prefs._parsedBlacklist = (prefs.blacklist || []).map(parseListEntry);
+      prefs._parsedWhitelist = (prefs.whitelist || []).map(parseListEntry);
+      cachedPrefs = prefs;
+      prefsFetchPromise = null;
+      return prefs;
+    });
   }
-  return cachedPrefs;
+  return prefsFetchPromise;
 }
 
 // --- DNR sync helpers ---
@@ -110,7 +116,7 @@ async function appendHistory(original, clean) {
 // --- Storage change listener: invalidate cache and re-apply DNR state ---
 chrome.storage.onChanged.addListener(async (changes, area) => {
   if (area !== "sync") return;
-  cachedPrefs = null; // Invalidate cache
+  cachedPrefs = null; prefsFetchPromise = null; // Invalidate cache
   if (changes.customParams || changes.dnrEnabled) {
     const prefs = await getPrefsWithCache();
     await applyDnrState(prefs);
@@ -134,10 +140,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true; // keep the channel open for the async response
   }
 
-  if (message.type === "GET_PREFS") {
-    getPrefs().then(sendResponse);
-    return true;
-  }
 });
 
 async function handleProcessUrl(rawUrl, { skipNotify = false } = {}) {

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -158,14 +158,14 @@ export function processUrl(rawUrl, prefs) {
     }
   }
 
-  const junkRemoved = removedTracking.length + (pathCleaned ? 1 : 0);
-
   // 5. Strip specific blacklisted affiliate values
+  let blacklistStripped = 0;
   for (const entry of parsedBlacklist) {
     if (entry.param && entry.value && domainMatches(hostname, entry.domain)) {
       const current = url.searchParams.get(entry.param);
       if (current === entry.value) {
         url.searchParams.delete(entry.param);
+        blacklistStripped++;
         // If this was the detected foreign affiliate, clear it — the toast must not fire
         // for a parameter we already removed via the blacklist.
         if (
@@ -181,6 +181,8 @@ export function processUrl(rawUrl, prefs) {
       }
     }
   }
+
+  const junkRemoved = removedTracking.length + blacklistStripped + (pathCleaned ? 1 : 0);
 
   // 6. Inject our affiliate tag when the link has none (skip if foreign detected or stripAllAffiliates)
   if (prefs.injectOwnAffiliate && !prefs.stripAllAffiliates && action !== "detected_foreign") {

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -99,7 +99,7 @@ export const TRANSLATIONS = {
   import_error:          { en: "Invalid file. Make sure it is a MUGA settings export.",                            es: "Archivo inválido. Asegúrate de que es una exportación de MUGA." },
 
   // ── Content script toast ──────────────────────────────────────────────────
-  toast_title:   { en: "MUGA detected an affiliate", es: "MUGA detectó un referido" },
+  toast_title:   { en: "MUGA detected an affiliate", es: "MUGA detectó un afiliado" },
   toast_tag_msg: { en: "carries the tag", es: "lleva el tag" },
   toast_keep:    { en: "Keep", es: "Mantener" },
   toast_remove:  { en: "Remove", es: "Quitar" },

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -209,6 +209,15 @@ function initExportImport() {
     const payload = {
       muga: true,
       version: chrome.runtime.getManifest().version,
+      enabled: prefs.enabled,
+      injectOwnAffiliate: prefs.injectOwnAffiliate,
+      notifyForeignAffiliate: prefs.notifyForeignAffiliate,
+      allowReplaceAffiliate: prefs.allowReplaceAffiliate,
+      stripAllAffiliates: prefs.stripAllAffiliates,
+      dnrEnabled: prefs.dnrEnabled,
+      blockPings: prefs.blockPings,
+      ampRedirect: prefs.ampRedirect,
+      unwrapRedirects: prefs.unwrapRedirects,
       blacklist: prefs.blacklist,
       whitelist: prefs.whitelist,
       customParams: prefs.customParams,
@@ -238,10 +247,18 @@ function initExportImport() {
         throw new Error("invalid");
       }
       const isValidEntry = e => typeof e === "string" && e.length > 0 && e.length < 500;
+      if (data.blacklist.length > 500 || data.whitelist.length > 500 || data.customParams.length > 200) {
+        throw new Error("invalid");
+      }
       if (!data.blacklist.every(isValidEntry) || !data.whitelist.every(isValidEntry) || !data.customParams.every(isValidEntry)) {
         throw new Error("invalid");
       }
-      await chrome.storage.sync.set({ blacklist: data.blacklist, whitelist: data.whitelist, customParams: data.customParams });
+      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "allowReplaceAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects"];
+      const toSave = { blacklist: data.blacklist, whitelist: data.whitelist, customParams: data.customParams };
+      for (const key of BOOL_KEYS) {
+        if (typeof data[key] === "boolean") toSave[key] = data[key];
+      }
+      await chrome.storage.sync.set(toSave);
       renderList("blacklist-items", data.blacklist, "blacklist");
       renderList("whitelist-items", data.whitelist, "whitelist");
       renderList("custom-params-items", data.customParams, "customParams");


### PR DESCRIPTION
## Summary
- **#111** Spanish toast title still said "referido" — fixed to "afiliado"
- **#115** Export/import only saved 3 lists — export now includes all 9 toggle prefs; import restores boolean prefs with validation; added array-length cap (500/500/200)
- **#116** Race condition in `getPrefsWithCache` — now caches the in-flight Promise so concurrent callers share it instead of issuing duplicate storage reads
- **#124** `junkRemoved` and stats under-reported — params stripped by blacklist `param::value` entries were never counted
- **#114** Dead `GET_PREFS` message handler removed — it called uncached `getPrefs()` and no code sends that message type

## Test plan
- [ ] `npm test` passes (112 tests)

Closes #111, closes #115, closes #116, closes #124, closes #114