### PR TITLE
fix(test): deflake tampered-signature verification assertion

### DIFF
--- a/tests/unit/remote-rules.test.mjs
+++ b/tests/unit/remote-rules.test.mjs
@@ -276,8 +276,12 @@ describe("verifySignature — Ed25519 via crypto.subtle", () => {
   test("tampered signature returns false", async () => {
     const msg = "1|2026-04-01T00:00:00Z|utm_test";
     const sig = signMessage(msg);
-    // flip last char to corrupt the sig
-    const badSig = sig.slice(0, -1) + (sig.endsWith("A") ? "B" : "A");
+    // Flip a char near the middle: the LAST base64 char of a 64-byte Ed25519
+    // signature only carries 2 data bits + 4 padding bits, so some swaps at the
+    // end (e.g. "A"<->"B") change only padding and leave the decoded bytes
+    // identical — verification still succeeds and the test is flaky.
+    const mid = Math.floor(sig.length / 2);
+    const badSig = sig.slice(0, mid) + (sig[mid] === "A" ? "B" : "A") + sig.slice(mid + 1);
     const result = await verifySignature(msg, badSig, [testPubB64], subtle);
     assert.strictEqual(result, false);
   });


### PR DESCRIPTION
## Problem

`tests/unit/remote-rules.test.mjs:276` — "tampered signature returns false" was flaky. It passed locally and on 2 of 3 CI runs of the audit Wave 1 PRs, failed on the third.

## Root cause

The test corrupts a valid signature by flipping the LAST base64 character:

```js
const badSig = sig.slice(0, -1) + (sig.endsWith("A") ? "B" : "A");
```

A 64-byte Ed25519 signature base64-encodes to 86 data chars + `==` padding. The last data char carries **2 data bits + 4 padding bits** (since 86 × 6 = 516 bits, and only 512 are real). Swapping between chars that differ only in their low bits (e.g. `A` → `B`, both have top 2 bits `00`) touches only padding bits, so the decoded signature bytes are identical and verification still succeeds → `result === true` → assertion fails.

Whether the test passed was a coin flip based on which char the random signature happened to end with.

## Fix

Flip a char near the middle of the base64 string. Mid chars carry 6 full data bits; any swap changes the decoded bytes deterministically.

## Verification

- Local `npm test`: 1085/1085 passing
- Comment in the test explains the padding quirk so nobody re-introduces the bug

## Related

Unblocks PR #305 CI (audit Wave 1 PR-B), which was hitting this flake.