### PR TITLE
refactor: simplify options UI (#176)

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -92,8 +92,8 @@ export const TRANSLATIONS = {
   section_redirects:     { en: "Redirect handling",                  es: "Gestión de redirecciones" },
   row_amp_label:         { en: "Redirect AMP pages to canonical URL", es: "Redirigir páginas AMP a la URL canónica" },
   row_amp_hint:          { en: "Replaces Google AMP links with the original article URL", es: "Reemplaza los enlaces AMP de Google con la URL original del artículo" },
-  row_unwrap_label:      { en: "Unwrap redirect-wrapper URLs",        es: "Desenvolver URLs de redirección" },
-  row_unwrap_hint:       { en: "Extracts the real destination from Facebook, Reddit, Google, Steam and similar redirect wrappers", es: "Extrae el destino real de redireccionadores de Facebook, Reddit, Google, Steam y similares" },
+  row_unwrap_label:      { en: "Unwrap redirect wrappers",            es: "Desenvolver redireccionadores" },
+  row_unwrap_hint:       { en: "Extracts the real destination from redirect-wrapper URLs (e.g., ?redirect=https://example.com)", es: "Extrae el destino real de URLs de redirección (ej: ?redirect=https://example.com)" },
 
   section_stats:         { en: "Statistics",                                                                        es: "Estadísticas" },
   stats_reset_btn:       { en: "Reset stats",                                                                       es: "Reiniciar stats" },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -150,46 +150,14 @@
         </div>
         <label class="toggle"><input type="checkbox" id="dnr-enabled"><span class="slider"></span></label>
       </div>
-    </div>
-  </section>
-
-  <section>
-    <h2 data-i18n="section_privacy">Privacy</h2>
-    <div class="card">
       <div class="row">
         <div class="row-label">
-          <strong data-i18n="row_pings_label">Block &lt;a ping&gt; tracking beacons</strong>
-          <small data-i18n="row_pings_hint">Removes ping attributes from links so the browser doesn't send tracking beacons on click</small>
-        </div>
-        <label class="toggle"><input type="checkbox" id="block-pings"><span class="slider"></span></label>
-      </div>
-    </div>
-  </section>
-
-  <section>
-    <h2 data-i18n="section_redirects">Redirect handling</h2>
-    <div class="card">
-      <div class="row">
-        <div class="row-label">
-          <strong data-i18n="row_amp_label">Redirect AMP pages to canonical URL</strong>
-          <small data-i18n="row_amp_hint">Replaces Google AMP links with the original article URL</small>
-        </div>
-        <label class="toggle"><input type="checkbox" id="amp-redirect"><span class="slider"></span></label>
-      </div>
-      <div class="row">
-        <div class="row-label">
-          <strong data-i18n="row_unwrap_label">Unwrap redirect-wrapper URLs</strong>
-          <small data-i18n="row_unwrap_hint">Extracts the real destination from Facebook, Reddit, Google, Steam and similar redirect wrappers</small>
+          <strong data-i18n="row_unwrap_label">Unwrap redirect wrappers</strong>
+          <small data-i18n="row_unwrap_hint">Extracts the real destination from redirect-wrapper URLs (e.g., ?redirect=https://example.com)</small>
         </div>
         <label class="toggle"><input type="checkbox" id="unwrap-redirects"><span class="slider"></span></label>
       </div>
     </div>
-  </section>
-
-  <section>
-    <h2 data-i18n="section_tracking_categories">Tracking categories</h2>
-    <div class="card" id="categories-card"></div>
-    <p class="hint" data-i18n="categories_hint" style="margin-top:8px"></p>
   </section>
 
   <section>


### PR DESCRIPTION
## Summary
- Removes "Tracking categories" section from HTML (backend logic untouched in options.js/storage.js)
- Removes "Privacy" section with block-pings from HTML (pref remains functional)
- Removes amp-redirect toggle and its now-empty "Redirect handling" section from HTML
- Merges "Unwrap redirect wrappers" into the "URL Cleaning" card alongside dnr-enabled
- Updates row_unwrap_label to "Unwrap redirect wrappers" (no platform names)
- Updates row_unwrap_hint to generic example

## Test plan
- [x] npm test passes (209/209)
- [ ] Options page shows: Affiliate settings, URL Cleaning (dnr + unwrap), Custom params, Blacklist, Whitelist, Language, Stats, Import/Export
- [ ] blockPings, ampRedirect, disabledCategories prefs still functional via storage