### PR TITLE
docs: fix CHANGELOG links, data_architect prefs table, manifest description drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,7 +511,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.9.2...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.9.10...HEAD
+[1.9.10]: https://github.com/yocreoquesi/muga/compare/v1.9.9...v1.9.10
+[1.9.9]: https://github.com/yocreoquesi/muga/compare/v1.9.8...v1.9.9
+[1.9.8]: https://github.com/yocreoquesi/muga/compare/v1.9.7...v1.9.8
+[1.9.7]: https://github.com/yocreoquesi/muga/compare/v1.9.6...v1.9.7
+[1.9.6]: https://github.com/yocreoquesi/muga/compare/v1.9.5...v1.9.6
+[1.9.5]: https://github.com/yocreoquesi/muga/compare/v1.9.4...v1.9.5
+[1.9.4]: https://github.com/yocreoquesi/muga/compare/v1.9.3...v1.9.4
+[1.9.3]: https://github.com/yocreoquesi/muga/compare/v1.9.2...v1.9.3
 [1.9.2]: https://github.com/yocreoquesi/muga/compare/v1.9.1...v1.9.2
 [1.9.1]: https://github.com/yocreoquesi/muga/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/yocreoquesi/muga/compare/v1.8.2...v1.9.0

--- a/docs/data_architect.md
+++ b/docs/data_architect.md
@@ -6,22 +6,32 @@ Reference document for all data stored by the extension.
 
 Synced across devices. ~100 KB quota.
 
+Source of truth: `PREF_DEFAULTS` in `src/lib/storage.js`.
+
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | boolean | `true` | Master on/off switch for all URL cleaning |
-| `injectOwnAffiliate` | boolean | `true` | Scenario B: inject ourTag when no affiliate present |
+| `injectOwnAffiliate` | boolean | `false` | Scenario B: inject ourTag when no affiliate present (opt-in during onboarding) |
 | `notifyForeignAffiliate` | boolean | `false` | Scenario C: show toast when foreign affiliate detected |
-| `allowReplaceAffiliate` | boolean | `false` | Scenario C: allow replacing foreign tag with ours (requires notifyForeignAffiliate) |
 | `stripAllAffiliates` | boolean | `false` | Strip ALL affiliate params, never inject |
-| `dnrEnabled` | boolean | `true` | Enable static DNR rule (declarativeNetRequest) for tracking param stripping |
-| `blockPings` | boolean | `true` | Block `<a ping>` and `navigator.sendBeacon` calls |
-| `ampRedirect` | boolean | `true` | Redirect AMP pages to canonical URL |
-| `unwrapRedirects` | boolean | `true` | Unwrap tracking redirect URLs (e.g. ?url=, ?redirect=) |
 | `blacklist` | string[] | `[]` | Domain/param/value entries to always strip. Format: `"domain"` or `"domain::param::value"` |
 | `whitelist` | string[] | `[]` | Affiliate values to never touch. Format: `"domain::param::value"` |
 | `customParams` | string[] | `[]` | Extra tracking param names to strip beyond built-in list |
-| `language` | string | `"en"` | UI language. Supported: `"en"`, `"es"` |
+| `dnrEnabled` | boolean | `true` | Enable static DNR rule (declarativeNetRequest) for tracking param stripping |
+| `contextMenuEnabled` | boolean | `true` | Show "Copy clean link" in the right-click context menu |
+| `blockPings` | boolean | `true` | Block `<a ping>` and `navigator.sendBeacon` calls |
+| `ampRedirect` | boolean | `true` | Redirect AMP pages to canonical URL |
+| `unwrapRedirects` | boolean | `true` | Unwrap tracking redirect URLs (e.g. ?url=, ?redirect=) |
+| `language` | string | `"en"` | UI language. Supported: `"en"`, `"es"`, `"pt"`, `"de"` |
 | `onboardingDone` | boolean | `false` | Whether the user has completed onboarding |
+| `consentVersion` | string\|null | `null` | ToS version accepted (e.g. `"1.0"`). Bump to re-trigger consent on ToS changes |
+| `consentDate` | number\|null | `null` | Unix timestamp (ms) of when the user accepted the ToS |
+| `disabledCategories` | string[] | `[]` | Param categories to skip stripping (e.g. `["utm", "ads"]`) |
+| `toastDuration` | number | `15` | How long the affiliate notification toast stays visible (seconds, 5–60) |
+| `paramBreakdown` | boolean | `true` | Show per-category param breakdown in popup cleaned-URL receipt |
+| `showReportButton` | boolean | `true` | Show "Report a problem" button in popup |
+| `domainStats` | boolean | `true` | Track and display per-domain tracker counts in popup |
+| `remoteRulesEnabled` | boolean | `false` | Opt-in: fetch signed remote parameter updates weekly. Default off (zero network activity on fresh install) |
 
 ### List entry format
 
@@ -36,7 +46,7 @@ Synced across devices. ~100 KB quota.
 
 ---
 
-## chrome.storage.local: Stats and ephemeral state
+## chrome.storage.local: Stats, device flags, and ephemeral state
 
 Device-only. ~10 MB quota.
 
@@ -47,6 +57,10 @@ Device-only. ~10 MB quota.
 | `stats.referralsSpotted` | number | `0` | Total foreign affiliates detected |
 | `firstUsed` | number\|null | `null` | Unix timestamp (ms) of first use. Used for nudge timing |
 | `nudgeDismissed` | boolean | `false` | Whether the user dismissed the review nudge |
+| `devMode` | boolean | `false` | Developer tools visible in Settings. Device-local — intentionally not synced across devices |
+| `domainStats` | object | `{}` | Per-domain tracker counts map (`{ domain: { params, urls } }`). Capped at 50 domains (LRU eviction) |
+| `remoteParams` | string[] | `[]` | Cached remote tracking params from the last signed fetch (only populated when remoteRulesEnabled) |
+| `remoteRulesMeta` | object | see below | Metadata for the last remote-rules fetch: `{ version, fetchedAt, paramCount, lastError, published }` |
 
 ---
 

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,7 +1,7 @@
 # MUGA: Store Listings
 
 > Version: 1.9.10
-> Last updated: 2026-04-01
+> Last updated: 2026-04-13
 > Status: Final listing for Chrome Web Store and Firefox AMO. 450+ tracking params, 150+ domain rules, 6 categories, 2 active affiliate programs, MV3 native.
 
 ---

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -22,7 +22,7 @@ URL cleaner: strips utm, fbclid, gclid and 450+ tracking params automatically. R
 
 ### Detailed description
 
-MUGA is a URL cleaner and tracking remover. It strips utm_source, utm_medium, utm_campaign, fbclid, gclid, msclkid, and 450+ more tracking parameters from every URL you visit, automatically, before the page loads. No buttons. No setup. No permission popups. Built natively for Manifest V3. Works on Chrome and Firefox.
+MUGA is a URL cleaner and tracking remover. It strips utm_source, utm_medium, utm_campaign, fbclid, gclid, msclkid, and 450+ more tracking parameters from every URL you visit, automatically, before the page loads. No buttons. No setup. No permission popups. Built natively for Manifest V3 on Chrome. Available for Firefox via Manifest V2.
 
 By default, MUGA never touches what isn't ours. If a link already has a creator's affiliate tag, we leave it alone. That is the "fair to every click" part, and what makes MUGA different from every other URL cleaner out there.
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
   "version": "1.9.10",
-  "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source, MV3.",
+  "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
 
   "permissions": [
     "storage",

--- a/tests/unit/changelog-links.test.mjs
+++ b/tests/unit/changelog-links.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * Regression test: CHANGELOG.md link references
+ *
+ * Asserts:
+ *   1. Every ## [x.y.z] header in CHANGELOG.md has a matching [x.y.z]: ...compare/...
+ *      link reference at the bottom of the file.
+ *   2. The [Unreleased] link references the latest version header, not a stale one.
+ *
+ * This prevents the Unreleased link from silently freezing when new releases are tagged.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+const changelog = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
+
+// Extract all versioned headers: ## [1.2.3]
+const headerVersions = [...changelog.matchAll(/^## \[(\d+\.\d+\.\d+)\]/gm)]
+  .map(m => m[1]);
+
+// Extract all link reference definitions: [x.y.z]: https://...
+const linkDefs = new Map(
+  [...changelog.matchAll(/^\[(\d+\.\d+\.\d+)\]:\s*(https?:\/\/\S+)/gm)]
+    .map(m => [m[1], m[2]])
+);
+
+// Extract the [Unreleased] link reference
+const unreleasedMatch = changelog.match(/^\[Unreleased\]:\s*https?:\/\/\S+compare\/v?(\d+\.\d+\.\d+)\.\.\.HEAD/m);
+
+describe("CHANGELOG.md link references", () => {
+  it("every ## [x.y.z] header has a matching link reference", () => {
+    const missing = headerVersions.filter(v => !linkDefs.has(v));
+    assert.deepEqual(
+      missing,
+      [],
+      `Missing link references for versions: ${missing.join(", ")}\n` +
+      "Add [x.y.z]: https://github.com/yocreoquesi/muga/compare/vPREV...vx.y.z for each."
+    );
+  });
+
+  it("[Unreleased] link references the latest released version", () => {
+    assert.ok(
+      unreleasedMatch,
+      "[Unreleased] link reference not found or does not follow ...compare/vX.Y.Z...HEAD format"
+    );
+
+    const latestVersion = headerVersions[0]; // first header = most recent release
+    const unreleasedBase = unreleasedMatch[1];
+
+    assert.equal(
+      unreleasedBase,
+      latestVersion,
+      `[Unreleased] points to v${unreleasedBase} but latest release header is ## [${latestVersion}].\n` +
+      `Update to: [Unreleased]: https://github.com/yocreoquesi/muga/compare/v${latestVersion}...HEAD`
+    );
+  });
+
+  it("link references follow the compare URL format", () => {
+    for (const [version, url] of linkDefs) {
+      const isCompare = url.includes("/compare/");
+      const isTag = url.includes("/releases/tag/");
+      assert.ok(
+        isCompare || isTag,
+        `[${version}] link does not use compare or releases/tag format: ${url}`
+      );
+    }
+  });
+});

--- a/tests/unit/docs-prefs-table.test.mjs
+++ b/tests/unit/docs-prefs-table.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Regression test: docs/data_architect.md sync-prefs table vs PREF_DEFAULTS
+ *
+ * Asserts that the set of keys documented in the "chrome.storage.sync" table
+ * in data_architect.md exactly matches the keys in PREF_DEFAULTS (src/lib/storage.js).
+ *
+ * Fails with a clear diff on mismatch so documentation drift is caught immediately.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+
+// ── Parse PREF_DEFAULTS keys from storage.js ─────────────────────────────────
+
+const storageSource = readFileSync(join(ROOT, "src", "lib", "storage.js"), "utf8");
+
+// Extract the PREF_DEFAULTS object body between the outermost braces
+const prefDefaultsMatch = storageSource.match(
+  /export\s+const\s+PREF_DEFAULTS\s*=\s*\{([\s\S]*?)\n\};/
+);
+assert.ok(prefDefaultsMatch, "Could not locate PREF_DEFAULTS export in src/lib/storage.js");
+
+const prefBody = prefDefaultsMatch[1];
+
+// Extract property names: lines like `  key:` or `  key :` (ignore comment lines)
+const prefKeys = new Set(
+  [...prefBody.matchAll(/^\s{1,4}(\w+)\s*:/gm)]
+    .map(m => m[1])
+    .filter(k => !["null", "false", "true"].includes(k))
+);
+
+// ── Parse documented keys from data_architect.md ──────────────────────────────
+
+const doc = readFileSync(join(ROOT, "docs", "data_architect.md"), "utf8");
+
+// Find the sync storage section: between "## chrome.storage.sync" and the next "##" heading
+const syncSectionMatch = doc.match(
+  /##\s+chrome\.storage\.sync[^\n]*\n([\s\S]*?)(?=\n##\s|\s*$)/
+);
+assert.ok(syncSectionMatch, "Could not locate '## chrome.storage.sync' section in docs/data_architect.md");
+
+const syncSection = syncSectionMatch[1];
+
+// Extract backtick-quoted key names from table rows: | `keyName` | ...
+const docKeys = new Set(
+  [...syncSection.matchAll(/^\|\s*`(\w+)`/gm)].map(m => m[1])
+);
+
+// ── Compare ───────────────────────────────────────────────────────────────────
+
+describe("docs/data_architect.md sync prefs table matches PREF_DEFAULTS", () => {
+  it("no keys in PREF_DEFAULTS are missing from the documentation table", () => {
+    const missingFromDoc = [...prefKeys].filter(k => !docKeys.has(k));
+    assert.deepEqual(
+      missingFromDoc,
+      [],
+      `Keys in PREF_DEFAULTS but NOT documented in data_architect.md:\n` +
+      missingFromDoc.map(k => `  - ${k}`).join("\n") + "\n" +
+      "Add a row for each missing key to the '## chrome.storage.sync' table."
+    );
+  });
+
+  it("no obsolete keys are present in the documentation table", () => {
+    const obsoleteInDoc = [...docKeys].filter(k => !prefKeys.has(k));
+    assert.deepEqual(
+      obsoleteInDoc,
+      [],
+      `Keys documented in data_architect.md but NOT in PREF_DEFAULTS:\n` +
+      obsoleteInDoc.map(k => `  - ${k}`).join("\n") + "\n" +
+      "Remove the row(s) for obsolete keys from the '## chrome.storage.sync' table."
+    );
+  });
+});

--- a/tests/unit/manifest-descriptions.test.mjs
+++ b/tests/unit/manifest-descriptions.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * Regression test: manifest description consistency
+ *
+ * Asserts:
+ *   1. Both manifest.json (MV3) and manifest.v2.json (MV2) end with identical
+ *      wording — "Open source." — so description drift cannot recur silently.
+ *   2. Neither manifest description contains platform-specific manifest version
+ *      labels ("MV3", "MV2") that belong only in one but not the other (guards
+ *      against re-introducing the "Open source, MV3." vs "Open source." split).
+ *   3. The Chrome Web Store description in store-listing.md does not claim
+ *      Firefox uses MV3 (the inaccurate "Works on Chrome and Firefox" claim
+ *      that implied a single MV3 build).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+
+const mv3 = JSON.parse(readFileSync(join(ROOT, "src", "manifest.json"), "utf8"));
+const mv2 = JSON.parse(readFileSync(join(ROOT, "src", "manifest.v2.json"), "utf8"));
+const storeListing = readFileSync(join(ROOT, "docs", "store-listing.md"), "utf8");
+
+describe("manifest description consistency", () => {
+  it("both manifests end with the same closing phrase", () => {
+    // Extract the terminal phrase after the last '. ' boundary
+    const tail = (desc) => desc.trim().split(". ").at(-1).replace(/\.$/, "").trim();
+
+    const mv3Tail = tail(mv3.description);
+    const mv2Tail = tail(mv2.description);
+
+    assert.equal(
+      mv3Tail,
+      mv2Tail,
+      `Manifest descriptions diverge at the closing phrase:\n` +
+      `  MV3 (manifest.json):    "...${mv3Tail}."\n` +
+      `  MV2 (manifest.v2.json): "...${mv2Tail}."\n` +
+      "Both manifests must end with identical wording (e.g. 'Open source.')."
+    );
+  });
+
+  it("manifest.json (MV3) description does not contain 'MV2'", () => {
+    assert.ok(
+      !mv3.description.includes("MV2"),
+      `manifest.json description should not reference MV2: "${mv3.description}"`
+    );
+  });
+
+  it("manifest.v2.json (MV2) description does not contain 'MV3'", () => {
+    assert.ok(
+      !mv2.description.includes("MV3"),
+      `manifest.v2.json description should not reference MV3: "${mv2.description}"`
+    );
+  });
+
+  it("Chrome Web Store listing does not claim Firefox uses MV3", () => {
+    // Extract Chrome Web Store detailed description section only
+    const cwsSectionMatch = storeListing.match(
+      /## Chrome Web Store[\s\S]*?(?=## Firefox Add-ons|$)/
+    );
+    assert.ok(cwsSectionMatch, "Could not locate Chrome Web Store section in store-listing.md");
+
+    const cwsSection = cwsSectionMatch[0];
+
+    // Must not contain a phrase like "Manifest V3. Works on Chrome and Firefox"
+    // which implies Firefox uses MV3. The correct form separates the claims:
+    // "Manifest V3 on Chrome. Available for Firefox via Manifest V2."
+    // Pattern: "Manifest V3" followed by "Works on" and "Firefox" on the same line.
+    const hasImpliedMV3ForFirefox = /Manifest V3[^.\n]*Works on[^.\n]*Firefox/i.test(cwsSection);
+    assert.ok(
+      !hasImpliedMV3ForFirefox,
+      "Chrome Web Store description uses 'Built natively for Manifest V3. Works on Chrome and Firefox' " +
+      "which implies Firefox uses MV3 — it uses MV2. " +
+      "Separate the claims, e.g. 'Manifest V3 on Chrome. Available for Firefox via Manifest V2.'"
+    );
+  });
+});


### PR DESCRIPTION
## Audit Wave 4 — Docs + Compatibility (PR-G)

Resolves 3 findings from the 2026-04-24 compatibility & docs audit.

---

### Finding 1 — [high] CHANGELOG `[Unreleased]` frozen at v1.9.2, missing compare links v1.9.3–v1.9.10

**Files**: `CHANGELOG.md`, `docs/store-listing.md`

- Updated `[Unreleased]` from `compare/v1.9.2...HEAD` → `compare/v1.9.10...HEAD`
- Added 8 missing link references: v1.9.3 through v1.9.10
- Updated `docs/store-listing.md` `Last updated:` from 2026-04-01 → 2026-04-13 (matches CHANGELOG v1.9.10 release date)
- **Regression test**: `tests/unit/changelog-links.test.mjs` — asserts every `## [x.y.z]` header has a matching link ref and `[Unreleased]` targets the latest release header

---

### Finding 2 — [medium] `docs/data_architect.md` prefs table stale (9 missing keys, 1 obsolete, wrong language list)

**Files**: `docs/data_architect.md`

- Removed obsolete `allowReplaceAffiliate` (removed from `PREF_DEFAULTS` in v1.7.0)
- Added 9 missing sync keys: `contextMenuEnabled`, `consentVersion`, `consentDate`, `disabledCategories`, `toastDuration`, `paramBreakdown`, `showReportButton`, `domainStats`, `remoteRulesEnabled`
- Updated language list from `"en", "es"` → `"en"`, `"es"`, `"pt"`, `"de"`
- Expanded local storage section: added `devMode`, `domainStats` map, `remoteParams`, `remoteRulesMeta`
- **Regression test**: `tests/unit/docs-prefs-table.test.mjs` — parses `PREF_DEFAULTS` and the `## chrome.storage.sync` table; fails with a clear diff if either side drifts

---

### Finding 3 — [medium] Manifest description drift + store-listing Firefox MV3 inaccuracy

**Files**: `src/manifest.json`, `docs/store-listing.md`  
**Decision**: Option A — both manifests end with "Open source." (MV3 suffix removed from MV3 manifest as redundant; MV2 manifest was already correct)

- Removed "MV3" suffix from `manifest.json` description: both manifests now end identically with "Open source."
- Fixed CWS blurb: "Built natively for Manifest V3. Works on Chrome and Firefox" implied Firefox uses MV3 (it uses MV2). Replaced with "Manifest V3 on Chrome. Available for Firefox via Manifest V2."
- **Regression test**: `tests/unit/manifest-descriptions.test.mjs` — asserts both manifests share the same closing phrase and the CWS listing cannot re-introduce the implied MV3-for-Firefox claim

---

### Regression tests summary

| Test file | Assertions | What it guards |
|---|---|---|
| `tests/unit/changelog-links.test.mjs` | 3 | CHANGELOG link refs complete and Unreleased points to latest |
| `tests/unit/docs-prefs-table.test.mjs` | 2 | doc table == PREF_DEFAULTS keys exactly (both directions) |
| `tests/unit/manifest-descriptions.test.mjs` | 4 | manifests share closing phrase; CWS blurb accurate |

**Test delta**: +9 tests (1468 → 1477), 0 failures. Lint: 0 errors.

---

No AI attribution. No code/workflow/secret touches — only docs, manifest descriptions, and regression tests.