### PR TITLE
ci: un-silence lint + pin actions by SHA + add minimal permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,19 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: "npm"
@@ -40,18 +43,18 @@ jobs:
       - name: Run unit tests
         run: npm test
 
-      - name: Lint extension (informational)
-        run: npm run lint || true
+      - name: Lint extension
+        run: npm run lint
 
   e2e:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -5,13 +5,16 @@ on:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
   workflow_dispatch:      # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   health-check:
     name: Domain compatibility smoke tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -14,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: "npm"
@@ -44,7 +47,7 @@ jobs:
           mv dist/firefox/*.zip dist/firefox/muga-${{ steps.version.outputs.VERSION }}-firefox.zip
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           name: "v${{ steps.version.outputs.VERSION }}"
           body: |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:chrome": "web-ext build --source-dir src/ --artifacts-dir dist/chrome/ --overwrite-dest",
     "build:firefox": "bash scripts/with-firefox-manifest.sh web-ext build --source-dir src/ --artifacts-dir dist/firefox/ --overwrite-dest",
     "build": "npm run build:chrome && npm run build:firefox",
-    "lint": "web-ext lint --source-dir src/",
+    "lint": "bash scripts/with-firefox-manifest.sh npx --no-install web-ext lint --source-dir src/",
     "test": "node --test --test-reporter=spec tests/unit/*.mjs",
     "test:serve": "npx serve tests/browser --listen 5555 --no-clipboard",
     "brand": "npx serve tools --listen 5556 --no-clipboard",

--- a/tests/unit/workflows-hardened.test.mjs
+++ b/tests/unit/workflows-hardened.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * MUGA — Workflow Hardening Regression Tests
+ *
+ * Invariants that prevent CI security regressions from being silently
+ * re-introduced: silenced lint, floating action tags, and missing
+ * workflow-level permissions blocks.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workflowsDir = join(__dirname, "../../.github/workflows");
+
+const WORKFLOW_FILES = ["ci.yml", "health-check.yml", "release.yml"];
+
+function readWorkflow(name) {
+  return readFileSync(join(workflowsDir, name), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Silenced lint guard
+// ---------------------------------------------------------------------------
+describe("silenced lint guard", () => {
+  test("ci.yml does not silence web-ext lint with || true", () => {
+    const content = readWorkflow("ci.yml");
+    // Match any variant: "npm run lint || true", "npm run lint|| true", etc.
+    const silenced = /npm\s+run\s+lint\s*\|\|\s*true/.test(content);
+    assert.ok(
+      !silenced,
+      "ci.yml silences 'npm run lint' with '|| true' — remove the || true so lint failures are visible"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHA pinning — every `uses:` must reference a full 40-char commit SHA
+// ---------------------------------------------------------------------------
+describe("action SHA pinning", () => {
+  for (const file of WORKFLOW_FILES) {
+    test(`${file}: all 'uses:' lines reference a 40-char commit SHA`, () => {
+      const content = readWorkflow(file);
+      const lines = content.split("\n");
+      const usesLines = lines.filter(l => /^\s+(-\s+)?uses:\s+\S/.test(l));
+
+      assert.ok(
+        usesLines.length > 0,
+        `${file} has no 'uses:' lines — check the file is being read correctly`
+      );
+
+      for (const line of usesLines) {
+        // Must match: uses: owner/repo@<40 hex chars>  (optional trailing comment)
+        const pinned = /uses:\s+[a-zA-Z0-9/_.-]+@[a-f0-9]{40}(\s.*)?$/.test(line.trim());
+        assert.ok(
+          pinned,
+          `${file} has an unpinned action: "${line.trim()}"\n` +
+          "All 'uses:' references must use a 40-character commit SHA, not a tag or branch."
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Workflow-level permissions block
+// ---------------------------------------------------------------------------
+describe("workflow-level permissions block", () => {
+  for (const file of WORKFLOW_FILES) {
+    test(`${file}: has a workflow-level 'permissions:' block`, () => {
+      const content = readWorkflow(file);
+      // A workflow-level permissions block appears at the top level (no leading spaces)
+      // before the first 'jobs:' key.
+      const jobsIndex = content.indexOf("\njobs:");
+      const preJobs = jobsIndex === -1 ? content : content.slice(0, jobsIndex);
+      const hasPermissions = /^permissions:/m.test(preJobs);
+      assert.ok(
+        hasPermissions,
+        `${file} is missing a workflow-level 'permissions:' block.\n` +
+        "Add 'permissions: { contents: read }' at the top level (before 'jobs:') to apply least-privilege defaults."
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- **Un-silence `web-ext lint`**: Removes `|| true` from the lint step in `ci.yml` so any manifest-level regression (bad key, wrong permission, etc.) fails CI visibly instead of passing silently.
- **Pin all GitHub Actions by commit SHA**: Replaces floating `@v4` / `@v2` tags with verified 40-char commit SHAs for `actions/checkout`, `actions/setup-node`, and `softprops/action-gh-release` across all three workflow files. Prevents supply-chain attacks where a tag is silently moved to a different commit.
- **Add workflow-level `permissions: contents: read`**: Adds least-privilege defaults to `ci.yml`, `health-check.yml`, and `release.yml`. The `release.yml` job-level `permissions: contents: write` (needed for GitHub Release creation) is preserved and takes precedence over the workflow default.
- **Regression test**: Adds `tests/unit/workflows-hardened.test.mjs` (7 tests using `node:test`) that will fail CI immediately if any of these three regressions are re-introduced.

## SHAs used (verified via `gh api` on 2026-04-24, all resolved as commit type — no annotation dereference needed)
- `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/setup-node@v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020`
- `softprops/action-gh-release@v2` → `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`

## Safety checklist
- Does NOT touch release secrets or AMO/CWS credential flow. `AMO_JWT_ISSUER`, `AMO_JWT_SECRET`, `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` env wiring is untouched.
- No secret value is echoed, logged, or committed.
- Existing `continue-on-error: true` on AMO/CWS upload steps is untouched.
- All 1092 unit tests pass locally after changes.

## Related engram topics
- `audit/muga/2026-04-24/security-privacy`
- `audit/muga/2026-04-24/tests-ci`

## Test plan
- [ ] Confirm CI passes on this branch (unit + E2E)
- [ ] Verify the lint step fails if a bad key is added to a manifest (manual smoke test)
- [ ] Confirm `workflows-hardened.test.mjs` fails if `@v4` tag is restored (regression guard)