### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -82,6 +82,10 @@
     ]
   },
 
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+
   "icons": {
     "16": "icons/16.png",
     "48": "icons/48.png",


### PR DESCRIPTION
Version bump for v1.4.0 release — UI redesign, domain-rules compat layer, tracking categories, 7 bugfixes, 244 tests.