### PR TITLE
ci: automated Firefox AMO submission on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,22 @@ jobs:
             dist/firefox/muga-${{ steps.version.outputs.VERSION }}-firefox.zip
           draft: false
           prerelease: false
+
+      # ── Firefox AMO submission ──────────────────────────────────────
+      - name: Prepare source code archive for AMO
+        run: git archive --format=zip --prefix=muga-source/ HEAD -o muga-source.zip
+
+      - name: Inject release notes into AMO metadata
+        run: bash scripts/prepare-amo-metadata.sh "${{ steps.version.outputs.VERSION }}"
+
+      - name: Submit to Firefox AMO
+        run: |
+          bash scripts/with-firefox-manifest.sh \
+            npx web-ext sign \
+              --source-dir=src/ \
+              --channel=listed \
+              --amo-metadata=amo-metadata.json \
+              --upload-source-code=muga-source.zip \
+              --api-key="${{ secrets.AMO_JWT_ISSUER }}" \
+              --api-secret="${{ secrets.AMO_JWT_SECRET }}" \
+              --approval-timeout=0

--- a/amo-metadata.json
+++ b/amo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "version": {
+    "license": "GPL-3.0-or-later",
+    "approval_notes": "No build step, no bundler, no minification. Source is plain vanilla JS (ES2022).\n\nTo verify:\n1. Unzip source code\n2. Compare src/ directory contents with the extension zip — they are identical\n3. npm ci && npm test (958+ unit tests)\n\nThe <all_urls> permission is required to clean tracking parameters from URLs on any website the user visits.\n\nOpen source: https://github.com/yocreoquesi/muga\nLicense: GPL-3.0"
+  }
+}

--- a/scripts/prepare-amo-metadata.sh
+++ b/scripts/prepare-amo-metadata.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Reads the latest CHANGELOG.md entry and injects release_notes into amo-metadata.json.
+# Usage: bash scripts/prepare-amo-metadata.sh [version]
+#   version: optional, defaults to package.json version
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="${1:-$(node -p "require('./package.json').version")}"
+
+# Extract the changelog section for this version (between ## [version] and next ## [)
+NOTES=$(sed -n "/^## \[$VERSION\]/,/^## \[/{/^## \[$VERSION\]/d;/^## \[/d;p}" "$ROOT/CHANGELOG.md" | sed '/^$/d')
+
+if [ -z "$NOTES" ]; then
+  echo "Warning: no CHANGELOG entry found for version $VERSION, using generic notes"
+  NOTES="Bug fixes and improvements. See https://github.com/yocreoquesi/muga/releases"
+fi
+
+# Build the release_notes JSON with node (handles escaping properly)
+node -e "
+const fs = require('fs');
+const meta = JSON.parse(fs.readFileSync('$ROOT/amo-metadata.json', 'utf8'));
+const notes = $(node -e "console.log(JSON.stringify(process.argv[1]))" -- "$NOTES");
+meta.version.release_notes = { 'en-US': notes };
+fs.writeFileSync('$ROOT/amo-metadata.json', JSON.stringify(meta, null, 2) + '\n');
+console.log('amo-metadata.json updated with release notes for v' + '$VERSION');
+"


### PR DESCRIPTION
## Summary
- Add `web-ext sign` step to release.yml with AMO JWT credentials from GitHub secrets
- Create `amo-metadata.json` with GPL-3.0 license and reviewer approval notes
- Create `scripts/prepare-amo-metadata.sh` to extract CHANGELOG release notes into metadata
- Upload source code archive via `--upload-source-code` for AMO review
- Uses `--approval-timeout=0` (submit and exit, don't block CI on manual review)

## Flow
`git tag v1.9.9 && git push --tags` → tests → build → GitHub Release → AMO submission

## Test plan
- [ ] All 958 tests pass
- [ ] `bash scripts/prepare-amo-metadata.sh 1.9.8` injects release notes correctly
- [ ] Verify on next real tag push