### PR TITLE
feat: explicit consent onboarding — ToS required, affiliate opt-in (#224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ After:  https://www.ebay.es/itm/123456789
 - Badge counter showing params stripped on current tab
 - Popup with before/after preview for the current page
 
-### On by default — opt-out in Settings
+### Optional — configured during first setup
 
 - **Pre-navigation cleaning** — browser-native DNR rules strip tracking params *before* the page loads, covering address-bar navigation, bookmarks, and external apps
 - **Block `<a ping>` beacons** — prevents background tracking requests on click
 - **AMP redirect** — silently redirects Google AMP pages to the canonical article URL
 - **Redirect-wrapper unwrapping** — unwraps Reddit, Steam, and generic `?redirect=`/`?url=` intermediaries
-- **Affiliate injection** — adds our tag when none is present *(you pay the same price)*
+- **Affiliate injection** — adds our tag when none is present *(you pay the same price; opt-in during onboarding)*
 
 ### Configurable
 
@@ -123,6 +123,7 @@ This is explained during onboarding before the feature is enabled, disclosed in 
 
 - Only fires when the link has **no affiliate tag at all**
 - The tag is added as a standard URL parameter — nothing hidden, nothing obfuscated
+- **Opt-in only** — you choose during first setup; off by default
 - Turn it off any time: Settings → toggle off, globally or per domain
 - We **never replace** an existing tag from another affiliate — that practice is what got [Honey sued](https://en.wikipedia.org/wiki/Honey_(browser_extension)), and it's explicitly something MUGA does not do
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -10,7 +10,7 @@
 
 export const PREF_DEFAULTS = {
   enabled: true,
-  injectOwnAffiliate: true,
+  injectOwnAffiliate: false,  // set to true only if user opts in during onboarding (#224)
   notifyForeignAffiliate: false,
   allowReplaceAffiliate: false,
   stripAllAffiliates: false,
@@ -24,6 +24,8 @@ export const PREF_DEFAULTS = {
   unwrapRedirects: true,
   language: "en",
   onboardingDone: false,
+  consentVersion: null,   // e.g. "1.0" — bump to re-trigger onboarding on ToS changes
+  consentDate: null,      // Unix timestamp (ms) of when the user accepted
   disabledCategories: [],  // e.g. ["utm", "ads"] — params in these categories are not stripped
 };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -69,7 +69,7 @@
 
   "web_accessible_resources": [
     {
-      "resources": ["onboarding/onboarding.html", "privacy/privacy.html"],
+      "resources": ["onboarding/onboarding.html", "privacy/privacy.html", "privacy/tos.html"],
       "matches": ["<all_urls>"]
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -66,7 +66,8 @@
 
   "web_accessible_resources": [
     "onboarding/onboarding.html",
-    "privacy/privacy.html"
+    "privacy/privacy.html",
+    "privacy/tos.html"
   ],
 
   "declarative_net_request": {

--- a/src/onboarding/onboarding.html
+++ b/src/onboarding/onboarding.html
@@ -57,67 +57,76 @@
     .feature-text strong { display: block; font-weight: 500; margin-bottom: 2px; }
     .feature-text small { color: var(--text2); font-size: 12px; line-height: 1.4; }
 
-    /* Consent rows */
-    .consent-row {
-      display: flex; align-items: flex-start; gap: 14px;
-      padding: 14px 16px; border-bottom: 0.5px solid var(--border);
+    /* Affiliate card */
+    .affiliate-body {
+      background: var(--bg2); border-radius: 12px;
+      border: 0.5px solid var(--border);
+      margin-left: 40px; padding: 16px;
     }
-    .consent-row:last-child { border-bottom: none; }
-    .consent-text { flex: 1; }
-    .consent-text strong { display: block; font-size: 13.5px; font-weight: 500; margin-bottom: 3px; }
-    .consent-text p { font-size: 12.5px; color: var(--text2); line-height: 1.5; }
-    .consent-text .badge {
-      display: inline-block; font-size: 10.5px; font-weight: 500;
-      padding: 1px 7px; border-radius: 99px; margin-bottom: 4px;
+    .affiliate-body p {
+      font-size: 13px; color: var(--text2); line-height: 1.6; margin-bottom: 14px;
     }
-    .badge-on { background: rgba(22, 163, 74, 0.1); color: var(--success); }
-    .badge-off { background: rgba(217, 119, 6, 0.1); color: var(--warn); }
+    .affiliate-body strong { color: var(--text); }
 
-    /* Toggle */
-    .toggle { position: relative; width: 40px; height: 22px; flex-shrink: 0; margin-top: 2px; }
-    .toggle input { opacity: 0; width: 0; height: 0; }
-    .slider {
-      position: absolute; inset: 0; background: #d1d5db;
-      border-radius: 22px; transition: background .2s; cursor: pointer;
-    }
-    .slider::before {
-      content: ''; position: absolute; width: 16px; height: 16px;
-      left: 3px; top: 3px; background: white; border-radius: 50%; transition: transform .2s;
-    }
-    .toggle input:checked + .slider { background: var(--accent); }
-    .toggle input:checked + .slider::before { transform: translateX(18px); }
-
-    /* Disclaimer */
     .disclaimer {
       font-size: 11.5px; color: var(--text2); line-height: 1.6;
-      padding: 12px 16px; background: var(--bg2);
-      border: 0.5px solid var(--border); border-radius: 10px;
-      margin: 0 0 0 40px;
+      padding: 10px 14px; background: var(--bg);
+      border: 0.5px solid var(--border); border-radius: 8px;
+      margin-bottom: 14px;
     }
     .disclaimer a { color: var(--accent); text-decoration: none; }
 
-    /* CTA */
-    .cta {
-      margin-top: 32px; text-align: center;
+    /* Consent checkboxes */
+    .consent-check {
+      display: flex; align-items: flex-start; gap: 12px;
+      padding: 13px 14px; background: var(--bg);
+      border: 0.5px solid var(--border); border-radius: 8px;
+      cursor: pointer; transition: border-color .15s;
+      margin-bottom: 10px;
     }
+    .consent-check:last-child { margin-bottom: 0; }
+    .consent-check:hover { border-color: var(--accent); }
+    .consent-check input[type="checkbox"] {
+      width: 16px; height: 16px; margin-top: 2px; flex-shrink: 0;
+      accent-color: var(--accent); cursor: pointer;
+    }
+    .consent-check-label { font-size: 13px; line-height: 1.5; }
+    .consent-check-label strong { display: block; font-weight: 500; margin-bottom: 2px; }
+    .consent-check-label small { color: var(--text2); font-size: 12px; }
+    .consent-check-label a { color: var(--accent); text-decoration: none; }
+
+    /* ToS section */
+    .tos-section {
+      margin-top: 16px;
+    }
+    .tos-check {
+      display: flex; align-items: flex-start; gap: 12px;
+      padding: 13px 16px; background: var(--bg2);
+      border: 0.5px solid var(--border); border-radius: 10px;
+      cursor: pointer; transition: border-color .15s;
+    }
+    .tos-check:hover { border-color: var(--accent); }
+    .tos-check input[type="checkbox"] {
+      width: 16px; height: 16px; margin-top: 2px; flex-shrink: 0;
+      accent-color: var(--accent); cursor: pointer;
+    }
+    .tos-check-label { font-size: 13px; line-height: 1.5; }
+    .tos-check-label a { color: var(--accent); text-decoration: none; }
+
+    /* CTA */
+    .cta { margin-top: 20px; }
     .btn-primary {
-      display: inline-block; padding: 14px 40px;
+      display: block; width: 100%; padding: 14px 40px;
       background: var(--accent); color: #fff;
       font-size: 15px; font-weight: 600; border: none;
       border-radius: 12px; cursor: pointer; transition: opacity .15s;
-      width: 100%; text-decoration: none; text-align: center;
+      text-align: center;
     }
-    .btn-primary:hover { opacity: 0.88; }
-    .btn-secondary {
-      display: block; padding: 11px 24px; margin-top: 10px;
-      background: transparent; color: var(--text2);
-      font-size: 13px; font-weight: 500;
-      border: 0.5px solid var(--border); border-radius: 10px;
-      cursor: pointer; transition: opacity .15s;
-      width: 100%; text-decoration: none; text-align: center;
+    .btn-primary:disabled {
+      opacity: 0.35; cursor: not-allowed;
     }
-    .btn-secondary:hover { opacity: 0.7; }
-    .cta-note { font-size: 11.5px; color: var(--text2); margin-top: 10px; }
+    .btn-primary:not(:disabled):hover { opacity: 0.88; }
+    .cta-note { font-size: 11.5px; color: var(--text2); margin-top: 10px; text-align: center; }
   </style>
 </head>
 <body>
@@ -135,29 +144,29 @@
         <div class="feature-row">
           <div class="feature-icon">🧹</div>
           <div class="feature-text">
-            <strong>Strips tracking parameters automatically</strong>
-            <small>UTMs, fbclid, gclid, msclkid, mc_cid, si (YouTube), eBay tracking tags, and 30+ others — removed before the page loads. 100% legal, no ToS conflicts.</small>
+            <strong>Strips 130+ tracking parameters automatically</strong>
+            <small>UTMs, fbclid, gclid, msclkid, mc_cid, si (YouTube), eBay tracking tags, and more — removed before the page loads.</small>
           </div>
         </div>
         <div class="feature-row">
           <div class="feature-icon">⚡</div>
           <div class="feature-text">
             <strong>Redirects Google AMP pages to the real article</strong>
-            <small>AMP URLs (google.com/amp/…) are silently redirected to the canonical article so you always land on the actual site.</small>
+            <small>AMP URLs are silently redirected to the canonical article so you always land on the actual site.</small>
           </div>
         </div>
         <div class="feature-row">
           <div class="feature-icon">🚫</div>
           <div class="feature-text">
             <strong>Blocks &lt;a ping&gt; tracking beacons</strong>
-            <small>Prevents browsers from firing the hidden ping requests that advertisers use to log every link you click.</small>
+            <small>Prevents the hidden ping requests advertisers use to log every link you click.</small>
           </div>
         </div>
         <div class="feature-row">
           <div class="feature-icon">🔗</div>
           <div class="feature-text">
             <strong>Unwraps redirect-wrapper URLs</strong>
-            <small>Extracts the real destination from tracking wrappers (e.g. l.facebook.com, t.co, redirect links) so you go straight to the target page.</small>
+            <small>Extracts the real destination from tracking wrappers so you go straight to the target page.</small>
           </div>
         </div>
         <div class="feature-row">
@@ -170,60 +179,56 @@
       </div>
     </div>
 
-    <!-- Step 2: Affiliate model — transparent explanation -->
+    <!-- Step 2: Affiliate model -->
     <div class="step">
       <div class="step-header">
         <div class="step-num">2</div>
-        <div class="step-title">How MUGA funds itself — no surprises</div>
+        <div class="step-title">How MUGA stays free — your choice</div>
       </div>
-      <div class="step-body">
-        <div class="consent-row">
-          <div class="consent-text">
-            <span class="badge badge-on">ON by default</span>
-            <strong>We add our affiliate tag when a link has no tag at all</strong>
-            <p>
-              When you navigate to a supported store (Amazon, Booking, AliExpress, eBay…)
-              and the link carries <em>no affiliate tag at all</em>, MUGA appends ours in the background.
-              The price you see is identical — affiliate tags don't affect what you pay,
-              they tell the store who referred you. We earn a small commission.
-              <br><br>
-              That's the whole model. You can disable it right now using the button below,
-              or any time later in Settings.
-            </p>
-          </div>
-          <label class="toggle">
-            <input type="checkbox" id="inject-toggle" checked>
-            <span class="slider"></span>
-          </label>
+      <div class="affiliate-body">
+        <p>
+          When you visit a supported store (Amazon, Booking.com, AliExpress…) and the link
+          has <strong>no affiliate tag at all</strong>, MUGA can silently add ours.
+          <strong>The price you pay is always identical</strong> — affiliate tags don't affect
+          what you pay, they tell the store who referred you. We earn a small commission.
+          <br><br>
+          This is how we keep MUGA free and actively maintained.
+        </p>
+        <div class="disclaimer">
+          <strong>What MUGA never does:</strong> replace or overwrite a tag that is already
+          in a link. If a creator's or another affiliate's tag is there, MUGA leaves it alone.
+          This is the exact opposite of what
+          <a href="https://en.wikipedia.org/wiki/Honey_(browser_extension)" target="_blank">Honey did</a>.
+          MUGA only acts on links that have <em>no tag at all</em>.
+          The source code is public — you can verify this yourself.
         </div>
-        <div class="consent-row">
-          <div class="consent-text">
-            <span class="badge badge-off">OFF by default</span>
-            <strong>Notify me when a link already carries someone else's affiliate tag</strong>
-            <p>
-              A small notification appears with three options: keep the original tag,
-              remove it, or swap it for ours. Auto-dismisses in 5 seconds.
-              Default is always "keep". Enable this if you want visibility.
-            </p>
+        <label class="consent-check" id="affiliate-label">
+          <input type="checkbox" id="affiliate-check">
+          <div class="consent-check-label">
+            <strong>Yes, support MUGA for free — allow our affiliate tag on links that have none</strong>
+            <small>You always pay the same price. You can disable this in Settings at any time.</small>
           </div>
-          <label class="toggle">
-            <input type="checkbox" id="notify-toggle">
-            <span class="slider"></span>
-          </label>
-        </div>
-      </div>
-      <div class="disclaimer" style="margin-top:10px">
-        <strong>What MUGA never does:</strong> replace or overwrite an affiliate tag that
-        is already in a link. If a creator's or another affiliate's tag is there, MUGA leaves it alone.
-        This is the exact opposite of what <a href="https://en.wikipedia.org/wiki/Honey_(browser_extension)" target="_blank">Honey did</a> — they silently replaced creators' tags with their own, which is why they got sued.
-        MUGA only acts on links that have <em>no tag at all</em>.
-        The source code is public — you can verify this yourself.
+        </label>
       </div>
     </div>
 
+    <!-- ToS acceptance -->
+    <div class="tos-section">
+      <label class="tos-check" id="tos-label">
+        <input type="checkbox" id="tos-check">
+        <div class="tos-check-label">
+          I have read and accept the
+          <a href="../privacy/tos.html" target="_blank">Terms of use</a>
+          and
+          <a href="../privacy/privacy.html" target="_blank">Privacy policy</a>
+          <small style="display:block;color:var(--text2);margin-top:3px">Required to continue</small>
+        </div>
+      </label>
+    </div>
+
+    <!-- CTA -->
     <div class="cta">
-      <button class="btn-primary" id="start-btn">Make my URLs great →</button>
-      <a class="btn-secondary" id="disable-affiliate-btn" href="../options/options.html#affiliate">Disable affiliate injection</a>
+      <button class="btn-primary" id="start-btn" disabled>Get started →</button>
       <p class="cta-note">You can change all of this later in Settings at any time.</p>
     </div>
   </div>

--- a/src/onboarding/onboarding.js
+++ b/src/onboarding/onboarding.js
@@ -1,19 +1,37 @@
 /**
  * MUGA — Onboarding page
- * Reads the user's toggle choices and saves them to storage, then closes.
+ *
+ * Two checkboxes:
+ *   - ToS acceptance (mandatory — button stays disabled until checked)
+ *   - Affiliate opt-in (optional — activates injectOwnAffiliate if checked)
+ *
+ * On "Get started": saves consent metadata + prefs, then closes the tab.
  */
 
+const CONSENT_VERSION = "1.0";
+
 document.addEventListener("DOMContentLoaded", () => {
-  const injectToggle = document.getElementById("inject-toggle");
-  const notifyToggle = document.getElementById("notify-toggle");
-  const startBtn     = document.getElementById("start-btn");
+  const tosCheck       = document.getElementById("tos-check");
+  const affiliateCheck = document.getElementById("affiliate-check");
+  const startBtn       = document.getElementById("start-btn");
+
+  function updateButton() {
+    startBtn.disabled = !tosCheck.checked;
+  }
+
+  tosCheck.addEventListener("change", updateButton);
 
   startBtn.addEventListener("click", async () => {
+    if (!tosCheck.checked) return;
+
     await chrome.storage.sync.set({
-      injectOwnAffiliate:    injectToggle.checked,
-      notifyForeignAffiliate: notifyToggle.checked,
-      onboardingDone: true,
+      onboardingDone:        true,
+      consentVersion:        CONSENT_VERSION,
+      consentDate:           Date.now(),
+      injectOwnAffiliate:    affiliateCheck.checked,
+      notifyForeignAffiliate: false,
     });
+
     window.close();
   });
 });

--- a/src/privacy/tos.html
+++ b/src/privacy/tos.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MUGA — Terms of Use</title>
+  <style>
+    :root {
+      --bg: #fff; --text: #1a1a1a; --text2: #555; --accent: #2563eb;
+      --border: rgba(0,0,0,0.08); --bg2: #f7f7f7;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root { --bg: #111; --text: #f0f0f0; --text2: #999; --bg2: #1c1c1e; --border: rgba(255,255,255,0.08); }
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg); color: var(--text);
+      max-width: 680px; margin: 0 auto; padding: 48px 24px; font-size: 15px; line-height: 1.7; }
+    h1 { font-size: 26px; font-weight: 700; margin-bottom: 6px; }
+    .meta { color: var(--text2); font-size: 13px; margin-bottom: 40px; }
+    h2 { font-size: 16px; font-weight: 600; margin: 32px 0 10px; }
+    p { margin-bottom: 14px; color: var(--text2); }
+    ul { margin: 8px 0 14px 20px; color: var(--text2); }
+    li { margin-bottom: 6px; }
+    .highlight {
+      background: var(--bg2); border-left: 3px solid var(--accent);
+      border-radius: 0 8px 8px 0; padding: 14px 16px; margin: 16px 0;
+      font-size: 14px; color: var(--text);
+    }
+    a { color: var(--accent); text-decoration: none; }
+    .placeholder-notice {
+      background: #fef3c7; border: 1px solid #d97706; border-radius: 8px;
+      padding: 12px 16px; margin-bottom: 32px; font-size: 13px; color: #92400e;
+    }
+    @media (prefers-color-scheme: dark) {
+      .placeholder-notice { background: #3b2100; border-color: #d97706; color: #fcd34d; }
+    }
+  </style>
+</head>
+<body>
+
+  <div class="placeholder-notice">
+    ⚠️ <strong>Draft — pending legal review.</strong> This document will be finalized before the extension is published on the Chrome Web Store and Firefox AMO.
+  </div>
+
+  <h1>Terms of Use</h1>
+  <p class="meta">MUGA — Make URLs Great Again · Version 1.0 · Last updated: 2026-03-22</p>
+
+  <div class="highlight">
+    MUGA is free and open-source software licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">GNU General Public License v3</a>. All processing happens locally in your browser — no data is ever sent to any server.
+  </div>
+
+  <h2>1. What MUGA does</h2>
+  <p>MUGA is a browser extension that:</p>
+  <ul>
+    <li>Strips tracking parameters (UTMs, click IDs, and similar) from URLs before pages load</li>
+    <li>Redirects Google AMP pages to their canonical article URLs</li>
+    <li>Blocks <code>&lt;a ping&gt;</code> tracking beacons on link clicks</li>
+    <li>Unwraps redirect-wrapper URLs to take you directly to the destination</li>
+    <li>Optionally adds our affiliate tag to links that carry no affiliate tag, if you opt in</li>
+  </ul>
+
+  <h2>2. Affiliate model</h2>
+  <p>MUGA is maintained by a small team. To keep the project alive and free, we participate in affiliate programs with a small number of stores (Amazon, Booking.com, AliExpress, and others).</p>
+  <p>If you opt in during setup, MUGA will add our affiliate tag to links that have <strong>no existing affiliate tag</strong>. This has no effect on the price you pay — affiliate tags tell the store who referred you, nothing more.</p>
+  <ul>
+    <li>MUGA <strong>never replaces</strong> an affiliate tag that is already present in a link</li>
+    <li>MUGA <strong>never replaces</strong> a creator's or another affiliate's tag with ours</li>
+    <li>Affiliate injection only fires on explicitly supported stores listed in the source code</li>
+    <li>You can disable affiliate injection at any time in Settings</li>
+  </ul>
+
+  <h2>3. No data collection</h2>
+  <p>MUGA does not collect, transmit, or store any browsing data. All URL processing happens exclusively inside your browser. We have no servers, no analytics, and no telemetry of any kind. See our <a href="privacy.html">Privacy Policy</a> for full details.</p>
+
+  <h2>4. License</h2>
+  <p>MUGA is released under the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">GNU General Public License v3 (GPL v3)</a>. You are free to use, study, modify, and distribute MUGA, provided that any derivative work is also released under GPL v3. The source code is available at <a href="https://github.com/yocreoquesi/muga" target="_blank">github.com/yocreoquesi/muga</a>.</p>
+
+  <h2>5. Disclaimer</h2>
+  <p>MUGA is provided "as is", without warranty of any kind. The authors are not liable for any damages arising from the use of this software. Affiliate commissions are not guaranteed — they depend on the affiliate programs of third-party stores and are subject to change.</p>
+
+  <h2>6. Changes to these terms</h2>
+  <p>If we make material changes to these terms, the extension will ask you to review and re-accept them on next use. The current version of this document is always available inside the extension.</p>
+
+  <h2>7. Contact</h2>
+  <p>Questions or concerns? Open an issue at <a href="https://github.com/yocreoquesi/muga/issues" target="_blank">github.com/yocreoquesi/muga/issues</a>.</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Redesigns the onboarding flow to use explicit, legally-sound consent.

## Changes

**`src/lib/storage.js`**
- `injectOwnAffiliate` default: `true` → `false`
- Added `consentVersion` and `consentDate` to `PREF_DEFAULTS`

**`src/onboarding/onboarding.html`**
- Full redesign: replaces old toggles with two checkboxes
- ToS + Privacy Policy checkbox: mandatory — "Get started" stays disabled until checked
- Affiliate opt-in checkbox: optional, unchecked by default

**`src/onboarding/onboarding.js`**
- Saves `consentVersion: "1.0"`, `consentDate: Date.now()`, `injectOwnAffiliate` on submit
- Button guard: returns early if ToS not checked

**`src/privacy/tos.html`** (new)
- Terms of Use placeholder, marked as draft pending legal review
- Covers: what MUGA does, affiliate model, no data collection, GPL v3 license, disclaimer

**Both manifests** — `tos.html` added to `web_accessible_resources`

**`README.md`** — affiliate injection documented as opt-in, not default-on

## Legal rationale

- GDPR: consent for commercial purposes must be free, informed, specific — cannot be forced
- ToS mandatory + affiliate optional = valid informed consent
- Resolves Firefox AMO opt-in risk as a side effect
- `consentVersion` allows re-triggering onboarding if terms change in future

## Tests

257 tests, 0 failures.

Closes #224