### PR TITLE
ci: repair weekly health check and sync README badge

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -16,7 +16,5 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - name: Run health-check tests
-        run: node --test tests/unit/health-check.test.mjs
       - name: Run full unit test suite
         run: npm test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.9.10-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-1001_pass-brightgreen)](#development)
+[![Tests](https://img.shields.io/badge/tests-967_pass-brightgreen)](#development)
 [![Health Check](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml/badge.svg)](https://github.com/yocreoquesi/muga/actions/workflows/health-check.yml)
 # MUGA: Clean URLs, Fair to Every Click
 


### PR DESCRIPTION
## Summary
- Fix the weekly health-check workflow: drop the dangling reference to `tests/unit/health-check.test.mjs`, which was deleted in #297 when the monolith was split into six topic files. The workflow has been failing every Monday since 2026-04-20.
- The remaining `npm test` step is the authoritative run and already covers the full suite.
- Sync the README test badge from 1001 to 967 to match the actual count after the split.

## Why
- CI regression — weekly health check was failing silently and masking real domain regressions.
- Badge drift — the staleness test only caught ±50, so the 1001 number was still passing while being visibly wrong.

## Test plan
- [x] `npm test` → 967/967 pass locally
- [ ] CI green on this PR
- [ ] Next weekly run (Monday) green