### PR TITLE
fix(security): remove 'destination' from REDIRECT_PARAMS — prevents SSO bypass

### DIFF
--- a/src/content/redirect-unwrap.js
+++ b/src/content/redirect-unwrap.js
@@ -18,7 +18,9 @@
     // Common redirect wrapper patterns — look for a destination URL in query params
     // "location", "return", "continue" intentionally excluded — too generic,
     // common in SPA routing and OAuth flows, high false-positive risk.
-    const REDIRECT_PARAMS = ["url", "redirect", "redirect_url", "destination", "dest", "goto", "returnUrl", "return_url"];
+    // "destination" intentionally excluded — used in SSO/corporate flows to indicate
+    // where to redirect AFTER authentication. Unwrapping it would bypass login. (#158)
+    const REDIRECT_PARAMS = ["url", "redirect", "redirect_url", "dest", "goto", "returnUrl", "return_url"];
 
     let parsed;
     try {

--- a/tests/unit/redirect-unwrap.test.mjs
+++ b/tests/unit/redirect-unwrap.test.mjs
@@ -22,8 +22,9 @@ import assert from "node:assert/strict";
 // Keep in sync with src/content/redirect-unwrap.js
 // "location", "return", "continue" excluded — too generic (SPA routing, OAuth flows)
 // "to", "next", "target" excluded — too generic (SPA routing, auth flows, UI targets)
+// "destination" excluded — SSO/corporate post-auth redirect target; unwrapping bypasses login (#158)
 const REDIRECT_PARAMS = [
-  "url", "redirect", "redirect_url", "destination", "dest",
+  "url", "redirect", "redirect_url", "dest",
   "goto", "returnUrl", "return_url",
 ];
 
@@ -93,13 +94,6 @@ describe("redirect-unwrap — supported wrapper patterns", () => {
     assert.equal(dest, "https://shop.com/product?id=42");
   });
 
-  test("Generic tracker with ?destination= param", () => {
-    const dest = extractRedirectDestination(
-      "https://partner.example.com/go?destination=https://merchant.com/deal"
-    );
-    assert.equal(dest, "https://merchant.com/deal");
-  });
-
   test("Generic tracker with ?goto= param", () => {
     const dest = extractRedirectDestination(
       "https://track.example.com/out?goto=https://publisher.com/article"
@@ -127,6 +121,16 @@ describe("redirect-unwrap — supported wrapper patterns", () => {
 // Safety guards — these must NOT be unwrapped
 // ---------------------------------------------------------------------------
 describe("redirect-unwrap — safety guards", () => {
+
+  test("SSO ?destination= param is NOT unwrapped (would bypass corporate login)", () => {
+    // "destination" is used by corporate/government SSO to signal post-auth redirect target.
+    // MUGA must NOT unwrap it — doing so lets the user reach the resource without
+    // completing authentication. See issue #158.
+    const dest = extractRedirectDestination(
+      "https://sso.empresa.com/login?destination=https://intranet.empresa.com/dashboard"
+    );
+    assert.equal(dest, null);
+  });
 
   test("same-origin destination is NOT unwrapped", () => {
     // Internal SPA navigation: ?next=/dashboard or ?next=https://same.com/page


### PR DESCRIPTION
## Summary

- Removes `"destination"` from `REDIRECT_PARAMS` in `src/content/redirect-unwrap.js`
- In corporate/government SSO flows, `?destination=` signals the post-authentication redirect target — NOT a redirect wrapper URL
- Unwrapping it would navigate the user to the intranet resource without completing login, bypassing authentication entirely

## Changes

- `src/content/redirect-unwrap.js` — removed `"destination"` from `REDIRECT_PARAMS`, added explanatory comment
- `tests/unit/redirect-unwrap.test.mjs` — removed the old "?destination= is unwrapped" test; added safety-guard test verifying `?destination=` returns `null`

## Test plan

- [x] `npm test` — 146 tests, 0 failures
- [x] New safety-guard test: `SSO ?destination= param is NOT unwrapped (would bypass corporate login)`
- [x] Old false-positive test (`Generic tracker with ?destination= param`) removed

Closes #158