### PR TITLE
feat/docs: remote-rules Phase 4 + 5 — i18n completeness + transparency + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MUGA will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Optional weekly updates for the tracking parameter list, off by default. Ed25519-signed payloads fetched from a public GitHub Pages endpoint (`https://yocreoquesi.github.io/muga/rules/v1/params.json`). Enable in Settings → Remote rule updates. Zero outbound requests on a default install. See `docs/transparency.html`. (#270)
+
 ## [1.9.10] - 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Settings give you full control: affiliate behavior, per-domain rules, blacklists
 - Strip all affiliate parameters (opt-in)
 - Strip all third-party affiliate tags (opt-in; our tag is always preserved)
 - Toast notification when a third-party affiliate is detected (opt-in)
+- **Remote rule updates** (optional, off by default): weekly signed updates to the tracking-param list from a public GitHub Pages endpoint. Zero outbound requests on a default install.
 - Export / Import settings as JSON
 - 4 languages: English, Spanish, Portuguese, German
 

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -109,8 +109,9 @@ Every URL is processed entirely inside your browser. MUGA never sends data anywh
 
 . Zero analytics, zero telemetry, zero data collection
 . No account, no sign-in, no cloud
-. Minimal permissions: storage, activeTab, contextMenus, declarativeNetRequestWithHostAccess, clipboardWrite
-. Nothing else. Ever.
+. Core permissions: storage, activeTab, contextMenus, declarativeNetRequestWithHostAccess, clipboardWrite
+. alarms: used to schedule a weekly background check for signed tracking-parameter updates when the user enables Remote rule updates in Settings. No alarm fires if the feature is disabled (off by default).
+. optional_host_permissions https://yocreoquesi.github.io/*: granted only when the user enables Remote rule updates. Used to fetch the signed tracking-parameter payload — single HTTPS GET per week, credentials-omit, no user data transmitted. Revocable at any time via browser settings.
 
 We evaluated 10+ affiliate programs from major retailers and marketplaces. All of them require redirect-based tracking that routes your clicks through external servers before reaching the store. We rejected every one of them and gave up that revenue rather than compromise your privacy. On those stores, MUGA actively strips the affiliate tracking parameters that redirect networks leave behind, and unwraps redirect URLs when possible so you go straight to the store.
 
@@ -224,8 +225,9 @@ Private by design
 Every URL is processed entirely inside your browser. MUGA never sends data anywhere.
 . Zero analytics, zero telemetry, zero data collection
 . No account, no sign-in, no cloud
-. Minimal permissions: storage, activeTab, contextMenus, declarativeNetRequest, clipboardWrite
-. Nothing else. Ever.
+. Core permissions: storage, activeTab, contextMenus, declarativeNetRequest, clipboardWrite
+. alarms: used to schedule a weekly background check for signed tracking-parameter updates when you enable Remote rule updates in Settings. No alarm fires on a default install.
+. optional_permissions https://yocreoquesi.github.io/*: granted only when you enable Remote rule updates. Used to fetch the signed tracking-parameter payload — single HTTPS GET per week, credentials-omit, no user data transmitted. Revocable at any time.
 
 
 Your rules

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -86,7 +86,7 @@
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
-      <span class="at-a-glance-value">0 <span class="tag-zero">zero</span></span>
+      <span class="at-a-glance-value">0 by default <span class="tag-zero">zero</span>. 1 HTTPS GET per week to <code>yocreoquesi.github.io</code> if you enable Remote rule updates in Settings (off by default). No cookies, no identifiers, no POST body — auditable open-source endpoint.</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Data collected</span>
@@ -164,6 +164,16 @@
     <div class="permission-why">Required for content scripts to run on every page (URL cleaning, ping blocking, AMP redirect, redirect unwrapping) and for declarativeNetRequest redirect rules to apply on all sites. Without this, MUGA would only work on a predefined list of domains.</div>
   </div>
 
+  <div class="permission-block">
+    <div class="permission-name">alarms</div>
+    <div class="permission-why">Used to schedule a weekly background check for signed tracking-parameter updates when you have enabled Remote rule updates in Settings. No alarm fires on a default install — the alarm handler reads your preference on every tick and returns immediately if the feature is off. This permission cannot be withheld; it is always declared so the alarm infrastructure is ready if you opt in.</div>
+  </div>
+
+  <div class="permission-block">
+    <div class="permission-name">optional_host_permissions: https://yocreoquesi.github.io/* <em>(Chrome MV3)</em> / optional_permissions <em>(Firefox MV2)</em></div>
+    <div class="permission-why">Granted only when you enable Remote rule updates. Used to perform one HTTPS GET per week to fetch the signed tracking-parameter list from the project's public GitHub Pages endpoint (<code>https://yocreoquesi.github.io/muga/rules/v1/params.json</code>). The request is sent with <code>credentials: "omit"</code> and <code>cache: "no-store"</code> — no cookies, no user identifiers, no POST body. The endpoint is open source and auditable. If you disable Remote rule updates, this permission remains granted but no code path uses it; you can revoke it at any time via your browser's extension settings.</div>
+  </div>
+
   <h2>How to Verify</h2>
 
   <p>Every claim on this page is verifiable. You don't have to take our word for it.</p>
@@ -172,7 +182,7 @@
     <li><strong>Read the source code</strong> — <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a>. Every line that runs in your browser is published there.</li>
     <li><strong>Build from source</strong> — Clone the repo and run <code>npm run build</code>. The output is the same extension distributed on the Chrome Web Store and Firefox AMO.</li>
     <li><strong>Diff the published extension</strong> — Unpack the installed extension (Chrome: <code>chrome://extensions</code> in developer mode; Firefox: extract the XPI) and diff the files against the published source. They should match exactly.</li>
-    <li><strong>Check network requests yourself</strong> — Open your browser's DevTools Network tab while using MUGA. You will see zero outbound requests initiated by the extension.</li>
+    <li><strong>Check network requests yourself</strong> — Open your browser's DevTools Network tab while using MUGA. On a default install (Remote rule updates off) you will see zero outbound requests initiated by the extension. If Remote rule updates are enabled, you will see one HTTPS GET to <code>yocreoquesi.github.io</code> per week at most.</li>
     <li><strong>Read the coding standards</strong> — <code>AGENTS.md</code> in the repository documents the automated review rules that enforce these constraints on every pull request.</li>
   </ul>
 


### PR DESCRIPTION
## Summary

- **T4.1 (EN/ES audit)**: All 20 design §11 keys already present from Phase 3 with quality EN/ES strings. No gaps found. `whatsNewRemoteRules` wired as a placeholder constant in `options.js` — no post-update splash surface exists in the codebase, so no wiring is possible without inventing a new surface (per design guidance, reported rather than invented).
- **T4.2 (PT/DE audit)**: All 20 keys present with mechanical translations and `// FIXME: needs native speaker review` comments on every PT/DE string. No gaps found.
- **T5.1 (`docs/transparency.html`)**: "External server connections" at-a-glance row updated to "0 by default" with explicit conditional clause for the opt-in path. Added attestation: no cookies, no identifiers, no POST body, opt-in only, auditable open-source endpoint. "Check network requests" bullet qualified for default install. Added `alarms` and `optional_host_permissions` permission blocks under "Permissions Explained".
- **T5.2 (`CHANGELOG.md`)**: `## [Unreleased]` section added with `### Added` entry for the remote-rules feature. Version bump to `[1.10.0]` deferred to Phase 8.
- **T5.3 (`README.md`)**: One-line mention added under the existing "Configurable" subsection. "Zero outbound requests on a default install" framing preserved. No new top-level section created.
- **T5.4 (`docs/store-listing.md`)**: `alarms` + `optional_host_permissions` (CWS) / `optional_permissions` (AMO) permission justifications added to both "PRIVATE. REALLY." and "Private by design" sections. Matching tone and format of surrounding copy.

## Test delta

- Before: 1562 passing, 0 fail
- After: 1562 passing, 0 fail (docs-only changes, no new tests needed)

## Lint status

Exit 0. 4 pre-existing warnings (unchanged).

## Safety

- Feature is OFF by default. Default install: zero outbound requests.
- No workflow files touched.
- No secrets touched.
- No force-push.
- No AI attribution.
- Conventional commits only.

## What's new re: `whatsNewRemoteRules` wiring

No post-update splash or "whats new" surface exists in the codebase (no `whatsNewX` pattern anywhere in `src/onboarding/`, `src/options/`, or `src/popup/`). The key is defined in i18n.js (REQ-I18N-1 satisfied) and referenced as a named constant in `options.js` with a `void` guard to prevent unused-var lint. Wiring it into a real surface would require inventing a new UI surface — out of scope per design guidance.