### PR TITLE
refactor: architecture fixes from audit — SW, validation, DNR ids, prefs routing

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -171,6 +171,9 @@ async function applyDnrState(prefs) {
 }
 
 // Matches http/https URLs in arbitrary text. Used by the "selection" context menu handler.
+// NOTE: content/cleaner.js contains an identical copy of this regex. Content scripts
+// cannot import ES modules, so the definition must stay in both files. The sync
+// regression test at tests/unit/url-regex-sync.test.mjs enforces identical literals.
 const URL_RE = /https?:\/\/[^\s"'<>()[\]{}]{1,2000}/g;
 
 // --- Context menu helpers ---

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -360,7 +360,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const ALLOWED_STAT_KEYS = ["urlsCleaned", "junkRemoved", "referralsSpotted"];
     if (ALLOWED_STAT_KEYS.includes(message.key)) incrementStat(message.key);
     sendResponse({ ok: true });
-    return;
+    return true;
   }
 
   // exposed for future dev-tools use

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -95,6 +95,18 @@ let cachedPrefs = null;
 let prefsFetchPromise = null;
 let _cacheVersion = 0;
 
+/**
+ * Invalidates the prefs cache so the next getPrefsWithCache() call re-fetches.
+ * Extracted to a single function so all three call-sites (storage.onChanged,
+ * ADD_TO_WHITELIST, ADD_TO_BLACKLIST) remain consistent when the cache
+ * mechanism evolves (e.g., adding a 4th invalidation flag).
+ */
+function _invalidatePrefsCache() {
+  cachedPrefs = null;
+  prefsFetchPromise = null;
+  _cacheVersion++;
+}
+
 // Serialize list mutations (whitelist/blacklist) to prevent race conditions
 // where two rapid messages read the same cached list and the second overwrites the first.
 let _listMutationQueue = Promise.resolve();
@@ -246,9 +258,7 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
   if (area !== "sync") return;
   // Any sync storage change (including disabledCategories, contextMenuEnabled, etc.)
   // must invalidate the prefs cache so the next getPrefsWithCache() reads fresh data.
-  cachedPrefs = null;
-  prefsFetchPromise = null;
-  _cacheVersion++;
+  _invalidatePrefsCache();
   if (changes.customParams || changes.dnrEnabled || changes.enabled) {
     const prefs = await getPrefsWithCache();
     await applyDnrState(prefs);
@@ -303,9 +313,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         await setPrefs({ whitelist: [...fresh.whitelist, entry] });
         logAction("whitelist_add", { entry });
       }
-      cachedPrefs = null;
-      prefsFetchPromise = null;
-      _cacheVersion++;
+      _invalidatePrefsCache();
       sendResponse({ ok: true });
     }).catch(err => {
       console.error("[MUGA] ADD_TO_WHITELIST handler failed:", err);
@@ -326,9 +334,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         await setPrefs({ blacklist: [...fresh.blacklist, entry] });
         logAction("blacklist_add", { entry });
       }
-      cachedPrefs = null;
-      prefsFetchPromise = null;
-      _cacheVersion++;
+      _invalidatePrefsCache();
       sendResponse({ ok: true });
     }).catch(err => {
       console.error("[MUGA] ADD_TO_BLACKLIST handler failed:", err);

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -9,6 +9,7 @@ import { getAffiliateDomains } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules } from "../lib/storage.js";
 import { isValidListEntry } from "../lib/validation.js";
 import { DNR_CUSTOM_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
+import { t } from "../lib/i18n.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -198,9 +199,11 @@ async function syncContextMenus(enabled) {
   const prefs = await getPrefsWithCache();
   if (!prefs.enabled) return;
   const lang = prefs.language || "en";
+  // Titles sourced from lib/i18n.js (ctx_copy_clean_link / ctx_copy_clean_selection).
+  // Canonical German (de): "Bereinigten Link kopieren" — see lib/i18n.js.
   const titles = {
-    copy: { es: "Copiar enlace limpio", pt: "Copiar link limpo", de: "Sauberen Link kopieren" }[lang] || "Copy clean link",
-    selection: { es: "Copiar enlaces limpios de la selección", pt: "Copiar links limpos da seleção", de: "Saubere Links der Auswahl kopieren" }[lang] || "Copy clean links in selection",
+    copy: t("ctx_copy_clean_link", lang),
+    selection: t("ctx_copy_clean_selection", lang),
   };
   chrome.contextMenus.create({
     id: "muga-copy-clean",

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -7,6 +7,7 @@
 import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getAffiliateDomains } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules } from "../lib/storage.js";
+import { isValidListEntry } from "../lib/validation.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -116,19 +117,6 @@ function getPrefsWithCache() {
     });
   }
   return prefsFetchPromise;
-}
-
-// --- Input validation helpers ---
-
-/** Validates a blacklist/whitelist entry: domain, domain::disabled, or domain::param::value */
-function isValidListEntry(entry) {
-  if (typeof entry !== "string" || entry.length === 0 || entry.length > 500) return false;
-  const parts = entry.split("::");
-  if (parts.length > 3) return false;
-  if (!parts[0] || !/^[a-zA-Z0-9.-]+$/.test(parts[0])) return false;
-  if (parts.length === 2 && parts[1] !== "disabled") return false;
-  if (parts.length === 3 && (!parts[1] || !parts[2])) return false;
-  return true;
 }
 
 // --- DNR sync helpers ---

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -8,6 +8,7 @@ import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getAffiliateDomains } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules } from "../lib/storage.js";
 import { isValidListEntry } from "../lib/validation.js";
+import { DNR_CUSTOM_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -123,14 +124,12 @@ function getPrefsWithCache() {
 // Firefox MV2 does not support declarativeNetRequest; guard all DNR calls.
 const hasDNR = typeof chrome.declarativeNetRequest !== "undefined";
 
-const DYNAMIC_RULE_ID = 1000;
-
 async function syncCustomParamsDNR(customParams) {
   if (!hasDNR) return;
   try {
     if (!customParams || customParams.length === 0) {
       await chrome.declarativeNetRequest.updateDynamicRules({
-        removeRuleIds: [DYNAMIC_RULE_ID],
+        removeRuleIds: [DNR_CUSTOM_PARAMS_RULE_ID],
         addRules: [],
       });
       return;
@@ -139,9 +138,9 @@ async function syncCustomParamsDNR(customParams) {
       .filter(p => /^[a-zA-Z0-9_.-]+$/.test(p.trim()))
       .map(p => p.trim().toLowerCase());
     await chrome.declarativeNetRequest.updateDynamicRules({
-      removeRuleIds: [DYNAMIC_RULE_ID],
+      removeRuleIds: [DNR_CUSTOM_PARAMS_RULE_ID],
       addRules: [{
-        id: DYNAMIC_RULE_ID,
+        id: DNR_CUSTOM_PARAMS_RULE_ID,
         priority: 1,
         action: {
           type: "redirect",

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -6,7 +6,7 @@
 
 import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getAffiliateDomains } from "../lib/affiliates.js";
-import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat } from "../lib/storage.js";
+import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules } from "../lib/storage.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -18,12 +18,40 @@ const _affiliateDomains = getAffiliateDomains();
 let _firstUsedSet = false;
 
 // B4: fetch domain-rules dynamically (import assertions incompatible with Firefox;
-//       top-level await disallowed in Chrome MV3 service workers)
+//       top-level await disallowed in Chrome MV3 service workers).
+// Cache-first: on each SW restart we attempt to read from chrome.storage.session
+// first. Only falls back to fetch() on a cache miss. On persistent fetch failure
+// (up to 3 attempts) we log the error and leave domainRules as [] so the SW can
+// still operate without domain-specific rules.
 let domainRules = [];
-let _domainRulesReady = fetch(chrome.runtime.getURL("rules/domain-rules.json"))
-  .then(r => r.json())
-  .then(data => { domainRules = data; })
-  .catch(err => console.warn("[MUGA] domain-rules.json fetch failed:", err));
+let _domainRulesReady = null;
+let _domainRulesFetchAttempts = 0;
+const DOMAIN_RULES_MAX_ATTEMPTS = 3;
+
+async function _loadDomainRules() {
+  const cached = await getCachedDomainRules();
+  if (cached) {
+    domainRules = cached;
+    return;
+  }
+  if (_domainRulesFetchAttempts >= DOMAIN_RULES_MAX_ATTEMPTS) {
+    console.error("[MUGA] domain-rules.json: max fetch attempts reached; domain rules unavailable");
+    return;
+  }
+  try {
+    _domainRulesFetchAttempts++;
+    const r = await fetch(chrome.runtime.getURL("rules/domain-rules.json"));
+    const data = await r.json();
+    domainRules = data;
+    await cacheDomainRules(data);
+  } catch (err) {
+    console.error("[MUGA] domain-rules.json fetch failed (attempt", _domainRulesFetchAttempts, "):", err);
+    // Null out so the next handleProcessUrl call retries (up to the cap)
+    _domainRulesReady = null;
+  }
+}
+
+_domainRulesReady = _loadDomainRules();
 
 // B3: chrome.action (MV3) does not exist in Firefox MV2; fall back to browserAction
 const actionApi = globalThis.chrome?.action || globalThis.chrome?.browserAction || {};
@@ -347,6 +375,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigation", skipStats = false } = {}) {
   if (!rawUrl?.startsWith("http")) return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
+  // _domainRulesReady is nulled on fetch failure to allow retry on the next call
+  if (!_domainRulesReady) _domainRulesReady = _loadDomainRules();
   await _domainRulesReady;
   const prefs = await getPrefsWithCache();
 

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -29,7 +29,10 @@
     });
   }
 
-  // Matches http/https URLs including query strings, stops at whitespace or common trailing punctuation
+  // Matches http/https URLs including query strings, stops at whitespace or common trailing punctuation.
+  // NOTE: background/service-worker.js contains an identical copy of this regex. Content scripts
+  // cannot import ES modules, so the definition must stay in both files. The sync
+  // regression test at tests/unit/url-regex-sync.test.mjs enforces identical literals.
   const URL_RE = /https?:\/\/[^\s"'<>()[\]{}]{1,2000}/g;
 
   // Parses a URL and returns its hostname without a leading "www." prefix.

--- a/src/lib/dnr-ids.js
+++ b/src/lib/dnr-ids.js
@@ -1,0 +1,30 @@
+/**
+ * MUGA: Declarative Net Request rule ID registry
+ *
+ * All DNR rule IDs used by MUGA are declared here so the namespace is visible
+ * in one place and future additions cannot silently collide with existing rules.
+ * A collision would cause one rule to silently overwrite another with no error.
+ *
+ * ID allocation:
+ *   1        — static ruleset (tracking-params.json, managed by the browser)
+ *   1000     — dynamic custom params rule (user-defined params, DNR redirect)
+ *   1001     — dynamic remote params rule (signed remote payload, DNR redirect)
+ *
+ * When adding a new dynamic rule, pick an ID > 1001, document it here, and
+ * verify it does not overlap with any existing entry in this file.
+ */
+
+/** ID of the static tracking-params ruleset (tracking-params.json). */
+export const DNR_STATIC_RULE_ID = 1;
+
+/**
+ * ID of the dynamic rule that removes user-defined custom params.
+ * Managed by syncCustomParamsDNR() in service-worker.js.
+ */
+export const DNR_CUSTOM_PARAMS_RULE_ID = 1000;
+
+/**
+ * ID of the dynamic rule that removes remotely-fetched tracking params.
+ * Managed by lib/remote-rules.js. Must not equal DNR_CUSTOM_PARAMS_RULE_ID.
+ */
+export const DNR_REMOTE_PARAMS_RULE_ID = 1001;

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -14,6 +14,7 @@
  */
 
 import { TRUSTED_PUBLIC_KEYS } from "./remote-rules-keys.js";
+import { DNR_REMOTE_PARAMS_RULE_ID } from "./dnr-ids.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -24,8 +25,12 @@ export const REMOTE_RULES_URL =
 /** chrome.alarms name for the weekly fetch alarm (REQ-FETCH-1). */
 export const REMOTE_ALARM_NAME = "muga-remote-rules";
 
-/** DNR rule ID for remote params. MUST NOT be 1000 (custom params). (REQ-MERGE-2) */
-export const REMOTE_RULE_ID = 1001;
+/**
+ * DNR rule ID for remote params. Re-exported from lib/dnr-ids.js for
+ * backwards compatibility with callers that import it from this module.
+ * The canonical value and collision-prevention comment live in dnr-ids.js.
+ */
+export const REMOTE_RULE_ID = DNR_REMOTE_PARAMS_RULE_ID;
 
 /** Maximum response body size before rejection (REQ-SECURITY-4, REQ-FETCH-4). */
 export const MAX_PAYLOAD_BYTES = 50 * 1024; // 50 KB

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -382,6 +382,47 @@ export const sessionStorage = {
 // create a de facto browsing history, the same privacy concern that rules out
 // persistent URL history. Evaluated and rejected 2026-03-30.
 
+// ── Domain-rules session cache ────────────────────────────────────────────────
+//
+// MV3 service workers are killed on inactivity and re-evaluated from scratch on
+// the next event. On every cold start, domainRules would require a fresh fetch()
+// of the bundled rules/domain-rules.json. This session cache persists the parsed
+// array across SW restarts using chrome.storage.session (falls back to the
+// in-memory store for Firefox MV2 compatibility).
+//
+// Cache key: "domainRulesCache"
+// Value: serialised JSON array of domain-rule objects.
+
+const DOMAIN_RULES_CACHE_KEY = "domainRulesCache";
+
+/**
+ * Persists the fetched domain rules into session storage so subsequent
+ * SW restarts can skip the fetch round-trip.
+ * @param {Array} rules - Parsed domain-rules array.
+ * @returns {Promise<void>}
+ */
+export async function cacheDomainRules(rules) {
+  try {
+    await sessionStorage.set({ [DOMAIN_RULES_CACHE_KEY]: rules });
+  } catch (err) {
+    console.warn("[MUGA] cacheDomainRules: failed to write session cache:", err);
+  }
+}
+
+/**
+ * Reads domain rules from session storage. Returns null on cache miss or error.
+ * @returns {Promise<Array|null>}
+ */
+export async function getCachedDomainRules() {
+  try {
+    const data = await sessionStorage.get({ [DOMAIN_RULES_CACHE_KEY]: null });
+    const cached = data[DOMAIN_RULES_CACHE_KEY];
+    return Array.isArray(cached) ? cached : null;
+  } catch {
+    return null;
+  }
+}
+
 // ── Remote rules: toggle + params cache ───────────────────────────────────────
 //
 // Toggle (remoteRulesEnabled) lives in chrome.storage.sync — it is a user

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -1,0 +1,28 @@
+/**
+ * MUGA: Input validation helpers
+ *
+ * Centralised validation logic shared between the service worker and the
+ * options page. Keeping it here prevents the two consumers from silently
+ * diverging when entry-format rules change (e.g., new ::variant keys).
+ */
+
+/**
+ * Validates a blacklist/whitelist entry.
+ *
+ * Accepted formats:
+ *   - "domain.com"                   (strip all params on this domain)
+ *   - "domain.com::disabled"         (disable cleaning on this domain)
+ *   - "domain.com::param::value"     (match a specific affiliate param/value)
+ *
+ * @param {*} entry - Value to validate.
+ * @returns {boolean} True if the entry is valid, false otherwise.
+ */
+export function isValidListEntry(entry) {
+  if (typeof entry !== "string" || entry.length === 0 || entry.length > 500) return false;
+  const parts = entry.split("::");
+  if (parts.length > 3) return false;
+  if (!parts[0] || !/^[a-zA-Z0-9.-]+$/.test(parts[0])) return false;
+  if (parts.length === 2 && parts[1] !== "disabled") return false;
+  if (parts.length === 3 && (!parts[1] || !parts[2])) return false;
+  return true;
+}

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -5,6 +5,7 @@
 import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
 import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
 import { PREF_DEFAULTS } from "../lib/storage.js";
+import { isValidListEntry } from "../lib/validation.js";
 
 let _currentLang = "en";
 
@@ -395,17 +396,6 @@ function initLanguageSelect() {
     renderList("blacklist-items", prefs.blacklist, "blacklist");
     renderList("whitelist-items", prefs.whitelist, "whitelist");
   });
-}
-
-/** Validates a blacklist/whitelist entry format. */
-function isValidListEntry(entry) {
-  if (typeof entry !== "string" || entry.length === 0 || entry.length > 500) return false;
-  const parts = entry.split("::");
-  if (parts.length > 3) return false;
-  if (!parts[0] || !/^[a-zA-Z0-9.-]+$/.test(parts[0])) return false;
-  if (parts.length === 2 && parts[1] !== "disabled") return false;
-  if (parts.length === 3 && (!parts[1] || !parts[2])) return false;
-  return true;
 }
 
 /** Serializes list mutations to prevent read-modify-write races. */

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -4,7 +4,7 @@
 
 import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
 import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
-import { PREF_DEFAULTS } from "../lib/storage.js";
+import { PREF_DEFAULTS, setPrefs } from "../lib/storage.js";
 import { isValidListEntry } from "../lib/validation.js";
 
 let _currentLang = "en";
@@ -113,7 +113,7 @@ async function init() {
   durationSelect.value = String(prefs.toastDuration || 15);
   durationSelect.addEventListener("change", () => {
     const val = Math.max(5, Math.min(60, parseInt(durationSelect.value, 10) || 15));
-    try { chrome.storage.sync.set({ toastDuration: val }); } catch (err) { console.error("[MUGA] save duration:", err); }
+    try { setPrefs({ toastDuration: val }); } catch (err) { console.error("[MUGA] save duration:", err); }
   });
 
   renderList("custom-params-items", prefs.customParams, "customParams");
@@ -146,7 +146,7 @@ function bindToggle(id, key, prefs) {
   const el = document.getElementById(id);
   el.checked = prefs[key];
   el.addEventListener("change", () => {
-    try { chrome.storage.sync.set({ [key]: el.checked }); } catch (err) { console.error("[MUGA] save toggle:", err); }
+    try { setPrefs({ [key]: el.checked }); } catch (err) { console.error("[MUGA] save toggle:", err); }
   });
 }
 
@@ -239,7 +239,7 @@ function renderCategories(disabledCategories) {
       } else {
         set.add(key);
       }
-      try { await chrome.storage.sync.set({ disabledCategories: [...set] }); } catch (err) { console.error("[MUGA] save category:", err); }
+      try { await setPrefs({ disabledCategories: [...set] }); } catch (err) { console.error("[MUGA] save category:", err); }
     });
 
     const slider = document.createElement("span");
@@ -387,7 +387,7 @@ function initLanguageSelect() {
   select.value = _currentLang;
   select.addEventListener("change", async () => {
     _currentLang = select.value;
-    try { await chrome.storage.sync.set({ language: _currentLang }); } catch (err) { console.error("[MUGA] save language:", err); }
+    try { await setPrefs({ language: _currentLang }); } catch (err) { console.error("[MUGA] save language:", err); }
     applyTranslations(_currentLang);
     // Re-render dynamic lists with new language
     let prefs;
@@ -425,7 +425,7 @@ function addEntry(listKey, inputId, containerId) {
     const list = prefs[listKey];
     if (!list.includes(value)) {
       list.push(value);
-      try { await chrome.storage.sync.set({ [listKey]: list }); } catch (err) { console.error("[MUGA] save entry:", err); }
+      try { await setPrefs({ [listKey]: list }); } catch (err) { console.error("[MUGA] save entry:", err); }
       renderList(containerId, list, listKey);
     }
     input.value = "";
@@ -441,7 +441,7 @@ function removeEntry(listKey, index) {
     try { prefs = await chrome.storage.sync.get({ [listKey]: [] }); } catch (err) { console.error("[MUGA] load list:", err); return; }
     const list = prefs[listKey];
     list.splice(index, 1);
-    try { await chrome.storage.sync.set({ [listKey]: list }); } catch (err) { console.error("[MUGA] save entry:", err); }
+    try { await setPrefs({ [listKey]: list }); } catch (err) { console.error("[MUGA] save entry:", err); }
     renderList(containerId, list, listKey);
   });
 }
@@ -551,7 +551,7 @@ function initExportImport() {
       if (["en", "es", "pt", "de"].includes(data.language)) {
         toSave.language = data.language;
       }
-      await chrome.storage.sync.set(toSave);
+      await setPrefs(toSave);
 
       // Re-read prefs and update all UI toggles and lists
       const newPrefs = await chrome.storage.sync.get(PREF_DEFAULTS);

--- a/tests/unit/content-script.test.mjs
+++ b/tests/unit/content-script.test.mjs
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
+import { isValidListEntry } from "../../src/lib/validation.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -25,17 +26,6 @@ const swSource = readFileSync(
 
 // Replicate the regex used in both files
 const URL_RE = /https?:\/\/[^\s"'<>()[\]{}]{1,2000}/g;
-
-// Replicate isValidListEntry from service-worker.js
-function isValidListEntry(entry) {
-  if (typeof entry !== "string" || entry.length === 0 || entry.length > 500) return false;
-  const parts = entry.split("::");
-  if (parts.length > 3) return false;
-  if (!parts[0] || !/^[a-zA-Z0-9.-]+$/.test(parts[0])) return false;
-  if (parts.length === 2 && parts[1] !== "disabled") return false;
-  if (parts.length === 3 && (!parts[1] || !parts[2])) return false;
-  return true;
-}
 
 // ── URL regex tests ──────────────────────────────────────────────────────────
 

--- a/tests/unit/dnr-ids.test.mjs
+++ b/tests/unit/dnr-ids.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * MUGA — Unit tests for src/lib/dnr-ids.js
+ *
+ * Verifies the DNR rule ID registry:
+ *   - All IDs are exported and have the expected values
+ *   - No two IDs collide (preventing silent rule overwrites)
+ *   - service-worker.js and remote-rules.js import from dnr-ids.js
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import {
+  DNR_STATIC_RULE_ID,
+  DNR_CUSTOM_PARAMS_RULE_ID,
+  DNR_REMOTE_PARAMS_RULE_ID,
+} from "../../src/lib/dnr-ids.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const swSource = readFileSync(
+  join(__dirname, "../../src/background/service-worker.js"),
+  "utf8"
+);
+const remoteRulesSource = readFileSync(
+  join(__dirname, "../../src/lib/remote-rules.js"),
+  "utf8"
+);
+const dnrIdsSource = readFileSync(
+  join(__dirname, "../../src/lib/dnr-ids.js"),
+  "utf8"
+);
+
+// ── Value assertions ─────────────────────────────────────────────────────────
+
+describe("dnr-ids.js — exported values", () => {
+  test("DNR_STATIC_RULE_ID is 1", () => {
+    assert.strictEqual(DNR_STATIC_RULE_ID, 1);
+  });
+
+  test("DNR_CUSTOM_PARAMS_RULE_ID is 1000", () => {
+    assert.strictEqual(DNR_CUSTOM_PARAMS_RULE_ID, 1000);
+  });
+
+  test("DNR_REMOTE_PARAMS_RULE_ID is 1001", () => {
+    assert.strictEqual(DNR_REMOTE_PARAMS_RULE_ID, 1001);
+  });
+});
+
+// ── No collision ─────────────────────────────────────────────────────────────
+
+describe("dnr-ids.js — no ID collisions", () => {
+  test("all three IDs are distinct", () => {
+    const ids = [DNR_STATIC_RULE_ID, DNR_CUSTOM_PARAMS_RULE_ID, DNR_REMOTE_PARAMS_RULE_ID];
+    const unique = new Set(ids);
+    assert.strictEqual(unique.size, ids.length, `DNR rule IDs must all be distinct; got: ${ids}`);
+  });
+
+  test("DNR_REMOTE_PARAMS_RULE_ID does not equal DNR_CUSTOM_PARAMS_RULE_ID", () => {
+    assert.notEqual(
+      DNR_REMOTE_PARAMS_RULE_ID,
+      DNR_CUSTOM_PARAMS_RULE_ID,
+      "Remote rule ID must differ from custom params rule ID"
+    );
+  });
+});
+
+// ── Import chain ─────────────────────────────────────────────────────────────
+
+describe("dnr-ids.js — import chain", () => {
+  test("service-worker.js imports from lib/dnr-ids.js", () => {
+    assert.ok(
+      swSource.includes('from "../lib/dnr-ids.js"'),
+      "service-worker.js must import from lib/dnr-ids.js"
+    );
+  });
+
+  test("service-worker.js uses DNR_CUSTOM_PARAMS_RULE_ID (not a bare literal 1000)", () => {
+    assert.ok(
+      swSource.includes("DNR_CUSTOM_PARAMS_RULE_ID"),
+      "service-worker.js must reference DNR_CUSTOM_PARAMS_RULE_ID"
+    );
+    // Ensure the bare constant 1000 is not used directly as a rule ID
+    assert.ok(
+      !swSource.includes("removeRuleIds: [1000]"),
+      "service-worker.js must not use bare literal 1000 as a DNR rule ID"
+    );
+  });
+
+  test("remote-rules.js imports from lib/dnr-ids.js", () => {
+    assert.ok(
+      remoteRulesSource.includes('from "./dnr-ids.js"'),
+      "remote-rules.js must import from lib/dnr-ids.js"
+    );
+  });
+
+  test("remote-rules.js REMOTE_RULE_ID is derived from DNR_REMOTE_PARAMS_RULE_ID", () => {
+    assert.ok(
+      remoteRulesSource.includes("DNR_REMOTE_PARAMS_RULE_ID"),
+      "remote-rules.js REMOTE_RULE_ID must be assigned from DNR_REMOTE_PARAMS_RULE_ID"
+    );
+  });
+
+  test("dnr-ids.js exports all three ID constants", () => {
+    assert.ok(dnrIdsSource.includes("export const DNR_STATIC_RULE_ID"));
+    assert.ok(dnrIdsSource.includes("export const DNR_CUSTOM_PARAMS_RULE_ID"));
+    assert.ok(dnrIdsSource.includes("export const DNR_REMOTE_PARAMS_RULE_ID"));
+  });
+});

--- a/tests/unit/export-import.test.mjs
+++ b/tests/unit/export-import.test.mjs
@@ -11,23 +11,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isValidListEntry } from "../../src/lib/validation.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OPTIONS_SOURCE = readFileSync(join(__dirname, "../../src/options/options.js"), "utf8");
-
-// ---------------------------------------------------------------------------
-// Extract isValidListEntry from source for pure-function testing
-// ---------------------------------------------------------------------------
-// Mirrors the function at line ~307 of options.js
-function isValidListEntry(entry) {
-  if (typeof entry !== "string" || entry.length === 0 || entry.length > 500) return false;
-  const parts = entry.split("::");
-  if (parts.length > 3) return false;
-  if (!parts[0] || !/^[a-zA-Z0-9.-]+$/.test(parts[0])) return false;
-  if (parts.length === 2 && parts[1] !== "disabled") return false;
-  if (parts.length === 3 && (!parts[1] || !parts[2])) return false;
-  return true;
-}
 
 // Extract isValidParam inline pattern from source (customParams validator in options.js)
 function isValidParam(e) {

--- a/tests/unit/misc-regression.test.mjs
+++ b/tests/unit/misc-regression.test.mjs
@@ -2,7 +2,8 @@
  * MUGA — Miscellaneous Regression Tests
  *
  * Smaller regression/smoke checks that don't fit a dedicated area:
- * storage flush behavior and TRACKING_PARAM_CATEGORIES shape.
+ * storage flush behavior, TRACKING_PARAM_CATEGORIES shape, and
+ * options.js write-path routing.
  */
 
 import { test, describe } from "node:test";
@@ -12,8 +13,9 @@ import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { TRACKING_PARAM_CATEGORIES } from "../../src/lib/affiliates.js";
 
+const _dir = dirname(fileURLToPath(import.meta.url));
+
 describe("Regression: storage.js uses setTimeout for MV3-safe flush", () => {
-  const _dir = dirname(fileURLToPath(import.meta.url));
   const storageSource = readFileSync(join(_dir, "../../src/lib/storage.js"), "utf8");
   test("flushStats uses setTimeout, not microtask", () => {
     assert.ok(storageSource.includes("setTimeout(_flushStats"), "Must use setTimeout for flush");
@@ -40,5 +42,28 @@ describe("TRACKING_PARAM_CATEGORIES — smoke test", () => {
         `Category "${catKey}" must have a non-empty params array`
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: options.js routes all sync writes through setPrefs()
+// ---------------------------------------------------------------------------
+describe("Regression: options.js uses setPrefs() for all sync writes", () => {
+  const optionsSource = readFileSync(join(_dir, "../../src/options/options.js"), "utf8");
+
+  test("options.js imports setPrefs from lib/storage.js", () => {
+    assert.ok(
+      optionsSource.includes("setPrefs") && optionsSource.includes('from "../lib/storage.js"'),
+      "options.js must import setPrefs from lib/storage.js"
+    );
+  });
+
+  test("options.js contains no direct chrome.storage.sync.set() calls", () => {
+    // All writes must go through setPrefs() so future logic in setPrefs
+    // (validation, quota guards, migration hooks) covers the options page too.
+    assert.ok(
+      !optionsSource.includes("chrome.storage.sync.set("),
+      "options.js must not call chrome.storage.sync.set() directly — use setPrefs() instead"
+    );
   });
 });

--- a/tests/unit/misc-regression.test.mjs
+++ b/tests/unit/misc-regression.test.mjs
@@ -46,6 +46,54 @@ describe("TRACKING_PARAM_CATEGORIES — smoke test", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Regression: SW context menu labels come from lib/i18n.js, not inline objects
+// ---------------------------------------------------------------------------
+describe("Regression: SW syncContextMenus uses lib/i18n.js translations", () => {
+  const swSource = readFileSync(join(_dir, "../../src/background/service-worker.js"), "utf8");
+
+  test("SW imports t() from lib/i18n.js", () => {
+    assert.ok(
+      swSource.includes('from "../lib/i18n.js"'),
+      "service-worker.js must import from lib/i18n.js"
+    );
+    assert.ok(
+      swSource.includes("{ t }") || swSource.includes("t,") || swSource.match(/import\s*\{[^}]*\bt\b[^}]*\}/),
+      "service-worker.js must import the t() function from lib/i18n.js"
+    );
+  });
+
+  test("syncContextMenus uses t() for context menu titles", () => {
+    const ctxBlock = swSource.slice(
+      swSource.indexOf("syncContextMenus"),
+      swSource.indexOf("muga-copy-clean-selection") + 200
+    );
+    assert.ok(
+      ctxBlock.includes('t("ctx_copy_clean_link"'),
+      "syncContextMenus must use t('ctx_copy_clean_link', lang) for copy title"
+    );
+    assert.ok(
+      ctxBlock.includes('t("ctx_copy_clean_selection"'),
+      "syncContextMenus must use t('ctx_copy_clean_selection', lang) for selection title"
+    );
+  });
+
+  test("inline German translation 'Sauberen Link kopieren' is gone from SW", () => {
+    assert.ok(
+      !swSource.includes("Sauberen Link kopieren"),
+      "SW must not contain the old inline German string 'Sauberen Link kopieren' — use t() from i18n.js"
+    );
+  });
+
+  test("canonical German translation 'Bereinigten Link kopieren' lives only in i18n.js", () => {
+    const i18nSource = readFileSync(join(_dir, "../../src/lib/i18n.js"), "utf8");
+    assert.ok(
+      i18nSource.includes("Bereinigten Link kopieren"),
+      "lib/i18n.js must contain the canonical German translation"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Regression: options.js routes all sync writes through setPrefs()
 // ---------------------------------------------------------------------------
 describe("Regression: options.js uses setPrefs() for all sync writes", () => {

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -10,20 +10,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
+import { isValidListEntry } from "../../src/lib/validation.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const swSource = readFileSync(join(__dirname, "../../src/background/service-worker.js"), "utf8");
-
-// Replicate isValidListEntry from service-worker.js
-function isValidListEntry(entry) {
-  if (typeof entry !== "string" || entry.length === 0 || entry.length > 500) return false;
-  const parts = entry.split("::");
-  if (parts.length > 3) return false;
-  if (!parts[0] || !/^[a-zA-Z0-9.-]+$/.test(parts[0])) return false;
-  if (parts.length === 2 && parts[1] !== "disabled") return false;
-  if (parts.length === 3 && (!parts[1] || !parts[2])) return false;
-  return true;
-}
 
 // ── Message handler structure verification ───────────────────────────────────
 

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -203,26 +203,58 @@ describe("Cache invalidation — version counter", () => {
     );
   });
 
-  test("storage change listener increments _cacheVersion", () => {
+  test("storage change listener invalidates prefs cache via _invalidatePrefsCache()", () => {
     const storageListener = swSource.slice(
       swSource.indexOf("chrome.storage.onChanged.addListener"),
       swSource.indexOf("chrome.storage.onChanged.addListener") + 500
     );
-    assert.ok(storageListener.includes("_cacheVersion++"), "storage listener should increment _cacheVersion");
+    assert.ok(
+      storageListener.includes("_invalidatePrefsCache()"),
+      "storage listener should call _invalidatePrefsCache() to invalidate the prefs cache"
+    );
   });
 
-  test("whitelist handler increments _cacheVersion", () => {
+  test("whitelist handler invalidates prefs cache via _invalidatePrefsCache()", () => {
     const whitelistHandler = swSource.slice(
       swSource.indexOf('"ADD_TO_WHITELIST"'),
       swSource.indexOf('"ADD_TO_BLACKLIST"')
     );
-    assert.ok(whitelistHandler.includes("_cacheVersion++"), "whitelist handler should increment _cacheVersion");
+    assert.ok(
+      whitelistHandler.includes("_invalidatePrefsCache()"),
+      "whitelist handler should call _invalidatePrefsCache()"
+    );
   });
 
-  test("blacklist handler increments _cacheVersion", () => {
+  test("blacklist handler invalidates prefs cache via _invalidatePrefsCache()", () => {
     const blacklistStart = swSource.indexOf('"ADD_TO_BLACKLIST"');
     const blacklistHandler = swSource.slice(blacklistStart, blacklistStart + 800);
-    assert.ok(blacklistHandler.includes("_cacheVersion++"), "blacklist handler should increment _cacheVersion");
+    assert.ok(
+      blacklistHandler.includes("_invalidatePrefsCache()"),
+      "blacklist handler should call _invalidatePrefsCache()"
+    );
+  });
+
+  test("_invalidatePrefsCache helper is defined and increments _cacheVersion", () => {
+    assert.ok(
+      swSource.includes("function _invalidatePrefsCache()"),
+      "_invalidatePrefsCache helper must be defined"
+    );
+    const helperBlock = swSource.slice(
+      swSource.indexOf("function _invalidatePrefsCache()"),
+      swSource.indexOf("function _invalidatePrefsCache()") + 200
+    );
+    assert.ok(
+      helperBlock.includes("_cacheVersion++"),
+      "_invalidatePrefsCache must increment _cacheVersion"
+    );
+    assert.ok(
+      helperBlock.includes("cachedPrefs = null"),
+      "_invalidatePrefsCache must null cachedPrefs"
+    );
+    assert.ok(
+      helperBlock.includes("prefsFetchPromise = null"),
+      "_invalidatePrefsCache must null prefsFetchPromise"
+    );
   });
 });
 

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -170,6 +170,28 @@ describe("Bug #229 — whitelist/blacklist entry format", () => {
   });
 });
 
+// ── INCREMENT_STAT handler returns true ──────────────────────────────────────
+
+describe("INCREMENT_STAT handler — response channel", () => {
+  test("INCREMENT_STAT handler returns true (keeps response channel open)", () => {
+    // All other branches return true to keep the sendResponse channel open.
+    // INCREMENT_STAT must also return true for consistency and future-safety.
+    const handlerBlock = swSource.slice(
+      swSource.indexOf('"INCREMENT_STAT"'),
+      swSource.indexOf('"CLEAR_DEBUG_LOG"')
+    );
+    // The block must NOT end with a bare `return;` (undefined)
+    assert.ok(
+      !handlerBlock.includes("sendResponse({ ok: true });\n    return;\n"),
+      "INCREMENT_STAT must not use bare return (returns undefined, closes channel early)"
+    );
+    assert.ok(
+      handlerBlock.includes("return true;"),
+      "INCREMENT_STAT handler must return true to keep the sendResponse channel open"
+    );
+  });
+});
+
 // ── Cache invalidation version counter ───────────────────────────────────────
 
 describe("Cache invalidation — version counter", () => {

--- a/tests/unit/url-regex-sync.test.mjs
+++ b/tests/unit/url-regex-sync.test.mjs
@@ -1,0 +1,94 @@
+/**
+ * MUGA — URL_RE sync regression test
+ *
+ * The URL regex used to extract http/https URLs from arbitrary text is
+ * duplicated in two files:
+ *   - src/background/service-worker.js  (used by the selection context menu fallback)
+ *   - src/content/cleaner.js            (used by the copy handler in the IIFE)
+ *
+ * Content scripts cannot import ES modules, so the definition must live in
+ * both files. This test asserts the two literals are identical so a bug fix
+ * or tightening of the pattern (e.g., handling Unicode, trailing commas) is
+ * never silently applied in only one place.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const swSource = readFileSync(
+  join(__dirname, "../../src/background/service-worker.js"),
+  "utf8"
+);
+const contentSource = readFileSync(
+  join(__dirname, "../../src/content/cleaner.js"),
+  "utf8"
+);
+
+/** Extracts the literal source of the URL_RE regex from a file's text. */
+function extractUrlReLiteral(source) {
+  // The regex literal contains escaped slashes (\/), so we cannot use a simple
+  // "stop at /" heuristic. Instead we capture the known pattern directly.
+  // The literal always follows: URL_RE = <literal>;
+  // We match from "URL_RE = " to the end of the literal by finding the closing
+  // /g (flags) that terminates the regex.
+  const match = source.match(/\bURL_RE\s*=\s*(\/https\?[^;]+)/);
+  if (!match) throw new Error("URL_RE not found in source");
+  // Trim any trailing whitespace or semicolon
+  return match[1].trim().replace(/;$/, "").trim();
+}
+
+/** Extracts the flags from a regex literal string like "/pattern/gi". */
+function extractFlags(literal) {
+  const lastSlash = literal.lastIndexOf("/");
+  return literal.slice(lastSlash + 1);
+}
+
+describe("URL_RE sync — service-worker.js vs content/cleaner.js", () => {
+  test("both files define URL_RE", () => {
+    assert.ok(swSource.includes("URL_RE"), "service-worker.js must define URL_RE");
+    assert.ok(contentSource.includes("URL_RE"), "content/cleaner.js must define URL_RE");
+  });
+
+  test("URL_RE literals are identical in both files", () => {
+    const swLiteral = extractUrlReLiteral(swSource);
+    const contentLiteral = extractUrlReLiteral(contentSource);
+    assert.strictEqual(
+      swLiteral,
+      contentLiteral,
+      `URL_RE literals diverged:\n  service-worker.js: ${swLiteral}\n  content/cleaner.js: ${contentLiteral}`
+    );
+  });
+
+  test("URL_RE matches http and https URLs", () => {
+    // Verify the extracted literal is semantically correct by re-evaluating it.
+    // eval is intentionally used here: we need to reconstruct the RegExp from
+    // the source literal to verify its semantics, not just its text.
+    const literal = extractUrlReLiteral(swSource);
+    // eslint-disable-next-line no-eval
+    const makeRe = () => eval(literal);
+    assert.ok(makeRe().test("https://example.com?utm_source=google"), "must match https URL");
+    assert.ok(makeRe().test("http://foo.bar/path?q=1"), "must match http URL");
+    assert.ok(!makeRe().test("ftp://example.com"), "must not match non-http(s) scheme");
+  });
+
+  test("URL_RE global flag is set in service-worker.js", () => {
+    const literal = extractUrlReLiteral(swSource);
+    assert.ok(
+      extractFlags(literal).includes("g"),
+      "URL_RE must have global flag for matchAll usage"
+    );
+  });
+
+  test("URL_RE global flag is set in content/cleaner.js", () => {
+    const literal = extractUrlReLiteral(contentSource);
+    assert.ok(
+      extractFlags(literal).includes("g"),
+      "URL_RE must have global flag for matchAll usage"
+    );
+  });
+});

--- a/tests/unit/validation.test.mjs
+++ b/tests/unit/validation.test.mjs
@@ -1,0 +1,156 @@
+/**
+ * MUGA — Unit tests for src/lib/validation.js
+ *
+ * Verifies isValidListEntry covers all documented formats and rejects
+ * invalid input. These tests use the shared module directly so any
+ * change to validation logic is immediately caught here.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { isValidListEntry } from "../../src/lib/validation.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VALIDATION_SOURCE = readFileSync(
+  join(__dirname, "../../src/lib/validation.js"),
+  "utf8"
+);
+const SW_SOURCE = readFileSync(
+  join(__dirname, "../../src/background/service-worker.js"),
+  "utf8"
+);
+const OPTIONS_SOURCE = readFileSync(
+  join(__dirname, "../../src/options/options.js"),
+  "utf8"
+);
+
+// ── Module exports ───────────────────────────────────────────────────────────
+
+describe("validation.js — module shape", () => {
+  test("exports isValidListEntry as a named export", () => {
+    assert.ok(
+      VALIDATION_SOURCE.includes("export function isValidListEntry("),
+      "isValidListEntry must be a named export"
+    );
+  });
+
+  test("service-worker imports isValidListEntry from lib/validation.js", () => {
+    assert.ok(
+      SW_SOURCE.includes('from "../lib/validation.js"'),
+      "SW must import from lib/validation.js instead of defining locally"
+    );
+    assert.ok(
+      !SW_SOURCE.includes("function isValidListEntry("),
+      "SW must not contain a local isValidListEntry definition"
+    );
+  });
+
+  test("options.js imports isValidListEntry from lib/validation.js", () => {
+    assert.ok(
+      OPTIONS_SOURCE.includes('from "../lib/validation.js"'),
+      "options.js must import from lib/validation.js instead of defining locally"
+    );
+    assert.ok(
+      !OPTIONS_SOURCE.includes("function isValidListEntry("),
+      "options.js must not contain a local isValidListEntry definition"
+    );
+  });
+});
+
+// ── Valid entries ────────────────────────────────────────────────────────────
+
+describe("isValidListEntry — valid formats", () => {
+  test("accepts plain domain", () => {
+    assert.ok(isValidListEntry("amazon.es"));
+    assert.ok(isValidListEntry("booking.com"));
+    assert.ok(isValidListEntry("sub.domain.co.uk"));
+  });
+
+  test("accepts domain::disabled", () => {
+    assert.ok(isValidListEntry("amazon.es::disabled"));
+    assert.ok(isValidListEntry("example.com::disabled"));
+  });
+
+  test("accepts domain::param::value", () => {
+    assert.ok(isValidListEntry("amazon.es::tag::youtuber-21"));
+    assert.ok(isValidListEntry("booking.com::aid::12345"));
+    assert.ok(isValidListEntry("shop.example.com::ref::abc"));
+  });
+
+  test("accepts single-label domain", () => {
+    assert.ok(isValidListEntry("localhost"));
+  });
+
+  test("accepts domain with digits", () => {
+    assert.ok(isValidListEntry("example123.com"));
+  });
+});
+
+// ── Invalid entries ──────────────────────────────────────────────────────────
+
+describe("isValidListEntry — invalid formats", () => {
+  test("rejects empty string", () => {
+    assert.ok(!isValidListEntry(""));
+  });
+
+  test("rejects non-string types", () => {
+    assert.ok(!isValidListEntry(null));
+    assert.ok(!isValidListEntry(undefined));
+    assert.ok(!isValidListEntry(42));
+    assert.ok(!isValidListEntry([]));
+    assert.ok(!isValidListEntry({}));
+  });
+
+  test("rejects string longer than 500 chars", () => {
+    assert.ok(!isValidListEntry("a".repeat(501)));
+  });
+
+  test("rejects domain with special characters", () => {
+    assert.ok(!isValidListEntry("amazon.es<script>"));
+    assert.ok(!isValidListEntry("amazon.es;drop"));
+    assert.ok(!isValidListEntry("amazon es"));
+    assert.ok(!isValidListEntry("amazon.es!"));
+  });
+
+  test("rejects 2-part entry that isn't ::disabled", () => {
+    assert.ok(!isValidListEntry("amazon.es::tag"));
+    assert.ok(!isValidListEntry("amazon.es::something"));
+    assert.ok(!isValidListEntry("amazon.es::enabled"));
+  });
+
+  test("rejects 3-part entry with empty param", () => {
+    assert.ok(!isValidListEntry("amazon.es::::value"));
+  });
+
+  test("rejects 3-part entry with empty value", () => {
+    assert.ok(!isValidListEntry("amazon.es::tag::"));
+  });
+
+  test("rejects 4+ parts", () => {
+    assert.ok(!isValidListEntry("a::b::c::d"));
+    assert.ok(!isValidListEntry("a::b::c::d::e"));
+  });
+
+  test("rejects param=value format (old format, no domain prefix)", () => {
+    assert.ok(!isValidListEntry("tag=youtuber-21"));
+    assert.ok(!isValidListEntry("aff=other-99"));
+  });
+});
+
+// ── Boundary conditions ──────────────────────────────────────────────────────
+
+describe("isValidListEntry — boundary conditions", () => {
+  test("accepts entry at exactly 500 chars", () => {
+    // Domain of 500 chars is the boundary — must be accepted
+    const domain = "a".repeat(497) + ".es"; // 500 chars total
+    assert.ok(isValidListEntry(domain));
+  });
+
+  test("rejects entry at exactly 501 chars", () => {
+    const domain = "a".repeat(498) + ".es"; // 501 chars total
+    assert.ok(!isValidListEntry(domain));
+  });
+});


### PR DESCRIPTION
## Summary

Resolves 8 findings from the architecture audit (Audit Wave 2). No AI attribution.

### Findings resolved

| # | Severity | Finding | Commit |
|---|----------|---------|--------|
| 1 | high | SW `domainRules` cold on every termination + silent fetch failure | `92cb20f` |
| 2 | high | `INCREMENT_STAT` handler returns `undefined` instead of `true` | `144fa5b` |
| 3 | high | `isValidListEntry` duplicated in SW, options.js, and 3 test files | `0828437` |
| 4 | high | `URL_RE` regex duplicated in SW and content script | `a8169bb` |
| 5 | medium | DNR rule IDs unguarded — bare literals 1000/1001 with no registry | `ffdb0f1` |
| 6 | medium | Cache invalidation block duplicated 3× in SW | `edf07b7` |
| 7 | medium | Options page bypasses `setPrefs()` — 7 raw `chrome.storage.sync.set` calls | `457e210` |
| 8 | medium | Context menu labels diverge — SW inline vs lib/i18n.js | `c244524` |

### Key decisions

- **Finding 4 (URL_RE)**: Content scripts cannot import ES modules, so the regex definition stays in both files. The fix is a sync regression test (`url-regex-sync.test.mjs`) that asserts the two literals are identical, plus cross-reference block comments in both files.
- **Finding 5 (DNR IDs)**: `REMOTE_RULE_ID` is re-exported from `remote-rules.js` (sourced from `dnr-ids.js`) to maintain backwards compatibility with existing tests and callers.
- **Finding 8 (i18n)**: Canonical German is now `"Bereinigten Link kopieren"` (from `lib/i18n.js`), replacing the incorrect inline `"Sauberen Link kopieren"`.

### Test delta

- Baseline: **1117 tests**
- After PR: **1159 tests** (+42)
- New test files: `validation.test.mjs`, `url-regex-sync.test.mjs`, `dnr-ids.test.mjs`
- Updated test files: `service-worker-patterns.test.mjs`, `misc-regression.test.mjs`, `export-import.test.mjs`, `content-script.test.mjs`

### Lint status

- Errors: **0**
- Warnings: **4** (unchanged from baseline, all pre-existing innerHTML warnings)

### Safety

- Branch only. No force-push.
- No `.github/workflows/`, `docs/`, `src/privacy/`, `tests/e2e/`, or secrets touched.
- `npm test` green after every commit. `npm run lint` exits 0 after every commit.
- No new `innerHTML` warnings introduced.