### PR TITLE
feat: simplify popup — remove inline options, show original URL, unify toast (#214)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -164,6 +164,30 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true; // keep the channel open for the async response
   }
 
+  if (message.type === "ADD_TO_WHITELIST") {
+    getPrefsWithCache().then(async prefs => {
+      const entry = message.tag;
+      if (entry && !prefs.whitelist.includes(entry)) {
+        await setPrefs({ whitelist: [...prefs.whitelist, entry] });
+        cachedPrefs = null;
+      }
+      sendResponse({ ok: true });
+    });
+    return true;
+  }
+
+  if (message.type === "ADD_TO_BLACKLIST") {
+    getPrefsWithCache().then(async prefs => {
+      const entry = message.tag;
+      if (entry && !prefs.blacklist.includes(entry)) {
+        await setPrefs({ blacklist: [...prefs.blacklist, entry] });
+        cachedPrefs = null;
+      }
+      sendResponse({ ok: true });
+    });
+    return true;
+  }
+
 });
 
 async function handleProcessUrl(rawUrl, { skipNotify = false } = {}) {

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -23,18 +23,18 @@
   // Toast strings — default English, overridden by stored language preference
   const STRINGS = {
     en: {
-      toast_title:   "MUGA detected an affiliate",
-      toast_tag_msg: "carries the tag",
-      toast_keep:    "Keep",
-      toast_remove:  "Remove",
+      toast_title:   "MUGA detected a third-party affiliate",
+      toast_tag_msg: "has an affiliate tag that isn't ours:",
+      toast_allow:   "Allow",
+      toast_block:   "Block",
       toast_ours:    "Use ours",
       toast_dismiss: "Dismiss",
     },
     es: {
       toast_title:   "MUGA detectó un afiliado ajeno",
-      toast_tag_msg: "lleva el tag",
-      toast_keep:    "Mantener",
-      toast_remove:  "Quitar",
+      toast_tag_msg: "tiene un tag de afiliado que no es nuestro:",
+      toast_allow:   "Permitir",
+      toast_block:   "Bloquear",
       toast_ours:    "Usar el nuestro",
       toast_dismiss: "Descartar",
     },
@@ -224,7 +224,7 @@
     notice.id = "muga-notice";
     notice.style.cssText = [
       "position:fixed", "bottom:20px", "right:20px",
-      "background:#1a1a1a", "color:#f0f0f0", "border-radius:10px",
+      "background:#1c1c1e", "color:#f0f0f0", "border-radius:10px",
       "padding:12px 16px",
       "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
       "font-size:13px", "line-height:1.5", "max-width:300px",
@@ -248,8 +248,8 @@
         ${escHtml(domain)} ${s.toast_tag_msg} <code style="${codeStyle}">${escHtml(affiliate.param)}=${escHtml(affiliate.value)}</code>
       </div>
       <div style="display:flex;gap:6px;flex-wrap:wrap">
-        <button data-choice="original" style="${btnStyle}">${s.toast_keep}</button>
-        <button data-choice="clean" style="${btnStyle}">${s.toast_remove}</button>
+        <button data-choice="original" style="${btnStyle}">${s.toast_allow}</button>
+        <button data-choice="clean" style="${btnStyle}">${s.toast_block}</button>
         ${oursBtn}
       </div>
       <div style="margin-top:6px;font-size:10px;color:#666;text-align:right;cursor:pointer" id="muga-dismiss">${s.toast_dismiss}</div>
@@ -260,13 +260,23 @@
     const timer = setTimeout(() => {
       notice.remove();
       callback("clean");
-    }, 5000);
+    }, 15000);
 
     notice.querySelectorAll("button[data-choice]").forEach(btn => {
       btn.addEventListener("click", () => {
         clearTimeout(timer);
         notice.remove();
-        callback(btn.dataset.choice);
+        const choice = btn.dataset.choice;
+        if (choice === "original") {
+          // "Allow" — add to whitelist
+          const tag = `${affiliate.param}=${affiliate.value}`;
+          chrome.runtime.sendMessage({ type: "ADD_TO_WHITELIST", tag });
+        } else if (choice === "clean") {
+          // "Block" — add to blacklist
+          const tag = `${affiliate.param}=${affiliate.value}`;
+          chrome.runtime.sendMessage({ type: "ADD_TO_BLACKLIST", tag });
+        }
+        callback(choice);
       });
     });
 

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -39,7 +39,7 @@ export const TRANSLATIONS = {
   opt_test_notify_label: { en: "Preview affiliate notification", es: "Previsualizar notificación de afiliado" },
   opt_test_notify_hint:  { en: "See how the toast looks when a third-party affiliate is detected", es: "Ve cómo se ve el aviso cuando se detecta un afiliado ajeno" },
   opt_test_notify_btn:   { en: "Preview", es: "Vista previa" },
-  link_advanced:    { en: "Advanced settings →", es: "Preferencias avanzadas →" },
+  link_advanced:    { en: "Settings →", es: "Ajustes →" },
   link_donate:      { en: "Support the project", es: "Apoyar el proyecto" },
   removed_params_label: { en: "Removed:", es: "Eliminado:" },
   tab_badge_label:      { en: "stripped this tab", es: "eliminados en esta pestaña" },
@@ -48,7 +48,7 @@ export const TRANSLATIONS = {
   history_copy_original: { en: "Copy original", es: "Copiar original" },
 
   // ── Options ──────────────────────────────────────────────────────────────
-  opts_title:      { en: "Advanced settings", es: "Preferencias avanzadas" },
+  opts_title:      { en: "Settings", es: "Ajustes" },
   opts_subtitle:   { en: "Make URLs Great Again", es: "Make URLs Great Again" },
   section_behaviour: { en: "Behaviour", es: "Comportamiento" },
   section_affiliate_settings: { en: "Affiliate settings", es: "Configuración de afiliados" },
@@ -112,10 +112,10 @@ export const TRANSLATIONS = {
   import_error:          { en: "Invalid file. Make sure it is a MUGA settings export.",                            es: "Archivo inválido. Asegúrate de que es una exportación de MUGA." },
 
   // ── Content script toast ──────────────────────────────────────────────────
-  toast_title:   { en: "MUGA detected an affiliate", es: "MUGA detectó un afiliado" },
-  toast_tag_msg: { en: "carries the tag", es: "lleva el tag" },
-  toast_keep:    { en: "Keep", es: "Mantener" },
-  toast_remove:  { en: "Remove", es: "Quitar" },
+  toast_title:   { en: "MUGA detected a third-party affiliate", es: "MUGA detectó un afiliado ajeno" },
+  toast_tag_msg: { en: "has an affiliate tag that isn't ours:", es: "tiene un tag de afiliado que no es nuestro:" },
+  toast_allow:   { en: "Allow", es: "Permitir" },
+  toast_block:   { en: "Block", es: "Bloquear" },
   toast_ours:    { en: "Use ours", es: "Usar el nuestro" },
   toast_dismiss: { en: "Dismiss", es: "Descartar" },
 };

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -93,7 +93,7 @@
   </style>
 </head>
 <body>
-  <h1 data-i18n="opts_title">Advanced settings</h1>
+  <h1 data-i18n="opts_title">Settings</h1>
   <p class="subtitle" data-i18n="opts_subtitle">Make URLs Great Again</p>
 
   <section>

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -220,6 +220,12 @@ header {
   text-decoration: line-through;
 }
 
+/* When the page URL is already clean: show without strikethrough */
+.preview-url.before.clean-url {
+  text-decoration: none;
+  color: var(--text);
+}
+
 .preview-url.after {
   color: var(--accent);
 }


### PR DESCRIPTION
## Summary

- Remove inline options section (two toggles + preview button) from popup — options live in Settings page only
- Footer link renamed "Advanced settings →" → "Settings →" (i18n: link_advanced, opts_title)
- Clean URL preview: when page URL is already clean, show it plainly (no strikethrough) via new .clean-url CSS class
- Toast redesign: updated copy, background #1c1c1e, buttons renamed Allow / Block, timeout 5 s → 15 s
- "Allow" sends ADD_TO_WHITELIST to service worker; "Block" sends ADD_TO_BLACKLIST
- service-worker.js handles both new message types via setPrefs

## Test plan

- [x] npm test — 250 tests, 0 failures
- [ ] Load extension in Chrome — popup shows only stats + URL preview + history + Settings footer link
- [ ] Navigate to clean page — URL shown plain without strikethrough
- [ ] Trigger foreign affiliate toast — shows "MUGA detected a third-party affiliate", Allow/Block buttons, 15 s timeout
- [ ] Click Allow — tag added to whitelist; Click Block — tag added to blacklist