### PR TITLE
fix: production audit round 3 — export completeness and import validation

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -24,7 +24,7 @@
       document.body.appendChild(el);
       el.focus();
       el.select();
-      try { document.execCommand("copy"); } catch {}
+      try { document.execCommand("copy"); } catch { /* legacy fallback — failure is silent by design */ }
       el.remove();
     });
   }

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -503,6 +503,9 @@ function initExportImport() {
       toastDuration: prefs.toastDuration,
       language: prefs.language,
       devMode: prefs.devMode,
+      paramBreakdown: prefs.paramBreakdown,
+      showReportButton: prefs.showReportButton,
+      domainStats: prefs.domainStats,
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -533,20 +536,21 @@ function initExportImport() {
       if (!data.muga || !Array.isArray(data.blacklist) || !Array.isArray(data.whitelist) || !Array.isArray(data.customParams)) {
         throw new Error("invalid");
       }
-      const isValidEntry = e => typeof e === "string" && e.length > 0 && e.length < 500 && /^[\x20-\x7E]+$/.test(e);
       if (data.blacklist.length > 500 || data.whitelist.length > 500 || data.customParams.length > 200) {
         throw new Error("invalid");
       }
-      if (!data.blacklist.every(isValidEntry) || !data.whitelist.every(isValidEntry) || !data.customParams.every(isValidEntry)) {
+      const isValidParam = e => typeof e === "string" && e.length > 0 && e.length < 500 && /^[a-zA-Z0-9_.\-]+$/.test(e);
+      if (!data.blacklist.every(isValidListEntry) || !data.whitelist.every(isValidListEntry) || !data.customParams.every(isValidParam)) {
         throw new Error("invalid");
       }
-      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled", "devMode"];
+      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled", "devMode", "paramBreakdown", "showReportButton", "domainStats"];
       const toSave = { blacklist: data.blacklist, whitelist: data.whitelist, customParams: data.customParams };
       for (const key of BOOL_KEYS) {
         if (typeof data[key] === "boolean") toSave[key] = data[key];
       }
-      // Handle disabledCategories (array of strings)
-      if (Array.isArray(data.disabledCategories) && data.disabledCategories.every(e => typeof e === "string")) {
+      // Handle disabledCategories (validated against known category keys)
+      const VALID_CATEGORIES = new Set(["utm", "ads", "email", "social", "platform_noise", "generic"]);
+      if (Array.isArray(data.disabledCategories) && data.disabledCategories.every(e => VALID_CATEGORIES.has(e))) {
         toSave.disabledCategories = data.disabledCategories;
       }
       // Handle toastDuration (number 5-60)

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -35,7 +35,7 @@ function _setClipboardIcon(el) {
 
 // ── Param breakdown ───────────────────────────────────────────────────────────
 
-/** Builds a reverse index: param name → { category key, label, labelEs }. Cached as singleton. */
+/** Builds a reverse index: param name → { category key, label, labelEs, labelPt, labelDe }. Cached as singleton. */
 let _paramIndex = null;
 function _buildParamIndex() {
   if (_paramIndex) return _paramIndex;
@@ -46,6 +46,8 @@ function _buildParamIndex() {
         categoryKey: catKey,
         label: catData.label,
         labelEs: catData.labelEs,
+        labelPt: catData.labelPt,
+        labelDe: catData.labelDe,
       });
     }
   }

--- a/tests/unit/export-import.test.mjs
+++ b/tests/unit/export-import.test.mjs
@@ -29,9 +29,9 @@ function isValidListEntry(entry) {
   return true;
 }
 
-// Extract isValidEntry inline pattern from source (line ~415 of options.js)
-function isValidEntry(e) {
-  return typeof e === "string" && e.length > 0 && e.length < 500 && /^[\x20-\x7E]+$/.test(e);
+// Extract isValidParam inline pattern from source (customParams validator in options.js)
+function isValidParam(e) {
+  return typeof e === "string" && e.length > 0 && e.length < 500 && /^[a-zA-Z0-9_.\-]+$/.test(e);
 }
 
 // ---------------------------------------------------------------------------
@@ -65,6 +65,9 @@ describe("export settings (source verification)", () => {
       "unwrapRedirects",
       "contextMenuEnabled",
       "devMode",
+      "paramBreakdown",
+      "showReportButton",
+      "domainStats",
     ];
     // Verify each boolean key appears in the export payload block
     for (const key of EXPECTED_BOOL_KEYS) {
@@ -128,10 +131,14 @@ describe("import settings (source verification)", () => {
     );
   });
 
-  test("6. import validates entries with printable ASCII check", () => {
+  test("6. import validates list entries with isValidListEntry and params with regex", () => {
     assert.ok(
-      /\^?\[\\x20-\\x7E\]\+\$/.test(OPTIONS_SOURCE),
-      "Import must validate entries with printable ASCII regex"
+      OPTIONS_SOURCE.includes("isValidListEntry"),
+      "Import must validate blacklist/whitelist entries with isValidListEntry"
+    );
+    assert.ok(
+      OPTIONS_SOURCE.includes("isValidParam"),
+      "Import must validate customParams entries with isValidParam"
     );
   });
 
@@ -163,14 +170,14 @@ describe("import settings (source verification)", () => {
     );
   });
 
-  test("11. import validates disabledCategories as array of strings", () => {
+  test("11. import validates disabledCategories against known category keys", () => {
     assert.ok(
       OPTIONS_SOURCE.includes("Array.isArray(data.disabledCategories)"),
       "Import must validate disabledCategories is an array"
     );
     assert.ok(
-      OPTIONS_SOURCE.includes('typeof e === "string"'),
-      "Import must validate disabledCategories entries are strings"
+      OPTIONS_SOURCE.includes("VALID_CATEGORIES"),
+      "Import must validate disabledCategories against VALID_CATEGORIES set"
     );
   });
 
@@ -266,38 +273,38 @@ describe("isValidListEntry (extracted function)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Extracted logic tests — isValidEntry (inline pattern)
+// Extracted logic tests — isValidParam (customParams validator)
 // ---------------------------------------------------------------------------
-describe("isValidEntry (extracted inline pattern)", () => {
+describe("isValidParam (extracted inline pattern)", () => {
 
-  test("26. valid ASCII string -> true", () => {
-    assert.strictEqual(isValidEntry("hello world"), true);
-    assert.strictEqual(isValidEntry("some-param_123"), true);
-    assert.strictEqual(isValidEntry("a"), true);
+  test("26. valid param strings -> true", () => {
+    assert.strictEqual(isValidParam("some-param_123"), true);
+    assert.strictEqual(isValidParam("ref_code"), true);
+    assert.strictEqual(isValidParam("a"), true);
   });
 
   test("27. empty string -> false", () => {
-    assert.strictEqual(isValidEntry(""), false);
+    assert.strictEqual(isValidParam(""), false);
   });
 
   test("28. non-string (number) -> false", () => {
-    assert.strictEqual(isValidEntry(42), false);
-    assert.strictEqual(isValidEntry(null), false);
-    assert.strictEqual(isValidEntry(undefined), false);
+    assert.strictEqual(isValidParam(42), false);
+    assert.strictEqual(isValidParam(null), false);
+    assert.strictEqual(isValidParam(undefined), false);
   });
 
-  test("29. string with non-ASCII chars: 'café' -> false", () => {
-    assert.strictEqual(isValidEntry("café"), false);
-    assert.strictEqual(isValidEntry("über"), false);
-    assert.strictEqual(isValidEntry("日本語"), false);
+  test("29. string with spaces or non-alphanumeric chars -> false", () => {
+    assert.strictEqual(isValidParam("hello world"), false);
+    assert.strictEqual(isValidParam("café"), false);
+    assert.strictEqual(isValidParam("param=value"), false);
   });
 
   test("30. string at length limit (499 chars) -> true", () => {
-    assert.strictEqual(isValidEntry("a".repeat(499)), true);
+    assert.strictEqual(isValidParam("a".repeat(499)), true);
   });
 
   test("31. string over limit (500+ chars) -> false", () => {
-    assert.strictEqual(isValidEntry("a".repeat(500)), false);
-    assert.strictEqual(isValidEntry("a".repeat(501)), false);
+    assert.strictEqual(isValidParam("a".repeat(500)), false);
+    assert.strictEqual(isValidParam("a".repeat(501)), false);
   });
 });


### PR DESCRIPTION
## Summary
- Add `paramBreakdown`, `showReportButton`, `domainStats` to export payload (were missing from settings backup)
- Use `isValidListEntry` for blacklist/whitelist import validation instead of weak ASCII-only check
- Validate `disabledCategories` against known category keys (`utm`, `ads`, `email`, `social`, `platform_noise`, `generic`)
- Add `labelPt`/`labelDe` to popup param index for complete i18n support
- Annotate empty catch in cleaner.js clipboard fallback

## Test plan
- [x] All 964 unit tests pass
- [x] GGA pre-commit review passed
- [x] Export now includes all PREF_DEFAULTS keys
- [x] Import rejects invalid list entries and unknown category keys