### PR TITLE
fix: remove _sri_browser_polyfill manifest key, bump to v1.5.1 (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MUGA will be documented in this file.
 
+## [1.5.1] — 2026-03-22
+
+### Bug Fixes
+- Remove `_sri_browser_polyfill` custom key from `manifest.json` — Chrome MV3 does not allow unrecognized manifest keys and was showing a warning on extension load. The SRI hash is enforced by CI via `tools/verify-polyfill-integrity.mjs` (#227)
+
 ## [1.5.0] — 2026-03-22
 
 ### Security & Compliance

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![MUGA — Make URLs Great Again](docs/assets/promo-marquee-1400x560.png)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.5.0-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.5.1-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-250_pass-brightgreen)](#development)
 [![Health Check](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml/badge.svg)](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml)
 [![Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-coming_soon-lightgrey)](#installation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Make URLs Great Again — clean URLs, no tracking, no unwanted referrals.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [
@@ -21,8 +21,6 @@
     "service_worker": "background/service-worker.js",
     "type": "module"
   },
-
-  "_sri_browser_polyfill": "sha256-ogk4EN2O4Ak+5NNOO0PRXB9pBcb0MPxmS2j4Da1JAk= (hex: a2093810df8e00393ee4d3adc243ea82d7e56471b40f0f66b64f8980da944094) — verified by tools/verify-polyfill-integrity.mjs (#97)",
 
   "content_scripts": [
     {

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [


### PR DESCRIPTION
## Problem
Chrome warns `Unrecognized manifest key '_sri_browser_polyfill'` on every extension load. Custom underscore-prefixed keys are not valid in Chrome MV3 manifests.

## Fix
- Remove `_sri_browser_polyfill` field from `manifest.json`
- The SRI hash is already enforced by CI (`tools/verify-polyfill-integrity.mjs`) and documented there — the manifest entry was redundant
- Version bump to v1.5.1
- CHANGELOG + README badge updated

## Tests
257 tests, 0 failures.

Closes #227