### PR TITLE
growth: sharpen copy and promo tile for launch (#240)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@
 [![Version](https://img.shields.io/badge/version-1.5.3-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-261_pass-brightgreen)](#development)
 [![Health Check](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml/badge.svg)](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml)
-[![Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-coming_soon-lightgrey)](#installation)
-[![Firefox Add-ons](https://img.shields.io/badge/Firefox_Add--ons-coming_soon-lightgrey)](#installation)
-
 # Every link. Cleaned. Before it loads.
 
-URLs arrive pre-loaded with `utm_source`, `fbclid`, `gclid`, Amazon noise, YouTube share tokens, and 130+ more. MUGA strips them — automatically, before the page renders. **Zero clicks. Zero configuration.**
+URLs arrive pre-loaded with `utm_source`, `fbclid`, `gclid`, Amazon noise, YouTube share tokens, and 130+ more. MUGA strips them — automatically, before the page renders. **Zero clicks. Zero configuration. Never replaces a creator's affiliate tag.**
 
 [Install from source](#installation) · [View source](https://github.com/yocreoquesi/muga) · [Privacy policy](https://yocreoquesi.github.io/muga/)
 

--- a/docs/producthunt-launch.md
+++ b/docs/producthunt-launch.md
@@ -8,13 +8,13 @@
 ## Taglines
 
 **Primary:**
-Drain the tracking swamp
+130+ trackers stripped. Automatically. Before the page loads.
 
 **Alternative 1:**
 Your links arrive dirty. MUGA cleans them.
 
 **Alternative 2:**
-130+ trackers stripped. Automatically. Before the page loads.
+Clean URLs. Before the page loads. Never replaces a creator's tag.
 
 ---
 

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -10,19 +10,17 @@
 
 ### Short description (132 chars max)
 
-Strips 130+ tracking params automatically. Affiliate injection is opt-in, transparent, and never replaces another creator's tag.
+130+ trackers stripped from every URL — automatically, before the page loads. No clicks. No setup. Never replaces a creator's tag.
 
-*(131 chars)*
+*(130 chars)*
 
 ---
 
 ### Detailed description
 
-URLs have become a swamp.
+Every URL you click is pre-loaded with trackers. MUGA strips 130+ of them — automatically, before the page loads. No clicks. No setup.
 
-Every link you click arrives pre-loaded with tracking tags — utm_source, fbclid, gclid, referral codes — put there to follow you across the web. You never asked for them. They're invisible. And every one of them tells advertisers exactly where you came from.
-
-MUGA drains the swamp.
+And unlike Honey, MUGA never replaces a creator's affiliate tag. Ever.
 
 ──────────────────────────────────────
 CLEAN LINKS. AUTOMATICALLY. ALWAYS.
@@ -134,9 +132,9 @@ privacy, URL cleaner, tracking protection, affiliate, UTM
 
 ### Summary (250 chars max)
 
-Strips 130+ tracking parameters from every URL, automatically. AMP redirect, ping blocking, redirect unwrapping. Affiliate injection is opt-in and transparent — we never replace another creator's tag. Open source, GPL v3.
+130+ trackers stripped from every URL — automatically, before the page loads. AMP redirect, ping blocking, redirect unwrapping. Unlike Honey, never replaces a creator's affiliate tag. Open source, GPL v3.
 
-*(221 chars)*
+*(205 chars)*
 
 ---
 

--- a/tools/screenshots/capture-promo.mjs
+++ b/tools/screenshots/capture-promo.mjs
@@ -1,0 +1,49 @@
+/**
+ * MUGA — Promo tile generator
+ *
+ * Renders tools/screenshots/promo-tile.html at exactly 1400×560 using Playwright
+ * and saves the result to docs/assets/promo-marquee-1400x560.png.
+ *
+ * No extension build needed — this is pure HTML/CSS, no live extension required.
+ *
+ * Usage:
+ *   npm run promo-tile
+ *   node tools/screenshots/capture-promo.mjs
+ */
+
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const htmlPath   = path.resolve(__dirname, 'promo-tile.html');
+const outputPath = path.resolve(__dirname, '../../docs/assets/promo-marquee-1400x560.png');
+
+const W = 1400;
+const H = 560;
+
+if (!fs.existsSync(htmlPath)) {
+  console.error('❌  promo-tile.html not found at', htmlPath);
+  process.exit(1);
+}
+
+console.log('🎨  Launching Chromium...');
+
+const browser = await chromium.launch({ headless: true });
+const page    = await browser.newPage();
+
+await page.setViewportSize({ width: W, height: H });
+await page.goto(`file://${htmlPath}`, { waitUntil: 'networkidle' });
+
+// Give web fonts a moment to load (falls back to system fonts if offline)
+await page.waitForTimeout(800);
+
+await page.screenshot({
+  path: outputPath,
+  clip: { x: 0, y: 0, width: W, height: H },
+});
+
+await browser.close();
+
+console.log(`✅  Promo tile saved → docs/assets/promo-marquee-1400x560.png  (${W}×${H})`);

--- a/tools/screenshots/capture-promo.py
+++ b/tools/screenshots/capture-promo.py
@@ -1,0 +1,272 @@
+"""
+MUGA — Promo tile generator (Pillow)
+
+Generates docs/assets/promo-marquee-1400x560.png
+No browser required — pure Python + Pillow.
+
+Usage:
+    python3 tools/screenshots/capture-promo.py
+    npm run promo-tile
+"""
+
+from PIL import Image, ImageDraw, ImageFont, ImageFilter
+import numpy as np
+import os, sys
+from pathlib import Path
+
+ROOT       = Path(__file__).resolve().parents[2]
+OUTPUT     = ROOT / "docs" / "assets" / "promo-marquee-1400x560.png"
+FONT_SANS  = "/usr/share/fonts/truetype/ubuntu/UbuntuSans[wdth,wght].ttf"
+FONT_MONO  = "/usr/share/fonts/truetype/ubuntu/UbuntuSansMono[wght].ttf"
+
+W, H = 1400, 560
+
+# ── Palette ─────────────────────────────────────────────────────────────────
+BG          = (10,  14,  26)
+BLUE        = (37,  99, 235)
+BLUE_LIGHT  = (96, 165, 250)
+BLUE_MID    = (59, 130, 246)
+WHITE       = (255, 255, 255)
+GREY_DIM    = (75,  85,  99)
+GREY_DARK   = (31,  41,  55)
+RED_MUTED   = (239, 68,  68)
+GREEN_CLEAN = (52, 211, 153)
+DIVIDER     = (37,  55, 100)
+
+def hex_alpha(rgb, a):
+    return rgb + (a,)
+
+def font(path, size):
+    try:
+        return ImageFont.truetype(path, size)
+    except Exception:
+        return ImageFont.load_default()
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def draw_rrect(draw, xy, radius, fill=None, outline=None, width=1):
+    """Rounded rectangle."""
+    x0, y0, x1, y1 = xy
+    r = radius
+    if fill:
+        draw.rounded_rectangle(xy, radius=r, fill=fill)
+    if outline:
+        draw.rounded_rectangle(xy, radius=r, outline=outline, width=width)
+
+
+def glow_layer(size, cx, cy, radius, color, alpha_max=60):
+    """Radial gradient glow as RGBA layer."""
+    w, h = size
+    layer = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    arr   = np.zeros((h, w, 4), dtype=np.uint8)
+    Y, X  = np.ogrid[:h, :w]
+    dist  = np.sqrt((X - cx)**2 + (Y - cy)**2)
+    a     = np.clip(1 - dist / radius, 0, 1) ** 1.5
+    arr[:, :, 0] = color[0]
+    arr[:, :, 1] = color[1]
+    arr[:, :, 2] = color[2]
+    arr[:, :, 3] = (a * alpha_max).astype(np.uint8)
+    return Image.fromarray(arr, "RGBA")
+
+
+def grid_layer(w, h, step=48, color=(37, 99, 235), alpha=14):
+    """Subtle dot-grid."""
+    layer = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    d     = ImageDraw.Draw(layer)
+    col   = color + (alpha,)
+    for x in range(0, w, step):
+        d.line([(x, 0), (x, h)], fill=col, width=1)
+    for y in range(0, h, step):
+        d.line([(0, y), (w, y)], fill=col, width=1)
+    return layer
+
+
+def draw_pill(draw, img_rgba, x, y, text, fnt):
+    """Draw a small pill badge."""
+    bbox   = draw.textbbox((0, 0), text, font=fnt)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    pad_x, pad_y = 12, 6
+    pw = tw + pad_x * 2
+    ph = th + pad_y * 2
+
+    pill = Image.new("RGBA", (pw, ph), (0, 0, 0, 0))
+    pd   = ImageDraw.Draw(pill)
+    fill_col = (37, 99, 235, 40)
+    out_col  = (37, 99, 235, 100)
+    pd.rounded_rectangle([0, 0, pw - 1, ph - 1], radius=ph // 2,
+                          fill=fill_col, outline=out_col, width=1)
+    pd.text((pad_x, pad_y), text, font=fnt, fill=BLUE_LIGHT + (220,))
+    img_rgba.paste(pill, (x, y), pill)
+    return pw + 8  # advance
+
+
+def draw_url_box(img_rgba, x, y, w, h, segments, border_color, bg_color, mono_fnt):
+    """Draw a URL box with colored segments."""
+    box = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    bd  = ImageDraw.Draw(box)
+    bd.rounded_rectangle([0, 0, w - 1, h - 1], radius=10,
+                          fill=bg_color, outline=border_color, width=1)
+    px = 18
+    for text, color in segments:
+        bd.text((px, 14), text, font=mono_fnt, fill=color)
+        bbox = bd.textbbox((px, 14), text, font=mono_fnt)
+        px  += bbox[2] - bbox[0]
+    img_rgba.paste(box, (x, y), box)
+
+
+# ── Build image ───────────────────────────────────────────────────────────────
+
+img  = Image.new("RGB", (W, H), BG)
+rgba = img.convert("RGBA")
+
+# Grid
+rgba = Image.alpha_composite(rgba, grid_layer(W, H))
+
+# Glow blobs
+rgba = Image.alpha_composite(rgba, glow_layer((W, H), -60,  -60,  520, BLUE,      50))
+rgba = Image.alpha_composite(rgba, glow_layer((W, H), 1350, 580,  400, BLUE_MID,  35))
+rgba = Image.alpha_composite(rgba, glow_layer((W, H), 420,  280,  300, BLUE,      20))
+
+draw = ImageDraw.Draw(rgba)
+
+# ── Fonts ─────────────────────────────────────────────────────────────────────
+f_logo    = font(FONT_SANS, 108)
+f_tagline = font(FONT_SANS, 19)
+f_pill    = font(FONT_SANS, 11)
+f_label   = font(FONT_SANS, 13)
+f_mono    = font(FONT_MONO, 17)
+f_arrow   = font(FONT_SANS, 14)
+f_stat_n  = font(FONT_SANS, 26)
+f_stat_l  = font(FONT_SANS, 12)
+f_footer  = font(FONT_SANS, 12)
+
+# ── Left: brand ───────────────────────────────────────────────────────────────
+LX = 72
+
+# MUGA logo — white with subtle blue tint
+draw.text((LX, 80), "MUGA", font=f_logo, fill=WHITE)
+
+# Tagline
+draw.text((LX, 200), "Make URLs Great Again", font=f_tagline, fill=BLUE_LIGHT)
+
+# Pills
+pill_y = 238
+pill_x = LX
+for label in ["130+ trackers stripped", "18 stores", "Zero data sent", "Open source"]:
+    adv = draw_pill(draw, rgba, pill_x, pill_y, label, f_pill)
+    pill_x += adv
+    if pill_x > LX + 310:
+        pill_x = LX
+        pill_y += 32
+
+# Refresh draw after compositing pills
+draw = ImageDraw.Draw(rgba)
+
+# ── Divider ───────────────────────────────────────────────────────────────────
+DX = 430
+for i in range(320):
+    t    = i / 319
+    # fade in and out
+    a    = int(120 * (1 - abs(t - 0.5) * 2) ** 0.5)
+    draw.point((DX, 120 + i), fill=BLUE + (a,))
+
+# ── Right: URL transformation ─────────────────────────────────────────────────
+RX = 468
+RW = W - RX - 60    # available width
+
+# "Before" label
+draw.text((RX, 94), "BEFORE", font=f_label, fill=GREY_DIM)
+
+# Dirty URL box — simplified for thumbnail legibility
+dirty_segments = [
+    ("amazon.es/dp/B08N5",  WHITE    + (200,)),
+    ("?",                   GREY_DIM + (180,)),
+    ("utm_source=google",   RED_MUTED + (230,)),
+    ("&gclid=EAIaIQ",       RED_MUTED + (210,)),
+    ("&fbclid=IwAR",        RED_MUTED + (200,)),
+]
+draw_url_box(rgba, RX, 114,
+             RW, 56,
+             dirty_segments,
+             border_color=(239, 68, 68, 60),
+             bg_color=(239, 68, 68, 18),
+             mono_fnt=f_mono)
+
+draw = ImageDraw.Draw(rgba)
+
+# Arrow row with badge
+AY = 192
+# left line
+draw.line([(RX, AY + 8), (RX + RW // 2 - 90, AY + 8)],
+          fill=BLUE + (80,), width=1)
+# badge
+badge_text = "  MUGA cleaned it  "
+bbox  = draw.textbbox((0, 0), badge_text, font=f_arrow)
+bw    = bbox[2] - bbox[0] + 4
+bh    = bbox[3] - bbox[1] + 12
+bx    = RX + RW // 2 - bw // 2
+by    = AY
+badge_layer = Image.new("RGBA", (bw, bh), (0, 0, 0, 0))
+bd = ImageDraw.Draw(badge_layer)
+bd.rounded_rectangle([0, 0, bw - 1, bh - 1], radius=bh // 2,
+                     fill=BLUE + (255,))
+bd.text((2, 6), badge_text, font=f_arrow, fill=WHITE + (255,))
+rgba.paste(badge_layer, (bx, by), badge_layer)
+draw = ImageDraw.Draw(rgba)
+# right line
+draw.line([(bx + bw + 4, AY + 8), (RX + RW, AY + 8)],
+          fill=BLUE + (80,), width=1)
+
+# "After" label
+draw.text((RX, 220), "AFTER", font=f_label, fill=GREY_DIM)
+
+# Clean URL box
+clean_segments = [
+    ("amazon.es/dp/B08N5", BLUE_LIGHT + (240,)),
+]
+draw_url_box(rgba, RX, 238,
+             RW, 56,
+             clean_segments,
+             border_color=(37, 99, 235, 80),
+             bg_color=(37, 99, 235, 25),
+             mono_fnt=f_mono)
+draw = ImageDraw.Draw(rgba)
+
+# ── Stats bar ─────────────────────────────────────────────────────────────────
+stats = [
+    ("130+", "tracking params"),
+    ("54",   "domain rules"),
+    ("100%", "local processing"),
+    ("0",    "data sent"),
+]
+SY    = 326
+sx    = RX
+sep_w = 1
+sep_h = 40
+for i, (num, label) in enumerate(stats):
+    # number
+    draw.text((sx, SY), num, font=f_stat_n, fill=WHITE)
+    nb = draw.textbbox((sx, SY), num, font=f_stat_n)
+    # label
+    draw.text((sx, SY + 34), label, font=f_stat_l, fill=GREY_DIM)
+    lb = draw.textbbox((sx, SY + 34), label, font=f_stat_l)
+    col_w = max(nb[2] - nb[0], lb[2] - lb[0])
+    sx += col_w + 28
+    # separator
+    if i < len(stats) - 1:
+        for dy in range(sep_h):
+            t = dy / (sep_h - 1)
+            a = int(80 * (1 - abs(t - 0.5) * 2))
+            draw.point((sx, SY + 4 + dy), fill=WHITE + (a,))
+        sx += sep_w + 28
+
+# ── Footer ────────────────────────────────────────────────────────────────────
+footer = "Every link. Cleaned. Before it loads."
+fb = draw.textbbox((0, 0), footer, font=f_footer)
+fw = fb[2] - fb[0]
+draw.text((W - fw - 72, H - 36), footer, font=f_footer, fill=GREY_DIM)
+
+# ── Save ──────────────────────────────────────────────────────────────────────
+final = rgba.convert("RGB")
+final.save(OUTPUT, "PNG", optimize=True)
+print(f"✅  Promo tile saved → {OUTPUT}  ({W}×{H})")

--- a/tools/screenshots/promo-tile.html
+++ b/tools/screenshots/promo-tile.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=1400">
+  <title>MUGA — Promo Tile</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      width: 1400px;
+      height: 560px;
+      overflow: hidden;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0a0e1a;
+      color: #fff;
+      position: relative;
+    }
+
+    /* ── Background grid ── */
+    .bg-grid {
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(37,99,235,0.06) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(37,99,235,0.06) 1px, transparent 1px);
+      background-size: 48px 48px;
+    }
+
+    /* ── Glow blobs ── */
+    .glow-left {
+      position: absolute;
+      width: 500px; height: 500px;
+      left: -100px; top: -100px;
+      background: radial-gradient(circle, rgba(37,99,235,0.18) 0%, transparent 70%);
+      pointer-events: none;
+    }
+    .glow-right {
+      position: absolute;
+      width: 400px; height: 400px;
+      right: 60px; bottom: -100px;
+      background: radial-gradient(circle, rgba(99,179,237,0.12) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    /* ── Main layout ── */
+    .layout {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      align-items: center;
+      height: 100%;
+      padding: 0 80px;
+      gap: 80px;
+    }
+
+    /* ── Left: brand ── */
+    .brand {
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .logo {
+      font-size: 88px;
+      font-weight: 900;
+      letter-spacing: -0.04em;
+      line-height: 1;
+      background: linear-gradient(135deg, #fff 0%, #93c5fd 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .tagline {
+      font-size: 17px;
+      font-weight: 500;
+      color: #93c5fd;
+      letter-spacing: 0.01em;
+    }
+
+    .pills {
+      display: flex;
+      gap: 8px;
+      margin-top: 12px;
+      flex-wrap: wrap;
+      max-width: 340px;
+    }
+
+    .pill {
+      font-size: 11px;
+      font-weight: 600;
+      padding: 4px 10px;
+      border-radius: 99px;
+      background: rgba(37,99,235,0.18);
+      border: 0.5px solid rgba(37,99,235,0.4);
+      color: #93c5fd;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    /* ── Divider ── */
+    .divider {
+      width: 1px;
+      height: 320px;
+      background: linear-gradient(to bottom, transparent, rgba(37,99,235,0.4) 30%, rgba(37,99,235,0.4) 70%, transparent);
+      flex-shrink: 0;
+    }
+
+    /* ── Right: URL transformation ── */
+    .transform {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .transform-label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #4b5563;
+    }
+
+    .url-block {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .url-box {
+      background: rgba(255,255,255,0.04);
+      border: 0.5px solid rgba(255,255,255,0.08);
+      border-radius: 10px;
+      padding: 14px 18px;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 12.5px;
+      line-height: 1.5;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .url-box.dirty {
+      border-color: rgba(239,68,68,0.25);
+      background: rgba(239,68,68,0.05);
+    }
+
+    .url-box.clean {
+      border-color: rgba(37,99,235,0.35);
+      background: rgba(37,99,235,0.08);
+    }
+
+    .url-base { color: #e5e7eb; }
+    .url-param { color: #f87171; }
+    .url-sep   { color: #6b7280; }
+    .url-clean-text { color: #60a5fa; }
+
+    /* ── Arrow ── */
+    .arrow-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 0 4px;
+    }
+
+    .arrow-line {
+      flex: 1;
+      height: 1px;
+      background: linear-gradient(to right, rgba(37,99,235,0.2), rgba(37,99,235,0.6));
+    }
+
+    .arrow-badge {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: #2563eb;
+      border-radius: 99px;
+      padding: 5px 14px 5px 10px;
+      font-size: 12px;
+      font-weight: 600;
+      color: #fff;
+      white-space: nowrap;
+    }
+
+    .arrow-badge svg {
+      width: 14px; height: 14px;
+      fill: none;
+      stroke: #fff;
+      stroke-width: 2.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .arrow-line-right {
+      flex: 1;
+      height: 1px;
+      background: linear-gradient(to right, rgba(37,99,235,0.6), rgba(37,99,235,0.1));
+    }
+
+    /* ── Stats bar ── */
+    .stats-bar {
+      display: flex;
+      gap: 32px;
+      align-items: center;
+      padding-top: 4px;
+    }
+
+    .stat {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .stat-num {
+      font-size: 22px;
+      font-weight: 800;
+      color: #fff;
+      letter-spacing: -0.02em;
+    }
+
+    .stat-label {
+      font-size: 11px;
+      color: #6b7280;
+      font-weight: 500;
+    }
+
+    .stat-sep {
+      width: 1px;
+      height: 32px;
+      background: rgba(255,255,255,0.08);
+    }
+
+    /* ── Bottom badge ── */
+    .bottom-badge {
+      position: absolute;
+      bottom: 28px;
+      right: 80px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      color: #374151;
+      font-weight: 500;
+    }
+
+    .bottom-badge svg {
+      width: 14px; height: 14px;
+      fill: none;
+      stroke: #374151;
+      stroke-width: 2;
+      stroke-linecap: round;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="bg-grid"></div>
+  <div class="glow-left"></div>
+  <div class="glow-right"></div>
+
+  <div class="layout">
+
+    <!-- Left: brand -->
+    <div class="brand">
+      <div class="logo">MUGA</div>
+      <div class="tagline">Make URLs Great Again</div>
+      <div class="pills">
+        <span class="pill">130+ trackers stripped</span>
+        <span class="pill">18 stores</span>
+        <span class="pill">Zero data sent</span>
+        <span class="pill">Open source</span>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- Right: URL transformation -->
+    <div class="transform">
+
+      <div class="url-block">
+        <div class="transform-label">Before</div>
+        <div class="url-box dirty">
+          <span class="url-base">amazon.es/dp/B08N5WRWNW</span><span class="url-sep">?</span><span class="url-param">utm_source=google</span><span class="url-sep">&amp;</span><span class="url-param">gclid=EAIaIQob</span><span class="url-sep">&amp;</span><span class="url-param">linkCode=ll1</span><span class="url-sep">&amp;</span><span class="url-param">pd_rd_r=xyz</span><span class="url-sep">&amp;</span><span class="url-param">pf_rd_p=def</span><span class="url-sep">&amp;</span><span class="url-param">ref_=nav_cs</span>
+        </div>
+      </div>
+
+      <div class="arrow-row">
+        <div class="arrow-line"></div>
+        <div class="arrow-badge">
+          <svg viewBox="0 0 24 24"><path d="M12 2L12 22M12 2C12 2 7 8 4 12M12 2C12 2 17 8 20 12"/></svg>
+          MUGA cleaned it
+        </div>
+        <div class="arrow-line-right"></div>
+      </div>
+
+      <div class="url-block">
+        <div class="transform-label">After</div>
+        <div class="url-box clean">
+          <span class="url-clean-text">amazon.es/dp/B08N5WRWNW</span>
+        </div>
+      </div>
+
+      <div class="stats-bar">
+        <div class="stat">
+          <span class="stat-num">130+</span>
+          <span class="stat-label">tracking params</span>
+        </div>
+        <div class="stat-sep"></div>
+        <div class="stat">
+          <span class="stat-num">54</span>
+          <span class="stat-label">domain rules</span>
+        </div>
+        <div class="stat-sep"></div>
+        <div class="stat">
+          <span class="stat-num">100%</span>
+          <span class="stat-label">local processing</span>
+        </div>
+        <div class="stat-sep"></div>
+        <div class="stat">
+          <span class="stat-num">0</span>
+          <span class="stat-label">data sent</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="bottom-badge">
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
+    Every link. Cleaned. Before it loads.
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Implements all 5 recommendations from the marketing review, timed for pre-launch.

## Changes

- **Store listing short description** — new hook leads with transformation: "130+ trackers stripped from every URL — automatically, before the page loads. No clicks. No setup. Never replaces a creator's tag." (was: defensive affiliate disclaimer)
- **ProductHunt primary tagline** — "130+ trackers stripped. Automatically. Before the page loads." (was: "Drain the tracking swamp" — US political reference, alienates non-US audience)
- **README hero** — removed "coming soon" Chrome/Firefox badges from hero badge row; added "Never replaces a creator's affiliate tag" to opening sentence
- **Anti-Honey differentiator** — appears above the fold in: README opening paragraph, store listing hook, AMO summary, detailed description opening
- **Promo tile** — mono font 13px → 17px; dirty URL simplified from 11 segments to 3 high-contrast ones for legibility at thumbnail scale

## Test plan

- [ ] Verify `docs/store-listing.md` short description is ≤132 chars
- [ ] Verify `docs/store-listing.md` AMO summary is ≤250 chars
- [ ] Regenerate promo tile: `npm run promo-tile` — check readability at 280×112 (thumbnail preview)
- [ ] README renders correctly on GitHub (badge row, hero paragraph)