### PR TITLE
fix: stores summary role=heading for a11y (#139)

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -179,8 +179,8 @@
   <section>
     <div class="card">
       <details class="stores-details">
-        <summary class="stores-summary">
-          <span data-i18n="section_stores">Supported stores</span>
+        <summary class="stores-summary" role="heading" aria-level="2">
+          <span data-i18n="section_stores">Affiliate stores</span>
           <span class="stores-count" id="stores-count"></span>
         </summary>
         <div class="stores-grid" id="stores-grid"></div>


### PR DESCRIPTION
Closes #139