### PR TITLE
fix: robustness — cache versioning, rewrite eviction, observer debounce

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -63,6 +63,7 @@ console.warn = (...args) => { _origWarn(...args); appendSessionLog("warn", args)
 
 let cachedPrefs = null;
 let prefsFetchPromise = null;
+let _cacheVersion = 0;
 
 // Serialize list mutations (whitelist/blacklist) to prevent race conditions
 // where two rapid messages read the same cached list and the second overwrites the first.
@@ -71,7 +72,13 @@ let _listMutationQueue = Promise.resolve();
 function getPrefsWithCache() {
   if (cachedPrefs) return Promise.resolve(cachedPrefs);
   if (!prefsFetchPromise) {
+    const versionAtStart = _cacheVersion;
     prefsFetchPromise = getPrefs().then(prefs => {
+      if (_cacheVersion !== versionAtStart) {
+        // Cache was invalidated while fetching — discard stale result
+        prefsFetchPromise = null;
+        return getPrefsWithCache();
+      }
       // Pre-parse blacklist/whitelist once so processUrl doesn't re-parse on every call
       prefs._parsedBlacklist = (prefs.blacklist || []).map(parseListEntry);
       prefs._parsedWhitelist = (prefs.whitelist || []).map(parseListEntry);
@@ -223,6 +230,7 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
   // must invalidate the prefs cache so the next getPrefsWithCache() reads fresh data.
   cachedPrefs = null;
   prefsFetchPromise = null;
+  _cacheVersion++;
   if (changes.customParams || changes.dnrEnabled || changes.enabled) {
     const prefs = await getPrefsWithCache();
     await applyDnrState(prefs);
@@ -279,6 +287,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
       cachedPrefs = null;
       prefsFetchPromise = null;
+      _cacheVersion++;
       sendResponse({ ok: true });
     }).catch(err => {
       console.error("[MUGA] ADD_TO_WHITELIST handler failed:", err);
@@ -301,6 +310,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
       cachedPrefs = null;
       prefsFetchPromise = null;
+      _cacheVersion++;
       sendResponse({ ok: true });
     }).catch(err => {
       console.error("[MUGA] ADD_TO_BLACKLIST handler failed:", err);

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -40,9 +40,16 @@
   const _rewriteLog = new Map(); // hostname -> { count, firstTs }
   function isRewriteLoop(hostname) {
     const now = Date.now();
+    // Evict stale entries older than 2s instead of bulk-clearing the entire map
+    if (_rewriteLog.size > 50) {
+      for (const [key, val] of _rewriteLog) {
+        if (now - val.firstTs > 2000) _rewriteLog.delete(key);
+      }
+      // Safety cap: if still over 200 after eviction, clear all
+      if (_rewriteLog.size > 200) _rewriteLog.clear();
+    }
     const entry = _rewriteLog.get(hostname);
     if (!entry || now - entry.firstTs > 2000) {
-      if (_rewriteLog.size > 200) _rewriteLog.clear();
       _rewriteLog.set(hostname, { count: 1, firstTs: now });
       return false;
     }
@@ -483,18 +490,20 @@
         root.querySelectorAll("a[ping]").forEach(a => a.removeAttribute("ping"));
       }
       removePingAttrs(document);
+      let _pingBatchId = 0;
       const observer = new MutationObserver(mutations => {
+        // Attribute changes: handle immediately (ping must be removed before click)
         for (const mutation of mutations) {
-          // Handle new nodes
-          for (const node of mutation.addedNodes) {
-            if (node.nodeType !== 1) continue;
-            if (node.hasAttribute?.("ping")) node.removeAttribute("ping");
-            removePingAttrs(node);
-          }
-          // Handle attribute changes on existing elements
           if (mutation.type === "attributes" && mutation.attributeName === "ping") {
             mutation.target.removeAttribute("ping");
           }
+        }
+        // New nodes: batch via rAF to avoid per-mutation DOM walks
+        if (!_pingBatchId) {
+          _pingBatchId = requestAnimationFrame(() => {
+            _pingBatchId = 0;
+            removePingAttrs(document);
+          });
         }
       });
       observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ["ping"] });

--- a/tests/unit/content-cleaner-patterns.test.mjs
+++ b/tests/unit/content-cleaner-patterns.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * MUGA — Tests for content script patterns (cleaner.js)
+ *
+ * Verifies rewrite loop eviction strategy and MutationObserver optimization
+ * by reading source code patterns.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cleanerSource = readFileSync(join(__dirname, "../../src/content/cleaner.js"), "utf8");
+
+// ── Rewrite loop eviction ────────────────────────────────────────────────────
+
+describe("Rewrite loop — time-based eviction", () => {
+  test("evicts stale entries older than 2s", () => {
+    assert.ok(
+      cleanerSource.includes("now - val.firstTs > 2000"),
+      "should delete entries older than 2000ms"
+    );
+  });
+
+  test("starts eviction scan at a reasonable threshold", () => {
+    assert.ok(
+      cleanerSource.includes("_rewriteLog.size > 50"),
+      "should trigger eviction scan when map exceeds 50 entries"
+    );
+  });
+
+  test("keeps safety cap at 200 entries after eviction", () => {
+    assert.ok(
+      cleanerSource.includes("_rewriteLog.size > 200"),
+      "should bulk-clear as safety net if still over 200 after eviction"
+    );
+  });
+
+  test("does not bulk-clear as first resort", () => {
+    // The eviction loop (delete stale) should appear BEFORE the safety-cap clear
+    const evictPos = cleanerSource.indexOf("now - val.firstTs > 2000");
+    const clearPos = cleanerSource.indexOf("_rewriteLog.size > 200");
+    assert.ok(evictPos < clearPos, "time-based eviction should run before safety-cap clear");
+  });
+});
+
+// ── MutationObserver ping blocking optimization ──────────────────────────────
+
+describe("MutationObserver — ping blocking debounce", () => {
+  test("handles attribute changes immediately (not batched)", () => {
+    // Attribute ping removal must be synchronous to prevent clicks
+    // before the next animation frame
+    const observerBlock = cleanerSource.slice(
+      cleanerSource.indexOf("new MutationObserver"),
+      cleanerSource.indexOf("observer.observe")
+    );
+    const attrCheckPos = observerBlock.indexOf('"attributes"');
+    const rafPos = observerBlock.indexOf("requestAnimationFrame");
+    assert.ok(
+      attrCheckPos < rafPos,
+      "attribute removal should happen before rAF batching"
+    );
+  });
+
+  test("batches childList mutations via requestAnimationFrame", () => {
+    assert.ok(
+      cleanerSource.includes("requestAnimationFrame"),
+      "should use rAF to batch new-node ping removal"
+    );
+  });
+
+  test("deduplicates rAF calls", () => {
+    assert.ok(
+      cleanerSource.includes("_pingBatchId"),
+      "should track pending rAF to avoid duplicate scheduling"
+    );
+  });
+});

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -170,6 +170,50 @@ describe("Bug #229 — whitelist/blacklist entry format", () => {
   });
 });
 
+// ── Cache invalidation version counter ───────────────────────────────────────
+
+describe("Cache invalidation — version counter", () => {
+  test("defines _cacheVersion counter", () => {
+    assert.ok(swSource.includes("let _cacheVersion = 0"), "_cacheVersion should be initialized to 0");
+  });
+
+  test("getPrefsWithCache captures version before fetch", () => {
+    assert.ok(
+      swSource.includes("const versionAtStart = _cacheVersion"),
+      "should snapshot _cacheVersion before starting async fetch"
+    );
+  });
+
+  test("getPrefsWithCache discards stale result when version changed", () => {
+    assert.ok(
+      swSource.includes("_cacheVersion !== versionAtStart"),
+      "should compare version after fetch completes"
+    );
+  });
+
+  test("storage change listener increments _cacheVersion", () => {
+    const storageListener = swSource.slice(
+      swSource.indexOf("chrome.storage.onChanged.addListener"),
+      swSource.indexOf("chrome.storage.onChanged.addListener") + 500
+    );
+    assert.ok(storageListener.includes("_cacheVersion++"), "storage listener should increment _cacheVersion");
+  });
+
+  test("whitelist handler increments _cacheVersion", () => {
+    const whitelistHandler = swSource.slice(
+      swSource.indexOf('"ADD_TO_WHITELIST"'),
+      swSource.indexOf('"ADD_TO_BLACKLIST"')
+    );
+    assert.ok(whitelistHandler.includes("_cacheVersion++"), "whitelist handler should increment _cacheVersion");
+  });
+
+  test("blacklist handler increments _cacheVersion", () => {
+    const blacklistStart = swSource.indexOf('"ADD_TO_BLACKLIST"');
+    const blacklistHandler = swSource.slice(blacklistStart, blacklistStart + 800);
+    assert.ok(blacklistHandler.includes("_cacheVersion++"), "blacklist handler should increment _cacheVersion");
+  });
+});
+
 // ── Onboarding consent verification ─────────────────────────────────────────
 
 describe("Onboarding consent — source code patterns", () => {


### PR DESCRIPTION
## Summary
- Add `_cacheVersion` counter to discard stale prefs fetched during concurrent invalidation
- Replace bulk `_rewriteLog.clear()` with time-based eviction of entries older than 2s
- Batch MutationObserver `childList` mutations via `requestAnimationFrame`, keep attribute removal synchronous

## Test plan
- [ ] All 957 tests pass
- [ ] New tests verify cache version pattern, eviction strategy, and rAF debounce
- [ ] Manual: extension loads and cleans URLs normally