### PR TITLE
feat: impact dashboard — param breakdown, domain stats, report button

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -6,7 +6,7 @@
 
 import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getAffiliateDomains } from "../lib/affiliates.js";
-import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage } from "../lib/storage.js";
+import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat } from "../lib/storage.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -207,10 +207,10 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 
 const HISTORY_MAX = 10;
 
-async function appendHistory(original, clean) {
+async function appendHistory(original, clean, removedTracking = []) {
   if (original === clean) return;
   const data = await sessionStorage.get({ history: [] });
-  const entry = { original, clean, ts: Date.now() };
+  const entry = { original, clean, ts: Date.now(), removedTracking };
   const history = [entry, ...data.history].slice(0, HISTORY_MAX);
   await sessionStorage.set({ history });
 }
@@ -379,8 +379,14 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
     if (!skipStats) {
       incrementStat("urlsCleaned");
       if (result.junkRemoved > 0) incrementStat("junkRemoved", result.junkRemoved);
+      if (prefs.domainStats && result.junkRemoved > 0) {
+        try {
+          const hostname = new URL(rawUrl).hostname.replace(/^www\./, "");
+          incrementDomainStat(hostname, result.junkRemoved);
+        } catch { /* invalid URL, skip domain stat */ }
+      }
     }
-    await appendHistory(rawUrl, result.cleanUrl);
+    await appendHistory(rawUrl, result.cleanUrl, result.removedTracking ?? []);
     if (parsedRaw) {
       const domain = parsedRaw.hostname.replace(/^www\./, "");
       const parsedClean = new URL(result.cleanUrl);

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -40,6 +40,21 @@ export const TRANSLATIONS = {
   share_btn:             { en: "Share", es: "Compartir" },
   confirm_cancel:        { en: "Cancel", es: "Cancelar" },
   confirm_ok:            { en: "OK", es: "OK" },
+  domain_stats_label:    { en: "Your top trackers", es: "Tus principales rastreadores" },
+  domain_stats_empty:    { en: "No domain stats yet. Keep browsing!", es: "Aún no hay estadísticas. ¡Sigue navegando!" },
+  domain_stats_params:   { en: "params stripped", es: "parámetros eliminados" },
+  domain_stats_urls:     { en: "URLs cleaned", es: "URLs limpiadas" },
+
+  // ── Popup: param breakdown (impact-dashboard) ─────────────────────────────
+  param_breakdown_label:      { en: "What was removed",                  es: "Qué se eliminó" },
+  param_category_analytics:   { en: "Analytics tracking",                es: "Rastreo analítico" },
+  param_category_social:      { en: "Social media tracking",             es: "Rastreo de redes sociales" },
+  param_category_advertising: { en: "Ad click tracking",                 es: "Rastreo de clics publicitarios" },
+  param_category_email:       { en: "Email campaign tracking",           es: "Rastreo de campañas de email" },
+  param_category_affiliate:   { en: "Affiliate network tracking",        es: "Rastreo de redes de afiliados" },
+  param_category_marketplace: { en: "Marketplace tracking",              es: "Rastreo de marketplace" },
+  param_category_ecommerce:   { en: "E-commerce tracking",               es: "Rastreo de e-commerce" },
+  param_category_other:       { en: "Other tracking",                    es: "Otro rastreo" },
 
   // ── Popup milestones ────────────────────────────────────────────────────
   milestone_10000: { en: "MUGA: Legendary URL cleaner", es: "MUGA: Limpiador legendario de URLs" },
@@ -170,6 +185,7 @@ export const TRANSLATIONS = {
   dev_url_action:             { en: "Action: %s",                                                        es: "Acción: %s" },
   dev_url_report_btn:         { en: "Report a problem with this URL",                                    es: "Reportar un problema con esta URL" },
   report_broken_label:        { en: "Report a bug or suggest an improvement",                            es: "Reportar un error o sugerir una mejora" },
+  report_dirty_url:           { en: "Report a problem with this URL",                                    es: "Reportar un problema con esta URL" },
   dev_report_broken_hint:     { en: "Opens a pre-filled GitHub issue with your browser and extension info", es: "Abre un issue de GitHub pre-rellenado con info de tu navegador y extensi\u00f3n" },
   dev_report_broken_btn:      { en: "Report",                                                            es: "Reportar" },
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -90,6 +90,9 @@ export const PREF_DEFAULTS = {
   //           breaking options.js which reads it via getPrefs(). (#259)
   toastDuration: 15,  // seconds: how long the affiliate notification stays visible
   devMode: false,
+  paramBreakdown: true,
+  showReportButton: true,
+  domainStats: true,
 };
 
 /**
@@ -237,7 +240,81 @@ if (typeof chrome !== "undefined" && chrome.runtime?.onSuspend) {
     if (Object.keys(_pendingStats).length > 0) {
       _flushStats();
     }
+    if (Object.keys(_pendingDomainStats).length > 0) {
+      _flushDomainStats();
+    }
   });
+}
+
+// ── Domain stats: per-domain tracking param counters ──────────────────────────
+
+export const DOMAIN_STATS_MAX = 50;
+
+let _pendingDomainStats = {};
+let _domainStatsFlushTimer = null;
+
+async function _flushDomainStats() {
+  _domainStatsFlushTimer = null;
+  if (Object.keys(_pendingDomainStats).length === 0) return;
+  const toFlush = _pendingDomainStats;
+  _pendingDomainStats = {};
+
+  try {
+    const local = await new Promise((resolve, reject) => {
+      chrome.storage.local.get({ domainStats: {} }, (result) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(result);
+      });
+    });
+    const stats = { ...(local.domainStats || {}) };
+    for (const [domain, delta] of Object.entries(toFlush)) {
+      if (!stats[domain]) stats[domain] = { params: 0, urls: 0 };
+      stats[domain].params += delta.params;
+      stats[domain].urls += delta.urls;
+    }
+    // Evict lowest-count domains if over cap
+    const entries = Object.entries(stats);
+    if (entries.length > DOMAIN_STATS_MAX) {
+      entries.sort((a, b) => a[1].params - b[1].params);
+      const keep = Object.fromEntries(entries.slice(entries.length - DOMAIN_STATS_MAX));
+      await setStats({ domainStats: keep });
+    } else {
+      await setStats({ domainStats: stats });
+    }
+  } catch {
+    // Restore pending so they aren't lost on write failure
+    for (const [domain, delta] of Object.entries(toFlush)) {
+      if (!_pendingDomainStats[domain]) _pendingDomainStats[domain] = { params: 0, urls: 0 };
+      _pendingDomainStats[domain].params += delta.params;
+      _pendingDomainStats[domain].urls += delta.urls;
+    }
+  }
+}
+
+/** Batches domain stat increments and flushes after 50ms. */
+export function incrementDomainStat(domain, paramsCount) {
+  if (!_pendingDomainStats[domain]) _pendingDomainStats[domain] = { params: 0, urls: 0 };
+  _pendingDomainStats[domain].params += paramsCount;
+  _pendingDomainStats[domain].urls += 1;
+  if (!_domainStatsFlushTimer) {
+    _domainStatsFlushTimer = setTimeout(_flushDomainStats, 50);
+  }
+}
+
+/** Reads per-domain stats from chrome.storage.local. */
+export async function getDomainStats() {
+  try {
+    const result = await new Promise((resolve, reject) => {
+      chrome.storage.local.get({ domainStats: {} }, (r) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(r);
+      });
+    });
+    return result.domainStats || {};
+  } catch (err) {
+    console.error("[MUGA] getDomainStats:", err);
+    return {};
+  }
 }
 
 // ── Session storage ponyfill: Firefox MV2 compat (#184) ──────────────────────

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -453,6 +453,7 @@ function initStatsSection() {
     await chrome.storage.local.set({
       stats: { urlsCleaned: 0, junkRemoved: 0, referralsSpotted: 0 },
       firstUsed: null,
+      domainStats: {},
       // nudgeDismissed and nudgeShownCount intentionally NOT reset:
       // resetting stats must not re-trigger the review nudge.
     });

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -212,6 +212,64 @@ header {
 .report-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 
+/* Domain stats panel */
+.domain-stats {
+  border-top: 0.5px solid var(--border);
+}
+
+.domain-stats > summary {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--text2);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.domain-stats > summary::-webkit-details-marker { display: none; }
+.domain-stats > summary::after { content: ' ›'; margin-left: auto; }
+
+#domain-stats-list {
+  padding: 0 0 4px;
+}
+
+.domain-stats-empty {
+  font-size: 12px;
+  color: var(--text2);
+  font-style: italic;
+  padding: 6px 16px 8px;
+}
+
+.domain-stats-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 6px;
+  align-items: center;
+  padding: 4px 16px;
+  border-top: 0.5px solid var(--border);
+  font-size: 11px;
+}
+
+.domain-stats-name {
+  color: var(--text);
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.domain-stats-params,
+.domain-stats-urls {
+  color: var(--text2);
+  white-space: nowrap;
+  font-size: 10px;
+}
+
+.domain-stats-params { color: var(--accent); }
+
 /* Session history */
 .history { border-top: 0.5px solid var(--border); }
 
@@ -380,4 +438,54 @@ footer a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; 
 .consent-gate-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* ── Param breakdown ─────────────────────────────────────────────────────── */
+.preview-breakdown {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text2);
+}
+.history-breakdown {
+  margin: 4px 0 2px;
+  font-size: 11px;
+  color: var(--text2);
+}
+.preview-breakdown > summary,
+.history-breakdown > summary {
+  cursor: pointer;
+  user-select: none;
+  color: var(--text2);
+  list-style: disclosure-closed;
+}
+.preview-breakdown[open] > summary,
+.history-breakdown[open] > summary {
+  list-style: disclosure-open;
+}
+.param-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+}
+.breakdown-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+.breakdown-cat {
+  font-weight: 600;
+  color: var(--text2);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.breakdown-cat::after {
+  content: ":";
+}
+.breakdown-params {
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", monospace;
+  font-size: 10px;
+  color: var(--text2);
+  word-break: break-all;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -33,6 +33,11 @@
     </div>
   </section>
 
+  <details class="domain-stats" id="domain-stats" hidden>
+    <summary data-i18n="domain_stats_label">Your top trackers</summary>
+    <div id="domain-stats-list"></div>
+  </details>
+
   <details class="history" id="history" hidden>
     <summary class="history-summary" data-i18n="history_label">This session</summary>
     <div id="history-list"></div>
@@ -47,7 +52,7 @@
     <div class="preview-url after" id="preview-after"></div>
     <div class="preview-removed" id="preview-removed" hidden aria-live="polite"></div>
     <div class="preview-url clean" id="preview-clean" hidden></div>
-    <a class="report-link" id="report-broken" href="#" hidden data-i18n="report_broken_label">Report a bug or suggest an improvement</a>
+    <a class="report-link" id="report-broken" href="#" hidden data-i18n="report_dirty_url">Report a problem with this URL</a>
   </section>
 
   <div class="growth-bar" id="growth-bar" hidden>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -5,7 +5,8 @@
 
 import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
 import { processUrl } from "../lib/cleaner.js";
-import { getPrefs, sessionStorage } from "../lib/storage.js";
+import { getPrefs, sessionStorage, getDomainStats } from "../lib/storage.js";
+import { TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
 
 /** Creates a clipboard SVG icon (12x12) via createElementNS. */
 function _createClipboardSvg() {
@@ -30,6 +31,63 @@ function _createClipboardSvg() {
 function _setClipboardIcon(el) {
   el.textContent = "";
   el.appendChild(_createClipboardSvg());
+}
+
+// ── Param breakdown ───────────────────────────────────────────────────────────
+
+/** Builds a reverse index: param name → { category key, label, labelEs }. Cached as singleton. */
+let _paramIndex = null;
+function _buildParamIndex() {
+  if (_paramIndex) return _paramIndex;
+  _paramIndex = new Map();
+  for (const [catKey, catData] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+    for (const param of catData.params) {
+      _paramIndex.set(param.toLowerCase(), {
+        categoryKey: catKey,
+        label: catData.label,
+        labelEs: catData.labelEs,
+      });
+    }
+  }
+  return _paramIndex;
+}
+
+/** Renders a param breakdown section showing removed params grouped by category. */
+function _renderParamBreakdown(removedTracking, lang) {
+  const index = _buildParamIndex();
+  // Group params by category
+  const groups = new Map();
+  for (const param of removedTracking) {
+    const info = index.get(param.toLowerCase());
+    const catKey = info ? info.categoryKey : "other";
+    const label = info
+      ? (lang === "es" ? info.labelEs : info.label)
+      : t("param_category_other", lang);
+    if (!groups.has(catKey)) groups.set(catKey, { label, params: [] });
+    groups.get(catKey).params.push(param);
+  }
+
+  const container = document.createElement("div");
+  container.className = "param-breakdown";
+
+  for (const [, group] of groups) {
+    const row = document.createElement("div");
+    row.className = "breakdown-row";
+
+    const catEl = document.createElement("span");
+    catEl.className = "breakdown-cat";
+    catEl.textContent = group.label;
+
+    const paramsEl = document.createElement("span");
+    paramsEl.className = "breakdown-params";
+    paramsEl.textContent = group.params.join(", ");
+
+    row.appendChild(catEl);
+    row.appendChild(paramsEl);
+    container.appendChild(row);
+  }
+
+  return container;
 }
 
 /** Initializes popup: loads prefs/stats, renders UI, binds event handlers. */
@@ -231,7 +289,8 @@ async function init() {
   });
 
   await showUrlPreview(prefs, lang);
-  await showHistory(lang);
+  await showHistory(prefs, lang);
+  await showDomainStats(prefs, lang);
 }
 
 /** Shows a live preview of URL cleaning for the current tab. */
@@ -289,8 +348,8 @@ async function showUrlPreview(prefs, lang) {
       removedEl.hidden = false;
     }
 
-    // Report broken site: only for advanced users when URL was modified
-    if (prefs.devMode) {
+    // Report broken site: visible to all users when URL was modified and feature flag is on
+    if (prefs.showReportButton) {
       const reportLink = document.getElementById("report-broken");
       reportLink.hidden = false;
       reportLink.addEventListener("click", (e) => {
@@ -322,6 +381,18 @@ async function showUrlPreview(prefs, lang) {
         } catch { /* invalid URL */ }
       });
     }
+
+    // Param breakdown: show removed params grouped by category when feature is on
+    if (prefs.paramBreakdown === true && result.removedTracking?.length > 0) {
+      const previewSection = document.getElementById("preview");
+      const details = document.createElement("details");
+      details.className = "preview-breakdown";
+      const summary = document.createElement("summary");
+      summary.textContent = t("param_breakdown_label", lang);
+      details.appendChild(summary);
+      details.appendChild(_renderParamBreakdown(result.removedTracking, lang));
+      previewSection.appendChild(details);
+    }
   }
 }
 
@@ -332,8 +403,55 @@ function formatStat(n) {
   return String(n);
 }
 
+/** Renders the per-domain tracker stats panel. */
+async function showDomainStats(prefs, lang) {
+  if (!prefs.domainStats) return;
+
+  const section = document.getElementById("domain-stats");
+  const list = document.getElementById("domain-stats-list");
+
+  const allStats = await getDomainStats();
+  const entries = Object.entries(allStats)
+    .sort((a, b) => b[1].params - a[1].params)
+    .slice(0, 10);
+
+  section.hidden = false;
+  const summary = section.querySelector("summary");
+  if (summary) summary.setAttribute("aria-label", t("domain_stats_label", lang));
+
+  if (entries.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "domain-stats-empty";
+    empty.textContent = t("domain_stats_empty", lang);
+    list.appendChild(empty);
+    return;
+  }
+
+  for (const [domain, data] of entries) {
+    const row = document.createElement("div");
+    row.className = "domain-stats-row";
+
+    const nameEl = document.createElement("span");
+    nameEl.className = "domain-stats-name";
+    nameEl.textContent = domain;
+
+    const paramsEl = document.createElement("span");
+    paramsEl.className = "domain-stats-params";
+    paramsEl.textContent = `${data.params} ${t("domain_stats_params", lang)}`;
+
+    const urlsEl = document.createElement("span");
+    urlsEl.className = "domain-stats-urls";
+    urlsEl.textContent = `${data.urls} ${t("domain_stats_urls", lang)}`;
+
+    row.appendChild(nameEl);
+    row.appendChild(paramsEl);
+    row.appendChild(urlsEl);
+    list.appendChild(row);
+  }
+}
+
 /** Renders the recent URL cleaning history list. */
-async function showHistory(lang) {
+async function showHistory(prefs, lang) {
   const data = await sessionStorage.get({ history: [] });
   const history = data.history;
 
@@ -385,6 +503,19 @@ async function showHistory(lang) {
     actionsDiv.appendChild(copyOrigBtn);
     entryDiv.appendChild(beforeDiv);
     entryDiv.appendChild(afterRow);
+
+    // Param breakdown: show removed params per history entry when feature is on
+    if (prefs.paramBreakdown === true && entry.removedTracking?.length > 0) {
+      const details = document.createElement("details");
+      details.className = "history-breakdown";
+      const summary = document.createElement("summary");
+      summary.setAttribute("aria-label", `${entry.removedTracking.length} ${t("param_breakdown_label", lang)}`);
+      summary.textContent = t("param_breakdown_label", lang);
+      details.appendChild(summary);
+      details.appendChild(_renderParamBreakdown(entry.removedTracking, lang));
+      entryDiv.appendChild(details);
+    }
+
     entryDiv.appendChild(actionsDiv);
     list.appendChild(entryDiv);
 

--- a/tests/unit/domain-stats.test.mjs
+++ b/tests/unit/domain-stats.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * MUGA: domain-stats unit tests
+ *
+ * Tests the domain stats system: constants, exports, eviction logic,
+ * feature flag default, and i18n key presence.
+ */
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Simulate the eviction logic extracted from _flushDomainStats. */
+function applyEviction(stats, max) {
+  const entries = Object.entries(stats);
+  if (entries.length <= max) return { ...stats };
+  entries.sort((a, b) => a[1].params - b[1].params);
+  return Object.fromEntries(entries.slice(entries.length - max));
+}
+
+// ── T3-1: DOMAIN_STATS_MAX constant equals 50 ────────────────────────────────
+
+describe("DOMAIN_STATS_MAX", () => {
+  it("T3-1: exports DOMAIN_STATS_MAX = 50", async () => {
+    const { DOMAIN_STATS_MAX } = await import("../../src/lib/storage.js");
+    assert.equal(DOMAIN_STATS_MAX, 50);
+  });
+});
+
+// ── T3-2: incrementDomainStat and getDomainStats are exported functions ───────
+
+describe("exports", () => {
+  it("T3-2: incrementDomainStat is an exported function", async () => {
+    const mod = await import("../../src/lib/storage.js");
+    assert.equal(typeof mod.incrementDomainStat, "function");
+  });
+
+  it("T3-5: getDomainStats is an exported function", async () => {
+    const mod = await import("../../src/lib/storage.js");
+    assert.equal(typeof mod.getDomainStats, "function");
+  });
+});
+
+// ── T3-3: Eviction logic — given 50+1 domains, lowest-count is evicted ───────
+
+describe("eviction logic", () => {
+  it("T3-3: evicts the lowest-count domain when cap is exceeded", () => {
+    const MAX = 50;
+
+    // Build 50 domains with params 1..50
+    const stats = {};
+    for (let i = 1; i <= MAX; i++) {
+      stats[`domain${i}.com`] = { params: i, urls: 1 };
+    }
+
+    // Add domain51 with params=0 (lowest)
+    stats["new-domain.com"] = { params: 0, urls: 1 };
+
+    assert.equal(Object.keys(stats).length, 51);
+
+    const kept = applyEviction(stats, MAX);
+
+    assert.equal(Object.keys(kept).length, MAX);
+    // The domain with 0 params (new-domain.com) must be evicted
+    assert.equal("new-domain.com" in kept, false);
+    // The domain with the lowest non-zero count (domain1.com, params=1) is kept
+    assert.equal("domain1.com" in kept, true);
+    // The highest-count domain must also be kept
+    assert.equal(`domain${MAX}.com` in kept, true);
+  });
+
+  it("T3-3b: does not evict when count is exactly at cap", () => {
+    const MAX = 50;
+    const stats = {};
+    for (let i = 1; i <= MAX; i++) {
+      stats[`domain${i}.com`] = { params: i, urls: 1 };
+    }
+    const kept = applyEviction(stats, MAX);
+    assert.equal(Object.keys(kept).length, MAX);
+  });
+});
+
+// ── T3-7: domainStats feature flag in PREF_DEFAULTS defaults to true ──────────
+
+describe("PREF_DEFAULTS.domainStats", () => {
+  it("T3-7: domainStats exists in PREF_DEFAULTS and defaults to true", async () => {
+    const { PREF_DEFAULTS } = await import("../../src/lib/storage.js");
+    assert.equal("domainStats" in PREF_DEFAULTS, true);
+    assert.equal(PREF_DEFAULTS.domainStats, true);
+  });
+});
+
+// ── T3-10: i18n keys exist with both en and es ────────────────────────────────
+
+describe("i18n keys for domain stats", () => {
+  const REQUIRED_KEYS = [
+    "domain_stats_label",
+    "domain_stats_empty",
+    "domain_stats_params",
+    "domain_stats_urls",
+  ];
+
+  it("T3-10: all domain stats i18n keys exist with en and es translations", async () => {
+    const { TRANSLATIONS } = await import("../../src/lib/i18n.js");
+    for (const key of REQUIRED_KEYS) {
+      assert.ok(key in TRANSLATIONS, `Missing i18n key: ${key}`);
+      assert.equal(typeof TRANSLATIONS[key].en, "string", `Missing EN for: ${key}`);
+      assert.ok(TRANSLATIONS[key].en.length > 0, `Empty EN string for: ${key}`);
+      assert.equal(typeof TRANSLATIONS[key].es, "string", `Missing ES for: ${key}`);
+      assert.ok(TRANSLATIONS[key].es.length > 0, `Empty ES string for: ${key}`);
+    }
+  });
+});

--- a/tests/unit/health-check.test.mjs
+++ b/tests/unit/health-check.test.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { processUrl } from "../../src/lib/cleaner.js";
 import { TRANSLATIONS } from "../../src/lib/i18n.js";
+import { TRACKING_PARAM_CATEGORIES } from "../../src/lib/affiliates.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -1275,5 +1276,27 @@ describe("Onboarding dedup — prevent double tabs", () => {
       afterFallback.includes("openOnboardingOnce()"),
       "fallback IIFE must call openOnboardingOnce()"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TRACKING_PARAM_CATEGORIES smoke test (Task 3.2)
+// ---------------------------------------------------------------------------
+describe("TRACKING_PARAM_CATEGORIES — smoke test", () => {
+  test("is a non-empty object and every category has a non-empty params array", () => {
+    assert.ok(
+      typeof TRACKING_PARAM_CATEGORIES === "object" && TRACKING_PARAM_CATEGORIES !== null,
+      "TRACKING_PARAM_CATEGORIES must be an object"
+    );
+    assert.ok(
+      Object.keys(TRACKING_PARAM_CATEGORIES).length > 0,
+      "TRACKING_PARAM_CATEGORIES must have at least one category"
+    );
+    for (const [catKey, catData] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+      assert.ok(
+        Array.isArray(catData.params) && catData.params.length > 0,
+        `Category "${catKey}" must have a non-empty params array`
+      );
+    }
   });
 });

--- a/tests/unit/param-categories.test.mjs
+++ b/tests/unit/param-categories.test.mjs
@@ -1,0 +1,164 @@
+/**
+ * MUGA — Param-categories integrity tests
+ *
+ * Validates the TRACKING_PARAM_CATEGORIES export from affiliates.js:
+ *   - Shape: every category has label, labelEs, and params
+ *   - Cross-reference: params in categories cover at least 80% of DNR removeParams
+ *   - i18n: all new impact-dashboard keys exist in both EN and ES
+ *
+ * Run with: node --test tests/unit/param-categories.test.mjs
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { TRACKING_PARAM_CATEGORIES } from "../../src/lib/affiliates.js";
+import { TRANSLATIONS } from "../../src/lib/i18n.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── T1-1: Category shape ─────────────────────────────────────────────────────
+
+describe("TRACKING_PARAM_CATEGORIES — shape validation", () => {
+  test("is a non-empty object", () => {
+    assert.ok(
+      typeof TRACKING_PARAM_CATEGORIES === "object" && TRACKING_PARAM_CATEGORIES !== null,
+      "TRACKING_PARAM_CATEGORIES must be an object"
+    );
+    assert.ok(
+      Object.keys(TRACKING_PARAM_CATEGORIES).length > 0,
+      "TRACKING_PARAM_CATEGORIES must have at least one category"
+    );
+  });
+
+  test("every category has label, labelEs, and params", () => {
+    for (const [catKey, catData] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+      assert.ok(
+        typeof catData.label === "string" && catData.label.length > 0,
+        `Category "${catKey}" must have a non-empty string label`
+      );
+      assert.ok(
+        typeof catData.labelEs === "string" && catData.labelEs.length > 0,
+        `Category "${catKey}" must have a non-empty string labelEs`
+      );
+      assert.ok(
+        Array.isArray(catData.params) && catData.params.length > 0,
+        `Category "${catKey}" must have a non-empty params array`
+      );
+    }
+  });
+
+  test("all labels are strings of at most 80 chars", () => {
+    for (const [catKey, catData] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+      assert.ok(
+        catData.label.length <= 80,
+        `Category "${catKey}" label is too long (${catData.label.length} chars): "${catData.label}"`
+      );
+      assert.ok(
+        catData.labelEs.length <= 80,
+        `Category "${catKey}" labelEs is too long (${catData.labelEs.length} chars): "${catData.labelEs}"`
+      );
+    }
+  });
+
+  test("params arrays contain only strings", () => {
+    for (const [catKey, catData] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
+      for (const param of catData.params) {
+        assert.ok(
+          typeof param === "string",
+          `Category "${catKey}" has non-string param: ${JSON.stringify(param)}`
+        );
+      }
+    }
+  });
+});
+
+// ── T1-2: Cross-reference with DNR tracking-params.json ──────────────────────
+
+describe("TRACKING_PARAM_CATEGORIES — DNR cross-reference", () => {
+  test("at least 80% of DNR removeParams are covered by some category", () => {
+    const trackingParamsJson = JSON.parse(
+      readFileSync(join(__dirname, "../../src/rules/tracking-params.json"), "utf8")
+    );
+
+    // Collect all removeParams from all DNR rules
+    const dnrParams = new Set();
+    for (const rule of trackingParamsJson) {
+      const removeParams = rule.action?.redirect?.transform?.queryTransform?.removeParams
+        ?? rule.action?.requestHeaders // guard for non-removeParams rules
+        ?? [];
+      if (Array.isArray(rule.action?.redirect?.transform?.queryTransform?.removeParams)) {
+        for (const p of rule.action.redirect.transform.queryTransform.removeParams) {
+          dnrParams.add(p.toLowerCase());
+        }
+      }
+    }
+
+    // Build the full set of categorised params (lowercase)
+    const categorisedParams = new Set();
+    for (const catData of Object.values(TRACKING_PARAM_CATEGORIES)) {
+      for (const param of catData.params) {
+        categorisedParams.add(param.toLowerCase());
+      }
+    }
+
+    // Count coverage
+    let covered = 0;
+    const uncovered = [];
+    for (const param of dnrParams) {
+      if (categorisedParams.has(param)) {
+        covered++;
+      } else {
+        uncovered.push(param);
+      }
+    }
+
+    const total = dnrParams.size;
+    const coveragePct = total > 0 ? (covered / total) * 100 : 100;
+
+    assert.ok(
+      total > 0,
+      "tracking-params.json must have at least one removeParams rule"
+    );
+    assert.ok(
+      coveragePct >= 80,
+      `Coverage is ${coveragePct.toFixed(1)}% (${covered}/${total}). Uncovered: ${uncovered.join(", ")}`
+    );
+  });
+});
+
+// ── T1-5: i18n keys ──────────────────────────────────────────────────────────
+
+describe("i18n — impact-dashboard param breakdown keys", () => {
+  const REQUIRED_KEYS = [
+    "param_breakdown_label",
+    "param_category_analytics",
+    "param_category_social",
+    "param_category_advertising",
+    "param_category_email",
+    "param_category_affiliate",
+    "param_category_marketplace",
+    "param_category_other",
+    "param_category_ecommerce",
+  ];
+
+  for (const key of REQUIRED_KEYS) {
+    test(`TRANSLATIONS has "${key}" with both en and es`, () => {
+      const entry = TRANSLATIONS[key];
+      assert.ok(
+        entry !== undefined,
+        `TRANSLATIONS is missing key "${key}"`
+      );
+      assert.ok(
+        typeof entry.en === "string" && entry.en.length > 0,
+        `TRANSLATIONS["${key}"].en must be a non-empty string`
+      );
+      assert.ok(
+        typeof entry.es === "string" && entry.es.length > 0,
+        `TRANSLATIONS["${key}"].es must be a non-empty string`
+      );
+    });
+  }
+});

--- a/tests/unit/report-button.test.mjs
+++ b/tests/unit/report-button.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * Tests for report button feature flag and i18n key.
+ *
+ * T2-1: Flag `showReportButton` exists in PREF_DEFAULTS and defaults to true
+ * T2-4: popup.js source does NOT gate #report-broken visibility on prefs.devMode
+ * T2-5: TRANSLATIONS has `report_dirty_url` key with both `en` and `es`
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+
+// ── Import source modules ────────────────────────────────────────────────────
+
+// storage.js uses chrome.* APIs at module level (the shim IIFE and the
+// onSuspend listener). Provide a minimal stub so the module can be imported
+// in a Node.js test environment without crashing.
+globalThis.chrome = {
+  storage: {
+    sync: {
+      get: () => Promise.resolve({}),
+      set: () => Promise.resolve(),
+    },
+    local: {
+      get: () => Promise.resolve({}),
+      set: () => Promise.resolve(),
+    },
+    session: undefined,
+  },
+  runtime: {
+    lastError: null,
+    onSuspend: { addListener: () => {} },
+  },
+};
+
+const { PREF_DEFAULTS } = await import("../../src/lib/storage.js");
+const { TRANSLATIONS } = await import("../../src/lib/i18n.js");
+
+// ── T2-1: showReportButton flag ──────────────────────────────────────────────
+
+test("T2-1: PREF_DEFAULTS has showReportButton defaulting to true", () => {
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(PREF_DEFAULTS, "showReportButton"),
+    "PREF_DEFAULTS must have a showReportButton key"
+  );
+  assert.strictEqual(
+    PREF_DEFAULTS.showReportButton,
+    true,
+    "showReportButton must default to true"
+  );
+});
+
+// ── T2-4: popup.js source must not gate report-broken on prefs.devMode ───────
+
+test("T2-4: popup.js does not gate #report-broken visibility on prefs.devMode", () => {
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+
+  // The only acceptable devMode reference is unrelated to the report button.
+  // We look for the specific pattern that would gate report visibility on devMode.
+  // Pattern: prefs.devMode inside a block that also references report-broken or reportLink.
+  // Simplest static check: the string `prefs.devMode` must not appear in proximity
+  // to `report-broken` or `reportLink` (within 300 chars of each other).
+
+  const devModeIdx = popupSrc.indexOf("prefs.devMode");
+  if (devModeIdx === -1) {
+    // No devMode gating at all — test passes
+    return;
+  }
+
+  // Check all occurrences of prefs.devMode
+  let searchFrom = 0;
+  while (true) {
+    const idx = popupSrc.indexOf("prefs.devMode", searchFrom);
+    if (idx === -1) break;
+
+    // Extract a window of 300 chars around the occurrence
+    const window = popupSrc.slice(Math.max(0, idx - 150), idx + 150);
+    assert.ok(
+      !window.includes("report-broken") && !window.includes("reportLink"),
+      `prefs.devMode must not gate the report button. Found proximity at char ${idx}:\n${window}`
+    );
+    searchFrom = idx + 1;
+  }
+});
+
+// ── T2-5: TRANSLATIONS has report_dirty_url with en and es ──────────────────
+
+test("T2-5: TRANSLATIONS has report_dirty_url key with en and es", () => {
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(TRANSLATIONS, "report_dirty_url"),
+    "TRANSLATIONS must have a report_dirty_url key"
+  );
+  assert.ok(
+    typeof TRANSLATIONS.report_dirty_url.en === "string" && TRANSLATIONS.report_dirty_url.en.length > 0,
+    "report_dirty_url must have a non-empty `en` translation"
+  );
+  assert.ok(
+    typeof TRANSLATIONS.report_dirty_url.es === "string" && TRANSLATIONS.report_dirty_url.es.length > 0,
+    "report_dirty_url must have a non-empty `es` translation"
+  );
+});


### PR DESCRIPTION
## Summary

Three new features that make MUGA's value **visible and educational** for users:

- **Param breakdown**: Expanding a history entry or URL preview shows exactly what was removed, grouped by category (Analytics, Social, Ads, etc.) with EN/ES labels. Uses existing `TRACKING_PARAM_CATEGORIES` — zero data duplication
- **Per-domain stats**: Collapsible "Your top trackers" section in popup showing which domains generate the most tracking noise. Stored locally with 50-domain cap and LRU eviction. Privacy-safe: domain names + counts only, no URLs or paths
- **Public report button**: "Report a problem with this URL" now visible to all users (was dev-tools-only). Pre-fills a GitHub issue with domain, version, action taken, and params removed. Gated by `showReportButton` feature flag

All three features are behind individual feature flags in `PREF_DEFAULTS` (default: true).

## Test plan
- [x] `npm test` — 922 pass, 0 fail (26 new tests, strict TDD)
- [ ] Manual: verify param breakdown renders correctly in popup history
- [ ] Manual: verify domain stats accumulate after browsing
- [ ] Manual: verify report button opens pre-filled GitHub issue
- [ ] Manual: verify feature flags disable each feature independently
- [ ] Manual: verify stats reset clears domain stats