### PR TITLE
chore: retroactive GPL v3 notice + CLAUDE.md update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestiona tags de afiliados y protege al usuario de sustitución silenciosa de afiliados (lo que hizo Honey).
 
 - **Nombre:** MUGA — Make URLs Great Again
-- **Repo:** https://github.com/yocreoquesi/muga (public, MIT)
-- **Versión actual:** 1.2.0
+- **Repo:** https://github.com/yocreoquesi/muga (public, GPL v3)
+- **Versión actual:** 1.3.0
 - **Contexto completo (privado):** lee `Muga.md` — nunca lo comitees
 
 ---

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ PRs welcome for new tracking parameters, new stores, or additional languages. Re
 
 [GPL v3](LICENSE) — forks and derivative works must remain open source under the same license.
 
+This project was relicensed from MIT to GPL v3 on 2026-03-22 by the sole copyright holder. All versions, including prior releases, are retroactively covered under GPL v3.
+
 ---
 
 *Built with the assistance of AI agents ([Claude](https://www.anthropic.com/claude) by Anthropic).*


### PR DESCRIPTION
Documents that the relicense from MIT to GPL v3 covers all prior versions. Updates CLAUDE.md which still referenced MIT and v1.2.0.