### PR TITLE
fix: history copy icon button aria-label describes purpose not state (#253)

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -151,7 +151,7 @@ async function showHistory(lang) {
 
     const copyCleanBtn = document.createElement("button");
     copyCleanBtn.className = "history-copy-clean-btn";
-    copyCleanBtn.setAttribute("aria-label", t("history_copied", lang));
+    copyCleanBtn.setAttribute("aria-label", t("history_copy_hint", lang));
     copyCleanBtn.innerHTML = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="5" y="5" width="9" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M11 5V3.5A1.5 1.5 0 0 0 9.5 2h-7A1.5 1.5 0 0 0 1 3.5v7A1.5 1.5 0 0 0 2.5 12H4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/></svg>`;
 
     afterRow.appendChild(afterDiv);


### PR DESCRIPTION
## Summary

- The SVG clipboard icon button in popup history entries had `aria-label` set to `t("history_copied")` → `"Copied!"`
- This is the post-action confirmation string, not a description of the button's purpose
- Screen readers would announce "Copied!" for a button that the user has not yet clicked
- Fix: use `t("history_copy_hint")` → `"Click to copy clean URL"` as the initial label

## Test plan

- [x] `npm test` passes (261/261)
- [ ] Manual: open popup → expand history → verify VoiceOver/NVDA reads "Click to copy clean URL" on the icon button

Closes #253