### PR TITLE
fix: ponyfill chrome.storage.session for Firefox MV2 compatibility (#184)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -5,7 +5,7 @@
  */
 
 import { processUrl, parseListEntry } from "../lib/cleaner.js";
-import { getPrefs, incrementStat, getStats, setStats, migrateStatsToLocal } from "../lib/storage.js";
+import { getPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage } from "../lib/storage.js";
 import domainRules from "../rules/domain-rules.json" with { type: "json" };
 
 // Run migration once on startup (no-op if already done)
@@ -83,23 +83,23 @@ chrome.action.setBadgeBackgroundColor({ color: "#2563eb" });
 async function updateTabBadge(tabId, junkRemoved) {
   if (!tabId || junkRemoved <= 0) return;
   const key = `tab_${tabId}`;
-  const data = await chrome.storage.session.get({ [key]: 0 });
+  const data = await sessionStorage.get({ [key]: 0 });
   const newCount = data[key] + junkRemoved;
-  await chrome.storage.session.set({ [key]: newCount });
+  await sessionStorage.set({ [key]: newCount });
   chrome.action.setBadgeText({ text: String(newCount), tabId });
 }
 
 // Clear badge when a tab starts navigating to a new page
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === "loading") {
-    chrome.storage.session.remove(`tab_${tabId}`);
+    sessionStorage.remove(`tab_${tabId}`);
     chrome.action.setBadgeText({ text: "", tabId });
   }
 });
 
 // Clean up session data when a tab closes
 chrome.tabs.onRemoved.addListener((tabId) => {
-  chrome.storage.session.remove(`tab_${tabId}`);
+  sessionStorage.remove(`tab_${tabId}`);
 });
 
 // --- Session history helpers ---
@@ -108,10 +108,10 @@ const HISTORY_MAX = 10;
 
 async function appendHistory(original, clean) {
   if (original === clean) return;
-  const data = await chrome.storage.session.get({ history: [] });
+  const data = await sessionStorage.get({ history: [] });
   const entry = { original, clean, ts: Date.now() };
   const history = [entry, ...data.history].slice(0, HISTORY_MAX);
-  await chrome.storage.session.set({ history });
+  await sessionStorage.set({ history });
 }
 
 // --- Storage change listener: invalidate cache and re-apply DNR state ---

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -90,6 +90,47 @@ export async function incrementStat(key, amount = 1) {
   await setStats({ stats });
 }
 
+// ── Session storage ponyfill — Firefox MV2 compat (#184) ─────────────────────
+//
+// chrome.storage.session is MV3-only (Chrome 102+). Firefox ships MUGA as MV2
+// and does not expose this API, causing crashes in the service worker and popup.
+// This ponyfill falls back to an in-memory Map when the API is unavailable.
+// The Map is cleared on extension reload/restart, matching session semantics.
+
+const _memStore = new Map();
+
+export const sessionStorage = {
+  get: (keys) => {
+    if (chrome.storage.session) return chrome.storage.session.get(keys);
+    const result = {};
+    const ks = Array.isArray(keys)
+      ? keys
+      : typeof keys === "string"
+      ? [keys]
+      : Object.keys(keys);
+    ks.forEach(k => {
+      if (_memStore.has(k)) {
+        result[k] = _memStore.get(k);
+      } else if (keys !== null && typeof keys === "object" && !Array.isArray(keys)) {
+        // Return default value when provided via object form { key: default }
+        result[k] = keys[k];
+      }
+    });
+    return Promise.resolve(result);
+  },
+  set: (items) => {
+    if (chrome.storage.session) return chrome.storage.session.set(items);
+    Object.entries(items).forEach(([k, v]) => _memStore.set(k, v));
+    return Promise.resolve();
+  },
+  remove: (keys) => {
+    if (chrome.storage.session) return chrome.storage.session.remove(keys);
+    const ks = Array.isArray(keys) ? keys : [keys];
+    ks.forEach(k => _memStore.delete(k));
+    return Promise.resolve();
+  },
+};
+
 /**
  * One-time migration: moves stats out of chrome.storage.sync into
  * chrome.storage.local. Safe to call on every startup — exits immediately

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -5,7 +5,7 @@
 
 import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
 import { processUrl } from "../lib/cleaner.js";
-import { getPrefs } from "../lib/storage.js";
+import { getPrefs, sessionStorage } from "../lib/storage.js";
 import { getSupportedStores } from "../lib/affiliates.js";
 
 async function init() {
@@ -98,7 +98,7 @@ async function showUrlPreview(prefs, lang) {
   // Show per-tab badge count (#89)
   if (tab?.id) {
     const key = `tab_${tab.id}`;
-    const sessionData = await chrome.storage.session.get({ [key]: 0 });
+    const sessionData = await sessionStorage.get({ [key]: 0 });
     const count = sessionData[key];
     if (count > 0) {
       const badge = document.getElementById("tab-badge");
@@ -145,7 +145,7 @@ function formatStat(n) {
 }
 
 async function showHistory(lang) {
-  const data = await chrome.storage.session.get({ history: [] });
+  const data = await sessionStorage.get({ history: [] });
   const history = data.history;
   if (!history.length) return;
 

--- a/tests/unit/session-storage.test.mjs
+++ b/tests/unit/session-storage.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * MUGA — Unit tests for sessionStorage ponyfill (src/lib/storage.js)
+ *
+ * Verifies that the in-memory fallback works correctly when
+ * chrome.storage.session is unavailable (Firefox MV2 — #184).
+ *
+ * Run with: npm test
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ---------------------------------------------------------------------------
+// Simulate Firefox MV2: chrome.storage.session is undefined
+// ---------------------------------------------------------------------------
+globalThis.chrome = {
+  storage: {
+    sync: {
+      get: (defaults, cb) => cb && cb({}),
+      set: (_data, cb) => cb && cb(),
+      remove: (_keys, cb) => cb && cb(),
+    },
+    local: {
+      get: (defaults, cb) => cb && cb({}),
+      set: (_data, cb) => cb && cb(),
+    },
+    // session intentionally absent — Firefox MV2 does not have it
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Import after mock so the module sees our chrome stub
+// ---------------------------------------------------------------------------
+const { sessionStorage } = await import("../../src/lib/storage.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sessionStorage ponyfill — in-memory fallback (chrome.storage.session undefined)", () => {
+
+  test("set and get a single key", async () => {
+    await sessionStorage.set({ foo: "bar" });
+    const result = await sessionStorage.get("foo");
+    assert.equal(result.foo, "bar");
+  });
+
+  test("get with object form returns default when key is absent", async () => {
+    const result = await sessionStorage.get({ missingKey: 42 });
+    assert.equal(result.missingKey, 42);
+  });
+
+  test("get with object form returns stored value over default", async () => {
+    await sessionStorage.set({ counter: 7 });
+    const result = await sessionStorage.get({ counter: 0 });
+    assert.equal(result.counter, 7);
+  });
+
+  test("remove deletes a key", async () => {
+    await sessionStorage.set({ toRemove: "yes" });
+    await sessionStorage.remove("toRemove");
+    const result = await sessionStorage.get({ toRemove: "default" });
+    assert.equal(result.toRemove, "default");
+  });
+
+  test("remove accepts an array of keys", async () => {
+    await sessionStorage.set({ a: 1, b: 2 });
+    await sessionStorage.remove(["a", "b"]);
+    const result = await sessionStorage.get({ a: 0, b: 0 });
+    assert.equal(result.a, 0);
+    assert.equal(result.b, 0);
+  });
+
+  test("set multiple keys at once", async () => {
+    await sessionStorage.set({ x: 10, y: 20 });
+    const result = await sessionStorage.get({ x: 0, y: 0 });
+    assert.equal(result.x, 10);
+    assert.equal(result.y, 20);
+  });
+
+  test("returns a Promise from get/set/remove", async () => {
+    assert.ok(sessionStorage.set({ p: 1 }) instanceof Promise);
+    assert.ok(sessionStorage.get("p") instanceof Promise);
+    assert.ok(sessionStorage.remove("p") instanceof Promise);
+  });
+});


### PR DESCRIPTION
## Summary
- `chrome.storage.session` is MV3-only; Firefox ships MUGA as MV2 and lacks this API, causing crashes in the service worker and popup
- Added `sessionStorage` ponyfill export in `src/lib/storage.js`: uses `chrome.storage.session` when available, falls back to an in-memory `Map` with the same async interface
- Replaced all `chrome.storage.session.get/set/remove` calls in `service-worker.js` and `popup.js` with the new `sessionStorage` helper
- Added `tests/unit/session-storage.test.mjs` with 7 tests covering the in-memory fallback (get/set/remove, defaults, arrays, Promise return types)

## Test plan
- [ ] `npm test` passes (219 tests, 0 failures)
- [ ] New ponyfill tests verify fallback behavior when `chrome.storage.session` is undefined
- [ ] Badge count and history still work in Chrome (session API path still used when available)