### PR TITLE
feat: update onboarding with affiliate transparency and disable CTA

### DIFF
--- a/src/onboarding/onboarding.html
+++ b/src/onboarding/onboarding.html
@@ -187,7 +187,8 @@
               The price you see is identical — affiliate tags don't affect what you pay,
               they tell the store who referred you. We earn a small commission.
               <br><br>
-              That's the whole model. You can disable it right now or any time later in Settings.
+              That's the whole model. You can disable it right now using the button below,
+              or any time later in Settings.
             </p>
           </div>
           <label class="toggle">


### PR DESCRIPTION
## Summary
- Rewrites Step 2 (affiliate section) with plain language: explains exactly when MUGA adds a tag (only when the link has none) and that the price is unaffected
- Explicitly states MUGA never replaces an existing tag, contrasting directly with Honey's behaviour
- Adds a visible secondary CTA \"Disable affiliate injection\" linking to options.html#affiliate for immediate opt-out from the onboarding page
- Adds a one-liner to the tagline confirming everything runs locally with no data sent to any server
- Adds `.btn-secondary` CSS class for the new CTA

## Test plan
- [ ] Open src/onboarding/onboarding.html in browser after build
- [ ] Verify \"Disable affiliate injection\" link opens options page at the affiliate toggle
- [ ] Verify primary CTA still triggers onboarding.js save logic
- [ ] Verify toggle states (inject ON, notify OFF) render correctly
- [ ] Verify dark mode styling is intact