### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to MUGA will be documented in this file.
 
+## [1.5.0] — 2026-03-22
+
+### Security & Compliance
+- **Explicit consent onboarding** — onboarding now requires active acceptance of Terms of Use and Privacy Policy before the extension activates. Affiliate injection is opt-in with a dedicated checkbox; ToS acceptance is mandatory (#224)
+- **Terms of Use** — new `src/privacy/tos.html` covering functionality, affiliate model, no-data-collection guarantee, GPL v3 license, and disclaimer
+- **`injectOwnAffiliate` default changed to `false`** — affiliate injection is now off until the user explicitly enables it during onboarding. Consent version and timestamp recorded in storage.
+- **Manifest description updated** — both MV3 and MV2 manifests now explicitly disclose affiliate injection as required by Chrome Web Store policies (#222)
+- **Temu removed from affiliate patterns** — proprietary affiliate program with opaque ToS poses unacceptable legal risk without a verified registered account. Tracking param stripping on temu.com is unaffected (#222)
+
+### Internal
+- 257 passing tests, 0 failures
+- `consentVersion` and `consentDate` fields added to `PREF_DEFAULTS`
+
 ## [1.4.0] — 2026-03-22
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![MUGA — Make URLs Great Again](docs/assets/promo-marquee-1400x560.png)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.4.0-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-250_pass-brightgreen)](#development)
 [![Health Check](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml/badge.svg)](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml)
 [![Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-coming_soon-lightgrey)](#installation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Make URLs Great Again — clean URLs, no tracking, no unwanted referrals.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [


### PR DESCRIPTION
Version bump and CHANGELOG for v1.5.0.

### What's in this release

**Security & Compliance (main changes since v1.4.0):**
- Explicit consent onboarding — ToS acceptance mandatory, affiliate opt-in optional (#224)
- Terms of Use document added (`src/privacy/tos.html`) (#224)
- `injectOwnAffiliate` default changed to `false` — user must opt in (#224)
- Manifest description updated to disclose affiliate injection for CWS compliance (#222)
- Temu removed from affiliate patterns — ToS risk (#222)

257 tests, 0 failures.