### PR TITLE
fix: production audit round 2 — i18n completeness and safety

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -169,8 +169,8 @@ async function syncContextMenus(enabled) {
   if (!prefs.enabled) return;
   const lang = prefs.language || "en";
   const titles = {
-    copy: lang === "es" ? "Copiar enlace limpio" : "Copy clean link",
-    selection: lang === "es" ? "Copiar enlaces limpios de la selección" : "Copy clean links in selection",
+    copy: { es: "Copiar enlace limpio", pt: "Copiar link limpo", de: "Sauberen Link kopieren" }[lang] || "Copy clean link",
+    selection: { es: "Copiar enlaces limpios de la selección", pt: "Copiar links limpos da seleção", de: "Saubere Links der Auswahl kopieren" }[lang] || "Copy clean links in selection",
   };
   chrome.contextMenus.create({
     id: "muga-copy-clean",

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -73,9 +73,25 @@
       toast_block:   "Eliminarlo",
       toast_dismiss: "Descartar",
     },
+    pt: {
+      toast_title:   "MUGA encontrou a tag de afiliado de outra pessoa",
+      toast_tag_msg: "tem uma tag de afiliado que não é nossa:",
+      toast_allow:   "Manter",
+      toast_block:   "Remover",
+      toast_dismiss: "Dispensar",
+    },
+    de: {
+      toast_title:   "MUGA hat ein fremdes Affiliate-Tag gefunden",
+      toast_tag_msg: "hat ein Affiliate-Tag, das nicht uns gehört:",
+      toast_allow:   "Behalten",
+      toast_block:   "Entfernen",
+      toast_dismiss: "Schließen",
+    },
   };
 
-  const browserLang = (navigator.language || "en").startsWith("es") ? "es" : "en";
+  const SUPPORTED_LANGS = { en: 1, es: 1, pt: 1, de: 1 };
+  const navLang = (navigator.language || "en").slice(0, 2);
+  const browserLang = navLang in SUPPORTED_LANGS ? navLang : "en";
   let s = STRINGS[browserLang];
   // Load language preference asynchronously. Toast will use it if shown after load.
   chrome.storage.sync.get({ language: browserLang }, (r) => {
@@ -333,7 +349,7 @@
       if (u.protocol !== "http:" && u.protocol !== "https:") return;
     } catch { return; }
     if (newTab) {
-      window.open(url, "_blank");
+      window.open(url, "_blank", "noopener,noreferrer");
     } else {
       window.location.href = url;
     }

--- a/src/content/redirect-unwrap.js
+++ b/src/content/redirect-unwrap.js
@@ -9,6 +9,9 @@
 
 (function () {
   "use strict";
+  function safeSessionGet(key) {
+    try { return sessionStorage.getItem(key); } catch { return null; /* incognito/quota */ }
+  }
   function safeSessionSet(key, value) {
     try { sessionStorage.setItem(key, value); } catch { /* incognito/quota */ }
   }
@@ -65,7 +68,7 @@
         }
         if (dest && ["http:", "https:"].includes(dest.protocol) && dest.hostname && dest.hostname !== parsed.hostname) {
           const sessionKey = "__muga_ruw_" + location.hostname + location.pathname;
-          if (!sessionStorage.getItem(sessionKey)) {
+          if (!safeSessionGet(sessionKey)) {
             safeSessionSet(sessionKey, "1");
             window.location.replace(dest.href);
             return;
@@ -106,7 +109,7 @@
               }
               if (dest && ["http:", "https:"].includes(dest.protocol)) {
                 const sessionKey = "__muga_ruw_" + location.hostname + location.pathname;
-                if (!sessionStorage.getItem(sessionKey)) {
+                if (!safeSessionGet(sessionKey)) {
                   safeSessionSet(sessionKey, "1");
                   window.location.replace(dest.href);
                   return;
@@ -131,7 +134,7 @@
         try { dest = new URL(decoded, parsed.origin); } catch { /* skip */ }
         if (dest && ["http:", "https:"].includes(dest.protocol)) {
           const sessionKey = "__muga_ruw_" + location.hostname + location.pathname;
-          if (!sessionStorage.getItem(sessionKey)) {
+          if (!safeSessionGet(sessionKey)) {
             safeSessionSet(sessionKey, "1");
             window.location.replace(dest.href);
             return;
@@ -173,7 +176,7 @@
       // Guard against redirect loops: if the destination points back to a page
       // that could redirect to us, bail out.
       const sessionKey = "__muga_ruw_" + location.hostname + location.pathname;
-      if (sessionStorage.getItem(sessionKey)) return;
+      if (safeSessionGet(sessionKey)) return;
       safeSessionSet(sessionKey, "1");
 
       window.location.replace(destination.href);

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -349,7 +349,8 @@ export async function getStoredLang() {
       chrome.storage.sync.get({ language: null }, r => {
         void chrome.runtime.lastError;
         try {
-          resolve(r?.language ?? browserLang());
+          const stored = r?.language;
+          resolve(stored && supported.has(stored) ? stored : browserLang());
         } catch (err) {
           console.error("[MUGA] getStoredLang:", err);
           resolve(browserLang());

--- a/src/onboarding/onboarding.html
+++ b/src/onboarding/onboarding.html
@@ -177,9 +177,9 @@
         <input type="checkbox" id="tos-check" aria-label="Accept terms of use">
         <div class="tos-check-label" data-i18n-html="ob_tos_label">
           I have read and accept the
-          <a href="../privacy/tos.html" target="_blank">Terms of use</a>
+          <a href="../privacy/tos.html" target="_blank" rel="noopener noreferrer">Terms of use</a>
           and
-          <a href="../privacy/privacy.html" target="_blank">Privacy policy</a>
+          <a href="../privacy/privacy.html" target="_blank" rel="noopener noreferrer">Privacy policy</a>
           <small class="tos-required-hint">Required to continue</small>
         </div>
       </label>

--- a/src/onboarding/onboarding.js
+++ b/src/onboarding/onboarding.js
@@ -31,14 +31,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   startBtn.addEventListener("click", async () => {
     if (!tosCheck.checked) return;
 
-    await chrome.storage.sync.set({
-      onboardingDone:        true,
-      consentVersion:        CONSENT_VERSION,
-      consentDate:           Date.now(),
-      injectOwnAffiliate:    affiliateCheck.checked,
-      notifyForeignAffiliate: false,
-    });
-
-    window.close();
+    try {
+      await chrome.storage.sync.set({
+        onboardingDone:        true,
+        consentVersion:        CONSENT_VERSION,
+        consentDate:           Date.now(),
+        injectOwnAffiliate:    affiliateCheck.checked,
+        notifyForeignAffiliate: false,
+        language:              lang,
+      });
+      window.close();
+    } catch (err) {
+      console.error("[MUGA] onboarding save:", err);
+      startBtn.textContent = "Error — please try again";
+      startBtn.disabled = false;
+    }
   });
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -61,7 +61,7 @@ function _renderParamBreakdown(removedTracking, lang) {
     const info = index.get(param.toLowerCase());
     const catKey = info ? info.categoryKey : "other";
     const label = info
-      ? (lang === "es" ? info.labelEs : info.label)
+      ? ({ es: info.labelEs, pt: info.labelPt, de: info.labelDe }[lang] || info.label)
       : t("param_category_other", lang);
     if (!groups.has(catKey)) groups.set(catKey, { label, params: [] });
     groups.get(catKey).params.push(param);

--- a/src/privacy/tos.html
+++ b/src/privacy/tos.html
@@ -38,12 +38,12 @@
   <p class="meta">MUGA: Fair to every click &nbsp;&middot;&nbsp; Version 1.1 &nbsp;&middot;&nbsp; Last updated: 2026-03-23</p>
 
   <div class="highlight">
-    MUGA is free and open-source software licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener">GNU General Public License v3</a>. You control what MUGA does. MUGA never acts behind your back. Nothing happens without your action.
+    MUGA is free and open-source software licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener noreferrer">GNU General Public License v3</a>. You control what MUGA does. MUGA never acts behind your back. Nothing happens without your action.
   </div>
 
   <h2>1. Scope and acceptance</h2>
   <p>These Terms of Use ("Terms") govern your use of the MUGA browser extension ("MUGA", "the Extension"). By installing or using MUGA you agree to be bound by these Terms and by the <a href="privacy.html">Privacy Policy</a>.</p>
-  <p>These Terms apply to the use of the Extension as a browser add-on. They supplement, but do not replace, the rights and obligations set out in the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener">GNU General Public License v3 (GPL v3)</a>, which governs the source code. In the event of a conflict between these Terms and the GPL v3 regarding the source code, the GPL v3 prevails.</p>
+  <p>These Terms apply to the use of the Extension as a browser add-on. They supplement, but do not replace, the rights and obligations set out in the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener noreferrer">GNU General Public License v3 (GPL v3)</a>, which governs the source code. In the event of a conflict between these Terms and the GPL v3 regarding the source code, the GPL v3 prevails.</p>
 
   <h2>2. What MUGA does</h2>
   <p>MUGA is a browser extension that:</p>
@@ -61,7 +61,7 @@
   <p>If you opted in during onboarding, MUGA adds our affiliate tag to URLs that contain <strong>no existing affiliate tag</strong>. This does not change the price you pay. Affiliate tags tell the store who referred the visit, nothing more. The developer may earn a small commission from qualifying purchases.</p>
   <ul>
     <li>By default, MUGA <strong>does not replace</strong> an affiliate tag that is already present in a URL. Replacing requires a separate, deliberate opt-in by the user</li>
-    <li>Affiliate tag injection only applies to the supported stores explicitly listed in the <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener">source code</a></li>
+    <li>Affiliate tag injection only applies to the supported stores explicitly listed in the <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">source code</a></li>
     <li>You can disable affiliate tag injection at any time in the Extension's Settings, no questions asked</li>
     <li>The developer may earn commissions from qualifying purchases through supported affiliate programs. This disclosure is required by the operating agreements of those programs</li>
   </ul>
@@ -74,7 +74,7 @@
   <p>When MUGA modifies a URL to include an affiliate tag and you navigate to that store, your interaction with the store is governed entirely by that store's own terms of service and privacy policy. MUGA has no control over and assumes no responsibility for the content, practices, or policies of third-party websites.</p>
 
   <h2>6. Open-source license</h2>
-  <p>MUGA is released under the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener">GNU General Public License v3 (GPL v3)</a>. You are free to use, study, modify, and distribute the source code, provided that any derivative work is also released under the GPL v3. The complete source code is available at <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener">github.com/yocreoquesi/muga</a>.</p>
+  <p>MUGA is released under the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener noreferrer">GNU General Public License v3 (GPL v3)</a>. You are free to use, study, modify, and distribute the source code, provided that any derivative work is also released under the GPL v3. The complete source code is available at <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a>.</p>
 
   <h2>7. Eligibility</h2>
   <p>MUGA is intended for general audiences. If you are under 16 years of age, you may only use MUGA with the consent of a parent or legal guardian, in accordance with Article 8 of the EU General Data Protection Regulation (GDPR). Since MUGA does not collect any personal data, no parental verification mechanism is required, but the age threshold applies to accepting these Terms.</p>
@@ -101,13 +101,13 @@
   <h2>11. Governing law and jurisdiction</h2>
   <p>These Terms are governed by and construed in accordance with the laws of Spain. Any disputes arising out of or in connection with these Terms shall be submitted to the competent courts of Spain.</p>
   <p>If you are a consumer habitually resident in the European Union, you additionally enjoy the protection afforded by the mandatory provisions of your country of residence. Nothing in these Terms affects your right to rely on those provisions.</p>
-  <p>The European Commission provides an <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener">Online Dispute Resolution (ODR) platform</a>. You can use this platform to seek out-of-court resolution of disputes related to online services.</p>
+  <p>The European Commission provides an <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer">Online Dispute Resolution (ODR) platform</a>. You can use this platform to seek out-of-court resolution of disputes related to online services.</p>
 
   <h2>12. Severability</h2>
   <p>If any provision of these Terms is found to be invalid or unenforceable by a court of competent jurisdiction, the remaining provisions shall continue in full force and effect. The invalid provision will be modified to the minimum extent necessary to make it valid and enforceable while preserving its original intent.</p>
 
   <h2>13. Contact</h2>
-  <p>Questions or concerns? Open an issue at <a href="https://github.com/yocreoquesi/muga/issues" target="_blank" rel="noopener">github.com/yocreoquesi/muga/issues</a>.</p>
+  <p>Questions or concerns? Open an issue at <a href="https://github.com/yocreoquesi/muga/issues" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga/issues</a>.</p>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
Second-pass production audit fixes.

### Critical
- noopener/noreferrer on window.open in cleaner.js
- pt/de toast translations in content script
- browserLang detection supports all 4 languages
- Onboarding storage write wrapped in try/catch with user feedback

### Warning
- Context menu titles translated for pt/de
- sessionStorage.getItem wrapped for incognito safety
- Popup param breakdown labels locale-aware
- Stored language validated against supported list
- rel="noopener noreferrer" on onboarding/tos links
- Detected language persisted on onboarding completion

## Test plan
- [x] All 964 tests pass
- [x] GGA passed on all files