### PR TITLE
feat: context menu toggle and keyboard shortcut reference in options (#179)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -203,17 +203,9 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   const prefs = await getPrefsWithCache();
   await applyDnrState(prefs);
 
-  chrome.contextMenus.create({
-    id: "muga-copy-clean",
-    title: "MUGA: Copy clean link",
-    contexts: ["link"],
-  });
-
-  chrome.contextMenus.create({
-    id: "muga-copy-clean-selection",
-    title: "MUGA: Copy clean link",
-    contexts: ["selection"],
-  });
+  if (prefs.contextMenuEnabled !== false) {
+    await syncContextMenus(true);
+  }
 
   if (details.reason === "install") {
     // First install — open the onboarding page in a new tab

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -87,6 +87,8 @@ export const TRANSLATIONS = {
   section_url_cleaning:  { en: "URL Cleaning",                       es: "Limpieza de URLs" },
   row_dnr_label:         { en: "Strip tracking parameters before navigation", es: "Eliminar parámetros de rastreo antes de navegar" },
   row_dnr_hint:          { en: "Uses browser-native rules to clean URLs from the address bar, bookmarks, and external apps", es: "Usa reglas nativas del navegador para limpiar URLs desde la barra de direcciones, marcadores y apps externas" },
+  row_context_menu_label: { en: "Right-click → Copy clean link", es: "Menú contextual → Copiar enlace limpio" },
+  row_context_menu_hint:  { en: "Alt+Shift+C also copies the clean URL of the current tab", es: "Alt+Shift+C también copia la URL limpia de la pestaña activa" },
   section_privacy:       { en: "Privacy",                            es: "Privacidad" },
   row_pings_label:       { en: "Block <a ping> tracking beacons",    es: "Bloquear balizas de rastreo <a ping>" },
   row_pings_hint:        { en: "Removes ping attributes from links so the browser doesn't send tracking beacons on click", es: "Elimina atributos ping para que el navegador no envíe balizas al hacer clic" },

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -18,6 +18,7 @@ export const PREF_DEFAULTS = {
   whitelist: [],     // e.g. ["amazon.es::tag::youtuber-21"]
   customParams: [],  // e.g. ["ref_code", "promo_id"]
   dnrEnabled: true,
+  contextMenuEnabled: true,
   blockPings: true,
   ampRedirect: true,
   unwrapRedirects: true,

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -157,6 +157,13 @@
         </div>
         <label class="toggle"><input type="checkbox" id="unwrap-redirects"><span class="slider"></span></label>
       </div>
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="row_context_menu_label">Right-click → Copy clean link</strong>
+          <small data-i18n="row_context_menu_hint">Alt+Shift+C also copies the clean URL of the current tab</small>
+        </div>
+        <label class="toggle"><input type="checkbox" id="context-menu-toggle"><span class="slider"></span></label>
+      </div>
     </div>
   </section>
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -20,6 +20,7 @@ async function init() {
   bindToggle("strip-affiliates", "stripAllAffiliates", prefs);
 
   bindToggle("dnr-enabled", "dnrEnabled", prefs);
+  bindToggle("context-menu-toggle", "contextMenuEnabled", prefs);
   bindToggle("block-pings", "blockPings", prefs);
   bindToggle("amp-redirect", "ampRedirect", prefs);
   bindToggle("unwrap-redirects", "unwrapRedirects", prefs);


### PR DESCRIPTION
## Summary
- Add contextMenuEnabled: true to PREF_DEFAULTS in storage.js
- Refactor service-worker.js: extract syncContextMenus() helper, check contextMenuEnabled in onInstalled, listen for storage changes to enable/disable context menus in real time
- Add context menu toggle row in options.html URL Cleaning section with shortcut hint (Alt+Shift+C)
- Bind context-menu-toggle to contextMenuEnabled pref in options.js
- Add row_context_menu_label and row_context_menu_hint i18n keys in EN and ES

## Test plan
- [ ] npm test passes (209 tests, 0 failures)
- [ ] Context menu toggle appears in options URL Cleaning section
- [ ] Disabling toggle removes context menu entries from right-click
- [ ] Enabling toggle restores context menu entries
- [ ] Shortcut hint "Alt+Shift+C also copies the clean URL of the current tab" shown in options