### PR TITLE
chore: release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to MUGA will be documented in this file.
 
+## [1.5.2] — 2026-03-22
+
+### Bug Fixes
+- **Toast Allow/Block buttons now work correctly** — the "Allow" and "Block" buttons in the foreign-affiliate toast were storing entries in `param=value` format, which `parseListEntry` treated as a domain name. The entries never matched any real hostname, so the buttons had no effect. Entries are now stored in `domain::param::value` format so the whitelist/blacklist rule fires on subsequent visits (#229)
+
+### Internal
+- 261 passing tests, 0 failures (4 new tests covering the #229 bug and its regression guard)
+
 ## [1.5.1] — 2026-03-22
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Make URLs Great Again — clean URLs, no tracking, no unwanted referrals.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA — Make URLs Great Again",
   "short_name": "MUGA",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Strips 130+ tracking params from every URL. Optionally adds our affiliate tag when a link has none — disclosed during onboarding, opt-out in Settings anytime.",
 
   "permissions": [


### PR DESCRIPTION
## Summary

- Bumps version to 1.5.2 in `package.json`, `src/manifest.json`, `src/manifest.v2.json`
- Adds CHANGELOG entry for [1.5.2] documenting the #229 bug fix
- Updates README version badge to 1.5.2 and test count to 261

## Changes in this release

- **fix #229**: Toast Allow/Block buttons now store whitelist/blacklist entries in `domain::param::value` format — buttons were previously broken (no effect)
- 4 new unit tests covering the fix and a regression guard

## Test plan

- [x] `npm test` passes — 261 tests, 0 failures