### PR TITLE
fix: prevent ourTag injection after blacklist removal (#183)

### DIFF
--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -241,12 +241,19 @@ export function processUrl(rawUrl, prefs, domainRules = []) {
 
   // 5. Strip specific blacklisted affiliate values
   let blacklistStripped = 0;
+  // Track whether a blacklist rule removed an affiliate param — if so, injection must be suppressed.
+  // Without this guard, a blacklisted competitor tag would be silently replaced by ourTag (#183).
+  let blacklistRemovedAffiliate = false;
   for (const entry of parsedBlacklist) {
     if (entry.param && entry.value && domainMatches(hostname, entry.domain)) {
       const current = url.searchParams.get(entry.param);
       if (current === entry.value) {
         url.searchParams.delete(entry.param);
         blacklistStripped++;
+        // If this param is an affiliate param for this host, flag injection suppression
+        if (affiliateParamNames.includes(entry.param.toLowerCase())) {
+          blacklistRemovedAffiliate = true;
+        }
         // If this was the detected foreign affiliate, clear it — the toast must not fire
         // for a parameter we already removed via the blacklist.
         if (
@@ -265,8 +272,9 @@ export function processUrl(rawUrl, prefs, domainRules = []) {
 
   const junkRemoved = removedTracking.length + blacklistStripped + (pathCleaned ? 1 : 0);
 
-  // 6. Inject our affiliate tag when the link has none (skip if foreign detected or stripAllAffiliates)
-  if (prefs.injectOwnAffiliate && !prefs.stripAllAffiliates && action !== "detected_foreign") {
+  // 6. Inject our affiliate tag when the link has none (skip if foreign detected, stripAllAffiliates,
+  //    or if a blacklist rule already removed an affiliate for this URL — blacklist takes priority (#183))
+  if (prefs.injectOwnAffiliate && !prefs.stripAllAffiliates && action !== "detected_foreign" && !blacklistRemovedAffiliate) {
     for (const pattern of patterns) {
       if (pattern.ourTag && !url.searchParams.has(pattern.param)) {
         url.searchParams.set(pattern.param, pattern.ourTag);

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -1035,3 +1035,44 @@ describe("ref is not a global tracking param (#160)", () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// Bug #183 — blacklist-specific + inject must NOT silently replace competitor tag
+// ---------------------------------------------------------------------------
+describe("Bug #183 — blacklist removal takes priority over affiliate injection", () => {
+  before(() => AFFILIATE_PATTERNS.push(TEST_PATTERN));
+  after(() => { const i = AFFILIATE_PATTERNS.indexOf(TEST_PATTERN); if (i !== -1) AFFILIATE_PATTERNS.splice(i, 1); });
+
+  test("blacklisted affiliate tag is removed and ourTag is NOT injected (#183)", () => {
+    const prefs = {
+      ...PREFS,
+      injectOwnAffiliate: true,
+      blacklist: ["shop.test.muga::aff::competitor-21"],
+    };
+    const { cleanUrl, action } = processUrl(
+      "https://shop.test.muga/product?aff=competitor-21&utm_source=email",
+      prefs
+    );
+    // The competitor tag must be gone
+    assert.ok(!cleanUrl.includes("competitor-21"), "competitor-21 must be stripped");
+    // Our tag must NOT have been silently injected
+    assert.ok(!cleanUrl.includes("muga-test-99"), "ourTag must NOT be injected after blacklist removal");
+    // Action must be cleaned, not injected
+    assert.notEqual(action, "injected", "action must not be 'injected' when blacklist removed the affiliate");
+  });
+
+  test("when no tag is present (no blacklist hit), ourTag is still injected normally (#183 non-regression)", () => {
+    const prefs = {
+      ...PREFS,
+      injectOwnAffiliate: true,
+      blacklist: ["shop.test.muga::aff::competitor-21"],
+    };
+    const { cleanUrl, action } = processUrl(
+      "https://shop.test.muga/product?color=blue",
+      prefs
+    );
+    // No blacklist rule fired — normal injection should proceed
+    assert.ok(cleanUrl.includes("muga-test-99"), "ourTag should be injected when no blacklist hit");
+    assert.equal(action, "injected");
+  });
+});


### PR DESCRIPTION
## Summary
- When a user blacklisted a specific competitor tag (e.g. `competitor-21`) AND had `injectOwnAffiliate: true`, the flow would silently replace the removed tag with `ourTag`
- Root cause: step 6 (inject) only skipped if `action === 'detected_foreign'`; after a blacklist removal the action was `'cleaned'`, so injection proceeded
- Fix: track `blacklistRemovedAffiliate` flag when a blacklisted entry deletes an affiliate param; suppress injection for that URL when the flag is set
- Added 2 regression tests in `cleaner.test.mjs` covering the bug scenario and the non-regression case (injection still works when no blacklist fires)

## Test plan
- [ ] `npm test` passes (212 tests, 0 failures)
- [ ] Test: blacklisted affiliate tag removed, `ourTag` NOT injected
- [ ] Test: no blacklist hit — normal injection still proceeds