### PR TITLE
feat: tracking param categories with per-category opt-out

### DIFF
--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -172,6 +172,149 @@ export const TRACKING_PARAMS = [
   "ab_version", // A/B test version
 ];
 
+export const TRACKING_PARAM_CATEGORIES = {
+  utm: {
+    label: "UTM / Campaign",
+    labelEs: "UTM / Campaña",
+    description: "Google Analytics UTM parameters (utm_source, utm_medium, etc.)",
+    descriptionEs: "Parámetros UTM de Google Analytics",
+    params: [
+      "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
+      "utm_id", "utm_source_platform", "utm_creative_format", "utm_marketing_tactic",
+    ],
+  },
+  ads: {
+    label: "Paid Ads Clicks",
+    labelEs: "Clics de publicidad",
+    description: "Click IDs from Google Ads, Facebook, TikTok, LinkedIn, Microsoft, Twitter, etc.",
+    descriptionEs: "IDs de clic de Google Ads, Facebook, TikTok, etc.",
+    params: [
+      // Google / Meta / Microsoft core
+      "fbclid", "gclid", "gclsrc", "dclid", "gbraid", "wbraid",
+      "msclkid", "tclid", "twclid",
+      // Affiliate networks
+      "irgwc", "cjevent", "tduid",
+      // Rakuten / LinkShare
+      "ranmid", "raneaid", "ransiteid",
+      // TradeTracker
+      "ttaid", "ttrk", "ttcid",
+      // Google Shopping
+      "srsltid",
+      // LinkedIn Ads
+      "li_fat_id", "li_extra", "li_source",
+      // Adobe Analytics
+      "s_kwcid", "ef_id",
+      // TikTok Ads
+      "ttclid",
+      // Microsoft Advertising
+      "mscid",
+      // Outbrain
+      "obOrigUrl", "outbrainclickid",
+      // Taboola
+      "taboola_campaign_id", "tblci",
+      // Criteo
+      "criteo_id",
+      // Google Ads additional
+      "gad_source",
+      // Facebook / Meta additional
+      "fbc", "fbp",
+      // Snapchat
+      "sccid",
+      // Reddit
+      "rdt_cid",
+      // Zemanta / Outbrain DSP
+      "zemclick",
+      // Generic click / ad IDs
+      "click_id", "ad_id",
+    ],
+  },
+  email: {
+    label: "Email Marketing",
+    labelEs: "Email marketing",
+    description: "Tracking from Klaviyo, HubSpot, Iterable, Marketo, Pardot, ActiveCampaign, etc.",
+    descriptionEs: "Rastreo de Klaviyo, HubSpot, Iterable, Marketo, etc.",
+    params: [
+      // Mailchimp
+      "mc_cid", "mc_eid", "mailingid", "hqemail",
+      // HubSpot
+      "_hsenc", "_hsmi", "hsctatracking", "__hstc", "__hsfp", "__hssc",
+      // Marketo
+      "mkt_tok", "_mkto_trk",
+      // Generic email
+      "trk", "trkcampaign",
+      // Iterable
+      "itm_campaign", "itm_content", "itm_medium", "itm_source", "itm_term",
+      // Klaviyo
+      "_kx", "klaviyo_id",
+      // ActiveCampaign
+      "vgo_ee",
+      // Pardot / Salesforce
+      "pi_ad_id", "pi_campaign_id", "sfdcImpactSrc",
+      // Drip
+      "dm_i",
+      // Omnisend
+      "omnisendContactID",
+      // Sendinblue / Brevo
+      "sib_id",
+    ],
+  },
+  social: {
+    label: "Social Media",
+    labelEs: "Redes sociales",
+    description: "Tracking from Instagram, Pinterest, Snapchat, TikTok shares, etc.",
+    descriptionEs: "Rastreo de Instagram, Pinterest, Snapchat, etc.",
+    params: [
+      // Instagram
+      "igshid", "igsh",
+      // Pinterest
+      "e_t", "epik", "pin_unauth",
+      // Snapchat
+      "sc_channel", "sc_country", "sc_funnel", "sc_segment", "sc_icid",
+    ],
+  },
+  platform_noise: {
+    label: "Platform Noise",
+    labelEs: "Ruido de plataforma",
+    description: "Session IDs, A/B test tokens, internal routing params added by CDNs and platforms.",
+    descriptionEs: "IDs de sesión, tokens A/B, parámetros internos de CDNs y plataformas.",
+    params: [
+      // YouTube share
+      "si",
+      // TikTok
+      "_r",
+      // Generic
+      "source", "campaign", "cid", "clickid",
+      // Microsoft / Windows
+      "ocid",
+      // Amazon
+      "psc", "spla",
+      "pd_rd_r", "pd_rd_w", "pd_rd_wg", "pd_rd_i",
+      "pf_rd_p", "pf_rd_r",
+      "linkcode", "linkid",
+      "ascsubtag", "asc_contentid", "asc_contenttype", "asc_campaign",
+      "th", "_encoding", "content-id", "ref_",
+      "__mk_es_es", "__mk_de_de", "__mk_fr_fr", "__mk_it_it",
+      "ie",
+      // eBay
+      "mkevt", "mkcid", "mkrid", "toolid", "customid",
+      // AliExpress
+      "aff_trace_key", "algo_expid", "algo_pvid", "btsid", "ws_ab_test",
+      // A/B test
+      "ab_channel", "ab_version",
+    ],
+  },
+  generic: {
+    label: "Generic Tracking",
+    labelEs: "Rastreo genérico",
+    description: "Common generic tracking params used across many platforms.",
+    descriptionEs: "Parámetros de rastreo genéricos usados en múltiples plataformas.",
+    params: [
+      "s_cid",
+      "wickedid",
+    ],
+  },
+};
+
 export const AFFILIATE_PATTERNS = [
   {
     id: "amazon_es",

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -3,7 +3,7 @@
  * Exported as a module for use in the service worker.
  */
 
-import { TRACKING_PARAMS, getPatternsForHost } from "./affiliates.js";
+import { TRACKING_PARAMS, TRACKING_PARAM_CATEGORIES, getPatternsForHost } from "./affiliates.js";
 
 /**
  * Parses a blacklist/whitelist entry string into a structured object.
@@ -155,12 +155,26 @@ export function processUrl(rawUrl, prefs, domainRules = []) {
   const affiliateParamNames = patterns.map(p => p.param.toLowerCase());
   const customParams = (prefs.customParams || []).map(p => p.toLowerCase());
   const preservedParams = getPreservedParams(hostname, domainRules);
+
+  // Build effective tracking params list: exclude params that belong to a disabled category
+  const disabledCategories = new Set(prefs.disabledCategories || []);
+  const disabledParams = new Set();
+  if (disabledCategories.size > 0) {
+    for (const [key, cat] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+      if (disabledCategories.has(key)) {
+        cat.params.forEach(p => disabledParams.add(p.toLowerCase()));
+      }
+    }
+  }
+
   for (const param of [...url.searchParams.keys()]) {
     const lower = param.toLowerCase();
     // Don't strip params that are affiliate identifiers for this host
     if (affiliateParamNames.includes(lower)) continue;
     // Don't strip params that are functional on this domain (domain-rules compatibility)
     if (preservedParams.has(lower)) continue;
+    // Don't strip params whose category has been disabled by the user
+    if (disabledParams.has(lower)) continue;
     if (TRACKING_PARAMS.includes(lower) || customParams.includes(lower)) {
       url.searchParams.delete(param);
       removedTracking.push(param);

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -72,6 +72,9 @@ export const TRANSLATIONS = {
   add_btn:  { en: "+ Add", es: "+ Añadir" },
   empty_list: { en: "No entries yet.", es: "Sin entradas todavía." },
   muga_disabled: { en: "MUGA is disabled", es: "MUGA está desactivado" },
+  section_tracking_categories: { en: "Tracking categories", es: "Categorías de rastreo" },
+  categories_hint: { en: "Enable or disable stripping for each param category. Disabling a category keeps those parameters in URLs.", es: "Activa o desactiva la eliminación por categoría. Desactivar una categoría conserva esos parámetros en las URLs." },
+
   section_language: { en: "Language", es: "Idioma" },
   lang_label:  { en: "Display language", es: "Idioma de la interfaz" },
   lang_hint:   { en: "Affects the popup and settings page. Does not affect URL processing.", es: "Afecta al popup y a esta página. No afecta al procesamiento de URLs." },

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -23,6 +23,7 @@ export const PREF_DEFAULTS = {
   unwrapRedirects: true,
   language: "en",
   onboardingDone: false,
+  disabledCategories: [],  // e.g. ["utm", "ads"] — params in these categories are not stripped
 };
 
 export async function getPrefs() {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -177,6 +177,12 @@
   </section>
 
   <section>
+    <h2 data-i18n="section_tracking_categories">Tracking categories</h2>
+    <div class="card" id="categories-card"></div>
+    <p class="hint" data-i18n="categories_hint" style="margin-top:8px"></p>
+  </section>
+
+  <section>
     <div class="card">
       <details class="stores-details">
         <summary class="stores-summary" role="heading" aria-level="2">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -3,7 +3,7 @@
  */
 
 import { applyTranslations, getStoredLang, t, SUPPORTED_LANGS } from "../lib/i18n.js";
-import { getSupportedStores } from "../lib/affiliates.js";
+import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
 import { PREF_DEFAULTS } from "../lib/storage.js";
 
 let currentLang = "en";
@@ -32,6 +32,7 @@ async function init() {
   renderList("custom-params-items", prefs.customParams, "customParams");
   renderList("blacklist-items", prefs.blacklist, "blacklist");
   renderList("whitelist-items", prefs.whitelist, "whitelist");
+  renderCategories(prefs.disabledCategories || []);
   renderStores();
   initLanguageSelect();
   bindListButtons();
@@ -92,6 +93,61 @@ function bindListButtons() {
     addEntry("blacklist", "bl-input", "blacklist-items"));
   document.getElementById("wl-add-btn").addEventListener("click", () =>
     addEntry("whitelist", "wl-input", "whitelist-items"));
+}
+
+function renderCategories(disabledCategories) {
+  const card = document.getElementById("categories-card");
+  card.innerHTML = "";
+  const disabled = new Set(disabledCategories);
+
+  for (const [key, cat] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+    const isEs = currentLang === "es";
+    const label = isEs ? cat.labelEs : cat.label;
+    const desc = isEs ? cat.descriptionEs : cat.description;
+
+    const row = document.createElement("div");
+    row.className = "row";
+
+    const labelDiv = document.createElement("div");
+    labelDiv.className = "row-label";
+
+    const strong = document.createElement("strong");
+    strong.textContent = label;
+
+    const small = document.createElement("small");
+    small.textContent = desc;
+
+    labelDiv.appendChild(strong);
+    labelDiv.appendChild(small);
+
+    const toggle = document.createElement("label");
+    toggle.className = "toggle";
+
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.id = `cat-${key}`;
+    input.checked = !disabled.has(key);
+    input.addEventListener("change", async () => {
+      const prefs = await chrome.storage.sync.get({ disabledCategories: [] });
+      const set = new Set(prefs.disabledCategories);
+      if (input.checked) {
+        set.delete(key);
+      } else {
+        set.add(key);
+      }
+      await chrome.storage.sync.set({ disabledCategories: [...set] });
+    });
+
+    const slider = document.createElement("span");
+    slider.className = "slider";
+
+    toggle.appendChild(input);
+    toggle.appendChild(slider);
+
+    row.appendChild(labelDiv);
+    row.appendChild(toggle);
+    card.appendChild(row);
+  }
 }
 
 function renderStores() {

--- a/tests/unit/categories.test.mjs
+++ b/tests/unit/categories.test.mjs
@@ -1,0 +1,124 @@
+/**
+ * MUGA — Unit tests for TRACKING_PARAM_CATEGORIES
+ *
+ * Coverage:
+ *   - Every param in TRACKING_PARAMS appears in exactly one category
+ *   - No param appears in more than one category
+ *   - Disabling 'utm' category does not strip utm_source
+ *   - Disabling 'ads' category does not strip fbclid
+ *   - Enabling all categories (default) strips everything normally
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { TRACKING_PARAMS, TRACKING_PARAM_CATEGORIES } from "../../src/lib/affiliates.js";
+import { processUrl } from "../../src/lib/cleaner.js";
+
+const DEFAULT_PREFS = {
+  enabled: true,
+  injectOwnAffiliate: false,
+  notifyForeignAffiliate: false,
+  allowReplaceAffiliate: false,
+  stripAllAffiliates: false,
+  blacklist: [],
+  whitelist: [],
+  customParams: [],
+  disabledCategories: [],
+};
+
+describe("TRACKING_PARAM_CATEGORIES integrity", () => {
+  test("every param in TRACKING_PARAMS appears in exactly one category", () => {
+    const allCategoryParams = new Map(); // param -> [categoryKeys]
+    for (const [key, cat] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+      for (const p of cat.params) {
+        const lower = p.toLowerCase();
+        if (!allCategoryParams.has(lower)) allCategoryParams.set(lower, []);
+        allCategoryParams.get(lower).push(key);
+      }
+    }
+
+    const missing = [];
+    const duplicates = [];
+
+    for (const param of TRACKING_PARAMS) {
+      const lower = param.toLowerCase();
+      const cats = allCategoryParams.get(lower);
+      if (!cats) {
+        missing.push(param);
+      } else if (cats.length > 1) {
+        duplicates.push({ param, categories: cats });
+      }
+    }
+
+    assert.deepEqual(missing, [], `Params missing from any category: ${missing.join(", ")}`);
+    assert.deepEqual(duplicates, [], `Params in more than one category: ${JSON.stringify(duplicates)}`);
+  });
+
+  test("no param appears in more than one category", () => {
+    const seen = new Map();
+    for (const [key, cat] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+      for (const p of cat.params) {
+        const lower = p.toLowerCase();
+        if (seen.has(lower)) {
+          assert.fail(`Param "${lower}" appears in both "${seen.get(lower)}" and "${key}"`);
+        }
+        seen.set(lower, key);
+      }
+    }
+  });
+});
+
+describe("processUrl — disabledCategories", () => {
+  test("disabling 'utm' category does not strip utm_source", () => {
+    const url = "https://example.com/page?utm_source=google&other=value";
+    const prefs = { ...DEFAULT_PREFS, disabledCategories: ["utm"] };
+    const result = processUrl(url, prefs);
+    const out = new URL(result.cleanUrl);
+    assert.equal(out.searchParams.get("utm_source"), "google", "utm_source should be preserved when utm category is disabled");
+  });
+
+  test("disabling 'ads' category does not strip fbclid", () => {
+    const url = "https://example.com/page?fbclid=abc123&other=value";
+    const prefs = { ...DEFAULT_PREFS, disabledCategories: ["ads"] };
+    const result = processUrl(url, prefs);
+    const out = new URL(result.cleanUrl);
+    assert.equal(out.searchParams.get("fbclid"), "abc123", "fbclid should be preserved when ads category is disabled");
+  });
+
+  test("disabling 'utm' does not affect non-utm params being stripped", () => {
+    const url = "https://example.com/page?utm_source=google&fbclid=abc";
+    const prefs = { ...DEFAULT_PREFS, disabledCategories: ["utm"] };
+    const result = processUrl(url, prefs);
+    const out = new URL(result.cleanUrl);
+    assert.equal(out.searchParams.get("utm_source"), "google", "utm_source preserved");
+    assert.equal(out.searchParams.get("fbclid"), null, "fbclid still stripped");
+  });
+
+  test("enabling all categories (default empty disabledCategories) strips utm_source", () => {
+    const url = "https://example.com/page?utm_source=google&utm_medium=cpc";
+    const prefs = { ...DEFAULT_PREFS, disabledCategories: [] };
+    const result = processUrl(url, prefs);
+    const out = new URL(result.cleanUrl);
+    assert.equal(out.searchParams.get("utm_source"), null, "utm_source should be stripped with default prefs");
+    assert.equal(out.searchParams.get("utm_medium"), null, "utm_medium should be stripped with default prefs");
+  });
+
+  test("enabling all categories (default) strips fbclid", () => {
+    const url = "https://example.com/page?fbclid=xyz789";
+    const prefs = { ...DEFAULT_PREFS, disabledCategories: [] };
+    const result = processUrl(url, prefs);
+    const out = new URL(result.cleanUrl);
+    assert.equal(out.searchParams.get("fbclid"), null, "fbclid should be stripped with default prefs");
+  });
+
+  test("disabling multiple categories preserves all their params", () => {
+    const url = "https://example.com/?utm_source=g&fbclid=x&igshid=y&mc_cid=z";
+    const prefs = { ...DEFAULT_PREFS, disabledCategories: ["utm", "ads", "social", "email"] };
+    const result = processUrl(url, prefs);
+    const out = new URL(result.cleanUrl);
+    assert.equal(out.searchParams.get("utm_source"), "g", "utm_source preserved");
+    assert.equal(out.searchParams.get("fbclid"), "x", "fbclid preserved");
+    assert.equal(out.searchParams.get("igshid"), "y", "igshid preserved");
+    assert.equal(out.searchParams.get("mc_cid"), "z", "mc_cid preserved");
+  });
+});


### PR DESCRIPTION
## Summary

- Organizes `TRACKING_PARAMS` into 6 named categories (`utm`, `ads`, `email`, `social`, `platform_noise`, `generic`) via a new `TRACKING_PARAM_CATEGORIES` export in `affiliates.js`
- Adds `disabledCategories: []` pref to `PREF_DEFAULTS` (synced via `chrome.storage.sync`)
- Updates `processUrl` to skip stripping params whose category is disabled
- Adds a "Tracking categories" section to the options page with per-category enable/disable toggles (EN + ES labels and descriptions)
- Adds 2 new i18n keys (`section_tracking_categories`, `categories_hint`)
- Adds `tests/unit/categories.test.mjs` with 8 tests covering category integrity and `disabledCategories` integration

Closes #170

## Test plan

- [ ] `npm test` passes — 192 tests, 0 failures
- [ ] Category integrity: every param in TRACKING_PARAMS appears in exactly one category
- [ ] Disabling `utm` category preserves `utm_source` in URLs
- [ ] Disabling `ads` category preserves `fbclid` in URLs
- [ ] Default empty `disabledCategories` strips everything as before (backwards compatible)
- [ ] Options page renders 6 category rows with toggles
- [ ] Toggling a category persists to `chrome.storage.sync`