### PR TITLE
growth: update store listing, ProductHunt draft, README for v1.5.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestion
 
 - **Nombre:** MUGA — Make URLs Great Again
 - **Repo:** https://github.com/yocreoquesi/muga (public, GPL v3)
-- **Versión actual:** 1.4.0
+- **Versión actual:** 1.5.2
 - **Contexto completo (privado):** lee `Muga.md` — nunca lo comitees
 
 ---
@@ -25,10 +25,10 @@ Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestion
 
 ---
 
-## Estado actual — v1.4.0
+## Estado actual — v1.5.2
 
 ### Phase 1 ✅ — Feature-complete
-- [x] Strip 65+ tracking params (Scenario A — siempre activo)
+- [x] Strip 130+ tracking params (Scenario A — siempre activo)
 - [x] Affiliate injection cuando no hay tag (Scenario B)
 - [x] Detección + toast de afiliado ajeno (Scenario C)
 - [x] Blacklist/whitelist enforcement (Scenario D)
@@ -158,7 +158,7 @@ muga/
 | Escenario | Qué hace | Activación |
 |---|---|---|
 | A | Strip tracking params (utm_*, fbclid, gclid, etc.) | Siempre, automático |
-| B | Inject ourTag cuando no hay afiliado | ON por defecto, opt-out |
+| B | Inject ourTag cuando no hay afiliado | OFF por defecto, opt-in (requiere consentimiento ToS) |
 | C | Toast cuando detecta afiliado ajeno | OFF por defecto, opt-in |
 | D | Strip todo si el dominio está en blacklist | Configurable por dominio |
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![MUGA — Make URLs Great Again](docs/assets/promo-marquee-1400x560.png)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.5.1-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-250_pass-brightgreen)](#development)
+[![Version](https://img.shields.io/badge/version-1.5.2-blue)](#)
+[![Tests](https://img.shields.io/badge/tests-261_pass-brightgreen)](#development)
 [![Health Check](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml/badge.svg)](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml)
 [![Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-coming_soon-lightgrey)](#installation)
 [![Firefox Add-ons](https://img.shields.io/badge/Firefox_Add--ons-coming_soon-lightgrey)](#installation)
@@ -38,6 +38,7 @@ Domain-specific rules for **54 sites** preserve functional query params (search 
 
 ## Before / after
 
+<!-- screenshot-needs-retake: ss1-before-after — captured on v1.2.x UI, retake once extension is loaded from dist/ -->
 ![Before and after URL cleaning](docs/assets/screenshot-ss1-before-after.png)
 
 <details>
@@ -103,12 +104,14 @@ After:  https://www.ebay.es/itm/123456789
 
 ## The popup
 
+<!-- screenshot-needs-retake: ss2-popup — captured on v1.2.x UI, retake once extension is loaded from dist/ -->
 ![Popup open on Amazon](docs/assets/screenshot-ss2-popup.png)
 
 ---
 
 ## Settings
 
+<!-- screenshot-needs-retake: ss3-options — captured on v1.2.x UI, retake once extension is loaded from dist/ -->
 ![Options page](docs/assets/screenshot-ss3-options.png)
 
 ---
@@ -166,7 +169,7 @@ Load unpacked from `chrome://extensions` (Developer mode) or `about:debugging` i
 ## Development
 
 ```bash
-npm test               # 250 unit tests
+npm test               # 261 unit tests
 npm run build:chrome
 npm run build:firefox
 ```

--- a/docs/producthunt-launch.md
+++ b/docs/producthunt-launch.md
@@ -1,0 +1,100 @@
+# MUGA — ProductHunt Launch
+
+> Version: 1.5.2
+> Created: 2026-03-22
+
+---
+
+## Taglines
+
+**Primary:**
+Drain the tracking swamp
+
+**Alternative 1:**
+Your links arrive dirty. MUGA cleans them.
+
+**Alternative 2:**
+130+ trackers stripped. Automatically. Before the page loads.
+
+---
+
+## 240-char description (ProductHunt)
+
+Every URL you click is packed with trackers — UTMs, fbclid, gclid, Amazon noise, YouTube tokens. MUGA strips 130+ of them before the page loads. AMP redirect, ping blocking, redirect unwrapping. Affiliate injection is opt-in and never replaces another creator's tag.
+
+*(264 chars — trim to fit if needed:)*
+
+Every URL you click is packed with trackers. MUGA strips 130+ automatically — UTMs, fbclid, gclid, AMP links, ping beacons. Affiliate injection is opt-in, transparent, and never replaces another creator's tag. Open source.
+
+*(222 chars — use this one)*
+
+---
+
+## Maker comment (launch day)
+
+---
+
+Hey PH — I'm Isabela, one of the people behind MUGA.
+
+The short version: we built this after the Honey scandal broke. For those who missed it — Honey, a browser extension with millions of users, was quietly replacing affiliate tags from creators without disclosure. Creators lost commissions they'd earned. Users had no idea it was happening.
+
+We wanted to build the opposite of that.
+
+MUGA strips 130+ tracking parameters from every URL you visit — automatically, before the page loads. UTMs, fbclid, gclid, Amazon session noise, YouTube share tokens — gone. You get the clean URL, the page loads normally, and nothing gets logged about where you came from.
+
+The affiliate model works like this: when you navigate to one of 18 supported stores and your link has no affiliate tag, we quietly add ours. You pay the exact same price. The store just knows you arrived via MUGA. That's how the project stays free and maintained.
+
+What we will never do: replace someone else's tag. Not silently, not ever. Enabling that behavior requires a separate, deliberate opt-in that is off by default — and even then, you're shown a toast notification asking you to confirm. The whole thing is disclosed during onboarding, in the Terms of Service, in the privacy policy, and in the source code. GPL v3. Read it.
+
+A few things that might surprise you:
+
+- AMP redirect is built in — Google AMP links go to the real article, automatically
+- Right-click any link to copy the clean version without visiting it
+- Alt+Shift+C copies the current tab's clean URL to clipboard
+- Export / import your full settings as JSON
+- Everything runs inside your browser — no server, no account, no telemetry
+
+Happy to answer anything in the comments. If you find a tracking param we're missing, open an issue — we usually ship fixes within 24 hours.
+
+---
+
+## Launch checklist
+
+### T-7 days
+- [ ] Confirm extension is published on Chrome Web Store and Firefox AMO
+- [ ] Final review of store listing copy (docs/store-listing.md)
+- [ ] Screenshots current and sharp (see README for which need retake)
+- [ ] Promo tile 1400x560 uploaded to PH gallery
+- [ ] ProductHunt profile is set up and linked to GitHub
+
+### T-3 days
+- [ ] Schedule launch for 00:01 PST (ProductHunt resets at midnight)
+- [ ] Prepare DM list: supporters, friends, people who follow privacy tools
+- [ ] Draft the "we're live" tweet / post for X, Mastodon, LinkedIn, Reddit (r/privacy, r/chrome, r/firefox)
+- [ ] Notify any influencers or YouTubers who tested the extension early
+
+### Launch day (T-0)
+- [ ] Post goes live at 00:01 PST
+- [ ] Post maker comment immediately (copy from above, personalize if needed)
+- [ ] Share on all channels (X, Mastodon, LinkedIn, Reddit, HN if relevant)
+- [ ] Monitor comments — respond to every question within 1 hour
+- [ ] DM supporters asking for upvotes and honest feedback
+- [ ] Check that Chrome Web Store and Firefox AMO links in the listing are working
+
+### Post-launch
+- [ ] Thank everyone who commented
+- [ ] File GitHub issues for every bug or feature request mentioned
+- [ ] Write a short retrospective (what worked, what didn't)
+- [ ] Update CHANGELOG.md with launch date
+
+---
+
+## Suggested hunters
+
+1. **Chris Messina** (@chrismessina) — invented the hashtag, prolific hunter of productivity and developer tools. Hunted many privacy-adjacent products. High reach, credible.
+
+2. **Benedikt Deicke** (@benediktdeicke) — co-founder of Userlist, active in indie hacker / privacy tooling space. Hunted several open-source developer utilities.
+
+3. **Fabian Maume** (@fabian_maume) — growth consultant who hunts frequently and has a track record with privacy, productivity, and browser extension launches. High volume hunter, responsive to outreach.
+
+> Reach out via Twitter DM or LinkedIn at least 5 days before planned launch. Include: what the product does (2 sentences), why it fits their hunting history, and a direct install link for them to try it.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,0 +1,157 @@
+# MUGA — Store Listings
+
+> Version: 1.5.2
+> Last updated: 2026-03-22
+> Status: Updated for v1.5.2 — new feature counts, opt-in affiliate model, Firefox AMO section added
+
+---
+
+## Chrome Web Store
+
+### Short description (132 chars max)
+
+Strips 130+ tracking params automatically. Affiliate injection is opt-in, transparent, and never replaces another creator's tag.
+
+*(131 chars)*
+
+---
+
+### Detailed description
+
+URLs have become a swamp.
+
+Every link you click arrives pre-loaded with tracking tags — utm_source, fbclid, gclid, referral codes — put there to follow you across the web. You never asked for them. They're invisible. And every one of them tells advertisers exactly where you came from.
+
+MUGA drains the swamp.
+
+──────────────────────────────────────
+CLEAN LINKS. AUTOMATICALLY. ALWAYS.
+──────────────────────────────────────
+
+MUGA strips the tracking garbage from every URL you visit, before the page even loads. No button to press. No setup. No permission popups. It just works.
+
+Before:
+https://www.amazon.es/dp/B09B8YWXDF?tag=youtuber-21&linkCode=ll1&linkId=abc123&pd_rd_r=xyz&pf_rd_p=def&utm_source=youtube&utm_medium=video&utm_campaign=review2026
+
+After:
+https://www.amazon.es/dp/B09B8YWXDF?tag=youtuber-21
+
+Before:
+https://www.youtube.com/watch?v=dQw4w9WgXcQ&si=abc123trackingtoken456789
+
+After:
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+Before:
+https://example.com/product?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale&gclid=EAIaIQ...
+
+After:
+https://example.com/product
+
+──────────────────────────────────────
+WHAT GETS STRIPPED
+──────────────────────────────────────
+
+MUGA recognizes over 130 tracking parameters — UTMs, fbclid, gclid, Amazon session noise, YouTube share tokens, TikTok click IDs, Pinterest tags, email marketing beacons, and more. Applied across 54 domain-specific rulesets so functional params (search queries, pagination, filters) are always preserved.
+
+What you get: shorter URLs, no tracking attached, and a browser that stops broadcasting your origin story to every site you visit.
+
+──────────────────────────────────────
+MORE THAN JUST PARAM STRIPPING
+──────────────────────────────────────
+
+• AMP redirect — Google AMP pages are silently redirected to the canonical article URL
+• Block <a ping> beacons — background tracking requests on click are suppressed
+• Redirect unwrapping — Reddit, Steam, and generic ?redirect=/?url= intermediaries are unwrapped automatically
+• Right-click any link → Copy clean link (no need to visit the page)
+• Alt+Shift+C — copy the clean URL of the current tab to clipboard
+• Export / Import settings as JSON — move your config across devices or back it up
+
+──────────────────────────────────────
+THE AFFILIATE MODEL — OPT-IN, HONEST, AUDITABLE
+──────────────────────────────────────
+
+Affiliate injection is off by default. You choose during first setup whether to enable it — and it requires explicit consent in the Terms of Service before it activates.
+
+When enabled: if you navigate to one of 18 supported stores and your link has no affiliate tag, MUGA quietly adds ours. You pay the exact same price — the store just knows you arrived via MUGA. That's how this extension stays free.
+
+• Off by default — opt-in during onboarding, requires ToS consent
+• Only fires when there is no existing affiliate tag — we never touch someone else's
+• Turn it off any time in Settings, globally or per domain
+• Disclosed during setup, in the privacy policy, and in the source code
+
+This is what Honey should have done. We will never replace anyone's tag — that requires a separate, deliberate opt-in that is disabled by default.
+
+──────────────────────────────────────
+YOUR RULES
+──────────────────────────────────────
+
+Blacklist a domain — strip everything on that site, no affiliate injection, minimal URL.
+
+Whitelist a tag — protect a specific creator's affiliate link so MUGA never touches it.
+
+Affiliate notifications — enable a toast when a third-party affiliate is detected. Default action is always "keep original". Replacing it with ours requires a separate, deliberate opt-in.
+
+Custom tracking params — add your own parameter names to strip on any site.
+
+Export / Import settings — back up or transfer your full config as JSON.
+
+Language — switch between English and Español any time in settings.
+
+Settings sync across all your Chrome devices automatically.
+
+──────────────────────────────────────
+PRIVATE. REALLY.
+──────────────────────────────────────
+
+Every URL is processed inside your browser. Nothing is ever sent to any server. No analytics. No telemetry. No account. No sign-in. The only network request MUGA makes is the one you chose: loading the page you wanted to visit.
+
+──────────────────────────────────────
+SUPPORTED STORES (affiliate features, opt-in)
+──────────────────────────────────────
+
+18 stores: Amazon (ES, DE, FR, IT, UK, US), Booking.com, AliExpress, PcComponentes, El Corte Inglés, eBay, Zalando (ES, DE), SHEIN, Fnac (ES, FR), MediaMarkt (ES, DE).
+
+Tracking removal works on every site on the web — no exceptions. If you ever find one, open an issue on GitHub. We fix them.
+
+──────────────────────────────────────
+OPEN SOURCE. GPL v3.
+──────────────────────────────────────
+
+The entire codebase is public on GitHub. Read it. Audit it. Fork it. If anything looks wrong, open an issue. Transparency is the point — it always was.
+
+https://github.com/yocreoquesi/muga
+
+---
+
+### Keywords (Chrome Web Store — max 5)
+
+privacy, URL cleaner, tracking protection, affiliate, UTM
+
+---
+
+## Firefox Add-ons (AMO)
+
+### Summary (250 chars max)
+
+Strips 130+ tracking parameters from every URL, automatically. AMP redirect, ping blocking, redirect unwrapping. Affiliate injection is opt-in and transparent — we never replace another creator's tag. Open source, GPL v3.
+
+*(221 chars)*
+
+---
+
+### Description
+
+Same as Chrome detailed description above — AMO accepts the same copy. Paste verbatim.
+
+AMO-specific notes:
+- License: GPL v3
+- Listed under: Privacy & Security
+- Tags: privacy, tracking, url-cleaner, affiliate
+
+---
+
+### AMO Categories
+
+- Primary: Privacy & Security
+- Secondary: Shopping


### PR DESCRIPTION
## Summary

- Updates `docs/store-listing.md` from v1.2.0 to v1.5.2: new counts (130+ params, 18 stores, 54 domain rules), affiliate injection reframed as opt-in with ToS consent, new features documented (AMP redirect, ping blocking, redirect unwrapping, Alt+Shift+C, export/import), Firefox AMO section added
- Creates `docs/producthunt-launch.md`: taglines, 240-char description, maker comment draft, launch checklist, suggested hunters
- Updates `README.md`: version badge 1.5.1 → 1.5.2, tests badge 250 → 261, dev section test count updated, three `<!-- screenshot-needs-retake -->` comments added to mark stale screenshots
- Updates `CLAUDE.md`: version 1.4.0 → 1.5.2, tracking params 65+ → 130+, Scenario B corrected to opt-in

Closes #100
Closes #101