### PR TITLE
fix: options page crash — missing block-pings, amp-redirect, categories-card (#244)

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -170,6 +170,38 @@
   </section>
 
   <section>
+    <h2 data-i18n="section_privacy">Privacy</h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="row_pings_label">Block &lt;a ping&gt; tracking beacons</strong>
+          <small data-i18n="row_pings_hint">Removes ping attributes from links so the browser doesn't send tracking beacons on click</small>
+        </div>
+        <label class="toggle"><input type="checkbox" id="block-pings"><span class="slider"></span></label>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 data-i18n="section_redirects">Redirect handling</h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="row_amp_label">Redirect AMP pages to canonical URL</strong>
+          <small data-i18n="row_amp_hint">Replaces Google AMP links with the original article URL</small>
+        </div>
+        <label class="toggle"><input type="checkbox" id="amp-redirect"><span class="slider"></span></label>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 data-i18n="section_tracking_categories">Tracking categories</h2>
+    <div class="card" id="categories-card"></div>
+    <p class="hint" style="margin-top:8px" data-i18n="categories_hint"></p>
+  </section>
+
+  <section>
     <h2 data-i18n="section_custom_params">Custom tracking params — always stripped everywhere</h2>
     <div class="card">
       <div class="list-section">


### PR DESCRIPTION
## Problem

`options.js` wires up three elements that don't exist in `options.html`:
- `bindToggle('block-pings', ...)` — no `#block-pings` element
- `bindToggle('amp-redirect', ...)` — no `#amp-redirect` element
- `renderCategories()` — no `#categories-card` element

Causes: `TypeError: Cannot set properties of null (setting 'checked')` immediately on options page load. Page fails to initialise — all toggles broken.

## Fix

Added three missing sections to `options.html`:
- **Privacy** → `#block-pings` toggle (block `<a ping>` beacons)
- **Redirect handling** → `#amp-redirect` toggle (AMP → canonical redirect)
- **Tracking categories** → `#categories-card` container

All i18n keys were already present in `i18n.js`. No JS changes needed.

## Test plan

- [ ] Open options page — no console errors
- [ ] Block pings toggle appears and saves to storage
- [ ] AMP redirect toggle appears and saves to storage
- [ ] Tracking categories section renders all 6 categories