### PR TITLE
fix: compliance — update manifest description and remove Temu (#222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ MUGA is an open-source project maintained by real people. To keep it maintained 
 
 When you navigate to a supported store and there is **no existing affiliate tag** in the link, MUGA adds ours. The price you pay is exactly the same — the store just knows you arrived via MUGA. That's how affiliate programs work.
 
-This is explained during onboarding before the feature is enabled, documented in the [privacy policy](https://yocreoquesi.github.io/muga/), and verifiable in the source code.
+This is explained during onboarding before the feature is enabled, disclosed in the extension description, documented in the [privacy policy](https://yocreoquesi.github.io/muga/), and verifiable in the source code.
 
 - Only fires when the link has **no affiliate tag at all**
 - The tag is added as a standard URL parameter — nothing hidden, nothing obfuscated
@@ -139,9 +139,9 @@ This is explained during onboarding before the feature is enabled, documented in
 
 ## Supported stores
 
-19 stores with affiliate tracking support:
+18 stores with affiliate tracking support:
 
-Amazon (ES, DE, FR, IT, UK, US) · Booking.com · AliExpress · PcComponentes · El Corte Inglés · eBay · Temu · Zalando (ES, DE) · SHEIN · Fnac (ES, FR) · MediaMarkt (ES, DE)
+Amazon (ES, DE, FR, IT, UK, US) · Booking.com · AliExpress · PcComponentes · El Corte Inglés · eBay · Zalando (ES, DE) · SHEIN · Fnac (ES, FR) · MediaMarkt (ES, DE)
 
 Affiliate injection is only active on stores where an account is registered and `ourTag` is set in the source. All other stores are listed as pending.
 

--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -414,14 +414,8 @@ export const AFFILIATE_PATTERNS = [
     type: "affiliate",
     ourTag: "",
   },
-  {
-    id: "temu",
-    name: "Temu",
-    domains: ["temu.com", "www.temu.com"],
-    param: "aff_id",
-    type: "affiliate",
-    ourTag: "muga-temu",  // TODO: fill in your Temu affiliate ID
-  },
+  // Temu removed — proprietary affiliate program with opaque ToS; high legal risk.
+  // Re-add once a verified affiliate account is registered and ToS confirmed. (#222)
   {
     id: "zalando_es",
     name: "Zalando ES",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
   "version": "1.4.0",
-  "description": "Clean URLs, no tracking, no unwanted referrals. You decide what happens to each link.",
+  "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [
     "storage",

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -3,7 +3,7 @@
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
   "version": "1.4.0",
-  "description": "Clean URLs, no tracking, no unwanted referrals. You decide what happens to each link.",
+  "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary

- **Manifest description updated** (both MV3 + MV2): replaces vague "no unwanted referrals" with explicit disclosure of affiliate injection, as required by Chrome Web Store developer policies
- **Temu removed from AFFILIATE_PATTERNS**: proprietary affiliate program with opaque ToS. High legal risk injecting `aff_id` without a verified account. Comment left in code explaining how to re-add when ready.
- **README**: store count 19 → 18, Temu removed from store list, added "disclosed in the extension description" to affiliate model paragraph

## What is NOT changed

- Temu tracking params continue to be stripped (they are in `TRACKING_PARAMS` via global rules, unaffected)
- All affiliate logic for other 18 stores unchanged
- 257 tests, 0 failures

Closes #222