### PR TITLE
fix: use correct AMO SPDX license slug (GPL-3.0-only)

### DIFF
--- a/amo-metadata.json
+++ b/amo-metadata.json
@@ -1,6 +1,6 @@
 {
   "version": {
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "approval_notes": "No build step, no bundler, no minification. Source is plain vanilla JS (ES2022).\n\nTo verify:\n1. Unzip source code\n2. Compare src/ directory contents with the extension zip — they are identical\n3. npm ci && npm test (958+ unit tests)\n\nThe <all_urls> permission is required to clean tracking parameters from URLs on any website the user visits.\n\nOpen source: https://github.com/yocreoquesi/muga\nLicense: GPL-3.0"
   }
 }


### PR DESCRIPTION
## Summary
- AMO API requires SPDX `-only` suffix for GPL licenses
- `GPL-3.0-or-later` (PR #275) and `GPL-3.0` (PR #283) both rejected
- Correct slug is `GPL-3.0-only` per [AMO license docs](https://mozilla.github.io/addons-server/topics/api/licenses.html)

## Test plan
- [ ] Re-tag v1.9.9 after merge to trigger release workflow
- [ ] Verify AMO submission step passes