### PR TITLE
fix: document silent catches, safe manifest swap script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev:chrome": "web-ext run --source-dir src/ --target chromium",
-    "dev:firefox": "cp src/manifest.json src/manifest.v3.json && cp src/manifest.v2.json src/manifest.json && web-ext run --source-dir src/ --target firefox-desktop; EXIT=$?; cp src/manifest.v3.json src/manifest.json && rm -f src/manifest.v3.json; exit $EXIT",
+    "dev:firefox": "bash scripts/with-firefox-manifest.sh web-ext run --source-dir src/ --target firefox-desktop",
     "build:chrome": "web-ext build --source-dir src/ --artifacts-dir dist/chrome/ --overwrite-dest",
-    "build:firefox": "cp src/manifest.json src/manifest.v3.json && cp src/manifest.v2.json src/manifest.json && web-ext build --source-dir src/ --artifacts-dir dist/firefox/ --overwrite-dest && cp src/manifest.v3.json src/manifest.json && rm src/manifest.v3.json",
+    "build:firefox": "bash scripts/with-firefox-manifest.sh web-ext build --source-dir src/ --artifacts-dir dist/firefox/ --overwrite-dest",
     "build": "npm run build:chrome && npm run build:firefox",
     "lint": "web-ext lint --source-dir src/",
     "test": "node --test --test-reporter=spec tests/unit/*.mjs",

--- a/scripts/with-firefox-manifest.sh
+++ b/scripts/with-firefox-manifest.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Temporarily swap manifest.json to MV2 for Firefox, run a command,
+# and guarantee restoration even on failure or interrupt.
+set -euo pipefail
+
+SRC="src/manifest.json"
+BACKUP="src/manifest.v3.json"
+
+cleanup() {
+  if [ -f "$BACKUP" ]; then
+    cp "$BACKUP" "$SRC"
+    rm -f "$BACKUP"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+cp "$SRC" "$BACKUP"
+cp src/manifest.v2.json "$SRC"
+
+"$@"

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -139,7 +139,7 @@
 
         // Count as 1 clean action regardless of how many URLs were in the selection
         const anyChanged = [...urlMap.values()].some((clean, i) => clean !== allUrls[i]);
-        if (anyChanged) chrome.runtime.sendMessage({ type: "INCREMENT_STAT", key: "urlsCleaned" }).catch(() => {});
+        if (anyChanged) chrome.runtime.sendMessage({ type: "INCREMENT_STAT", key: "urlsCleaned" }).catch(() => { /* expected: channel may close */ });
 
         navigator.clipboard.writeText(finalText)
           .then(() => sendResponse({ ok: true }))
@@ -209,7 +209,7 @@
 
       await copyToClipboard(result);
     } catch {
-      navigator.clipboard.writeText(trimmed).catch(() => {});
+      navigator.clipboard.writeText(trimmed).catch(() => { /* best-effort fallback */ });
     }
   });
 
@@ -435,12 +435,12 @@
           // can match it correctly against the affiliate patterns (#229)
           const hostname = new URL(originalUrl).hostname.replace(/^www\./, "");
           const tag = `${hostname}::${affiliate.param}::${affiliate.value}`;
-          chrome.runtime.sendMessage({ type: "ADD_TO_WHITELIST", tag }).catch(() => {});
+          chrome.runtime.sendMessage({ type: "ADD_TO_WHITELIST", tag }).catch(() => { /* expected: channel may close */ });
         } else if (choice === "clean") {
           // "Block": add to blacklist in domain::param::value format (#229)
           const hostname = new URL(originalUrl).hostname.replace(/^www\./, "");
           const tag = `${hostname}::${affiliate.param}::${affiliate.value}`;
-          chrome.runtime.sendMessage({ type: "ADD_TO_BLACKLIST", tag }).catch(() => {});
+          chrome.runtime.sendMessage({ type: "ADD_TO_BLACKLIST", tag }).catch(() => { /* expected: channel may close */ });
         }
         callback(choice);
       });


### PR DESCRIPTION
## Summary
- Add explanatory comments to fire-and-forget `.catch()` handlers in content scripts
- Create `scripts/with-firefox-manifest.sh` with trap-based manifest restoration
- Simplify `dev:firefox` and `build:firefox` npm scripts

## Test plan
- [ ] All 958 tests pass
- [ ] `npm run build:firefox` swaps and restores manifest correctly