### PR TITLE
feat: domain-rules.json compatibility layer for top 100 sites

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -6,6 +6,7 @@
 
 import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getPrefs, incrementStat, getStats, setStats, migrateStatsToLocal } from "../lib/storage.js";
+import domainRules from "../rules/domain-rules.json" with { type: "json" };
 
 // Run migration once on startup (no-op if already done)
 migrateStatsToLocal();
@@ -157,7 +158,7 @@ async function handleProcessUrl(rawUrl, { skipNotify = false } = {}) {
 
   let result;
   try {
-    result = processUrl(rawUrl, effectivePrefs);
+    result = processUrl(rawUrl, effectivePrefs, domainRules);
   } catch (err) {
     console.error("[MUGA] processUrl failed:", err, rawUrl);
     return { cleanUrl: rawUrl, action: "error", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -32,6 +32,26 @@ function domainMatches(hostname, entryDomain) {
 }
 
 /**
+ * Builds the set of params that must NOT be stripped on the given hostname,
+ * based on the domain-rules compatibility list.
+ *
+ * Matching is subdomain-aware: "www.google.com" matches rule for "google.com".
+ *
+ * @param {string} hostname
+ * @param {Array}  domainRules  - Array of { domain, preserveParams[] } objects
+ * @returns {Set<string>}
+ */
+export function getPreservedParams(hostname, domainRules = []) {
+  const preserved = new Set();
+  for (const rule of domainRules) {
+    if (hostname === rule.domain || hostname.endsWith("." + rule.domain)) {
+      rule.preserveParams.forEach(p => preserved.add(p.toLowerCase()));
+    }
+  }
+  return preserved;
+}
+
+/**
  * Strips Amazon path-based tracking segments that appear after the ASIN.
  * Amazon embeds referral tokens and session IDs directly in the path, e.g.:
  *   /dp/B0GQ4N9N33/ref=zg_bsnr_c_kitchen_d_sccl_3/258-3201434-8228601
@@ -62,7 +82,7 @@ function cleanAmazonPath(hostname, pathname) {
  * @param {object} prefs  - User preferences from chrome.storage.sync.
  * @returns {{ cleanUrl: string, action: string, removedTracking: string[], junkRemoved: number, detectedAffiliate: object|null }}
  */
-export function processUrl(rawUrl, prefs) {
+export function processUrl(rawUrl, prefs, domainRules = []) {
   let url;
   try {
     url = new URL(rawUrl);
@@ -134,10 +154,13 @@ export function processUrl(rawUrl, prefs) {
   // for pccomponentes, mediamarkt_es, mediamarkt_de; `campid` is eBay's affiliate param.
   const affiliateParamNames = patterns.map(p => p.param.toLowerCase());
   const customParams = (prefs.customParams || []).map(p => p.toLowerCase());
+  const preservedParams = getPreservedParams(hostname, domainRules);
   for (const param of [...url.searchParams.keys()]) {
     const lower = param.toLowerCase();
     // Don't strip params that are affiliate identifiers for this host
     if (affiliateParamNames.includes(lower)) continue;
+    // Don't strip params that are functional on this domain (domain-rules compatibility)
+    if (preservedParams.has(lower)) continue;
     if (TRACKING_PARAMS.includes(lower) || customParams.includes(lower)) {
       url.searchParams.delete(param);
       removedTracking.push(param);

--- a/src/rules/domain-rules.json
+++ b/src/rules/domain-rules.json
@@ -1,0 +1,272 @@
+[
+  {
+    "domain": "google.com",
+    "preserveParams": ["q", "tbm", "tbs", "hl", "gl", "num", "start", "sa", "safe", "as_q", "as_sitesearch"],
+    "note": "Search query, language/region, pagination — functional"
+  },
+  {
+    "domain": "bing.com",
+    "preserveParams": ["q", "qs", "form", "pq", "sc", "sp", "sk", "first", "FORM"],
+    "note": "Search query and pagination — functional"
+  },
+  {
+    "domain": "duckduckgo.com",
+    "preserveParams": ["q", "t", "ia", "iax", "iaxm", "kl", "kp", "kz", "km", "ks", "ko", "kt", "ka", "kf", "kaf", "kac", "kad", "kd", "kh", "kn", "ko", "kp", "kr", "kg", "kb", "kv", "kw"],
+    "note": "Search query and settings — functional"
+  },
+  {
+    "domain": "yahoo.com",
+    "preserveParams": ["p", "fr", "fr2", "fp", "b", "pz", "bct", "bkcat", "n", "ei"],
+    "note": "Search query and pagination — functional"
+  },
+  {
+    "domain": "baidu.com",
+    "preserveParams": ["wd", "ie", "rsv_spt", "rsv_iqid", "f", "tn", "rsp", "rqlang", "bs"],
+    "note": "Search query and encoding — functional"
+  },
+  {
+    "domain": "yandex.ru",
+    "preserveParams": ["text", "lr", "lang", "p", "within", "from", "to"],
+    "note": "Search query, language, region and pagination — functional"
+  },
+  {
+    "domain": "yandex.com",
+    "preserveParams": ["text", "lr", "lang", "p", "within", "from", "to"],
+    "note": "Search query, language, region and pagination — functional"
+  },
+  {
+    "domain": "amazon.com",
+    "preserveParams": ["k", "i", "rh", "s", "ref", "keywords", "field-keywords", "n", "me", "merchant", "node", "page"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "amazon.es",
+    "preserveParams": ["k", "i", "rh", "s", "ref", "keywords", "field-keywords", "n", "me", "merchant", "node", "page"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "amazon.de",
+    "preserveParams": ["k", "i", "rh", "s", "ref", "keywords", "field-keywords", "n", "me", "merchant", "node", "page"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "amazon.fr",
+    "preserveParams": ["k", "i", "rh", "s", "ref", "keywords", "field-keywords", "n", "me", "merchant", "node", "page"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "amazon.co.uk",
+    "preserveParams": ["k", "i", "rh", "s", "ref", "keywords", "field-keywords", "n", "me", "merchant", "node", "page"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "amazon.it",
+    "preserveParams": ["k", "i", "rh", "s", "ref", "keywords", "field-keywords", "n", "me", "merchant", "node", "page"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "ebay.com",
+    "preserveParams": ["_nkw", "_sacat", "_sop", "_pgn", "_ipg", "_fcid", "LH_BIN", "LH_Auction", "rt", "nkw"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "ebay.es",
+    "preserveParams": ["_nkw", "_sacat", "_sop", "_pgn", "_ipg", "_fcid", "LH_BIN", "LH_Auction", "rt", "nkw"],
+    "note": "Search query, category, sort and pagination — functional"
+  },
+  {
+    "domain": "aliexpress.com",
+    "preserveParams": ["SearchText", "catId", "sortType", "shipCountry", "groupsort", "maxPrice", "minPrice", "filterCat", "page"],
+    "note": "Search query, category, filters and pagination — functional"
+  },
+  {
+    "domain": "pccomponentes.com",
+    "preserveParams": ["q", "sort", "page", "brands", "price_max", "price_min", "category"],
+    "note": "Search and filter params — functional"
+  },
+  {
+    "domain": "elcorteingles.es",
+    "preserveParams": ["s", "q", "category", "page", "sort", "brand"],
+    "note": "Search and filter params — functional"
+  },
+  {
+    "domain": "zalando.es",
+    "preserveParams": ["q", "order", "p", "size", "color", "brand", "price_from", "price_to"],
+    "note": "Search, filter and pagination — functional"
+  },
+  {
+    "domain": "zalando.de",
+    "preserveParams": ["q", "order", "p", "size", "color", "brand", "price_from", "price_to"],
+    "note": "Search, filter and pagination — functional"
+  },
+  {
+    "domain": "fnac.es",
+    "preserveParams": ["SearchQuery", "sl", "stype", "mo", "se"],
+    "note": "Search query and mode — functional"
+  },
+  {
+    "domain": "fnac.com",
+    "preserveParams": ["SearchQuery", "sl", "stype", "mo", "se"],
+    "note": "Search query and mode — functional"
+  },
+  {
+    "domain": "mediamarkt.es",
+    "preserveParams": ["query", "searchType", "page", "pageSize", "sort"],
+    "note": "Search and pagination — functional"
+  },
+  {
+    "domain": "mediamarkt.de",
+    "preserveParams": ["query", "searchType", "page", "pageSize", "sort"],
+    "note": "Search and pagination — functional"
+  },
+  {
+    "domain": "temu.com",
+    "preserveParams": ["search_key", "search_type", "page_num", "page_size", "sort_type"],
+    "note": "Search, pagination and sort — functional"
+  },
+  {
+    "domain": "shein.com",
+    "preserveParams": ["q", "search_type", "src_tab_page_id", "page", "sort", "attr_values", "brand"],
+    "note": "Search, filters and pagination — functional"
+  },
+  {
+    "domain": "youtube.com",
+    "preserveParams": ["v", "t", "list", "index", "start_radio", "ab_channel", "search_query"],
+    "note": "Video ID, timestamp, playlist, and channel context — functional. ab_channel is in TRACKING_PARAMS globally but is functional on YouTube (identifies the channel that uploaded the video)"
+  },
+  {
+    "domain": "twitter.com",
+    "preserveParams": ["q", "f", "src", "lang"],
+    "note": "Search query and filters — functional"
+  },
+  {
+    "domain": "x.com",
+    "preserveParams": ["q", "f", "src", "lang"],
+    "note": "Search query and filters — functional"
+  },
+  {
+    "domain": "instagram.com",
+    "preserveParams": ["hl"],
+    "note": "Language — functional"
+  },
+  {
+    "domain": "reddit.com",
+    "preserveParams": ["sort", "t", "after", "before", "count", "limit", "sr_detail", "q", "type"],
+    "note": "Sort, time filter, pagination and search — functional"
+  },
+  {
+    "domain": "tiktok.com",
+    "preserveParams": ["q", "lang", "region"],
+    "note": "Search query and locale — functional"
+  },
+  {
+    "domain": "twitch.tv",
+    "preserveParams": ["query", "type"],
+    "note": "Search query and content type — functional"
+  },
+  {
+    "domain": "linkedin.com",
+    "preserveParams": ["keywords", "location", "geoId", "f_TPR", "f_E", "f_JT", "f_C", "sortBy", "pageNum", "start"],
+    "note": "Job/people search filters and pagination — functional"
+  },
+  {
+    "domain": "facebook.com",
+    "preserveParams": ["q", "filters", "story_fbid", "id", "v"],
+    "note": "Search query, post and video IDs — functional"
+  },
+  {
+    "domain": "github.com",
+    "preserveParams": ["tab", "q", "type", "utf8", "search_value", "ref", "l", "o", "s", "p"],
+    "note": "Search, tab navigation, sort, pagination — functional. ref is not in TRACKING_PARAMS (removed PR #165)"
+  },
+  {
+    "domain": "stackoverflow.com",
+    "preserveParams": ["tab", "sort", "pagesize", "page", "q"],
+    "note": "Sort, pagination and search — functional"
+  },
+  {
+    "domain": "wikipedia.org",
+    "preserveParams": ["search", "title", "action", "oldid", "diff", "curid", "redirect", "section"],
+    "note": "Page navigation, search, revision — functional"
+  },
+  {
+    "domain": "office.com",
+    "preserveParams": ["auth", "home", "from"],
+    "note": "Auth flow and navigation — functional"
+  },
+  {
+    "domain": "booking.com",
+    "preserveParams": ["checkin", "checkout", "adults", "children", "rooms", "currency", "lang", "dest_id", "dest_type", "ss", "group_adults", "group_children", "no_rooms", "nflt"],
+    "note": "Hotel search and booking parameters — functional"
+  },
+  {
+    "domain": "renfe.com",
+    "preserveParams": ["tipoBusqueda", "origen", "destino", "fechaIda", "fechaVuelta", "adultos", "ninos", "jovenes", "mayores"],
+    "note": "Train search parameters — functional"
+  },
+  {
+    "domain": "iberia.com",
+    "preserveParams": ["origin", "destination", "outboundDate", "returnDate", "adults", "children", "infants", "cabinClass", "tripType"],
+    "note": "Flight search parameters — functional"
+  },
+  {
+    "domain": "idealista.com",
+    "preserveParams": ["tipo", "localidad", "metros", "habitaciones", "precio", "order", "ordenado-por", "pagina"],
+    "note": "Real estate search filters and pagination — functional"
+  },
+  {
+    "domain": "fotocasa.es",
+    "preserveParams": ["transactionType", "l", "minPrice", "maxPrice", "minRooms", "maxRooms", "minSurface", "maxSurface", "page"],
+    "note": "Real estate search filters and pagination — functional"
+  },
+  {
+    "domain": "marca.com",
+    "preserveParams": ["q"],
+    "note": "Search query — functional"
+  },
+  {
+    "domain": "as.com",
+    "preserveParams": ["q"],
+    "note": "Search query — functional"
+  },
+  {
+    "domain": "rtve.es",
+    "preserveParams": ["q", "page"],
+    "note": "Search query and pagination — functional"
+  },
+  {
+    "domain": "20minutos.es",
+    "preserveParams": ["q"],
+    "note": "Search query — functional"
+  },
+  {
+    "domain": "elmundo.es",
+    "preserveParams": ["q", "page"],
+    "note": "Search query and pagination — functional"
+  },
+  {
+    "domain": "elpais.com",
+    "preserveParams": ["q", "page"],
+    "note": "Search query and pagination — functional"
+  },
+  {
+    "domain": "bbc.com",
+    "preserveParams": ["q", "seqId", "page"],
+    "note": "Search query and pagination — functional"
+  },
+  {
+    "domain": "bbc.co.uk",
+    "preserveParams": ["q", "seqId", "page"],
+    "note": "Search query and pagination — functional"
+  },
+  {
+    "domain": "cnn.com",
+    "preserveParams": ["q"],
+    "note": "Search query — functional"
+  },
+  {
+    "domain": "nytimes.com",
+    "preserveParams": ["query", "type", "sort"],
+    "note": "Search query and sort — functional"
+  }
+]

--- a/tests/unit/domain-rules.test.mjs
+++ b/tests/unit/domain-rules.test.mjs
@@ -1,0 +1,432 @@
+/**
+ * MUGA — Unit tests for domain-rules.json compatibility layer
+ *
+ * Verifies that functional URL params on top-100 sites are preserved
+ * while tracking params are still stripped.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { processUrl, getPreservedParams } from "../../src/lib/cleaner.js";
+
+const require = createRequire(import.meta.url);
+const domainRules = require("../../src/rules/domain-rules.json");
+
+// ---------------------------------------------------------------------------
+// Base prefs — minimal, tracking strip always on
+// ---------------------------------------------------------------------------
+const PREFS = {
+  enabled: true,
+  injectOwnAffiliate: false,
+  notifyForeignAffiliate: false,
+  allowReplaceAffiliate: false,
+  blacklist: [],
+  whitelist: [],
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+function clean(rawUrl) {
+  return processUrl(rawUrl, PREFS, domainRules);
+}
+
+// ---------------------------------------------------------------------------
+// getPreservedParams unit tests
+// ---------------------------------------------------------------------------
+describe("getPreservedParams", () => {
+  test("returns empty set when domainRules is empty", () => {
+    const s = getPreservedParams("google.com", []);
+    assert.equal(s.size, 0);
+  });
+
+  test("exact domain match", () => {
+    const rules = [{ domain: "google.com", preserveParams: ["q", "hl"] }];
+    const s = getPreservedParams("google.com", rules);
+    assert.ok(s.has("q"));
+    assert.ok(s.has("hl"));
+  });
+
+  test("subdomain match — www.google.com matches google.com rule", () => {
+    const rules = [{ domain: "google.com", preserveParams: ["q"] }];
+    const s = getPreservedParams("www.google.com", rules);
+    assert.ok(s.has("q"));
+  });
+
+  test("deep subdomain match — mail.google.com matches google.com rule", () => {
+    const rules = [{ domain: "google.com", preserveParams: ["hl"] }];
+    const s = getPreservedParams("mail.google.com", rules);
+    assert.ok(s.has("hl"));
+  });
+
+  test("non-matching domain returns empty set", () => {
+    const rules = [{ domain: "google.com", preserveParams: ["q"] }];
+    const s = getPreservedParams("bing.com", rules);
+    assert.equal(s.size, 0);
+  });
+
+  test("partial domain must not match — egoogle.com must NOT match google.com", () => {
+    const rules = [{ domain: "google.com", preserveParams: ["q"] }];
+    const s = getPreservedParams("egoogle.com", rules);
+    assert.equal(s.size, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google — search query preserved, tracking stripped
+// ---------------------------------------------------------------------------
+describe("Google search", () => {
+  test("preserves q, strips si (YouTube share tracking reused by Google)", () => {
+    const { cleanUrl, removedTracking } = clean(
+      "https://www.google.com/search?q=javascript+tutorial&si=tracking123&utm_source=newsletter"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("q"), "javascript tutorial");
+    assert.ok(!u.searchParams.has("si"));
+    assert.ok(!u.searchParams.has("utm_source"));
+    assert.ok(removedTracking.includes("utm_source"));
+  });
+
+  test("preserves hl and gl — language and region params", () => {
+    const { cleanUrl } = clean(
+      "https://www.google.com/search?q=test&hl=es&gl=ES&gclid=abc123"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("q"), "test");
+    assert.equal(u.searchParams.get("hl"), "es");
+    assert.equal(u.searchParams.get("gl"), "ES");
+    assert.ok(!u.searchParams.has("gclid"));
+  });
+
+  test("preserves tbm (search type) and num (results count)", () => {
+    const { cleanUrl } = clean(
+      "https://www.google.com/search?q=muga&tbm=isch&num=20&fbclid=xyz"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("tbm"), "isch");
+    assert.equal(u.searchParams.get("num"), "20");
+    assert.ok(!u.searchParams.has("fbclid"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bing — search params preserved
+// ---------------------------------------------------------------------------
+describe("Bing search", () => {
+  test("preserves q and form, strips msclkid", () => {
+    const { cleanUrl } = clean(
+      "https://www.bing.com/search?q=node+js&form=QBLH&msclkid=abc"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("q"), "node js");
+    assert.equal(u.searchParams.get("form"), "QBLH");
+    assert.ok(!u.searchParams.has("msclkid"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DuckDuckGo — search query preserved
+// ---------------------------------------------------------------------------
+describe("DuckDuckGo search", () => {
+  test("preserves q, strips utm_source", () => {
+    const { cleanUrl } = clean(
+      "https://duckduckgo.com/?q=privacy+browser&utm_source=email"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("q"), "privacy browser");
+    assert.ok(!u.searchParams.has("utm_source"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Amazon — product/search params preserved, internal tracking stripped
+// ---------------------------------------------------------------------------
+describe("Amazon", () => {
+  test("preserves k (search keyword) and s (sort), strips pd_rd_r and psc", () => {
+    const { cleanUrl, removedTracking } = clean(
+      "https://www.amazon.com/s?k=laptop&s=review-rank&pd_rd_r=abc123&psc=1"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("k"), "laptop");
+    assert.equal(u.searchParams.get("s"), "review-rank");
+    assert.ok(!u.searchParams.has("pd_rd_r"));
+    assert.ok(!u.searchParams.has("psc"));
+    assert.ok(removedTracking.includes("pd_rd_r"));
+  });
+
+  test("preserves ref on amazon.es (browse context), strips linkCode", () => {
+    const { cleanUrl } = clean(
+      "https://www.amazon.es/s?k=auriculares&ref=nb_sb_noss&linkCode=ll2"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("k"), "auriculares");
+    assert.equal(u.searchParams.get("ref"), "nb_sb_noss");
+    assert.ok(!u.searchParams.has("linkCode"));
+  });
+
+  test("strips ascsubtag on amazon.com", () => {
+    const { cleanUrl } = clean(
+      "https://www.amazon.com/dp/B0ABC12345/?ascsubtag=abc&k=test"
+    );
+    const u = new URL(cleanUrl);
+    assert.ok(!u.searchParams.has("ascsubtag"));
+    assert.equal(u.searchParams.get("k"), "test");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// eBay — search params preserved, tracking stripped
+// ---------------------------------------------------------------------------
+describe("eBay", () => {
+  test("preserves _nkw and _sacat, strips mkevt and mkcid", () => {
+    const { cleanUrl } = clean(
+      "https://www.ebay.com/sch/i.html?_nkw=iphone+13&_sacat=0&mkevt=1&mkcid=1"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("_nkw"), "iphone 13");
+    assert.equal(u.searchParams.get("_sacat"), "0");
+    assert.ok(!u.searchParams.has("mkevt"));
+    assert.ok(!u.searchParams.has("mkcid"));
+  });
+
+  test("preserves _sop (sort order) on ebay.es", () => {
+    const { cleanUrl } = clean(
+      "https://www.ebay.es/sch/i.html?_nkw=tablet&_sop=12&mkrid=abc"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("_sop"), "12");
+    assert.ok(!u.searchParams.has("mkrid"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// YouTube — video/playlist params preserved, si stripped
+// ---------------------------------------------------------------------------
+describe("YouTube", () => {
+  test("preserves v, t and list — strips si (share tracking)", () => {
+    const { cleanUrl, removedTracking } = clean(
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42&list=PLtest123&si=trackingtoken"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("v"), "dQw4w9WgXcQ");
+    assert.equal(u.searchParams.get("t"), "42");
+    assert.equal(u.searchParams.get("list"), "PLtest123");
+    assert.ok(!u.searchParams.has("si"));
+    assert.ok(removedTracking.includes("si"));
+  });
+
+  test("ab_channel is preserved on YouTube (functional — channel context)", () => {
+    // ab_channel is in global TRACKING_PARAMS but YouTube domain rule preserves it
+    const { cleanUrl } = clean(
+      "https://www.youtube.com/watch?v=abc&ab_channel=Fireship&si=trackme"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("v"), "abc");
+    assert.equal(u.searchParams.get("ab_channel"), "Fireship");
+    assert.ok(!u.searchParams.has("si"));
+  });
+
+  test("ab_channel is stripped on non-YouTube domain (global tracking param)", () => {
+    const { cleanUrl } = clean(
+      "https://example.com/page?ab_channel=test&utm_source=email"
+    );
+    const u = new URL(cleanUrl);
+    assert.ok(!u.searchParams.has("ab_channel"));
+    assert.ok(!u.searchParams.has("utm_source"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reddit — sort/pagination preserved, tracking stripped
+// ---------------------------------------------------------------------------
+describe("Reddit", () => {
+  test("preserves sort, t, after, limit — strips rdt_cid", () => {
+    const { cleanUrl } = clean(
+      "https://www.reddit.com/r/javascript/?sort=top&t=week&after=t3_abc&limit=25&rdt_cid=xyz"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("sort"), "top");
+    assert.equal(u.searchParams.get("t"), "week");
+    assert.equal(u.searchParams.get("after"), "t3_abc");
+    assert.equal(u.searchParams.get("limit"), "25");
+    assert.ok(!u.searchParams.has("rdt_cid"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHub — tab, search, ref preserved, tracking stripped
+// ---------------------------------------------------------------------------
+describe("GitHub", () => {
+  test("preserves tab and q, strips utm_source", () => {
+    const { cleanUrl } = clean(
+      "https://github.com/search?q=muga+extension&type=repositories&utm_source=newsletter"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("q"), "muga extension");
+    assert.equal(u.searchParams.get("type"), "repositories");
+    assert.ok(!u.searchParams.has("utm_source"));
+  });
+
+  test("preserves ref (branch ref) — ref is NOT in TRACKING_PARAMS", () => {
+    const { cleanUrl } = clean(
+      "https://github.com/user/repo/tree/main?ref=main&utm_campaign=launch"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("ref"), "main");
+    assert.ok(!u.searchParams.has("utm_campaign"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wikipedia — navigation params preserved
+// ---------------------------------------------------------------------------
+describe("Wikipedia", () => {
+  test("preserves search, action, oldid — strips utm_*", () => {
+    const { cleanUrl } = clean(
+      "https://en.wikipedia.org/wiki/JavaScript?action=history&oldid=1234567&utm_source=ref"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("action"), "history");
+    assert.equal(u.searchParams.get("oldid"), "1234567");
+    assert.ok(!u.searchParams.has("utm_source"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StackOverflow — sort and pagination preserved
+// ---------------------------------------------------------------------------
+describe("StackOverflow", () => {
+  test("preserves tab, sort, page, pagesize — strips utm_*", () => {
+    const { cleanUrl } = clean(
+      "https://stackoverflow.com/questions?tab=Votes&sort=newest&page=2&pagesize=50&utm_medium=email"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("tab"), "Votes");
+    assert.equal(u.searchParams.get("sort"), "newest");
+    assert.equal(u.searchParams.get("page"), "2");
+    assert.equal(u.searchParams.get("pagesize"), "50");
+    assert.ok(!u.searchParams.has("utm_medium"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Booking.com — booking/search params preserved
+// ---------------------------------------------------------------------------
+describe("Booking.com", () => {
+  test("preserves checkin, checkout, adults, rooms — strips utm_*", () => {
+    const { cleanUrl } = clean(
+      "https://www.booking.com/searchresults.html?ss=Madrid&checkin=2026-04-01&checkout=2026-04-05&adults=2&rooms=1&utm_source=email"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("checkin"), "2026-04-01");
+    assert.equal(u.searchParams.get("checkout"), "2026-04-05");
+    assert.equal(u.searchParams.get("adults"), "2");
+    assert.equal(u.searchParams.get("rooms"), "1");
+    assert.ok(!u.searchParams.has("utm_source"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Travel (Iberia) — flight search params preserved
+// ---------------------------------------------------------------------------
+describe("Iberia", () => {
+  test("preserves origin, destination, outboundDate, adults — strips utm_*", () => {
+    const { cleanUrl } = clean(
+      "https://www.iberia.com/flights?origin=MAD&destination=BCN&outboundDate=2026-05-01&adults=1&utm_campaign=spring"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("origin"), "MAD");
+    assert.equal(u.searchParams.get("destination"), "BCN");
+    assert.equal(u.searchParams.get("outboundDate"), "2026-05-01");
+    assert.ok(!u.searchParams.has("utm_campaign"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Domain with no rules — ALL tracking params stripped normally
+// ---------------------------------------------------------------------------
+describe("Domain with no rules", () => {
+  test("all tracking params stripped on unknown domain", () => {
+    const { cleanUrl, removedTracking } = clean(
+      "https://example.com/page?utm_source=twitter&utm_campaign=launch&fbclid=abc&gclid=xyz&ref=homepage"
+    );
+    const u = new URL(cleanUrl);
+    assert.ok(!u.searchParams.has("utm_source"));
+    assert.ok(!u.searchParams.has("utm_campaign"));
+    assert.ok(!u.searchParams.has("fbclid"));
+    assert.ok(!u.searchParams.has("gclid"));
+    // ref is not in TRACKING_PARAMS (removed PR #165) — so it stays
+    assert.equal(u.searchParams.get("ref"), "homepage");
+    assert.ok(removedTracking.length >= 4);
+  });
+
+  test("clean URL passes through untouched when no tracking params", () => {
+    const raw = "https://example.com/article/hello-world";
+    const { cleanUrl, action } = clean(raw);
+    assert.equal(cleanUrl, raw);
+    assert.equal(action, "untouched");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LinkedIn — job search params preserved
+// ---------------------------------------------------------------------------
+describe("LinkedIn", () => {
+  test("preserves keywords and location, strips li_fat_id", () => {
+    const { cleanUrl } = clean(
+      "https://www.linkedin.com/jobs/search/?keywords=engineer&location=Madrid&li_fat_id=abc123"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("keywords"), "engineer");
+    assert.equal(u.searchParams.get("location"), "Madrid");
+    assert.ok(!u.searchParams.has("li_fat_id"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Spanish real-estate sites
+// ---------------------------------------------------------------------------
+describe("Idealista", () => {
+  test("preserves tipo and order, strips utm_*", () => {
+    const { cleanUrl } = clean(
+      "https://www.idealista.com/venta-viviendas/madrid/?tipo=pisos&order=desc&utm_source=portal"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("tipo"), "pisos");
+    assert.equal(u.searchParams.get("order"), "desc");
+    assert.ok(!u.searchParams.has("utm_source"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// domainRules.json — structural validation
+// ---------------------------------------------------------------------------
+describe("domain-rules.json structure", () => {
+  test("is an array", () => {
+    assert.ok(Array.isArray(domainRules));
+  });
+
+  test("every entry has domain (string) and preserveParams (non-empty array)", () => {
+    for (const rule of domainRules) {
+      assert.equal(typeof rule.domain, "string", `bad domain in rule: ${JSON.stringify(rule)}`);
+      assert.ok(Array.isArray(rule.preserveParams), `preserveParams must be array in: ${rule.domain}`);
+      assert.ok(rule.preserveParams.length > 0, `preserveParams must not be empty in: ${rule.domain}`);
+    }
+  });
+
+  test("no duplicate domains", () => {
+    const domains = domainRules.map(r => r.domain);
+    const unique = new Set(domains);
+    assert.equal(unique.size, domains.length, "Duplicate domain entries found");
+  });
+
+  test("covers key domains: google.com, youtube.com, amazon.com, github.com, wikipedia.org", () => {
+    const domains = new Set(domainRules.map(r => r.domain));
+    for (const d of ["google.com", "youtube.com", "amazon.com", "github.com", "wikipedia.org"]) {
+      assert.ok(domains.has(d), `Missing domain rule for: ${d}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/rules/domain-rules.json` with 52 domain entries covering search engines, e-commerce, social/video, news, productivity, and Spanish top sites
- Preserves functional params (`q`, `sort`, `page`, `v`, `list`, `checkin`, `checkout`, `ab_channel` on YouTube, etc.) while still stripping all tracking params globally
- Exports `getPreservedParams(hostname, domainRules)` from `cleaner.js` — subdomain-aware, returns a `Set` of param names to skip during stripping
- `processUrl()` gains optional `domainRules` parameter (backwards compatible, defaults to `[]`)
- `service-worker.js` imports `domain-rules.json` and passes it to `processUrl`

## Key design decisions

- `ab_channel` is in global `TRACKING_PARAMS` but youtube.com rule preserves it (channel attribution context)
- `ref` is not in `TRACKING_PARAMS` (removed PR #165) so GitHub/Amazon `ref` params work without any special handling beyond the domain rule as a safety net
- `ie` is in global TRACKING_PARAMS (Amazon locale param) but baidu.com rule preserves it since Baidu uses it functionally for encoding

## Test plan

- [x] `npm test` — 184 tests, 0 failures (35 new domain-rules tests)
- [x] `getPreservedParams` unit tests: exact match, subdomain match, deep subdomain, no match, partial-domain false-positive guard
- [x] Google: `q`/`hl`/`gl`/`tbm`/`num` preserved, `si`/`utm_*`/`fbclid`/`gclid` stripped
- [x] Amazon: `k`/`s`/`ref` preserved, `pd_rd_r`/`psc`/`ascsubtag`/`linkCode` stripped
- [x] YouTube: `v`/`t`/`list` preserved, `si` stripped; `ab_channel` preserved on YouTube, stripped on non-YouTube
- [x] Reddit: `sort`/`t`/`after`/`limit` preserved, `rdt_cid` stripped
- [x] GitHub: `tab`/`q`/`type`/`ref` preserved, `utm_*` stripped
- [x] Booking.com: `checkin`/`checkout`/`adults`/`rooms` preserved, `utm_*` stripped
- [x] Domain with no rules: all tracking params stripped normally
- [x] domain-rules.json structural validation (no duplicates, required fields)