### PR TITLE
test(e2e): remove external deps + deterministic waits + hygiene guard

### DIFF
--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -8,7 +8,7 @@ const extensionPath = path.resolve(__dirname, "src");
 export default defineConfig({
   testDir: "tests/e2e",
   timeout: 30_000,
-  retries: 0,
+  retries: process.env.CI ? 1 : 0,
   workers: 1, // extensions require serial execution
   reporter: [["list"]],
   use: {

--- a/tests/e2e/export-import.spec.mjs
+++ b/tests/e2e/export-import.spec.mjs
@@ -19,7 +19,8 @@ async function setCheckbox(page, id, checked) {
     },
     { id, checked }
   );
-  await page.waitForTimeout(200);
+  // Wait for the checkbox state to reflect the requested value
+  await expect(page.locator(`#${id}`)).toBeChecked({ checked });
 }
 
 test.describe("Export / Import", () => {
@@ -96,12 +97,12 @@ test.describe("Export / Import", () => {
 
     // Enable dev mode to see import button (force: hidden by toggle CSS)
     await setCheckbox(page, "dev-mode", true);
-    await page.waitForTimeout(300);
-
-    // Import
+    // Wait for dev-mode panel to reveal the import button before interacting
     const fileInput = page.locator("#import-file");
+    await expect(fileInput).toBeAttached();
+
+    // Import — subsequent expect() calls auto-wait for the UI to update
     await fileInput.setInputFiles(tmpPath);
-    await page.waitForTimeout(1000);
 
     // Verify toggles updated
     await expect(page.locator("#inject")).toBeChecked();
@@ -125,18 +126,18 @@ test.describe("Export / Import", () => {
 
   test("import rejects invalid files", async ({ optionsPage: page }) => {
     await setCheckbox(page, "dev-mode", true);
-    await page.waitForTimeout(300);
+    // Wait for dev-mode panel to reveal the import button before interacting
+    const fileInput = page.locator("#import-file");
+    await expect(fileInput).toBeAttached();
 
     // Create an invalid file (missing muga flag)
     const tmpPath = path.join(os.tmpdir(), "muga-bad-import.json");
     fs.writeFileSync(tmpPath, JSON.stringify({ not_muga: true }));
 
-    const fileInput = page.locator("#import-file");
     await fileInput.setInputFiles(tmpPath);
-    await page.waitForTimeout(500);
 
     // The import should be rejected — no settings changed, no crash
-    // Blacklist should still be empty
+    // Blacklist should still be empty (expect auto-waits)
     const items = page.locator("#blacklist-items .list-item");
     await expect(items).toHaveCount(0);
 

--- a/tests/e2e/options.spec.mjs
+++ b/tests/e2e/options.spec.mjs
@@ -23,7 +23,8 @@ async function setCheckbox(page, id, checked) {
     },
     { id, checked }
   );
-  await page.waitForTimeout(200);
+  // Wait for the checkbox state to reflect the requested value
+  await expect(page.locator(`#${id}`)).toBeChecked({ checked });
 }
 
 test.describe("Options — toggles", () => {
@@ -85,17 +86,15 @@ test.describe("Options — blacklist", () => {
     // Add
     await input.fill("example.com");
     await addBtn.click();
-    await page.waitForTimeout(300);
 
-    // Entry appears in list
+    // Entry appears in list (expect auto-waits for DOM update)
     await expect(list).toContainText("example.com");
 
     // Remove (click the × button)
     const removeBtn = list.locator("button").first();
     await removeBtn.click();
-    await page.waitForTimeout(300);
 
-    // Entry is gone
+    // Entry is gone (expect auto-waits)
     await expect(list).not.toContainText("example.com");
   });
 
@@ -122,14 +121,14 @@ test.describe("Options — whitelist", () => {
 
     await input.fill("mysite.org::tag::partner-01");
     await addBtn.click();
-    await page.waitForTimeout(300);
 
+    // expect auto-waits for DOM update
     await expect(list).toContainText("mysite.org");
 
     const removeBtn = list.locator("button").first();
     await removeBtn.click();
-    await page.waitForTimeout(300);
 
+    // expect auto-waits
     await expect(list).not.toContainText("mysite.org");
   });
 });
@@ -144,24 +143,20 @@ test.describe("Options — language", () => {
     const select = page.locator("#lang-select");
     const title = page.locator("h1");
 
-    // Switch to Spanish
+    // Switch to Spanish (toHaveText auto-waits for the text to change)
     await select.selectOption("es");
-    await page.waitForTimeout(500);
     await expect(title).toHaveText("Ajustes");
 
     // Switch to Portuguese
     await select.selectOption("pt");
-    await page.waitForTimeout(500);
     await expect(title).toHaveText("Configurações");
 
     // Switch to German
     await select.selectOption("de");
-    await page.waitForTimeout(500);
     await expect(title).toHaveText("Einstellungen");
 
     // Back to English
     await select.selectOption("en");
-    await page.waitForTimeout(500);
     await expect(title).toHaveText("Settings");
   });
 });
@@ -203,8 +198,8 @@ test.describe("Options — advanced settings", () => {
     await input.scrollIntoViewIfNeeded();
     await input.fill("https://example.com?utm_source=test&utm_medium=email&fbclid=abc123");
     await testBtn.click();
-    await page.waitForTimeout(500);
 
+    // toBeVisible auto-waits for the result card to appear
     await expect(result).toBeVisible();
     const text = await cleanUrl.textContent();
     // URL constructor normalizes: example.com -> example.com/

--- a/tests/e2e/popup.spec.mjs
+++ b/tests/e2e/popup.spec.mjs
@@ -36,15 +36,15 @@ test.describe("Popup", () => {
       el.checked = false;
       el.dispatchEvent(new Event("change"));
     });
-    await page.waitForTimeout(300);
 
-    // Verify in storage
-    const enabled = await page.evaluate(() => {
-      return new Promise((resolve) => {
+    // Wait for the storage write to complete before reading it back
+    const enabled = await page.waitForFunction(async () => {
+      const result = await new Promise((resolve) => {
         chrome.storage.sync.get({ enabled: true }, (r) => resolve(r.enabled));
       });
+      return result === false ? false : undefined;
     });
-    expect(enabled).toBe(false);
+    expect(await enabled.jsonValue()).toBe(false);
 
     // Re-enable
     await page.evaluate(() => {
@@ -52,7 +52,14 @@ test.describe("Popup", () => {
       el.checked = true;
       el.dispatchEvent(new Event("change"));
     });
-    await page.waitForTimeout(300);
+
+    // Wait for re-enable to persist
+    await page.waitForFunction(async () => {
+      const result = await new Promise((resolve) => {
+        chrome.storage.sync.get({ enabled: true }, (r) => resolve(r.enabled));
+      });
+      return result === true ? true : undefined;
+    });
   });
 
   test("settings link opens options page", async ({ context, extensionId, popupPage: page }) => {

--- a/tests/e2e/url-cleaning.spec.mjs
+++ b/tests/e2e/url-cleaning.spec.mjs
@@ -2,11 +2,20 @@
  * E2E: URL cleaning in real navigation
  *
  * Tests that the extension actually strips tracking parameters
- * from URLs when navigating to real pages. Uses httpbin.org
- * as a stable test target that echoes query params.
+ * from URLs when navigating to real pages. Uses page.route() to
+ * intercept requests so no actual network traffic leaves the browser —
+ * DNR rules still fire on the URL before Playwright's route handler,
+ * so assertions on page.url() correctly reflect extension behaviour.
  */
 
 import { test, expect } from "./fixtures.mjs";
+
+/** Stub all requests to a given hostname with a minimal HTML response. */
+async function stubHost(page, hostname) {
+  await page.route(`**/${hostname}/**`, (route) =>
+    route.fulfill({ status: 200, contentType: "text/html", body: "<html><body>ok</body></html>" })
+  );
+}
 
 test.describe("URL cleaning — real navigation", () => {
   test.beforeEach(async ({ context, extensionId }) => {
@@ -22,12 +31,13 @@ test.describe("URL cleaning — real navigation", () => {
       });
     });
     await page.close();
-    // Small wait for DNR rules to apply
+    // REASON: DNR rule propagation has no observable signal after storage.set resolves.
     await new Promise((r) => setTimeout(r, 500));
   });
 
   test("strips utm_source from URL via DNR", async ({ context }) => {
     const page = await context.newPage();
+    await stubHost(page, "httpbin.org");
 
     await page.goto("https://httpbin.org/get?utm_source=test&real_param=keep");
     await page.waitForLoadState("domcontentloaded");
@@ -41,6 +51,7 @@ test.describe("URL cleaning — real navigation", () => {
 
   test("strips fbclid from URL via DNR", async ({ context }) => {
     const page = await context.newPage();
+    await stubHost(page, "httpbin.org");
 
     await page.goto("https://httpbin.org/get?fbclid=abc123&page=1");
     await page.waitForLoadState("domcontentloaded");
@@ -54,6 +65,7 @@ test.describe("URL cleaning — real navigation", () => {
 
   test("strips multiple tracking params at once", async ({ context }) => {
     const page = await context.newPage();
+    await stubHost(page, "httpbin.org");
 
     await page.goto(
       "https://httpbin.org/get?utm_source=google&utm_medium=cpc&utm_campaign=test&gclid=xyz&actual=data"
@@ -72,6 +84,7 @@ test.describe("URL cleaning — real navigation", () => {
 
   test("leaves clean URLs untouched", async ({ context }) => {
     const page = await context.newPage();
+    await stubHost(page, "httpbin.org");
 
     await page.goto("https://httpbin.org/get?q=hello&page=2");
     await page.waitForLoadState("domcontentloaded");
@@ -100,11 +113,17 @@ test.describe("URL cleaning — stats tracking", () => {
 
     await helperPage.close();
 
-    // Navigate to a dirty URL
+    // Navigate to a dirty URL — intercepted locally so no network egress
     const page = await context.newPage();
+    await page.route("**/httpbin.org/**", (route) =>
+      route.fulfill({ status: 200, contentType: "text/html", body: "<html><body>ok</body></html>" })
+    );
     await page.goto("https://httpbin.org/get?utm_source=test&utm_medium=email");
     await page.waitForLoadState("domcontentloaded");
-    await page.waitForTimeout(1000); // Wait for stat increment message
+
+    // REASON: stat increment is sent from the content script via messaging; there is
+    // no DOM or storage signal we can poll without coupling to implementation details.
+    await page.waitForTimeout(500);
 
     // Read stats after
     const verifyPage = await context.newPage();

--- a/tests/unit/e2e-hygiene.test.mjs
+++ b/tests/unit/e2e-hygiene.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * MUGA — E2E Hygiene Guard
+ *
+ * Asserts that E2E specs remain hermetic:
+ *  1. No external service URLs (httpbin.org, example.com, example.net,
+ *     or bare http:// navigations outside of page.route() stubs).
+ *  2. No wall-clock waitForTimeout() calls with arguments ≥ 500 ms.
+ *  3. playwright.config.mjs has a non-zero retries value or a
+ *     process.env.CI conditional.
+ *
+ * Run with: npm test
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "../..");
+const e2eDir = join(root, "tests/e2e");
+
+/** Read all *.mjs files in the e2e directory (exclude fixtures.mjs — not a spec). */
+function readE2ESpecs() {
+  const files = readdirSync(e2eDir).filter(
+    (f) => f.endsWith(".mjs") && f !== "fixtures.mjs"
+  );
+  return files.map((f) => ({
+    name: f,
+    path: join(e2eDir, f),
+    content: readFileSync(join(e2eDir, f), "utf8"),
+  }));
+}
+
+const specs = readE2ESpecs();
+
+// ---------------------------------------------------------------------------
+// 1. No external service URLs outside of page.route() stubs
+// ---------------------------------------------------------------------------
+
+describe("E2E hygiene — no external service dependencies", () => {
+  /**
+   * Hosts that MUST be stubbed via page.route() or stubHost() before navigation.
+   * A spec file is clean if: every host in this list that appears in a page.goto()
+   * call in the file ALSO has a corresponding page.route() or stubHost() call
+   * referencing the same host anywhere in the file.
+   *
+   * example.com is excluded from this list because it is used legitimately
+   * as inline URL-tester input (not navigated to).
+   */
+  const FORBIDDEN_HOSTS = ["httpbin.org", "example.net"];
+
+  for (const spec of specs) {
+    test(`${spec.name} — no forbidden external navigations without route stubs`, () => {
+      for (const host of FORBIDDEN_HOSTS) {
+        const content = spec.content;
+
+        // Check if this file navigates to the forbidden host
+        const navigatesToHost = new RegExp(
+          `page\\.goto\\s*\\(\\s*["'\`]https?://${host.replace(".", "\\.")}`
+        ).test(content);
+
+        if (!navigatesToHost) continue; // Host not used — nothing to check
+
+        // The file navigates to this host: it MUST also stub it
+        const hasStub =
+          content.includes(`page.route("**/${host}/`) ||
+          content.includes(`page.route('**/${host}/`) ||
+          content.includes(`page.route(\`**/${host}/`) ||
+          content.includes(`stubHost(page, "${host}"`) ||
+          content.includes(`stubHost(page, '${host}'`);
+
+        assert.ok(
+          hasStub,
+          `${spec.name} navigates to "${host}" but has no page.route() stub for it.\n` +
+          `  Add: await page.route("**/${host}/**", route => route.fulfill({...}))\n` +
+          `  or use the stubHost() helper before each page.goto() to that host.`
+        );
+      }
+    });
+
+    test(`${spec.name} — no bare http:// navigations`, () => {
+      // Disallow page.goto("http://...") — all navigations should be https or chrome-extension://
+      const lines = spec.content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.match(/page\.goto\s*\(\s*["'`]http:\/\//)) continue;
+        if (line.trimStart().startsWith("//") || line.trimStart().startsWith("*")) continue;
+
+        assert.fail(
+          `${spec.name}:${i + 1} — page.goto() with bare http:// found.\n` +
+          `  Line: ${line.trim()}\n` +
+          `  Use https:// or a chrome-extension:// URL, and stub with page.route() if needed.`
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. No waitForTimeout() calls with argument >= 500 ms
+// ---------------------------------------------------------------------------
+
+describe("E2E hygiene — no long waitForTimeout calls", () => {
+  /**
+   * Match waitForTimeout( followed by a numeric literal >= 500.
+   * Accepts: waitForTimeout(500), waitForTimeout( 1000 ), waitForTimeout(2_000)
+   * The REASON comment exemption: if the same line (or the line above) has
+   * "// REASON:" we skip it — author has documented why it is necessary.
+   */
+  const TIMEOUT_RE = /waitForTimeout\s*\(\s*([\d_]+)\s*\)/g;
+
+  for (const spec of specs) {
+    test(`${spec.name} — no waitForTimeout >= 500 ms without justification`, () => {
+      const lines = spec.content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        let match;
+        const re = new RegExp(TIMEOUT_RE.source, "g");
+        while ((match = re.exec(line)) !== null) {
+          const raw = match[1].replace(/_/g, "");
+          const ms = parseInt(raw, 10);
+          if (ms < 500) continue;
+
+          // Check for REASON exemption on this line or any of the 3 preceding lines
+          // (a REASON comment may span multiple lines before the waitForTimeout call)
+          const context3 = lines.slice(Math.max(0, i - 3), i + 1).join("\n");
+          const hasReason = context3.includes("// REASON:");
+
+          assert.ok(
+            hasReason,
+            `${spec.name}:${i + 1} — waitForTimeout(${ms}) is >= 500 ms and has no REASON comment.\n` +
+            `  Line: ${line.trim()}\n` +
+            `  Either replace with a deterministic signal or add a "// REASON: <why>" comment.`
+          );
+        }
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. playwright.config.mjs has non-zero retries
+// ---------------------------------------------------------------------------
+
+describe("E2E hygiene — playwright.config.mjs has retries configured", () => {
+  test("retries is non-zero or uses process.env.CI conditional", () => {
+    const configPath = join(root, "playwright.config.mjs");
+    const content = readFileSync(configPath, "utf8");
+
+    // Accept: retries: 1, retries: 2, retries: process.env.CI ? N : M (where N > 0)
+    const hasRetries = /retries\s*:/.test(content);
+    assert.ok(hasRetries, "playwright.config.mjs must contain a 'retries:' key");
+
+    // Must NOT be a plain zero: retries: 0
+    const isPlainZero = /retries\s*:\s*0\b/.test(content);
+    assert.ok(
+      !isPlainZero,
+      "playwright.config.mjs has retries: 0. Set to 1, or use process.env.CI ? 1 : 0."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Removes external dependency**: `url-cleaning.spec.mjs` navigated to `httpbin.org` in 5 tests. All 5 now use `page.route()` stubs to serve a minimal HTML response locally — network never leaves the browser. DNR rules still fire on the URL before Playwright's route handler, so assertions on `page.url()` remain valid.
- **Eliminates 15+ `waitForTimeout` calls**: `setCheckbox()` helpers in `options.spec.mjs` and `export-import.spec.mjs` now use `expect().toBeChecked()`. List mutations, language switching, and URL tester results rely on Playwright's built-in auto-wait. The popup storage test uses `waitForFunction` to poll `chrome.storage.sync`. One `waitForTimeout(500)` retained in the stats-tracking test with a `// REASON:` comment (content-script messaging has no synchronous observable signal).
- **Adds `retries: process.env.CI ? 1 : 0`** in `playwright.config.mjs` so transient infra failures in CI get one automatic retry without masking local failures.
- **Adds regression guard** `tests/unit/e2e-hygiene.test.mjs` that fails CI if: (a) a forbidden external host is navigated to without a `page.route()` stub, (b) any `waitForTimeout(≥500)` appears without a `// REASON:` comment, or (c) `playwright.config.mjs` reverts to `retries: 0`.

Refs audit topic: `audit/muga/2026-04-24/tests-ci`

## Test plan

- [ ] `npm test` passes (1104 tests, +19 from baseline)
- [ ] `npm run test:e2e` in CI — no httpbin.org requests in network tab
- [ ] Intentionally add `httpbin.org` to a spec without a stub → `e2e-hygiene` test fails
- [ ] Intentionally add `waitForTimeout(1000)` without REASON → `e2e-hygiene` test fails
- [ ] Intentionally set `retries: 0` in config → `e2e-hygiene` test fails