### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestion
 
 - **Nombre:** MUGA — Make URLs Great Again
 - **Repo:** https://github.com/yocreoquesi/muga (public, GPL v3)
-- **Versión actual:** 1.3.0
+- **Versión actual:** 1.4.0
 - **Contexto completo (privado):** lee `Muga.md` — nunca lo comitees
 
 ---
@@ -25,7 +25,7 @@ Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestion
 
 ---
 
-## Estado actual — v1.2.0
+## Estado actual — v1.4.0
 
 ### Phase 1 ✅ — Feature-complete
 - [x] Strip 65+ tracking params (Scenario A — siempre activo)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Make URLs Great Again — clean URLs, no tracking, no unwanted referrals.",
   "type": "module",
   "scripts": {

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -75,6 +75,23 @@ async function applyDnrState(prefs) {
 // Matches http/https URLs in arbitrary text — used by the "selection" context menu handler
 const URL_RE = /https?:\/\/[^\s"'<>()[\]{}]+/g;
 
+// --- Context menu helpers ---
+
+async function syncContextMenus(enabled) {
+  await chrome.contextMenus.removeAll();
+  if (!enabled) return;
+  chrome.contextMenus.create({
+    id: "muga-copy-clean",
+    title: "Copy clean link",
+    contexts: ["link"],
+  });
+  chrome.contextMenus.create({
+    id: "muga-copy-clean-selection",
+    title: "Copy clean links in selection",
+    contexts: ["selection"],
+  });
+}
+
 // Set badge appearance once on startup
 chrome.action.setBadgeBackgroundColor({ color: "#2563eb" });
 
@@ -117,10 +134,16 @@ async function appendHistory(original, clean) {
 // --- Storage change listener: invalidate cache and re-apply DNR state ---
 chrome.storage.onChanged.addListener(async (changes, area) => {
   if (area !== "sync") return;
-  cachedPrefs = null; prefsFetchPromise = null; // Invalidate cache
+  // Any sync storage change (including disabledCategories, contextMenuEnabled, etc.)
+  // must invalidate the prefs cache so the next getPrefsWithCache() reads fresh data.
+  cachedPrefs = null;
+  prefsFetchPromise = null;
   if (changes.customParams || changes.dnrEnabled) {
     const prefs = await getPrefsWithCache();
     await applyDnrState(prefs);
+  }
+  if (changes.contextMenuEnabled) {
+    await syncContextMenus(changes.contextMenuEnabled.newValue !== false);
   }
 });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -82,6 +82,10 @@
     ]
   },
 
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+
   "icons": {
     "16": "icons/16.png",
     "48": "icons/48.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Clean URLs, no tracking, no unwanted referrals. You decide what happens to each link.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Clean URLs, no tracking, no unwanted referrals. You decide what happens to each link.",
 
   "permissions": [


### PR DESCRIPTION
Version bump for v1.4.0 release — UI redesign, domain-rules compat layer, tracking categories, 7 bugfixes, 244 tests.