### PR TITLE
fix: toast Allow/Block build entry as domain::param::value (#229)

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -268,12 +268,15 @@
         notice.remove();
         const choice = btn.dataset.choice;
         if (choice === "original") {
-          // "Allow" — add to whitelist
-          const tag = `${affiliate.param}=${affiliate.value}`;
+          // "Allow" — add to whitelist in domain::param::value format so parseListEntry
+          // can match it correctly against the affiliate patterns (#229)
+          const hostname = new URL(originalUrl).hostname.replace(/^www\./, "");
+          const tag = `${hostname}::${affiliate.param}::${affiliate.value}`;
           chrome.runtime.sendMessage({ type: "ADD_TO_WHITELIST", tag });
         } else if (choice === "clean") {
-          // "Block" — add to blacklist
-          const tag = `${affiliate.param}=${affiliate.value}`;
+          // "Block" — add to blacklist in domain::param::value format (#229)
+          const hostname = new URL(originalUrl).hostname.replace(/^www\./, "");
+          const tag = `${hostname}::${affiliate.param}::${affiliate.value}`;
           chrome.runtime.sendMessage({ type: "ADD_TO_BLACKLIST", tag });
         }
         callback(choice);


### PR DESCRIPTION
## Summary

- Fixes #229: the foreign-affiliate toast's Allow and Block buttons were storing entries in `param=value` format instead of the `domain::param::value` format expected by `parseListEntry`
- The malformed entries were treated as domain-only blacklist/whitelist rules matching a hostname like `"aff=competitor-99"`, which never matched any real domain — so the buttons had no effect
- Now builds the entry as `hostname::param::value` so the rule is correctly applied on subsequent visits to that domain

## Test plan

- [x] `npm test` passes — 257 tests, 0 failures
- [ ] Manual: trigger the foreign affiliate toast → click Allow → revisit the same URL → no toast should appear (tag is now whitelisted)
- [ ] Manual: trigger the foreign affiliate toast → click Block → revisit the same URL → affiliate param should be stripped silently