### PR TITLE
feat: clickable stats expand history with copy-original option (#178)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -104,7 +104,7 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 
 // --- Session history helpers ---
 
-const HISTORY_MAX = 5;
+const HISTORY_MAX = 10;
 
 async function appendHistory(original, clean) {
   if (original === clean) return;

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -45,6 +45,7 @@ export const TRANSLATIONS = {
   tab_badge_label:      { en: "stripped this tab", es: "eliminados en esta pestaña" },
   history_copy_hint:    { en: "Click to copy clean URL", es: "Clic para copiar URL limpia" },
   history_copied:       { en: "Copied!", es: "¡Copiado!" },
+  history_copy_original: { en: "Copy original", es: "Copiar original" },
 
   // ── Options ──────────────────────────────────────────────────────────────
   opts_title:      { en: "Advanced settings", es: "Preferencias avanzadas" },

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -78,6 +78,12 @@ header {
   line-height: 1.3;
 }
 
+.stat-clickable {
+  cursor: pointer;
+}
+.stat-clickable:hover { background: var(--bg2); }
+.stat-clickable:hover .stat-value { text-decoration: underline; }
+
 .options {
   padding: 8px 0;
   border-bottom: 0.5px solid var(--border);
@@ -280,6 +286,23 @@ header {
 .history-entry:hover { background: var(--bg2); }
 .history-entry:hover .history-url.after { text-decoration: underline; }
 .history-entry.copied .history-url.after { color: #16a34a; }
+
+.history-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 3px;
+}
+
+.history-copy-btn {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  border: 0.5px solid var(--border);
+  background: var(--bg);
+  color: var(--text2);
+  cursor: pointer;
+}
+.history-copy-btn:hover { background: var(--bg2); color: var(--text); }
 
 footer {
   display: flex;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -19,7 +19,7 @@
   </header>
 
   <section class="stats">
-    <div class="stat">
+    <div class="stat stat-clickable" id="stat-urls-wrap" role="button" tabindex="0" title="Show history">
       <span class="stat-value" id="stat-urls">0</span>
       <span class="stat-label" data-i18n="stat_urls">URLs cleaned</span>
     </div>
@@ -32,6 +32,11 @@
       <span class="stat-label" data-i18n="stat_referrals">affiliates detected</span>
     </div>
   </section>
+
+  <details class="history" id="history" hidden>
+    <summary class="history-summary" data-i18n="history_label">Recent</summary>
+    <div id="history-list"></div>
+  </details>
 
   <section class="preview" id="preview" hidden>
     <div class="preview-header">
@@ -75,11 +80,6 @@
       <button class="btn-test-notify" id="test-notify-btn" data-i18n="opt_test_notify_btn">Preview</button>
     </div>
   </section>
-
-  <details class="history" id="history" hidden>
-    <summary class="history-summary" data-i18n="history_label">Recent</summary>
-    <div id="history-list"></div>
-  </details>
 
   <footer>
     <a href="#" id="open-options" data-i18n="link_advanced">Advanced settings →</a>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -55,6 +55,20 @@ async function init() {
     chrome.runtime.openOptionsPage();
   });
 
+  // Clicking the URLs-cleaned stat toggles the history panel (#178)
+  const statUrlsWrap = document.getElementById("stat-urls-wrap");
+  statUrlsWrap.addEventListener("click", () => {
+    const historySection = document.getElementById("history");
+    if (historySection.hidden) return; // no history to show
+    historySection.open = !historySection.open;
+  });
+  statUrlsWrap.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      statUrlsWrap.click();
+    }
+  });
+
   document.getElementById("test-notify-btn").addEventListener("click", async () => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (!tab?.id) {
@@ -154,8 +168,18 @@ async function showHistory(lang) {
     afterDiv.className = "history-url after";
     afterDiv.textContent = entry.clean;
 
+    const actionsDiv = document.createElement("div");
+    actionsDiv.className = "history-actions";
+
+    const copyOrigBtn = document.createElement("button");
+    copyOrigBtn.className = "history-copy-btn";
+    copyOrigBtn.textContent = t("history_copy_original", lang);
+    copyOrigBtn.setAttribute("aria-label", t("history_copy_original", lang));
+
+    actionsDiv.appendChild(copyOrigBtn);
     entryDiv.appendChild(beforeDiv);
     entryDiv.appendChild(afterDiv);
+    entryDiv.appendChild(actionsDiv);
     list.appendChild(entryDiv);
 
     // Keyboard activation for history entries (#127)
@@ -167,7 +191,8 @@ async function showHistory(lang) {
     });
 
     // Click to copy clean URL (#87)
-    entryDiv.addEventListener("click", () => {
+    entryDiv.addEventListener("click", (e) => {
+      if (e.target === copyOrigBtn) return; // handled separately
       navigator.clipboard.writeText(entry.clean).then(() => {
         const orig = afterDiv.textContent;
         entryDiv.classList.add("copied");
@@ -176,6 +201,16 @@ async function showHistory(lang) {
           entryDiv.classList.remove("copied");
           afterDiv.textContent = orig;
         }, 1200);
+      });
+    });
+
+    // Copy original URL button (#178)
+    copyOrigBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      navigator.clipboard.writeText(entry.original).then(() => {
+        const origText = copyOrigBtn.textContent;
+        copyOrigBtn.textContent = t("history_copied", lang);
+        setTimeout(() => { copyOrigBtn.textContent = origText; }, 1200);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Move history panel directly below stats section in popup
- Make #stat-urls-wrap clickable (cursor pointer, underline on hover) to toggle history open/closed
- Increase HISTORY_MAX from 5 to 10 in service-worker.js
- Add "Copy original" button to each history entry that copies entry.original to clipboard
- Add history_copy_original i18n key in EN and ES

## Test plan
- [ ] npm test passes (209 tests, 0 failures)
- [ ] History panel appears below stats section
- [ ] Clicking URLs cleaned stat toggles history open/closed
- [ ] Each history entry shows "Copy original" button
- [ ] Clicking "Copy original" copies the pre-cleaned URL
- [ ] HISTORY_MAX is now 10 (up to 10 entries stored)