### PR TITLE
fix: post-merge audit round 2 + docs for launch (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/yocreoquesi/muga/compare/v1.5.4...v1.6.0
+[1.5.4]: https://github.com/yocreoquesi/muga/compare/v1.5.3...v1.5.4
+[1.5.3]: https://github.com/yocreoquesi/muga/compare/v1.5.2...v1.5.3
+[1.5.2]: https://github.com/yocreoquesi/muga/compare/v1.5.1...v1.5.2
+[1.5.1]: https://github.com/yocreoquesi/muga/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/yocreoquesi/muga/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/yocreoquesi/muga/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/yocreoquesi/muga/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/yocreoquesi/muga/compare/v1.1.0...v1.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestion
 
 - **Nombre:** MUGA — Make URLs Great Again
 - **Repo:** https://github.com/yocreoquesi/muga (public, GPL v3)
-- **Versión actual:** 1.5.2
+- **Versión actual:** 1.6.0
 - **Contexto completo (privado):** lee `Muga.md` — nunca lo comitees
 
 ---
@@ -25,7 +25,7 @@ Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestion
 
 ---
 
-## Estado actual — v1.5.2
+## Estado actual — v1.6.0
 
 ### Phase 1 ✅ — Feature-complete
 - [x] Strip 130+ tracking params (Scenario A — siempre activo)
@@ -39,6 +39,9 @@ Browser extension (Chrome + Firefox) que limpia URLs de tracking params, gestion
 - [x] Badge counter por tab
 - [x] Export/import settings JSON
 - [x] GitHub Actions release workflow
+- [x] Developer tools (preview toast, debug log, URL tester)
+- [x] Selection cleaning (copy clean links in selection via DOM)
+- [x] History improvements (full URL display, clipboard icon per entry)
 
 ### Pendiente (bloqueado por pasos manuales)
 - [ ] ourTag rellenado en affiliates.js (requiere cuentas de afiliado registradas)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.6.0-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-281_pass-brightgreen)](#development)
+[![Tests](https://img.shields.io/badge/tests-328_pass-brightgreen)](#development)
 [![Health Check](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml/badge.svg)](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml)
 # Every link. Cleaned. Before it loads.
 
@@ -166,7 +166,7 @@ Load unpacked from `chrome://extensions` (Developer mode) or `about:debugging` i
 ## Development
 
 ```bash
-npm test               # 261 unit tests
+npm test               # 328 unit tests
 npm run build:chrome
 npm run build:firefox
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,12 +74,12 @@
     <li><strong>tabs</strong> — to open the onboarding page on first install and send clipboard messages.</li>
     <li><strong>contextMenus</strong> — to add the "Copy clean link" right-click option.</li>
     <li><strong>clipboardWrite</strong> — to copy the clean URL to your clipboard.</li>
-    <li><strong>declarativeNetRequest</strong> — reserved for future static redirect rules.</li>
+    <li><strong>declarativeNetRequest</strong> — Used for pre-navigation stripping of tracking parameters before the page loads.</li>
     <li><strong>host_permissions: all_urls</strong> — to intercept link clicks on every page and add affiliate tags where applicable.</li>
   </ul>
 
   <h2>Open source</h2>
-  <p>MUGA is licensed under the <a href="https://github.com/yocreoquesi/muga/blob/main/LICENSE">MIT License</a>. The complete source code is public. If you want to verify that this privacy policy accurately describes the extension's behaviour, read the code — it's all there.</p>
+  <p>MUGA is licensed under the <a href="https://github.com/yocreoquesi/muga/blob/main/LICENSE">GNU General Public License v3 (GPL v3)</a>. The complete source code is public. If you want to verify that this privacy policy accurately describes the extension's behaviour, read the code — it's all there.</p>
 
   <h2>Contact</h2>
   <p>Questions or concerns: open an issue at <a href="https://github.com/yocreoquesi/muga/issues">github.com/yocreoquesi/muga/issues</a>.</p>

--- a/docs/producthunt-launch.md
+++ b/docs/producthunt-launch.md
@@ -1,6 +1,6 @@
 # MUGA — ProductHunt Launch
 
-> Version: 1.5.2
+> Version: 1.6.0
 > Created: 2026-03-22
 
 ---

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,8 +1,8 @@
 # MUGA — Store Listings
 
-> Version: 1.5.2
+> Version: 1.6.0
 > Last updated: 2026-03-22
-> Status: Updated for v1.5.2 — new feature counts, opt-in affiliate model, Firefox AMO section added
+> Status: Updated for v1.6.0 — new feature counts, opt-in affiliate model, Firefox AMO section added
 
 ---
 

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -64,26 +64,30 @@ function getPrefsWithCache() {
 const DYNAMIC_RULE_ID = 1000;
 
 async function syncCustomParamsDNR(customParams) {
-  if (!customParams || customParams.length === 0) {
+  try {
+    if (!customParams || customParams.length === 0) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: [DYNAMIC_RULE_ID],
+        addRules: [],
+      });
+      return;
+    }
+    const normalized = customParams.map(p => p.trim().toLowerCase());
     await chrome.declarativeNetRequest.updateDynamicRules({
       removeRuleIds: [DYNAMIC_RULE_ID],
-      addRules: [],
+      addRules: [{
+        id: DYNAMIC_RULE_ID,
+        priority: 1,
+        action: {
+          type: "redirect",
+          redirect: { transform: { queryTransform: { removeParams: normalized } } },
+        },
+        condition: { urlFilter: "*", resourceTypes: ["main_frame"] },
+      }],
     });
-    return;
+  } catch (err) {
+    console.error("[MUGA] syncCustomParamsDNR failed:", err);
   }
-  const normalized = customParams.map(p => p.trim().toLowerCase());
-  await chrome.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: [DYNAMIC_RULE_ID],
-    addRules: [{
-      id: DYNAMIC_RULE_ID,
-      priority: 1,
-      action: {
-        type: "redirect",
-        redirect: { transform: { queryTransform: { removeParams: normalized } } },
-      },
-      condition: { urlFilter: "*", resourceTypes: ["main_frame"] },
-    }],
-  });
 }
 
 async function applyDnrState(prefs) {
@@ -108,20 +112,26 @@ const URL_RE = /https?:\/\/[^\s"'<>()[\]{}]+/g;
 async function syncContextMenus(enabled) {
   await chrome.contextMenus.removeAll();
   if (!enabled) return;
+  const prefs = await getPrefsWithCache();
+  const lang = prefs.language || "en";
+  const titles = {
+    copy: lang === "es" ? "Copiar enlace limpio" : "Copy clean link",
+    selection: lang === "es" ? "Copiar enlaces limpios de la selección" : "Copy clean links in selection",
+  };
   chrome.contextMenus.create({
     id: "muga-copy-clean",
-    title: "Copy clean link",
+    title: titles.copy,
     contexts: ["link"],
   });
   chrome.contextMenus.create({
     id: "muga-copy-clean-selection",
-    title: "Copy clean links in selection",
+    title: titles.selection,
     contexts: ["selection"],
   });
 }
 
 // Set badge appearance once on startup
-actionApi.setBadgeBackgroundColor({ color: "#2563eb" });
+actionApi.setBadgeBackgroundColor?.({ color: "#2563eb" });
 
 // --- Badge helpers ---
 
@@ -131,14 +141,14 @@ async function updateTabBadge(tabId, junkRemoved) {
   const data = await sessionStorage.get({ [key]: 0 });
   const newCount = data[key] + junkRemoved;
   await sessionStorage.set({ [key]: newCount });
-  actionApi.setBadgeText({ text: String(newCount), tabId });
+  actionApi.setBadgeText?.({ text: String(newCount), tabId });
 }
 
 // Clear badge when a tab starts navigating to a new page
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === "loading") {
     sessionStorage.remove(`tab_${tabId}`);
-    actionApi.setBadgeText({ text: "", tabId });
+    actionApi.setBadgeText?.({ text: "", tabId });
   }
 });
 
@@ -170,8 +180,11 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
     const prefs = await getPrefsWithCache();
     await applyDnrState(prefs);
   }
-  if (changes.contextMenuEnabled) {
-    await syncContextMenus(changes.contextMenuEnabled.newValue !== false);
+  if (changes.contextMenuEnabled || changes.language) {
+    const enabled = changes.contextMenuEnabled
+      ? changes.contextMenuEnabled.newValue !== false
+      : (await getPrefsWithCache()).contextMenuEnabled !== false;
+    await syncContextMenus(enabled);
   }
 });
 
@@ -242,7 +255,7 @@ async function handleProcessUrl(rawUrl, { skipNotify = false } = {}) {
   const prefs = await getPrefsWithCache();
 
   if (!prefs.enabled) {
-    return { cleanUrl: rawUrl, action: "untouched" };
+    return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
   }
 
   // On copy: suppress the toast and affiliate injection — user didn't navigate,
@@ -268,14 +281,14 @@ async function handleProcessUrl(rawUrl, { skipNotify = false } = {}) {
   // Update stats and session history — only count if the URL actually changed (S13)
   const urlChanged = result.cleanUrl !== rawUrl;
   if (result.action !== "untouched" && (urlChanged || result.junkRemoved > 0)) {
-    await incrementStat("urlsCleaned");
+    incrementStat("urlsCleaned");
     await appendHistory(rawUrl, result.cleanUrl);
   }
   if (result.junkRemoved > 0) {
-    await incrementStat("junkRemoved", result.junkRemoved);
+    incrementStat("junkRemoved", result.junkRemoved);
   }
   if (result.action === "detected_foreign") {
-    await incrementStat("referralsSpotted");
+    incrementStat("referralsSpotted");
     // If the user has "replace foreign affiliate" enabled, build the URL with our tag
     if (prefs.allowReplaceAffiliate && result.detectedAffiliate?.pattern?.ourTag) {
       const url = new URL(result.cleanUrl);

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -11,10 +11,6 @@
 (function () {
   "use strict";
 
-  function escHtml(str) {
-    return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-  }
-
   // Prevent double execution in iframes
   if (window.self !== window.top) return;
   if (window.__mugaActive) return;
@@ -286,6 +282,8 @@
 
     const notice = document.createElement("div");
     notice.id = "muga-notice";
+    notice.setAttribute("role", "alert");
+    notice.setAttribute("aria-live", "assertive");
     notice.style.cssText = [
       "position:fixed", "bottom:20px", "right:20px",
       "background:#1c1c1e", "color:#f0f0f0", "border-radius:10px",
@@ -296,7 +294,7 @@
       "border:0.5px solid rgba(255,255,255,0.1)",
     ].join(";");
 
-    const domain = new URL(originalUrl).hostname.replace("www.", "");
+    const domain = new URL(originalUrl).hostname.replace(/^www\./, "");
 
     const btnStyle = "flex:1;padding:5px 8px;border-radius:6px;border:0.5px solid rgba(255,255,255,0.2);background:transparent;color:#f0f0f0;font-size:11px;cursor:pointer";
     const codeStyle = "background:rgba(255,255,255,0.1);padding:1px 4px;border-radius:3px";
@@ -338,8 +336,8 @@
       btnDiv.appendChild(oursBtn);
     }
 
-    const dismissDiv = document.createElement("div");
-    dismissDiv.style.cssText = "margin-top:6px;font-size:10px;color:#666;text-align:right;cursor:pointer";
+    const dismissDiv = document.createElement("button");
+    dismissDiv.style.cssText = "margin-top:6px;font-size:10px;color:#666;text-align:right;cursor:pointer;background:none;border:none;display:block;width:100%";
     dismissDiv.id = "muga-dismiss";
     dismissDiv.textContent = s.toast_dismiss;
 

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -90,7 +90,7 @@ export function processUrl(rawUrl, prefs, domainRules = []) {
   try {
     url = new URL(rawUrl);
   } catch {
-    return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], detectedAffiliate: null };
+    return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
   }
 
   const hostname = url.hostname;
@@ -121,7 +121,7 @@ export function processUrl(rawUrl, prefs, domainRules = []) {
     // C10 — count params removed so junkRemoved is reported correctly
     const blacklistedParamCount = [...url.searchParams.keys()].length;
     url.search = "";
-    return { cleanUrl: url.toString(), action: "blacklisted", removedTracking: [], junkRemoved: blacklistedParamCount, detectedAffiliate: null };
+    return { cleanUrl: url.toString(), action: "blacklisted", removedTracking: [], junkRemoved: blacklistedParamCount + (pathCleaned ? 1 : 0), detectedAffiliate: null };
   }
 
   const patterns = getPatternsForHost(hostname);
@@ -159,12 +159,12 @@ export function processUrl(rawUrl, prefs, domainRules = []) {
         removedTrackingForSkip.push(param);
       }
     }
-    const actionForSkip = removedTrackingForSkip.length > 0 ? "cleaned" : "untouched";
+    const actionForSkip = (removedTrackingForSkip.length > 0 || pathCleaned) ? "cleaned" : "untouched";
     return {
       cleanUrl: url.toString(),
       action: actionForSkip,
       removedTracking: removedTrackingForSkip,
-      junkRemoved: removedTrackingForSkip.length,
+      junkRemoved: removedTrackingForSkip.length + (pathCleaned ? 1 : 0),
       detectedAffiliate: null,
     };
   }

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -24,10 +24,6 @@ export const TRANSLATIONS = {
   stat_urls:       { en: "URLs cleaned",      es: "URLs limpias" },
   stat_junk:       { en: "junk removed",      es: "basura eliminada" },
   stat_referrals:  { en: "affiliates detected", es: "afiliados detectados" },
-  nudge_text:      { en: "You've quietly cleaned {n} URLs. Enjoying MUGA?", es: "Has limpiado {n} URLs sin esfuerzo. ¿Te gusta MUGA?" },
-  nudge_review:    { en: "⭐ Leave a review", es: "⭐ Deja una reseña" },
-  nudge_kofi:      { en: "☕ Ko-fi",          es: "☕ Ko-fi" },
-  nudge_dismiss:   { en: "✕",                 es: "✕" },
   preview_label:   { en: "This page",                     es: "Esta página" },
   history_label:        { en: "Recent",                               es: "Recientes" },
   history_empty:        { en: "No URLs cleaned in this session yet.", es: "Aún no se han limpiado URLs en esta sesión." },
@@ -39,6 +35,7 @@ export const TRANSLATIONS = {
   history_copy_hint:    { en: "Click to copy clean URL", es: "Clic para copiar URL limpia" },
   history_copied:       { en: "Copied!", es: "¡Copiado!" },
   history_copy_original: { en: "Copy original", es: "Copiar original" },
+  show_history:          { en: "Show history", es: "Mostrar historial" },
 
   // ── Options ──────────────────────────────────────────────────────────────
   opts_title:      { en: "Settings", es: "Ajustes" },
@@ -175,6 +172,10 @@ export function applyTranslations(lang) {
   document.querySelectorAll("[data-i18n-placeholder]").forEach(el => {
     const key = el.getAttribute("data-i18n-placeholder");
     el.placeholder = t(key, lang);
+  });
+  document.querySelectorAll("[data-i18n-title]").forEach(el => {
+    const key = el.getAttribute("data-i18n-title");
+    el.title = t(key, lang);
   });
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -60,7 +60,6 @@
     .hint { font-size: 11.5px; color: var(--text2); margin-top: 8px; line-height: 1.5; }
     .empty { font-size: 12px; color: var(--text2); font-style: italic; }
     /* Stores collapsible */
-    .stores-details { }
     .stores-summary {
       display: flex; align-items: center; justify-content: space-between;
       padding: 12px 16px; cursor: pointer; list-style: none;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -2,7 +2,7 @@
  * MUGA — Options page
  */
 
-import { applyTranslations, getStoredLang, t, SUPPORTED_LANGS } from "../lib/i18n.js";
+import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
 import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
 import { PREF_DEFAULTS } from "../lib/storage.js";
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -19,7 +19,7 @@
   </header>
 
   <section class="stats">
-    <div class="stat stat-clickable" id="stat-urls-wrap" role="button" tabindex="0" title="Show history" aria-expanded="false">
+    <div class="stat stat-clickable" id="stat-urls-wrap" role="button" tabindex="0" title="Show history" data-i18n-title="show_history" aria-expanded="false">
       <span class="stat-value" id="stat-urls">0</span>
       <span class="stat-label" data-i18n="stat_urls">URLs cleaned</span>
     </div>

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -74,12 +74,12 @@
     <li><strong>tabs</strong> — to open the onboarding page on first install and send clipboard messages.</li>
     <li><strong>contextMenus</strong> — to add the "Copy clean link" right-click option.</li>
     <li><strong>clipboardWrite</strong> — to copy the clean URL to your clipboard.</li>
-    <li><strong>declarativeNetRequest</strong> — reserved for future static redirect rules.</li>
+    <li><strong>declarativeNetRequest</strong> — Used for pre-navigation stripping of tracking parameters before the page loads.</li>
     <li><strong>host_permissions: all_urls</strong> — to intercept link clicks on every page and add affiliate tags where applicable.</li>
   </ul>
 
   <h2>Open source</h2>
-  <p>MUGA is licensed under the <a href="https://github.com/yocreoquesi/muga/blob/main/LICENSE">MIT License</a>. The complete source code is public. If you want to verify that this privacy policy accurately describes the extension's behaviour, read the code — it's all there.</p>
+  <p>MUGA is licensed under the <a href="https://github.com/yocreoquesi/muga/blob/main/LICENSE">GNU General Public License v3 (GPL v3)</a>. The complete source code is public. If you want to verify that this privacy policy accurately describes the extension's behaviour, read the code — it's all there.</p>
 
   <h2>Contact</h2>
   <p>Questions or concerns: open an issue at <a href="https://github.com/yocreoquesi/muga/issues">github.com/yocreoquesi/muga/issues</a>.</p>

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -1682,58 +1682,8 @@ describe("Regression — B1 setPrefs is exported from storage.js", () => {
 });
 
 // ---------------------------------------------------------------------------
-// N9 — escHtml (content/cleaner.js) — replicated because IIFE cannot be imported
-// ---------------------------------------------------------------------------
-
-/**
- * Replica of escHtml from src/content/cleaner.js.
- * Kept in sync via source-text verification test below.
- */
-function escHtml(str) {
-  return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
-
-describe("N9 — escHtml (content/cleaner.js)", () => {
-
-  test("escapes <script> tag", () => {
-    assert.equal(escHtml("<script>alert(1)</script>"), "&lt;script&gt;alert(1)&lt;/script&gt;");
-  });
-
-  test("escapes double quotes", () => {
-    assert.equal(escHtml('value="test"'), "value=&quot;test&quot;");
-  });
-
-  test("escapes ampersand", () => {
-    assert.equal(escHtml("a & b"), "a &amp; b");
-  });
-
-  test("escapes mixed HTML characters", () => {
-    assert.equal(escHtml('<img src="x" onerror="alert(1)">'),
-      '&lt;img src=&quot;x&quot; onerror=&quot;alert(1)&quot;&gt;');
-  });
-
-  test("handles empty string", () => {
-    assert.equal(escHtml(""), "");
-  });
-
-  test("handles non-string input (number)", () => {
-    assert.equal(escHtml(42), "42");
-  });
-
-  test("handles null/undefined via String() coercion", () => {
-    assert.equal(escHtml(null), "null");
-    assert.equal(escHtml(undefined), "undefined");
-  });
-
-  test("C11 sync — source contains identical escHtml implementation", () => {
-    assert.ok(
-      CONTENT_CLEANER_SOURCE.includes(
-        'return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");'
-      ),
-      "content/cleaner.js must contain the same escHtml implementation"
-    );
-  });
-});
+// N9 — escHtml was removed from content/cleaner.js (dead code — toast uses createElement+textContent)
+// The escHtml tests have been removed accordingly.
 
 // ---------------------------------------------------------------------------
 // N9 — formatStat (popup.js) — replicated because popup.js has browser deps


### PR DESCRIPTION
## Summary

Second round of audit fixes after PR #260 merge, plus documentation updates for store launch.

### Code fixes (10)
- **processUrl**: complete return shape on all paths (junkRemoved, detectedAffiliate)
- **syncCustomParamsDNR**: try/catch prevents DNR failure from blocking onInstalled/onboarding
- **pathCleaned**: now counted in junkRemoved for whitelisted/blacklisted domains
- **actionApi**: optional chaining prevents crash if neither badge API exists
- **Context menus**: titles now respect user language preference (EN/ES)
- **Toast a11y**: `role="alert"` + `aria-live="assertive"`, dismiss is now `<button>`
- **escHtml**: removed dead code after createElement rewrite
- **hostname regex**: anchored `www.` strip in toast
- **Cleanup**: removed unused import, empty CSS rule, 4 dead i18n keys

### Docs fixes (6)
- Privacy policy: MIT → GPL v3, DNR description updated
- CLAUDE.md: v1.5.2 → v1.6.0 with new Phase 1 features
- README: test badge updated to 328
- CHANGELOG: comparison links for v1.5.0–v1.6.0
- store-listing.md + producthunt-launch.md: version bump

## Test plan
- [x] `npm test` — 328 pass, 0 fail
- [ ] Manual: load in Chrome, verify service worker registers without errors
- [ ] Manual: verify context menus appear in correct language
- [ ] Manual: verify toast is announced by screen reader

Closes #261