### PR TITLE
fix: test count, mac shortcut, stat label, CHANGELOG ordering, param count, docs (#113 #119 #128 #122 #129 #117 #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to MUGA will be documented in this file.
 ## [1.3.0] — 2026-03-21
 
 ### Added
-- **Pre-navigation DNR stripping** — browser-native `declarativeNetRequest` rules strip 69 tracking parameters *before* the page loads, covering address-bar navigation, bookmarks, and external app links. Togglable via Settings → URL Cleaning.
+- **Pre-navigation DNR stripping** — browser-native `declarativeNetRequest` rules strip 89 tracking parameters *before* the page loads, covering address-bar navigation, bookmarks, and external app links. Togglable via Settings → URL Cleaning.
 - **Block `<a ping>` tracking beacons** — removes `ping` attributes from links so the browser doesn't send a background tracking request on click. Enabled by default; Settings → Privacy.
 - **AMP redirect** — detects Google AMP pages and silently redirects to the canonical article URL. Enabled by default; Settings → Redirect handling.
 - **Redirect-wrapper unwrapping** — unwraps common redirect intermediaries (Reddit `out.reddit.com`, Steam `linkfilter/`, and generic `?redirect=`, `?destination=`, `?url=`, `?to=` patterns). Enabled by default; Settings → Redirect handling.
@@ -25,14 +25,6 @@ All notable changes to MUGA will be documented in this file.
 ### Security
 - Toast rendering hardened with `escHtml()` to prevent XSS via malicious affiliate param values.
 - Options page list rendering migrated from `innerHTML` to `createElement` + `textContent`.
-
----
-
-## [1.0.1] - 2026-03-19
-
-### Fixed
-- Strip Amazon path-based tracking (`/ref=.../session-id`) after the ASIN in product URLs
-- Add missing Amazon query params: `_encoding`, `content-id`, `ref_`, `pd_rd_i`
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -59,7 +51,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [1.0.1] — 2026-03-19
+## [1.1.0] — 2026-03-19
 
 ### Added
 - **Clean URL on copy (Ctrl+C)** — when the user selects a URL as text on any page and copies it, MUGA strips tracking parameters before the text reaches the clipboard. Respects the `injectOwnAffiliate` setting: if affiliate injection is enabled, our tag is added to the copied URL too. No toast is shown on copy.
@@ -68,6 +60,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - GitHub Actions release workflow: use wildcard `*.zip` when renaming build artifacts — web-ext generates `muga_make_urls_great_again-X.Y.Z.zip`, not `muga-X.Y.Z.zip`
 - GitHub Actions release workflow: add `permissions: contents: write` so the workflow can create GitHub Releases
+
+---
+
+## [1.0.1] — 2026-03-19
+
+### Fixed
+- Strip Amazon path-based tracking (`/ref=.../session-id`) after the ASIN in product URLs
+- Add missing Amazon query params: `_encoding`, `content-id`, `ref_`, `pd_rd_i`
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,12 @@ Types: `feat`, `fix`, `test`, `docs`, `ci`, `refactor`
 ## Building the extension
 
 ```bash
-npm run build
+npm run build          # both targets
+npm run build:chrome   # Chrome MV3 only → dist/chrome/
+npm run build:firefox  # Firefox MV2 only → dist/firefox/
 ```
 
-Output goes to `dist/`. Uses `web-ext` (Mozilla). The build generates both MV3 (Chrome) and MV2 (Firefox) packages.
+Output goes to `dist/`. Uses `web-ext` (Mozilla).
 
 ## Browser compatibility
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.3.0-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-105_pass-brightgreen)](#development)
+[![Tests](https://img.shields.io/badge/tests-112_pass-brightgreen)](#development)
 [![Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-coming_soon-lightgrey)](#installation)
 [![Firefox Add-ons](https://img.shields.io/badge/Firefox_Add--ons-coming_soon-lightgrey)](#installation)
 
@@ -140,7 +140,7 @@ Load unpacked from `chrome://extensions` (Developer mode) or `about:debugging` i
 ## Development
 
 ```bash
-npm test               # 105 unit tests
+npm test               # 112 unit tests
 npm run build:chrome
 npm run build:firefox
 ```
@@ -151,7 +151,7 @@ New release: tag `vX.Y.Z` → push → GitHub Actions builds and publishes autom
 
 ## Contributing
 
-PRs welcome for new tracking parameters, new stores, or additional languages. See [`src/lib/affiliates.js`](src/lib/affiliates.js) for the store database and [`tests/unit/cleaner.test.mjs`](tests/unit/cleaner.test.mjs) for the test suite.
+PRs welcome for new tracking parameters, new stores, or additional languages. Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, workflow, and conventions. See [`src/lib/affiliates.js`](src/lib/affiliates.js) for the store database and [`tests/unit/cleaner.test.mjs`](tests/unit/cleaner.test.mjs) for the test suite.
 
 ---
 

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -40,7 +40,8 @@
   "commands": {
     "copy-clean-url": {
       "suggested_key": {
-        "default": "Alt+Shift+C"
+        "default": "Alt+Shift+C",
+        "mac": "Alt+Shift+C"
       },
       "description": "Copy clean URL of the current tab"
     }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -29,7 +29,7 @@
     </div>
     <div class="stat">
       <span class="stat-value" id="stat-referrals">0</span>
-      <span class="stat-label" data-i18n="stat_referrals">referrals spotted</span>
+      <span class="stat-label" data-i18n="stat_referrals">affiliates detected</span>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- **#113** README test badge + dev section: 105 → 112
- **#119** `manifest.v2.json` commands: add `mac` key (was missing vs MV3 manifest)
- **#128** `popup.html` stat-label hardcoded fallback: "referrals spotted" → "affiliates detected"
- **#122** CHANGELOG ordering fixed: 1.3.0 → 1.2.0 → 1.1.0 → 1.0.1 → 1.0.0; renamed misplaced second 1.0.1 block to 1.1.0 (Ctrl+C copy feature); moved Amazon bugfix block to correct 1.0.1 position
- **#129** CHANGELOG v1.3.0 DNR param count: 69 → 89 (matches README and actual `tracking-params.json`)
- **#117** README Contributing: link to `CONTRIBUTING.md`
- **#136** `CONTRIBUTING.md` Building section: document `build:chrome` and `build:firefox` split targets

## Test plan
- [ ] `npm test` passes (112 tests)

Closes #113, closes #119, closes #128, closes #122, closes #129, closes #117, closes #136