### PR TITLE
fix: Firefox MV2 — shim runtime.sendMessage, deduplicate polyfill

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -59,6 +59,11 @@
     for (const m of ["query", "create", "sendMessage", "remove"]) wrapMethod(chrome.tabs, m);
   }
 
+  // chrome.runtime
+  if (chrome.runtime) {
+    wrapMethod(chrome.runtime, "sendMessage");
+  }
+
   // chrome.contextMenus
   if (chrome.contextMenus) {
     wrapMethod(chrome.contextMenus, "removeAll");

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,12 +30,7 @@
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/amp-redirect.js"],
-      "run_at": "document_end"
-    },
-    {
-      "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/redirect-unwrap.js"],
+      "js": ["content/amp-redirect.js", "content/redirect-unwrap.js"],
       "run_at": "document_end"
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -26,12 +26,7 @@
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/amp-redirect.js"],
-      "run_at": "document_end"
-    },
-    {
-      "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/redirect-unwrap.js"],
+      "js": ["content/amp-redirect.js", "content/redirect-unwrap.js"],
       "run_at": "document_end"
     }
   ],

--- a/tests/unit/health-check.test.mjs
+++ b/tests/unit/health-check.test.mjs
@@ -853,6 +853,17 @@ describe("Firefox MV2 compatibility guards", () => {
     );
   });
 
+  test("shimChromePromises wraps chrome.runtime.sendMessage", () => {
+    const shimBlock = STORAGE_SOURCE.slice(
+      STORAGE_SOURCE.indexOf("shimChromePromises"),
+      STORAGE_SOURCE.indexOf("// ── Sync:")
+    );
+    assert.ok(
+      shimBlock.includes('wrapMethod(chrome.runtime, "sendMessage")'),
+      "shim must wrap chrome.runtime.sendMessage for Firefox MV2"
+    );
+  });
+
   test("Promise shim wraps chrome.storage.sync and chrome.storage.local", () => {
     assert.ok(
       STORAGE_SOURCE.includes("chrome.storage?.sync") && STORAGE_SOURCE.includes("chrome.storage?.local"),
@@ -1002,11 +1013,11 @@ describe("Firefox MV2 manifest structure", () => {
       `strict_min_version (${minVersion}) must not exceed 128 to support Firefox ESR`);
   });
 
-  test("content scripts include browser-polyfill.min.js", () => {
-    for (const cs of MANIFEST_V2.content_scripts) {
-      assert.ok(cs.js.includes("lib/browser-polyfill.min.js"),
-        `Content script [${cs.js.join(", ")}] must include browser-polyfill.min.js`);
-    }
+  test("browser-polyfill.min.js loads in document_start entry", () => {
+    const startEntry = MANIFEST_V2.content_scripts.find(cs => cs.run_at === "document_start");
+    assert.ok(startEntry, "must have a document_start content script entry");
+    assert.ok(startEntry.js.includes("lib/browser-polyfill.min.js"),
+      "document_start entry must include browser-polyfill.min.js");
   });
 
   test("version matches package.json", () => {


### PR DESCRIPTION
## Summary
- Add `chrome.runtime.sendMessage` to `shimChromePromises` wrapper for Firefox MV2
- Merge `document_end` content scripts into single entry (polyfill already loaded at `document_start`)
- Update both `manifest.json` (MV3) and `manifest.v2.json` (MV2)

## Test plan
- [ ] All 958 tests pass
- [ ] `web-ext lint` passes (warnings only)
- [ ] Manual: extension loads in Firefox and Chrome, content scripts execute correctly