### PR TITLE
Redesign popup, options, and onboarding surfaces

### DIFF
--- a/src/onboarding/onboarding.html
+++ b/src/onboarding/onboarding.html
@@ -6,110 +6,192 @@
   <title data-i18n="ob_page_title">Welcome to MUGA</title>
   <style>
     :root {
-      --bg: #fff; --bg2: #f7f7f7; --border: rgba(0,0,0,0.08);
-      --text: #1a1a1a; --text2: #555; --accent: #2563eb;
-      --success: #16a34a; --warn: #d97706;
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", system-ui, sans-serif;
+      --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+      --surface-0: #FAFAF7; --surface-1: #FFFFFF; --surface-2: #F3F2EC; --surface-3: #E9E8E0;
+      --text-1: #1A1916; --text-2: #53524C; --text-3: #7A7970;
+      --border-1: #E5E4DC; --border-2: #D4D3C9;
+      --accent: #B8862C; --accent-strong: #8C651F; --accent-soft: #F5EBD3; --on-accent: #FAFAF7;
+      --success: #2F6B3A; --success-soft: #E1EFE2;
+      --r-sm: 4px; --r-md: 6px; --r-lg: 10px;
+      --shadow-1: 0 1px 2px rgba(26,25,22,.06), 0 1px 1px rgba(26,25,22,.04);
+      --dur: 200ms; --ease: cubic-bezier(.2,.7,.2,1);
+      /* aliases */
+      --bg: var(--surface-0); --bg2: var(--surface-1); --border: var(--border-1);
+      --text: var(--text-1); --text2: var(--text-2);
     }
     @media (prefers-color-scheme: dark) {
       :root {
-        --bg: #111; --bg2: #1c1c1e; --border: rgba(255,255,255,0.08);
-        --text: #f0f0f0; --text2: #aaa; --accent: #60a5fa;
+        --surface-0: #121210; --surface-1: #1C1B18; --surface-2: #26251F; --surface-3: #32302A;
+        --text-1: #F2F0E8; --text-2: #B3B1A6; --text-3: #8A887D;
+        --border-1: #2E2D27; --border-2: #3D3B34;
+        --accent: #D4A64A; --accent-strong: #E8BE66; --accent-soft: #3A2F15; --on-accent: #1A1916;
+        --success: #6FB57C; --success-soft: #1F2F22;
       }
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      background: var(--bg); color: var(--text);
-      min-height: 100vh; display: flex; align-items: center; justify-content: center;
-      padding: 32px 16px;
+      font-family: var(--font-sans);
+      background: var(--surface-0); color: var(--text-1);
+      min-height: 100vh;
+      display: flex; align-items: center; justify-content: center;
+      padding: 48px 24px;
+      -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
     }
-    .container { max-width: 560px; width: 100%; }
+    :focus { outline: none; }
+    :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+    .container { max-width: 600px; width: 100%; }
 
-    /* Header */
-    .logo { font-size: 28px; font-weight: 700; letter-spacing: -0.03em; margin-bottom: 6px; }
-    .tagline { font-size: 16px; color: var(--text2); margin-bottom: 36px; line-height: 1.5; }
+    /* Wordmark + tagline */
+    .logo {
+      display: inline-flex; align-items: center; gap: 10px;
+      font-size: 14px; font-weight: 600; letter-spacing: .12em; text-transform: uppercase;
+      color: var(--text-1); margin-bottom: 18px;
+    }
+    .logo::before {
+      content: ''; width: 28px; height: 28px; border-radius: var(--r-sm);
+      background: var(--accent-soft);
+      background-image:
+        linear-gradient(135deg, transparent 47%, var(--accent-strong) 47%, var(--accent-strong) 53%, transparent 53%),
+        linear-gradient(45deg, transparent 47%, var(--accent-strong) 47%, var(--accent-strong) 53%, transparent 53%);
+    }
+    .tagline {
+      font-size: 22px; line-height: 1.35;
+      color: var(--text-1);
+      margin-bottom: 8px;
+      font-weight: 500;
+      letter-spacing: -0.01em;
+      max-width: 26ch;
+      text-wrap: balance;
+    }
+    .tagline span:nth-child(2) { display: block; font-size: 15px; color: var(--text-2); font-weight: 400; margin-top: 6px; max-width: 48ch; }
+    .tagline small {
+      display: block; margin-top: 12px;
+      font-size: 12.5px !important; color: var(--text-3) !important; line-height: 1.6;
+      max-width: 52ch;
+    }
+    .tagline { margin-bottom: 36px; }
 
     /* Sections */
     .section { margin-bottom: 24px; }
-    .section-title { font-size: 16px; font-weight: 600; margin-bottom: 10px; }
+    .section-title {
+      font-size: 11px; font-weight: 500;
+      color: var(--text-3); text-transform: uppercase; letter-spacing: .1em;
+      margin-bottom: 12px; padding: 0 4px;
+    }
     .section-body {
-      background: var(--bg2); border-radius: 12px;
-      border: 0.5px solid var(--border); overflow: hidden;
+      background: var(--surface-1);
+      border-radius: var(--r-lg);
+      border: 1px solid var(--border-1);
+      box-shadow: var(--shadow-1);
+      overflow: hidden;
     }
 
     /* Feature rows */
     .feature-row {
-      display: flex; align-items: flex-start; gap: 12px;
-      padding: 13px 16px; border-bottom: 0.5px solid var(--border); font-size: 13.5px;
+      display: flex; align-items: flex-start; gap: 14px;
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--border-1);
+      font-size: 14px;
     }
     .feature-row:last-child { border-bottom: none; }
-    .feature-icon { font-size: 13px; line-height: 1; flex-shrink: 0; margin-top: 2px; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; background: #e8f0fe; color: #1a56db; border-radius: 6px; font-weight: 700; }
-    .feature-text strong { display: block; font-weight: 500; margin-bottom: 2px; }
-    .feature-text small { color: var(--text2); font-size: 12px; line-height: 1.4; }
+    .feature-icon {
+      font-size: 13px; line-height: 1;
+      flex-shrink: 0; margin-top: 1px;
+      width: 26px; height: 26px;
+      display: flex; align-items: center; justify-content: center;
+      background: var(--accent-soft); color: var(--accent-strong);
+      border-radius: var(--r-sm);
+      font-weight: 600; font-family: var(--font-mono);
+    }
+    .feature-text strong { display: block; font-weight: 500; margin-bottom: 3px; color: var(--text-1); letter-spacing: -0.005em; }
+    .feature-text small { color: var(--text-2); font-size: 12.5px; line-height: 1.5; }
 
     /* Affiliate card */
     .affiliate-body {
-      background: var(--bg2); border-radius: 12px;
-      border: 0.5px solid var(--border);
-      padding: 16px;
+      background: var(--surface-1);
+      border-radius: var(--r-lg);
+      border: 1px solid var(--border-1);
+      box-shadow: var(--shadow-1);
+      padding: 20px;
     }
     .affiliate-body p {
-      font-size: 13px; color: var(--text2); line-height: 1.6; margin-bottom: 14px;
+      font-size: 13.5px; color: var(--text-2); line-height: 1.65; margin-bottom: 16px;
     }
-    .affiliate-body strong { color: var(--text); }
+    .affiliate-body strong { color: var(--text-1); font-weight: 500; }
 
     /* Consent checkboxes */
     .consent-check {
       display: flex; align-items: flex-start; gap: 12px;
-      padding: 13px 14px; background: var(--bg);
-      border: 0.5px solid var(--border); border-radius: 8px;
-      cursor: pointer; transition: border-color .15s;
+      padding: 14px 16px;
+      background: var(--surface-2);
+      border: 1px solid var(--border-1);
+      border-radius: var(--r-md);
+      cursor: pointer;
+      transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease);
       margin-bottom: 10px;
     }
     .consent-check:last-child { margin-bottom: 0; }
-    .consent-check:hover { border-color: var(--accent); }
+    .consent-check:hover { border-color: var(--border-2); }
+    .consent-check:has(input:checked) {
+      border-color: var(--accent); background: var(--accent-soft);
+    }
     .consent-check input[type="checkbox"] {
       width: 16px; height: 16px; margin-top: 2px; flex-shrink: 0;
-      accent-color: var(--accent); cursor: pointer;
+      accent-color: var(--accent-strong); cursor: pointer;
     }
-    .consent-check-label { font-size: 13px; line-height: 1.5; }
-    .consent-check-label strong { display: block; font-weight: 500; margin-bottom: 2px; }
-    .consent-check-label small { color: var(--text2); font-size: 12px; }
-    .consent-check-label a { color: var(--accent); text-decoration: none; }
+    .consent-check-label { font-size: 13px; line-height: 1.55; color: var(--text-1); }
+    .consent-check-label strong { display: block; font-weight: 500; margin-bottom: 3px; }
+    .consent-check-label small { color: var(--text-2); font-size: 12px; }
+    .consent-check-label a { color: var(--accent-strong); text-decoration: underline; text-underline-offset: 2px; }
 
     /* ToS section */
-    .tos-section {
-      margin-top: 16px;
-    }
+    .tos-section { margin-top: 18px; }
     .tos-check {
       display: flex; align-items: flex-start; gap: 12px;
-      padding: 13px 16px; background: var(--bg2);
-      border: 0.5px solid var(--border); border-radius: 10px;
-      cursor: pointer; transition: border-color .15s;
+      padding: 14px 18px;
+      background: var(--surface-1);
+      border: 1.5px solid var(--border-1);
+      border-radius: var(--r-md);
+      cursor: pointer;
+      transition: border-color var(--dur) var(--ease), background var(--dur) var(--ease);
     }
-    .tos-check:hover { border-color: var(--accent); }
+    .tos-check:hover { border-color: var(--border-2); }
+    .tos-check:has(input:checked) {
+      border-color: var(--accent); background: var(--accent-soft);
+    }
     .tos-check input[type="checkbox"] {
       width: 16px; height: 16px; margin-top: 2px; flex-shrink: 0;
-      accent-color: var(--accent); cursor: pointer;
+      accent-color: var(--accent-strong); cursor: pointer;
     }
-    .tos-check-label { font-size: 13px; line-height: 1.5; }
-    .tos-check-label a { color: var(--accent); text-decoration: none; }
-    .tos-required-hint { display: block; color: var(--text2); margin-top: 3px; }
+    .tos-check-label { font-size: 13px; line-height: 1.55; color: var(--text-1); }
+    .tos-check-label a { color: var(--accent-strong); text-decoration: underline; text-underline-offset: 2px; }
+    .tos-required-hint { display: block; color: var(--text-3); margin-top: 4px; font-size: 11.5px; }
 
     /* CTA */
-    .cta { margin-top: 20px; }
+    .cta { margin-top: 24px; }
     .btn-primary {
-      display: block; width: 100%; padding: 14px 40px;
-      background: var(--accent); color: #fff;
-      font-size: 15px; font-weight: 600; border: none;
-      border-radius: 12px; cursor: pointer; transition: opacity .15s;
+      display: block; width: 100%;
+      padding: 14px 40px;
+      background: var(--accent-strong); color: var(--on-accent);
+      font-size: 14px; font-weight: 500;
+      letter-spacing: -0.005em;
+      border: 1px solid var(--accent-strong);
+      border-radius: var(--r-md);
+      cursor: pointer;
+      transition: filter var(--dur) var(--ease), opacity var(--dur) var(--ease);
       text-align: center;
     }
     .btn-primary:disabled {
-      opacity: 0.35; cursor: not-allowed;
+      opacity: .35; cursor: not-allowed;
+      background: var(--surface-3); color: var(--text-3); border-color: var(--border-2);
     }
-    .btn-primary:not(:disabled):hover { opacity: 0.88; }
-    .cta-note { font-size: 11.5px; color: var(--text2); margin-top: 10px; text-align: center; }
+    .btn-primary:not(:disabled):hover { filter: brightness(1.08); }
+    .cta-note {
+      font-size: 11.5px; color: var(--text-3);
+      margin-top: 12px; text-align: center;
+      letter-spacing: .04em; text-transform: uppercase;
+    }
   </style>
 </head>
 <body>

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,146 +1,538 @@
+/* =========================================================================
+   MUGA options — redesigned per Claude Design handoff (2026-04).
+   Warm-neutral surfaces, muted amber accent, hairline borders.
+   ========================================================================= */
+
 :root {
-  --bg: #fff; --bg2: #f5f5f5; --border: rgba(0,0,0,0.08);
-  --text: #1a1a1a; --text2: #555; --accent: #2563eb;
-  --danger: #dc2626; --success: #16a34a; --toggle-off: #d1d5db;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  --surface-0: #FAFAF7;
+  --surface-1: #FFFFFF;
+  --surface-2: #F3F2EC;
+  --surface-3: #E9E8E0;
+
+  --text-1: #1A1916;
+  --text-2: #53524C;
+  --text-3: #7A7970;
+
+  --border-1: #E5E4DC;
+  --border-2: #D4D3C9;
+
+  --accent: #B8862C;
+  --accent-strong: #8C651F;
+  --accent-soft: #F5EBD3;
+  --on-accent: #FAFAF7;
+
+  --success: #2F6B3A;
+  --success-soft: #E1EFE2;
+  --warning: #8A5A10;
+  --warning-soft: #F5E9CF;
+  --danger:  #8E2A2A;
+  --danger-soft:  #F3DADA;
+  --info:    #2A5880;
+  --info-soft: #DCE7F1;
+
+  --shadow-1: 0 1px 2px rgba(26,25,22,.06), 0 1px 1px rgba(26,25,22,.04);
+  --shadow-2: 0 4px 12px rgba(26,25,22,.08), 0 2px 4px rgba(26,25,22,.04);
+
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-lg: 10px;
+  --r-pill: 999px;
+
+  --dur: 200ms;
+  --ease: cubic-bezier(.2,.7,.2,1);
+
+  /* Aliases for any inline styles in HTML */
+  --bg: var(--surface-1);
+  --bg2: var(--surface-2);
+  --border: var(--border-1);
+  --text: var(--text-1);
+  --text2: var(--text-2);
+  --toggle-off: var(--border-2);
 }
+
 @media (prefers-color-scheme: dark) {
-  :root { --bg: #1c1c1e; --bg2: #2c2c2e; --border: rgba(255,255,255,0.08);
-    --text: #f0f0f0; --text2: #aaa; --accent: #60a5fa; --toggle-off: #48484a;
-    --danger: #ef4444; --success: #4ade80; }
+  :root {
+    --surface-0: #121210;
+    --surface-1: #1C1B18;
+    --surface-2: #26251F;
+    --surface-3: #32302A;
+
+    --text-1: #F2F0E8;
+    --text-2: #B3B1A6;
+    --text-3: #8A887D;
+
+    --border-1: #2E2D27;
+    --border-2: #3D3B34;
+
+    --accent: #D4A64A;
+    --accent-strong: #E8BE66;
+    --accent-soft: #3A2F15;
+    --on-accent: #1A1916;
+
+    --success: #6FB57C;
+    --success-soft: #1F2F22;
+    --warning: #E0B16B;
+    --warning-soft: #3A2F15;
+    --danger:  #E08686;
+    --danger-soft:  #3A1F1F;
+    --info:    #8FB5D9;
+    --info-soft: #1F2A35;
+  }
 }
+
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: var(--bg); color: var(--text); max-width: 640px;
-  margin: 0 auto; padding: 32px 24px; font-size: 14px; }
-h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
-.subtitle { color: var(--text2); font-size: 13px; margin-bottom: 28px; }
-section { margin-bottom: 28px; }
-h2 { font-size: 13px; font-weight: 500; color: var(--text2);
-  text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; }
-.card { background: var(--bg2); border-radius: 10px;
-  border: 0.5px solid var(--border); overflow: hidden; }
-.row { display: flex; align-items: center; justify-content: space-between;
-  padding: 13px 16px; border-bottom: 0.5px solid var(--border); gap: 12px; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--surface-0);
+  color: var(--text-1);
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 48px 32px 64px;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ---------- Page header ------------------------------------------------- */
+h1 {
+  font-size: 28px;
+  line-height: 34px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin-bottom: 6px;
+  color: var(--text-1);
+}
+
+.subtitle {
+  color: var(--text-2);
+  font-size: 14px;
+  margin-bottom: 36px;
+}
+
+/* ---------- Sections ---------------------------------------------------- */
+section { margin-bottom: 32px; }
+
+h2 {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  margin-bottom: 12px;
+  padding: 0 4px;
+}
+
+/* ---------- Card -------------------------------------------------------- */
+.card {
+  background: var(--surface-1);
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border-1);
+  box-shadow: var(--shadow-1);
+  overflow: hidden;
+}
+
+/* ---------- Row --------------------------------------------------------- */
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-1);
+  gap: 16px;
+}
 .row:last-child { border-bottom: none; }
-.row-label { flex: 1; }
-.row-label strong { display: block; font-size: 13.5px; font-weight: 500; }
-.row-label small { color: var(--text2); font-size: 12px; display: block; margin-top: 2px; }
-.toggle { position: relative; width: 36px; height: 20px; flex-shrink: 0; }
+
+.row-label { flex: 1; min-width: 0; }
+.row-label strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-1);
+  letter-spacing: -0.005em;
+}
+.row-label small {
+  color: var(--text-2);
+  font-size: 12.5px;
+  display: block;
+  margin-top: 4px;
+  line-height: 1.5;
+}
+
+/* ---------- Toggle ------------------------------------------------------ */
+.toggle {
+  position: relative;
+  width: 34px;
+  height: 20px;
+  flex-shrink: 0;
+}
 .toggle input { opacity: 0; width: 0; height: 0; }
-.slider { position: absolute; inset: 0; background: var(--toggle-off, #d1d5db);
-  border-radius: 20px; transition: background .2s; cursor: pointer; }
-.slider::before { content: ''; position: absolute; width: 14px; height: 14px;
-  left: 3px; top: 3px; background: white; border-radius: 50%; transition: transform .2s; }
-.toggle input:checked + .slider { background: var(--accent); }
-.toggle input:checked + .slider::before { transform: translateX(16px); }
+
+.slider {
+  position: absolute;
+  inset: 0;
+  background: var(--border-2);
+  border-radius: var(--r-pill);
+  transition: background var(--dur) var(--ease);
+  cursor: pointer;
+}
+.slider::before {
+  content: '';
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  left: 2px;
+  top: 2px;
+  background: var(--surface-1);
+  border-radius: 50%;
+  box-shadow: var(--shadow-1);
+  transition: transform var(--dur) var(--ease);
+}
+.toggle input:checked + .slider { background: var(--accent-strong); }
+.toggle input:checked + .slider::before { transform: translateX(14px); }
 .toggle input:focus-visible + .slider {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.list-section { padding: 12px 16px; }
-.list-items { margin-bottom: 10px; min-height: 20px; }
-.list-item { display: flex; align-items: center; justify-content: space-between;
-  padding: 6px 10px; background: var(--bg); border-radius: 6px;
-  margin-bottom: 5px; font-size: 12.5px; font-family: monospace; }
-.del-btn { background: none; border: none; color: var(--danger);
-  cursor: pointer; font-size: 16px; line-height: 1; padding: 0 4px; }
-.add-row { display: flex; gap: 8px; }
-.add-row input { flex: 1; padding: 7px 10px; border-radius: 6px;
-  border: 0.5px solid var(--border); background: var(--bg);
-  color: var(--text); font-size: 13px; font-family: monospace; }
-.add-btn { padding: 7px 14px; border-radius: 6px;
-  border: 0.5px solid var(--border); background: transparent;
-  color: var(--text); font-size: 13px; cursor: pointer; }
-.add-btn:hover { background: var(--bg2); }
-.del-btn:focus-visible, .add-btn:focus-visible, .add-row input:focus-visible, .lang-select:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+
+/* ---------- List sections (blacklist/whitelist/custom params) ----------- */
+.list-section { padding: 16px 20px; }
+
+.list-items {
+  margin-bottom: 12px;
+  min-height: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
-.hint { font-size: 11.5px; color: var(--text2); margin-top: 8px; line-height: 1.5; }
-.empty { font-size: 12px; color: var(--text2); font-style: italic; }
-.empty.stores-empty { padding: 8px 16px 12px; }
-/* Stores collapsible */
+
+.list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-1);
+  border-radius: var(--r-sm);
+  font-size: 12.5px;
+  font-family: var(--font-mono);
+  color: var(--text-1);
+}
+
+.del-btn {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: var(--r-sm);
+  transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+}
+.del-btn:hover { color: var(--danger); background: var(--danger-soft); }
+
+/* ---------- Inputs / buttons -------------------------------------------- */
+.add-row {
+  display: flex;
+  gap: 8px;
+}
+
+.add-row input,
+input[type="text"]:not(.add-row input) {
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-2);
+  background: var(--surface-1);
+  color: var(--text-1);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+}
+.add-row input:hover { border-color: var(--text-3); }
+.add-row input:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.add-btn {
+  padding: 8px 14px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-2);
+  background: var(--surface-1);
+  color: var(--text-1);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease);
+}
+.add-btn:hover { background: var(--surface-2); border-color: var(--text-3); }
+
+.hint {
+  font-size: 12px;
+  color: var(--text-3);
+  margin-top: 10px;
+  line-height: 1.5;
+}
+
+.empty {
+  font-size: 12.5px;
+  color: var(--text-3);
+  font-style: italic;
+}
+.empty.stores-empty { padding: 8px 20px 12px; }
+
+/* ---------- Stores ------------------------------------------------------ */
 .stores-summary {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 12px 16px; cursor: pointer; list-style: none;
-  font-size: 13px; font-weight: 600; color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-1);
   user-select: none;
 }
 .stores-summary::-webkit-details-marker { display: none; }
-.stores-summary::after { content: '›'; font-size: 16px; color: var(--text2); transition: transform 0.2s; }
+.stores-summary::after {
+  content: '›';
+  font-size: 16px;
+  color: var(--text-3);
+  transition: transform var(--dur) var(--ease);
+}
 .stores-details[open] .stores-summary::after { transform: rotate(90deg); }
-.stores-count { font-weight: 400; font-size: 11.5px; color: var(--text2); margin-left: 6px; }
-/* Stores grid */
-.stores-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 8px; padding: 4px 16px 8px; }
-.store-chip { display: flex; align-items: flex-start; gap: 8px;
-  padding: 8px 10px; background: var(--bg); border-radius: 8px;
-  border: 0.5px solid var(--border); font-size: 12.5px; }
+.stores-count {
+  font-weight: 400;
+  font-size: 11.5px;
+  color: var(--text-3);
+  margin-left: 6px;
+}
+
+.stores-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px;
+  padding: 4px 20px 12px;
+}
+
+.store-chip {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--surface-2);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-1);
+  font-size: 12.5px;
+  transition: background var(--dur) var(--ease);
+}
 .store-chip.store-group { cursor: pointer; }
-.store-chip.store-group:hover { background: var(--bg2); }
-.store-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: var(--toggle-off, #d1d5db); margin-top: 4px; }
+.store-chip.store-group:hover { background: var(--surface-3); }
+
+.store-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--border-2);
+  margin-top: 5px;
+}
 .store-dot.active { background: var(--success); }
+
 .store-info { flex: 1; min-width: 0; }
 .store-header { display: flex; align-items: center; gap: 5px; }
-.store-name { font-weight: 500; }
-.store-count { font-size: 11px; color: var(--text2); }
-.store-arrow { font-size: 13px; color: var(--text2); transition: transform 0.15s; margin-left: auto; }
+.store-name { font-weight: 500; color: var(--text-1); }
+.store-count { font-size: 11px; color: var(--text-3); }
+.store-arrow {
+  font-size: 13px;
+  color: var(--text-3);
+  transition: transform var(--dur) var(--ease);
+  margin-left: auto;
+}
 .store-chip.open .store-arrow { transform: rotate(90deg); }
-.store-param { font-size: 11px; color: var(--text2); font-family: monospace; overflow: hidden; text-overflow: ellipsis; }
-.store-detail { margin-top: 6px; padding-top: 6px; border-top: 0.5px solid var(--border); display: flex; flex-direction: column; gap: 5px; }
+.store-param {
+  font-size: 11px;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.store-detail {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-1);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
 .store-detail[hidden] { display: none; }
 .store-detail-row { display: flex; align-items: center; gap: 6px; }
 .store-detail-row .store-dot { width: 5px; height: 5px; margin-top: 0; }
 .store-detail-row .store-name { font-size: 11.5px; font-weight: 400; }
 .store-detail-row .store-param { font-size: 10px; }
-/* Language select */
+
+/* ---------- Language select --------------------------------------------- */
 .lang-select {
-  padding: 7px 10px; border-radius: 8px; font-size: 13px;
-  border: 0.5px solid var(--border); background: var(--bg);
-  color: var(--text); cursor: pointer; min-width: 120px;
+  padding: 7px 12px;
+  border-radius: var(--r-md);
+  font-size: 13px;
+  border: 1px solid var(--border-2);
+  background: var(--surface-1);
+  color: var(--text-1);
+  cursor: pointer;
+  min-width: 130px;
+  transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
 }
-/* Toast notification */
+.lang-select:hover { border-color: var(--text-3); }
+.lang-select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+/* ---------- Toast ------------------------------------------------------- */
 .toast {
-  position: fixed; bottom: 20px; right: 20px;
-  background: var(--text); color: var(--bg);
-  padding: 10px 18px; border-radius: 8px;
-  font-size: 13px; z-index: 1000;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-  opacity: 0; transform: translateY(8px);
-  transition: opacity 0.2s, transform 0.2s;
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: var(--surface-1);
+  color: var(--text-1);
+  padding: 12px 18px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-1);
+  font-size: 13px;
+  z-index: 1000;
+  box-shadow: var(--shadow-2);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease);
   pointer-events: none;
 }
-.toast.visible { opacity: 1; transform: translateY(0); pointer-events: auto; }
-/* Confirm dialog */
+.toast::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: var(--accent-strong);
+  border-radius: 3px 0 0 3px;
+}
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+/* ---------- Confirm dialog ---------------------------------------------- */
 .confirm-overlay {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex; align-items: center; justify-content: center;
+  position: fixed;
+  inset: 0;
+  background: rgba(26,25,22,.45);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   z-index: 1000;
 }
+
 .confirm-box {
-  background: var(--bg); border-radius: 12px;
-  border: 0.5px solid var(--border);
-  padding: 24px; max-width: 340px; width: 90%;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+  background: var(--surface-1);
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border-1);
+  padding: 24px;
+  max-width: 360px;
+  width: 90%;
+  box-shadow: var(--shadow-2);
 }
-.confirm-box p { font-size: 14px; margin-bottom: 16px; line-height: 1.5; }
-.confirm-btns { display: flex; gap: 8px; justify-content: flex-end; }
+.confirm-box p {
+  font-size: 14px;
+  margin-bottom: 18px;
+  line-height: 1.55;
+  color: var(--text-1);
+}
+.confirm-btns {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
 .confirm-btns button {
-  padding: 8px 16px; border-radius: 8px; border: none;
-  font-size: 13px; cursor: pointer;
+  padding: 8px 16px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-2);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--dur) var(--ease);
 }
 .confirm-cancel {
-  background: var(--bg2); color: var(--text);
-  border: 0.5px solid var(--border);
+  background: var(--surface-1);
+  color: var(--text-1);
+  border-color: var(--border-2);
 }
-.confirm-ok { background: var(--danger); color: #fff; border: none; }
-.confirm-cancel:focus-visible, .confirm-ok:focus-visible {
-  outline: 2px solid var(--accent); outline-offset: 2px;
+.confirm-cancel:hover { background: var(--surface-2); }
+.confirm-ok {
+  background: var(--danger);
+  color: #fff;
+  border-color: var(--danger);
 }
-/* Version */
-.version-info { text-align: center; font-size: 12px; color: var(--text2); margin-bottom: 6px; }
-/* Footer */
-.footer-links { text-align: center; padding-top: 4px; padding-bottom: 8px; }
-.footer-links a { font-size: 12px; color: var(--text2); text-decoration: none; }
-.footer-links a:hover { color: var(--accent); }
-.footer-links a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+.confirm-ok:hover { filter: brightness(1.08); }
+
+/* ---------- Version + footer ------------------------------------------- */
+.version-info {
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-3);
+  margin: 32px 0 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.footer-links {
+  text-align: center;
+  padding-top: 4px;
+  padding-bottom: 16px;
+}
+.footer-links a {
+  font-size: 12px;
+  color: var(--text-2);
+  text-decoration: none;
+  padding: 2px 4px;
+  border-radius: 2px;
+  transition: color var(--dur) var(--ease);
+}
+.footer-links a:hover { color: var(--accent-strong); }
+
+/* ---------- Dev URL tester result -------------------------------------- */
+#dev-url-clean {
+  padding: 8px 10px;
+  background: var(--success-soft);
+  color: var(--text-1) !important;
+  border-radius: var(--r-sm);
+  border: 1px solid transparent;
+  position: relative;
+}
+
+/* ---------- Inline-styled buttons inheriting .add-btn ------------------ */
+.report-btn {
+  background: none;
+  border: none;
+  color: var(--accent-strong);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,66 +1,197 @@
-/* MUGA popup: 300px de ancho, tema claro/oscuro automático */
+/* =========================================================================
+   MUGA popup — redesigned per Claude Design handoff (2026-04).
+   Warm-neutral surfaces, muted amber accent, monospace URL diff.
+   ========================================================================= */
 
 :root {
-  --bg: #ffffff;
-  --bg2: #f5f5f5;
-  --border: rgba(0,0,0,0.08);
-  --text: #1a1a1a;
-  --text2: #555;
-  --accent: #2563eb;
-  --toggle-off: #d1d5db;
-  --toggle-on: #2563eb;
-  --success: #16a34a;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  --surface-0: #FAFAF7;
+  --surface-1: #FFFFFF;
+  --surface-2: #F3F2EC;
+  --surface-3: #E9E8E0;
+
+  --text-1: #1A1916;
+  --text-2: #53524C;
+  --text-3: #7A7970;
+  --text-link: #3B4E2B;
+
+  --border-1: #E5E4DC;
+  --border-2: #D4D3C9;
+
+  --accent: #B8862C;
+  --accent-strong: #8C651F;
+  --accent-soft: #F5EBD3;
+  --on-accent: #FAFAF7;
+
+  --success: #2F6B3A;
+  --success-soft: #E1EFE2;
+  --warning: #8A5A10;
+  --warning-soft: #F5E9CF;
+  --info:    #2A5880;
+  --info-soft: #DCE7F1;
+
+  --diff-strip: #C94A2A;
+  --diff-strip-bg: rgba(201, 74, 42, .10);
+  --diff-keep: #2F6B3A;
+
+  --shadow-1: 0 1px 2px rgba(26,25,22,.06), 0 1px 1px rgba(26,25,22,.04);
+  --shadow-2: 0 4px 12px rgba(26,25,22,.08), 0 2px 4px rgba(26,25,22,.04);
+
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-lg: 10px;
+  --r-pill: 999px;
+
+  --dur: 200ms;
+  --ease: cubic-bezier(.2,.7,.2,1);
+
+  /* Backwards-compatible aliases used by JS that touches inline styles */
+  --bg: var(--surface-1);
+  --bg2: var(--surface-2);
+  --border: var(--border-1);
+  --text: var(--text-1);
+  --text2: var(--text-2);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #1c1c1e;
-    --bg2: #2c2c2e;
-    --border: rgba(255,255,255,0.08);
-    --text: #f0f0f0;
-    --text2: #aaa;
-    --accent: #60a5fa;
-    --toggle-off: #48484a;
-    --success: #4ade80;
+    --surface-0: #121210;
+    --surface-1: #1C1B18;
+    --surface-2: #26251F;
+    --surface-3: #32302A;
+
+    --text-1: #F2F0E8;
+    --text-2: #B3B1A6;
+    --text-3: #8A887D;
+    --text-link: #D4B878;
+
+    --border-1: #2E2D27;
+    --border-2: #3D3B34;
+
+    --accent: #D4A64A;
+    --accent-strong: #E8BE66;
+    --accent-soft: #3A2F15;
+    --on-accent: #1A1916;
+
+    --success: #6FB57C;
+    --success-soft: #1F2F22;
+    --warning: #E0B16B;
+    --warning-soft: #3A2F15;
+    --info:    #8FB5D9;
+    --info-soft: #1F2A35;
+
+    --diff-strip: #E08670;
+    --diff-strip-bg: rgba(224, 134, 112, .14);
+    --diff-keep: #8FC99A;
   }
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: var(--bg);
-  color: var(--text);
-  width: 300px;
+  font-family: var(--font-sans);
+  background: var(--surface-1);
+  color: var(--text-1);
+  width: 380px;
   font-size: 13px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ---------- Header ------------------------------------------------------- */
 header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px 12px;
-  border-bottom: 0.5px solid var(--border);
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-1);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.brand-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  display: grid;
+  place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
 }
 
 .logo {
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 600;
-  letter-spacing: -0.02em;
-  color: var(--text);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-1);
 }
 
+/* ---------- Toggle ------------------------------------------------------- */
+.toggle-wrap { display: inline-flex; align-items: center; gap: 8px; }
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 34px;
+  height: 20px;
+  flex-shrink: 0;
+}
+.toggle input { opacity: 0; width: 0; height: 0; }
+
+.slider {
+  position: absolute;
+  inset: 0;
+  background: var(--border-2);
+  border-radius: var(--r-pill);
+  transition: background var(--dur) var(--ease);
+  cursor: pointer;
+}
+.slider::before {
+  content: '';
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  left: 2px;
+  top: 2px;
+  background: var(--surface-1);
+  border-radius: 50%;
+  box-shadow: var(--shadow-1);
+  transition: transform var(--dur) var(--ease);
+}
+.toggle input:checked + .slider { background: var(--accent-strong); }
+.toggle input:checked + .slider::before { transform: translateX(14px); }
+.toggle input:focus-visible + .slider {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ---------- Stats strip -------------------------------------------------- */
 .stats {
   display: flex;
-  gap: 0;
-  border-bottom: 0.5px solid var(--border);
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border-1);
 }
 
 .stat {
   flex: 1;
   padding: 12px 8px;
   text-align: center;
-  border-right: 0.5px solid var(--border);
+  border-right: 1px solid var(--border-1);
+  background: transparent;
 }
 .stat:last-child { border-right: none; }
 
@@ -68,194 +199,179 @@ header {
   display: block;
   font-size: 20px;
   font-weight: 500;
-  color: var(--text);
-  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-1);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
 }
 
 .stat-label {
   display: block;
   font-size: 10px;
-  color: var(--text2);
-  margin-top: 2px;
+  color: var(--text-3);
+  margin-top: 3px;
   line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: .04em;
 }
 
-.stat-clickable {
-  cursor: pointer;
-}
-.stat-clickable:hover { background: var(--bg2); }
-.stat-clickable:hover .stat-value { text-decoration: underline; }
+.stat-clickable { cursor: pointer; transition: background var(--dur) var(--ease); }
+.stat-clickable:hover { background: var(--surface-3); }
 .stat-clickable:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
-
-/* Toggle switch */
-.toggle {
-  position: relative;
-  display: inline-block;
-  width: 36px;
-  height: 20px;
-  flex-shrink: 0;
-}
-
-
-.toggle input { opacity: 0; width: 0; height: 0; }
-
-.slider {
-  position: absolute;
-  inset: 0;
-  background: var(--toggle-off);
-  border-radius: 20px;
-  transition: background 0.2s;
-  cursor: pointer;
-}
-
-.slider::before {
-  content: '';
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  left: 3px;
-  top: 3px;
-  background: white;
-  border-radius: 50%;
-  transition: transform 0.2s;
-}
-
-
-.toggle input:checked + .slider { background: var(--toggle-on); }
-.toggle input:checked + .slider::before { transform: translateX(16px); }
-
-.toggle input:focus-visible + .slider {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-/* URL preview */
+/* ---------- URL preview (this page) ------------------------------------- */
 .preview {
-  padding: 8px 14px 10px;
-  border-bottom: 0.5px solid var(--border);
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-1);
+  background: var(--surface-1);
 }
 
 .preview-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 }
 
-.preview-header .preview-label { margin-bottom: 0; }
+.preview-label {
+  font-size: 10px;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  font-weight: 500;
+}
 
 .tab-badge {
   font-size: 10px;
   color: var(--success);
   font-weight: 500;
-}
-
-.preview-removed {
-  font-size: 10px;
-  color: var(--text2);
-  margin-top: 4px;
-  line-height: 1.4;
-  font-family: monospace;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.preview-label {
-  font-size: 10px;
-  color: var(--text2);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: 5px;
+  padding: 2px 7px;
+  background: var(--success-soft);
+  border-radius: var(--r-pill);
 }
 
 .preview-url {
   font-size: 11px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.5;
+  padding: 6px 8px;
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  border: 1px solid var(--border-1);
 }
+
+.preview-url + .preview-url { margin-top: 4px; }
 
 .preview-url.before {
-  color: var(--text2);
+  color: var(--diff-strip);
   text-decoration: line-through;
+  text-decoration-thickness: 1.5px;
+  background: var(--diff-strip-bg);
+  border-color: transparent;
 }
 
-/* When the page URL is already clean: show without strikethrough */
 .preview-url.before.clean-url {
   text-decoration: none;
-  color: var(--text);
+  color: var(--text-1);
+  background: var(--surface-2);
+  border-color: var(--border-1);
 }
 
 .preview-url.after {
-  color: var(--accent);
+  color: var(--text-1);
+  background: var(--success-soft);
+  border-color: transparent;
+  position: relative;
+}
+.preview-url.after::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 2px;
+  background: var(--success);
+  border-radius: 2px 0 0 2px;
 }
 
 .preview-url.clean {
   color: var(--success);
-  font-family: inherit;
-  font-size: 11.5px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  background: var(--success-soft);
+  border-color: transparent;
+}
+
+.preview-removed {
+  font-size: 10px;
+  color: var(--text-3);
+  margin-top: 6px;
+  line-height: 1.4;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .report-link {
-  display: block;
-  font-size: 10px;
-  color: var(--text2);
+  display: inline-block;
+  font-size: 10.5px;
+  color: var(--text-2);
   text-decoration: underline;
+  text-underline-offset: 2px;
   cursor: pointer;
-  margin-top: 6px;
+  margin-top: 8px;
 }
-.report-link:hover { color: var(--accent); }
-.report-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.report-link:hover { color: var(--accent-strong); }
 
-
-/* Domain stats panel */
-.domain-stats {
-  border-top: 0.5px solid var(--border);
-}
+/* ---------- Domain stats panel ------------------------------------------ */
+.domain-stats { border-top: 1px solid var(--border-1); }
 
 .domain-stats > summary {
   display: flex;
   align-items: center;
-  padding: 8px 16px;
-  font-size: 11px;
-  color: var(--text2);
+  padding: 10px 14px;
+  font-size: 10px;
+  color: var(--text-3);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: .06em;
   cursor: pointer;
   list-style: none;
   user-select: none;
+  font-weight: 500;
 }
 .domain-stats > summary::-webkit-details-marker { display: none; }
-.domain-stats > summary::after { content: ' ›'; margin-left: auto; }
-
-#domain-stats-list {
-  padding: 0 0 4px;
+.domain-stats > summary::after {
+  content: '›';
+  margin-left: auto;
+  color: var(--text-3);
+  transition: transform var(--dur) var(--ease);
 }
+.domain-stats[open] > summary::after { transform: rotate(90deg); }
+
+#domain-stats-list { padding: 0 0 6px; }
 
 .domain-stats-empty {
   font-size: 12px;
-  color: var(--text2);
+  color: var(--text-3);
   font-style: italic;
-  padding: 6px 16px 8px;
+  padding: 6px 14px 8px;
 }
 
 .domain-stats-row {
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 6px;
+  gap: 8px;
   align-items: center;
-  padding: 4px 16px;
-  border-top: 0.5px solid var(--border);
+  padding: 6px 14px;
+  border-top: 1px solid var(--border-1);
   font-size: 11px;
 }
 
 .domain-stats-name {
-  color: var(--text);
-  font-family: monospace;
+  color: var(--text-1);
+  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -263,53 +379,72 @@ header {
 
 .domain-stats-params,
 .domain-stats-urls {
-  color: var(--text2);
+  color: var(--text-3);
   white-space: nowrap;
   font-size: 10px;
+  font-variant-numeric: tabular-nums;
 }
 
-.domain-stats-params { color: var(--accent); }
+.domain-stats-params {
+  color: var(--accent-strong);
+  font-weight: 500;
+}
 
-/* Session history */
-.history { border-top: 0.5px solid var(--border); }
+/* ---------- Session history --------------------------------------------- */
+.history { border-top: 1px solid var(--border-1); }
 
 .history-summary {
   display: flex;
   align-items: center;
-  padding: 8px 16px;
-  font-size: 11px;
-  color: var(--text2);
+  padding: 10px 14px;
+  font-size: 10px;
+  color: var(--text-3);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: .06em;
   cursor: pointer;
   list-style: none;
   user-select: none;
+  font-weight: 500;
 }
 .history-summary::-webkit-details-marker { display: none; }
-.history-summary::after { content: ' ›'; margin-left: auto; }
+.history-summary::after {
+  content: '›';
+  margin-left: auto;
+  color: var(--text-3);
+  transition: transform var(--dur) var(--ease);
+}
+.history[open] .history-summary::after { transform: rotate(90deg); }
 
 .history-entry {
-  padding: 4px 16px 5px;
-  border-top: 0.5px solid var(--border);
+  padding: 8px 14px;
+  border-top: 1px solid var(--border-1);
   cursor: pointer;
+  transition: background var(--dur) var(--ease);
 }
+.history-entry:hover { background: var(--surface-2); }
 
 .history-url {
   font-size: 10.5px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   white-space: normal;
   overflow-wrap: break-word;
   word-break: break-all;
   line-height: 1.5;
 }
 
-.history-url.before { color: var(--text2); text-decoration: line-through; }
-.history-url.after  { color: var(--accent); }
+.history-url.before {
+  color: var(--diff-strip);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  opacity: .8;
+}
+.history-url.after { color: var(--text-1); }
 
 .history-after-row {
   display: flex;
   align-items: flex-start;
-  gap: 4px;
+  gap: 6px;
+  margin-top: 4px;
 }
 .history-after-row .history-url.after { flex: 1; }
 
@@ -318,155 +453,177 @@ header {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 1px 2px;
-  color: var(--text2);
+  padding: 2px 4px;
+  color: var(--text-3);
   line-height: 1;
-  border-radius: 3px;
+  border-radius: var(--r-sm);
   display: flex;
   align-items: center;
-  opacity: 0.6;
-  transition: opacity 0.15s;
+  opacity: .65;
+  transition: opacity var(--dur) var(--ease), color var(--dur) var(--ease);
 }
-.history-copy-clean-btn:hover { opacity: 1; color: var(--accent); }
+.history-copy-clean-btn:hover { opacity: 1; color: var(--accent-strong); }
 .history-entry.copied .history-copy-clean-btn { color: var(--success); opacity: 1; }
-
-.history-entry:hover { background: var(--bg2); }
-.history-entry:hover .history-url.after { text-decoration: underline; }
 .history-entry.copied .history-url.after { color: var(--success); }
 
 .history-actions {
   display: flex;
   justify-content: flex-end;
-  margin-top: 3px;
+  margin-top: 6px;
 }
 
 .history-copy-btn {
-  font-size: 10px;
-  padding: 2px 7px;
-  border-radius: 4px;
-  border: 0.5px solid var(--border);
-  background: var(--bg);
-  color: var(--text2);
+  font-size: 10.5px;
+  padding: 3px 9px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-2);
+  background: var(--surface-1);
+  color: var(--text-2);
   cursor: pointer;
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
 }
-.history-copy-btn:hover { background: var(--bg2); color: var(--text); }
-.history-copy-btn:focus-visible,
-.history-copy-clean-btn:focus-visible,
-.history-entry:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-.history-empty { font-size: 12px; color: var(--text2); font-style: italic; padding: 10px 16px 8px; }
+.history-copy-btn:hover { background: var(--surface-2); color: var(--text-1); }
 
+.history-empty {
+  font-size: 12px;
+  color: var(--text-3);
+  font-style: italic;
+  padding: 12px 14px;
+}
+
+/* ---------- Footer ------------------------------------------------------- */
 footer {
   display: flex;
   justify-content: space-between;
-  padding: 10px 16px;
+  align-items: center;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border-1);
+  background: var(--surface-1);
 }
 
 footer a {
   font-size: 11.5px;
-  color: var(--text2);
+  color: var(--text-2);
   text-decoration: none;
+  padding: 2px 4px;
+  border-radius: 2px;
+  transition: color var(--dur) var(--ease);
 }
+footer a:hover { color: var(--accent-strong); }
 
-footer a:hover { color: var(--accent); }
-footer a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
-
-/* Growth bar */
+/* ---------- Growth bar (rate / share) ----------------------------------- */
 .growth-bar {
-  display: flex; gap: 6px; padding: 6px 16px;
-  border-top: 0.5px solid var(--border);
+  display: flex;
+  gap: 6px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border-1);
+  background: var(--surface-2);
 }
-.growth-btn {
-  flex: 1; padding: 5px 8px; border-radius: 6px; font-size: 11px;
-  border: 0.5px solid var(--border); background: var(--bg2);
-  color: var(--text2); cursor: pointer; transition: background 0.15s;
-}
-.growth-btn:hover { background: var(--border); color: var(--text); }
-.growth-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-/* Screen-reader only utility: visually hidden but accessible */
+.growth-btn {
+  flex: 1;
+  padding: 7px 10px;
+  border-radius: var(--r-md);
+  font-size: 11.5px;
+  font-weight: 500;
+  border: 1px solid var(--border-2);
+  background: var(--surface-1);
+  color: var(--text-2);
+  cursor: pointer;
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+}
+.growth-btn:hover {
+  background: var(--surface-1);
+  color: var(--text-1);
+  border-color: var(--border-strong, var(--text-1));
+}
+
+/* ---------- Screen-reader only ------------------------------------------ */
 .sr-only {
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
 }
 
-/* Consent gate: shown when user hasn't accepted ToS */
+/* ---------- Consent gate ------------------------------------------------- */
 .consent-gate {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 32px 20px;
+  padding: 36px 24px;
   text-align: center;
-  min-height: 200px;
+  min-height: 220px;
+  background: var(--surface-1);
 }
 .consent-gate-logo {
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  margin-bottom: 12px;
-  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+  color: var(--accent-strong);
 }
 .consent-gate-msg {
   font-size: 13px;
-  color: var(--text2);
-  line-height: 1.5;
-  margin-bottom: 18px;
+  color: var(--text-2);
+  line-height: 1.55;
+  margin-bottom: 20px;
+  max-width: 280px;
 }
 .consent-gate-btn {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 10px 24px;
-  font-size: 14px;
-  font-weight: 600;
+  background: var(--accent-strong);
+  color: var(--on-accent);
+  border: 1px solid var(--accent-strong);
+  border-radius: var(--r-md);
+  padding: 9px 22px;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
+  transition: filter var(--dur) var(--ease);
 }
-.consent-gate-btn:hover {
-  opacity: 0.9;
-}
-.consent-gate-btn:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
+.consent-gate-btn:hover { filter: brightness(1.08); }
 
-/* ── Param breakdown ─────────────────────────────────────────────────────── */
+/* ---------- Param breakdown ---------------------------------------------- */
 .preview-breakdown {
-  margin-top: 6px;
+  margin-top: 8px;
   font-size: 11px;
-  color: var(--text2);
+  color: var(--text-2);
 }
 .history-breakdown {
-  margin: 4px 0 2px;
+  margin: 6px 0 2px;
   font-size: 11px;
-  color: var(--text2);
+  color: var(--text-2);
 }
 .preview-breakdown > summary,
 .history-breakdown > summary {
   cursor: pointer;
   user-select: none;
-  color: var(--text2);
+  color: var(--text-3);
   list-style: disclosure-closed;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  font-size: 10px;
+  font-weight: 500;
 }
 .preview-breakdown[open] > summary,
 .history-breakdown[open] > summary {
   list-style: disclosure-open;
+  color: var(--text-2);
 }
 .param-breakdown {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  margin-top: 4px;
+  gap: 4px;
+  margin-top: 6px;
+  padding: 8px 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-1);
+  border-radius: var(--r-sm);
 }
 .breakdown-row {
   display: flex;
@@ -476,16 +633,17 @@ footer a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; 
 }
 .breakdown-cat {
   font-weight: 600;
-  color: var(--text2);
+  color: var(--text-2);
   white-space: nowrap;
   flex-shrink: 0;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: .03em;
 }
-.breakdown-cat::after {
-  content: ":";
-}
+.breakdown-cat::after { content: ":"; }
 .breakdown-params {
-  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", monospace;
-  font-size: 10px;
-  color: var(--text2);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-3);
   word-break: break-all;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -8,7 +8,15 @@
 </head>
 <body>
   <header>
-    <div class="logo" id="logo-text">MUGA</div>
+    <div class="brand">
+      <span class="brand-mark" aria-hidden="true">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 4 L8 9 L4 8 L7 13 L4 16 L9 16 L12 20 L15 16 L20 16 L17 13 L20 8 L16 9 Z"/>
+          <circle cx="12" cy="12" r="1" fill="currentColor"/>
+        </svg>
+      </span>
+      <span class="logo" id="logo-text">MUGA</span>
+    </div>
     <div class="toggle-wrap">
       <span class="toggle-label sr-only" data-i18n="toggle_enabled">Enable MUGA</span>
       <label class="toggle" title="Enable / disable MUGA">


### PR DESCRIPTION
## Summary

Applies a redesign across the three user-facing surfaces — popup, options, and onboarding — based on a Claude Design handoff bundle. The redesign introduces a shared visual language: warm-neutral surfaces, a muted amber accent (replacing the previous blue), monospace URL diffs with strip/keep colors, hairline borders, and refined typography.

## What changed

- **Popup** (`src/popup/popup.css`, `src/popup/popup.html`)
  - New token system (warm neutrals, amber accent, semantic colors)
  - Brand mark glyph added next to the wordmark in the header
  - Monospace URL preview with strip-through styling for removed params
  - Refined toggle, stats strip, history rows, growth bar, consent gate
  - All `popup.js` IDs/DOM hooks preserved — no JS changes required

- **Options** (`src/options/options.css`)
  - Single-column structure preserved (no risk to `options.js` selectors)
  - Card style with subtle shadow and 1px borders
  - Sectioned uppercase H2s, mono inputs with focus rings
  - Restyled stores grid, language select, toast, and confirm dialog

- **Onboarding** (`src/onboarding/onboarding.html`)
  - Inline `<style>` block fully replaced with token-driven theme
  - Wordmark + glyph header, balanced tagline typography
  - `:has()`-driven selected state on consent and ToS checkboxes
  - Accent-strong primary CTA

All three surfaces follow `prefers-color-scheme: dark` automatically.

## Reviewer notes

- Pure visual change — no functional behavior, no `manifest.json`, and no JS modifications.
- All existing element IDs and class hooks consumed by `popup.js`, `options.js`, and `onboarding.js` were preserved deliberately.
- The deeper layout reorganizations from the design (per-site toggle, sticky sidebar nav for options, multi-step onboarding) were intentionally **not** applied here to keep this PR low-risk; they can land in a follow-up.

## Test plan

- [ ] `npm run lint`
- [ ] `npm run dev:chrome` — open the popup on a tracked URL and verify diff rendering
- [ ] Open Settings, toggle each row, add/remove a blacklist entry, open a confirm dialog
- [ ] Re-trigger onboarding and verify ToS gate enables the CTA only when checked
- [ ] Toggle OS dark mode and re-verify all three surfaces