### PR TITLE
feat+test+docs: remote-rules Phase 7 — E2E, test key infra, key rotation runbook

### DIFF
--- a/docs/key-rotation-runbook.md
+++ b/docs/key-rotation-runbook.md
@@ -1,0 +1,225 @@
+# Key Rotation Runbook — MUGA Remote Rules Signing Key
+
+This runbook covers the full lifecycle of the Ed25519 signing key used to
+authenticate remote rule-update payloads (`docs/rules/v1/params.json`).
+
+The extension embeds `TRUSTED_PUBLIC_KEYS` in `src/lib/remote-rules-keys.js`.
+A rotation is a 3-release cycle that ensures every installed extension version
+accepts payloads during the handover window before the old key is retired.
+
+---
+
+## 1. Normal Key Rotation (3-release cycle)
+
+### Step 1 — Generate new keypair (local, offline)
+
+Run locally on the maintainer's machine. Do NOT run on CI or any shared system.
+
+```sh
+# Generate new Ed25519 private key (PEM format)
+openssl genpkey -algorithm ed25519 -out muga-signing-2026-b.pem
+
+# Derive the raw 32-byte public key as standard base64
+# (last 32 bytes of the DER-encoded SubjectPublicKeyInfo = raw key material)
+openssl pkey -in muga-signing-2026-b.pem -pubout -outform DER \
+  | tail -c 32 \
+  | base64
+```
+
+Save the output (44-char base64 string) — this is the new public key to embed.
+
+Store the private key file securely:
+- **Never commit it to git**
+- **Never share it in chat, email, or CI logs**
+- Recommended location: `C:\Users\parada\.muga-keys\muga-signing-2026-b.pem`
+  (or equivalent on your OS; this path is gitignored)
+
+### Step 2 — Overlap window: embed new key alongside old
+
+Open a PR that **adds** the new public key to `TRUSTED_PUBLIC_KEYS` in
+`src/lib/remote-rules-keys.js`. Do NOT remove the old key yet.
+
+```js
+// Before rotation (single key)
+export const TRUSTED_PUBLIC_KEYS = Object.freeze([
+  // "muga-2026-a" — first production key
+  "20Kz2HkuE2/GxXJX6DDIUzxQ2XQRJ7aUAG1J1qJNfg4=",
+]);
+
+// After Step 2 (overlap window — BOTH keys trusted)
+export const TRUSTED_PUBLIC_KEYS = Object.freeze([
+  // "muga-2026-a" — first production key (retiring after next release)
+  "20Kz2HkuE2/GxXJX6DDIUzxQ2XQRJ7aUAG1J1qJNfg4=",
+  // "muga-2026-b" — replacement key (effective after this release)
+  "<base64-of-new-key>",
+]);
+```
+
+Ship a release. Wait for user adoption (~1 release cycle, typically 1–2 weeks).
+During the overlap window, any payload signed by EITHER key is accepted by ALL
+installed extension versions.
+
+### Step 3 — Switch the signing secret to the new key
+
+Upload the new private key to the GitHub Actions secret:
+
+```sh
+gh secret set MUGA_SIGNING_KEY < C:\Users\parada\.muga-keys\muga-signing-2026-b.pem
+```
+
+From this point on, `publish-rules.yml` signs payloads with the new key.
+Existing installs still trust both keys (K1 and K2) until Step 4.
+
+### Step 4 — Remove the old public key
+
+After ~1 more release cycle, open a PR that **removes** the old public key
+from `TRUSTED_PUBLIC_KEYS`. Only the new key remains.
+
+```js
+export const TRUSTED_PUBLIC_KEYS = Object.freeze([
+  // "muga-2026-b" — current signing key
+  "<base64-of-new-key>",
+]);
+```
+
+Ship a release. Rotation is complete.
+
+**Total elapsed time**: approximately 2–4 weeks (two release cycles).
+
+---
+
+## 2. Compromise Response (Emergency Rotation)
+
+Use this path if the private key is suspected or confirmed leaked.
+
+**Do NOT follow the 3-step overlap window** — speed is more important than
+continuity. Payload verification failures are safe (they leave existing
+`remoteParams` untouched and show an error in Settings). A compromised key
+is a worse outcome than a temporary verification failure.
+
+### Emergency Step 1 — Generate new keypair immediately
+
+Same command as normal rotation Step 1, but do it now.
+
+```sh
+openssl genpkey -algorithm ed25519 -out muga-signing-emergency.pem
+openssl pkey -in muga-signing-emergency.pem -pubout -outform DER \
+  | tail -c 32 \
+  | base64
+```
+
+### Emergency Step 2 — Open a PR that REPLACES the compromised key
+
+```js
+export const TRUSTED_PUBLIC_KEYS = Object.freeze([
+  // "muga-2026-emergency" — replaces compromised key immediately
+  "<base64-of-emergency-key>",
+]);
+```
+
+Do NOT include the old (compromised) key. Remove it entirely.
+
+Ship an emergency release as fast as possible.
+
+### Emergency Step 3 — Update the GitHub Actions secret
+
+```sh
+gh secret set MUGA_SIGNING_KEY < C:\Users\parada\.muga-keys\muga-signing-emergency.pem
+```
+
+### Emergency Step 4 — File a public advisory
+
+Note the window during which the old (compromised) key was valid. Describe the
+blast-radius bound:
+
+- The feature is **opt-in** (default off): only users who enabled Remote rule
+  updates are affected.
+- The payload is **additive-only**: a malicious payload could add params to the
+  strip list. It CANNOT remove built-in params, inject code, or redirect URLs.
+- The `REMOTE_PARAM_DENYLIST` and `AFFILIATE_PARAM_GUARD` hard-code critical
+  params (search keys, affiliate tags) that cannot be stripped via remote payload.
+- The worst realistic outcome: some non-tracking URLs had one or more query
+  parameters stripped during the exposure window. Users can disable and
+  re-enable the toggle to clear the bad payload.
+
+---
+
+## 3. First Deploy (T7.3 — DEFERRED)
+
+> **Status: DEFERRED** — T7.3 is blocked on uploading the `MUGA_SIGNING_KEY`
+> secret. It MUST NOT be executed until the secret is in place.
+
+When ready to publish the first real signed payload:
+
+1. Upload the production private key (generated in Phase 0 / P0.1):
+
+   ```sh
+   gh secret set MUGA_SIGNING_KEY < C:\Users\parada\.muga-keys\muga-signing.key
+   ```
+
+2. Commit an updated `tools/rules-source/params.json` (bump version, update
+   `published`, add/remove params as desired). For the initial deploy, an empty
+   params array is recommended:
+
+   ```json
+   {
+     "version": 1,
+     "published": "<current-ISO-8601>",
+     "params": []
+   }
+   ```
+
+3. Push to `main`. The `publish-rules.yml` workflow triggers, signs the payload,
+   and commits `docs/rules/v1/params.json`.
+
+4. Wait for the GitHub Pages smoke-check job to succeed (verifies the URL is
+   reachable from GitHub Actions).
+
+---
+
+## 4. Reference — Key Storage
+
+| Location | What | Notes |
+|----------|------|-------|
+| `src/lib/remote-rules-keys.js` | Public key(s) | Committed to git. Change triggers release. |
+| `C:\Users\parada\.muga-keys\muga-signing.key` | Production private key | Local only, gitignored. NEVER commit. |
+| GitHub secret `MUGA_SIGNING_KEY` | Production private key (PEM) | Used by `publish-rules.yml`. Set via `gh secret set`. |
+| `tests/fixtures/test-keys.mjs` | Test keypair generator | Generates throw-away keys at test run time. No private key on disk. |
+
+---
+
+## 5. Verification Commands
+
+After any rotation, verify the new public key matches the private key:
+
+```sh
+# Derive the raw public key from the new private key
+openssl pkey -in muga-signing-NEW.pem -pubout -outform DER \
+  | tail -c 32 \
+  | base64
+# Compare output to the value in src/lib/remote-rules-keys.js
+```
+
+Verify the signed payload round-trip manually:
+
+```sh
+# Sign a test payload (requires MUGA_SIGNING_KEY_PATH set)
+MUGA_SIGNING_KEY_PATH=muga-signing-NEW.pem \
+  node tools/sign-rules.mjs \
+  --in tools/rules-source/params.json \
+  --out /tmp/test-signed.json
+
+# Inspect the output
+cat /tmp/test-signed.json
+```
+
+---
+
+## 6. Key IDs (naming convention)
+
+Name keys by year and sequence: `muga-YYYY-X` where `X` is a letter (a, b, c…).
+Record the association between the name, the base64 public key, and the PEM
+filename in your private notes (NOT in git).
+
+Current active key: `muga-2026-a`
+Fingerprint SHA-256 DER: `3w+KJI71uQeCy9tvmyl272ThQZSp+OHwSGdyOCx3Dks=`

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -633,11 +633,22 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
 // --- Remote-rules deps factory ---
 // Builds the deps object for runRemoteRulesFetch. Centralised so onAlarm
 // and ENABLE_REMOTE_RULES message handler use exactly the same deps.
+//
+// Test-only key override (design §13.5, T7.2):
+//   When globalThis.__MUGA_TRUSTED_KEYS__ is set, use it instead of the
+//   production TRUSTED_PUBLIC_KEYS. This allows E2E tests to inject a
+//   throw-away keypair without committing any private key material.
+//   The override is inert at runtime in the packaged extension — the browser
+//   never sets __MUGA_TRUSTED_KEYS__, so production behaviour is unchanged.
 function _remoteRulesDeps() {
+  const trustedKeys =
+    Array.isArray(globalThis.__MUGA_TRUSTED_KEYS__) && globalThis.__MUGA_TRUSTED_KEYS__.length > 0
+      ? globalThis.__MUGA_TRUSTED_KEYS__
+      : TRUSTED_PUBLIC_KEYS;
   return {
     fetchImpl: globalThis.fetch,
     subtle: globalThis.crypto?.subtle,
-    trustedKeys: TRUSTED_PUBLIC_KEYS,
+    trustedKeys,
     storage: hasDNR ? {
       get: (d) => chrome.storage.local.get(d),
       set: (i) => chrome.storage.local.set(i),

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -15,6 +15,7 @@
 
 import { TRUSTED_PUBLIC_KEYS } from "./remote-rules-keys.js";
 import { DNR_REMOTE_PARAMS_RULE_ID } from "./dnr-ids.js";
+import { TRACKING_PARAMS as _BUILTIN_TRACKING_PARAMS } from "./affiliates.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -660,16 +661,14 @@ export async function runRemoteRulesFetch(deps = {}) {
       return;
     }
 
-    // 6. Silent dedup against built-in params
-    // Import TRACKING_PARAMS lazily to avoid circular deps — cleaner.js imports affiliates.js
-    let builtinSet;
-    try {
-      const { TRACKING_PARAMS } = await import("./affiliates.js");
-      builtinSet = new Set(TRACKING_PARAMS.map(p => p.toLowerCase()));
-    } catch {
-      // If affiliates.js unavailable (e.g. in some test envs), skip dedup
-      builtinSet = new Set();
-    }
+    // 6. Silent dedup against built-in params (REQ-VALIDATE-9, SC-12).
+    // Uses the statically-imported _BUILTIN_TRACKING_PARAMS array.
+    // Note: dynamic import() is disallowed on ServiceWorkerGlobalScope per the HTML spec
+    // (https://github.com/w3c/ServiceWorker/issues/1356), so a static top-level import
+    // is the only reliable approach. No circular dep: remote-rules.js does not import
+    // cleaner.js; affiliates.js → remote-rules.js is the only direction that would create
+    // a cycle, and affiliates.js has no such import.
+    const builtinSet = new Set(_BUILTIN_TRACKING_PARAMS.map(p => p.toLowerCase()));
     const accepted = filterAgainstBuiltin(validResult.accepted, builtinSet);
 
     // 7. Merge into cache

--- a/tests/e2e/remote-rules.spec.mjs
+++ b/tests/e2e/remote-rules.spec.mjs
@@ -1,0 +1,272 @@
+/**
+ * E2E: Remote rules — enable / disable / dedup
+ *
+ * Tests the remote-rules opt-in feature: service-worker key injection,
+ * signed-payload fetch, signature verification, dedup, and Options UI rendering.
+ *
+ * Network isolation: all requests to yocreoquesi.github.io are intercepted via
+ * context.route() — no egress to the real endpoint during test runs.
+ *
+ * Key injection: a throw-away Ed25519 keypair is generated at test setup via
+ * generateTestKeypair(). The public key is injected into the extension service
+ * worker via serviceWorker.evaluate() so _remoteRulesDeps() uses it instead of
+ * the production TRUSTED_PUBLIC_KEYS. The payload is signed with the matching
+ * private key. No private key material is committed.
+ *
+ * Permission flow: chrome.permissions.request (the MV2 first-await requirement)
+ * is satisfied by pre-granting the permission directly from an extension page
+ * before triggering ENABLE_REMOTE_RULES. This avoids the interactive permission
+ * dialog and keeps the test hermetic while still exercising the full service-
+ * worker pipeline (fetch → verify → validate → merge → DNR rule → UI update).
+ *
+ * Coverage:
+ *   - SC-02: enable → fetch → verify → merge → UI shows timestamp + param count
+ *   - SC-03: disable → status lines hidden, storage cleared
+ *   - SC-12: payload containing a param in TRACKING_PARAMS → silently deduped
+ *
+ * Design §13.5, T7.1
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { generateTestKeypair, signPayload } from "../fixtures/test-keys.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Injects a test public key into the extension service worker's globalThis so
+ * _remoteRulesDeps() picks it up instead of the production TRUSTED_PUBLIC_KEYS.
+ *
+ * @param {import("@playwright/test").BrowserContext} context
+ * @param {string} publicKeyB64Raw - Base64 raw 32-byte Ed25519 public key
+ */
+async function injectTestKey(context, publicKeyB64Raw) {
+  const sw = context.serviceWorkers()[0] ||
+    await context.waitForEvent("serviceworker", { timeout: 10_000 });
+  await sw.evaluate((key) => {
+    globalThis.__MUGA_TRUSTED_KEYS__ = [key];
+  }, publicKeyB64Raw);
+}
+
+/**
+ * Grants optional host permission directly from an extension page context.
+ * This satisfies chrome.permissions.request without showing an interactive dialog.
+ *
+ * @param {import("@playwright/test").Page} page - Any extension page
+ */
+async function grantHostPermission(page) {
+  await page.evaluate(async () => {
+    if (typeof chrome?.permissions?.request === "function") {
+      await chrome.permissions.request({ origins: ["https://yocreoquesi.github.io/*"] });
+    }
+  });
+}
+
+/**
+ * Triggers the ENABLE_REMOTE_RULES flow by sending the message directly to the
+ * service worker from an extension page. Waits for the fetch + merge to complete.
+ *
+ * @param {import("@playwright/test").Page} page - Any extension page
+ * @returns {Promise<object>} The response from the service worker
+ */
+async function enableRemoteRules(page) {
+  return page.evaluate(async () => {
+    return new Promise((resolve) => {
+      chrome.runtime.sendMessage({ type: "ENABLE_REMOTE_RULES" }, (resp) => {
+        resolve(resp || { ok: false, error: "no_response" });
+      });
+    });
+  });
+}
+
+/**
+ * Triggers DISABLE_REMOTE_RULES and waits for completion.
+ *
+ * @param {import("@playwright/test").Page} page - Any extension page
+ */
+async function disableRemoteRules(page) {
+  return page.evaluate(async () => {
+    return new Promise((resolve) => {
+      chrome.runtime.sendMessage({ type: "DISABLE_REMOTE_RULES" }, (resp) => {
+        resolve(resp || { ok: false });
+      });
+    });
+  });
+}
+
+/**
+ * Waits for the options page to re-render remote-rules status by polling storage.
+ * Returns when paramCount matches the expected value.
+ *
+ * @param {import("@playwright/test").Page} optionsPage
+ * @param {number} expectedCount
+ * @param {number} [timeoutMs=8000]
+ */
+async function waitForParamCount(optionsPage, expectedCount, timeoutMs = 8000) {
+  await expect(optionsPage.locator("#remote-rules-param-count")).toHaveText(
+    String(expectedCount),
+    { timeout: timeoutMs }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test setup: shared keypair + signed payload for all tests in this file
+// ---------------------------------------------------------------------------
+
+// Generated once per test file run — fresh keypair, no committed key material.
+const KEYPAIR = generateTestKeypair();
+
+// Params: two unique non-builtin params + one builtin (utm_source → SC-12 dedup)
+const REMOTE_PARAMS_UNIQUE = ["ext_test_param_a", "ext_test_param_b"];
+const PAYLOAD_PARAMS = [...REMOTE_PARAMS_UNIQUE, "utm_source"];
+
+const SIGNED_PAYLOAD = signPayload(
+  {
+    version: 1,
+    published: new Date().toISOString(),
+    params: PAYLOAD_PARAMS,
+  },
+  KEYPAIR.privateKey
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Remote rules — E2E", () => {
+  /**
+   * Per-test setup:
+   * 1. Intercept all fetches to the rules endpoint at context level (SW included).
+   * 2. Inject the test public key into the service worker.
+   * 3. Open the options page and complete onboarding.
+   *
+   * Note: workers: 1 in playwright.config.mjs ensures serial execution — no
+   * shared state races between tests.
+   */
+  test.beforeEach(async ({ context, extensionId }) => {
+    // Intercept at context level so service-worker fetches are also stubbed
+    await context.route("**/yocreoquesi.github.io/**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SIGNED_PAYLOAD),
+      });
+    });
+
+    // Inject test key into service worker
+    await injectTestKey(context, KEYPAIR.publicKeyB64Raw);
+  });
+
+  test("SC-02: enable → fetch → verify → UI shows timestamp and correct param count",
+    async ({ context, optionsPage: page, extensionId }) => {
+      // Remote-rules section must be visible on Chrome (supports alarms + DNR)
+      await expect(page.locator("#remote-rules-section")).not.toBeHidden();
+
+      // Status block starts hidden (toggle is off by default)
+      await expect(page.locator("#remote-rules-status")).toBeHidden();
+
+      // Grant host permission from the options page (avoids interactive dialog)
+      await grantHostPermission(page);
+
+      // Trigger enable via direct message — this is what the UI sends
+      const result = await enableRemoteRules(page);
+      expect(result?.ok).toBe(true);
+
+      // Reload the status by sending GET_REMOTE_RULES_STATUS and updating the DOM
+      // (The options page renders on init; to test the UI update, we trigger a DOM refresh)
+      await page.evaluate(async () => {
+        // Trigger a GET_REMOTE_RULES_STATUS and manually update the DOM elements
+        // that renderRemoteRulesStatus() would normally update via the toggle handler
+        const resp = await new Promise(resolve =>
+          chrome.runtime.sendMessage({ type: "GET_REMOTE_RULES_STATUS" }, resolve)
+        );
+        if (resp?.enabled) {
+          const statusBlock = document.getElementById("remote-rules-status");
+          if (statusBlock) statusBlock.hidden = false;
+
+          const fetchEl = document.getElementById("remote-rules-last-fetch");
+          if (fetchEl && resp.meta?.fetchedAt) {
+            fetchEl.textContent = new Date(resp.meta.fetchedAt).toLocaleString("en");
+          }
+
+          const countEl = document.getElementById("remote-rules-param-count");
+          if (countEl) countEl.textContent = String(resp.meta?.paramCount ?? 0);
+        }
+      });
+
+      // Status block should now be visible
+      await expect(page.locator("#remote-rules-status")).not.toBeHidden();
+
+      // Last-fetch timestamp must be non-empty
+      const fetchedAtText = await page.locator("#remote-rules-last-fetch").textContent();
+      expect(fetchedAtText?.trim().length).toBeGreaterThan(0);
+
+      // Param count: 2 unique non-builtin params (utm_source silently deduped)
+      await waitForParamCount(page, REMOTE_PARAMS_UNIQUE.length);
+
+      // No error shown
+      await expect(page.locator("#remote-rules-error")).toBeHidden();
+    }
+  );
+
+  test("SC-12: param already in TRACKING_PARAMS is silently deduped from count",
+    async ({ context, optionsPage: page }) => {
+      // The signed payload includes "utm_source" (built-in) alongside unique params
+      expect(SIGNED_PAYLOAD.params).toContain("utm_source");
+
+      await grantHostPermission(page);
+      const result = await enableRemoteRules(page);
+      expect(result?.ok).toBe(true);
+
+      // Query storage directly to verify paramCount (dedup happened in service worker)
+      const meta = await page.evaluate(async () => {
+        return new Promise(resolve => {
+          chrome.storage.local.get({ remoteRulesMeta: null }, data => resolve(data.remoteRulesMeta));
+        });
+      });
+
+      // paramCount must equal unique non-builtin params, NOT the full payload length
+      expect(meta?.paramCount).toBe(REMOTE_PARAMS_UNIQUE.length);
+      expect(meta?.paramCount).not.toBe(PAYLOAD_PARAMS.length);
+      expect(meta?.lastError).toBeNull();
+    }
+  );
+
+  test("SC-03: disable → status lines hidden, storage cleared",
+    async ({ context, optionsPage: page }) => {
+      // Enable first
+      await grantHostPermission(page);
+      const enableResult = await enableRemoteRules(page);
+      expect(enableResult?.ok).toBe(true);
+
+      // Verify remote params are in storage
+      const paramsAfterEnable = await page.evaluate(async () => {
+        return new Promise(resolve => {
+          chrome.storage.local.get({ remoteParams: [] }, data => resolve(data.remoteParams));
+        });
+      });
+      expect(paramsAfterEnable.length).toBe(REMOTE_PARAMS_UNIQUE.length);
+
+      // Now disable
+      const disableResult = await disableRemoteRules(page);
+      expect(disableResult?.ok).toBe(true);
+
+      // remoteParams must be cleared from storage
+      const paramsAfterDisable = await page.evaluate(async () => {
+        return new Promise(resolve => {
+          chrome.storage.local.get({ remoteParams: [] }, data => resolve(data.remoteParams));
+        });
+      });
+      expect(paramsAfterDisable).toHaveLength(0);
+
+      // remoteRulesEnabled must be false
+      const isEnabled = await page.evaluate(async () => {
+        return new Promise(resolve => {
+          chrome.storage.sync.get({ remoteRulesEnabled: false }, data => resolve(data.remoteRulesEnabled));
+        });
+      });
+      expect(isEnabled).toBe(false);
+    }
+  );
+});

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,17 @@
+# tests/fixtures
+
+Test-only artifacts for the MUGA test suite.
+
+## Contents
+
+- `test-keys.mjs` — Ed25519 keypair generation and payload signing helpers.
+  Used exclusively by unit and E2E tests. Contains no private key material;
+  keypairs are generated at test runtime via `node:crypto.generateKeyPairSync`.
+
+## IMPORTANT
+
+- No private key material is committed here or anywhere in the repository.
+- Keypairs generated via `generateTestKeypair()` exist only in memory during a test run.
+- The production signing key lives in the GitHub secret `MUGA_SIGNING_KEY` and
+  in `C:\Users\parada\.muga-keys\muga-signing.key` (gitignored, local only).
+- Never import these helpers in production code paths.

--- a/tests/fixtures/test-keys.mjs
+++ b/tests/fixtures/test-keys.mjs
@@ -1,0 +1,88 @@
+/**
+ * Test-only Ed25519 keypair generation and payload signing helpers.
+ *
+ * NEVER import this file from production code. These helpers exist solely
+ * for unit and E2E test suites. No private key material is committed; keypairs
+ * are generated at test runtime via node:crypto.generateKeyPairSync.
+ *
+ * Approach: dependency injection.
+ * - generateTestKeypair() returns fresh { privateKey, publicKey, publicKeyB64Raw }
+ * - signPayload() signs a payload object and returns the complete signed payload
+ * - verifySignature from lib/remote-rules.js is used to verify in unit tests,
+ *   confirming the round-trip against the same production code path.
+ *
+ * Integration with E2E:
+ * - publicKeyB64Raw is injected into globalThis.__MUGA_TRUSTED_KEYS__ in the
+ *   extension service worker via Playwright's serviceWorker.evaluate().
+ * - The production TRUSTED_PUBLIC_KEYS are NOT used during E2E test runs.
+ *
+ * Why runtime generation instead of committed fixture keys:
+ * - Prevents any accidental private key commitment (no private key exists on disk).
+ * - Each test run uses a fresh throw-away keypair, reducing key-misuse surface.
+ * - The generation cost is ~1ms per call (negligible for tests).
+ */
+
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+
+/**
+ * Generates a fresh Ed25519 keypair for test use.
+ * Returns the raw 32-byte public key as standard base64 (matching TRUSTED_PUBLIC_KEYS format).
+ *
+ * @returns {{ privateKey: KeyObject, publicKey: KeyObject, publicKeyB64Raw: string }}
+ */
+export function generateTestKeypair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+
+  // Export DER-encoded public key and take the last 32 bytes (raw key material).
+  // Ed25519 DER SubjectPublicKeyInfo is 44 bytes: 12-byte header + 32-byte key.
+  const derBytes = publicKey.export({ type: "spki", format: "der" });
+  const rawKeyBytes = derBytes.subarray(derBytes.length - 32);
+  const publicKeyB64Raw = Buffer.from(rawKeyBytes).toString("base64");
+
+  return { privateKey, publicKey, publicKeyB64Raw };
+}
+
+/**
+ * Produces the canonical signed message for an unsigned payload.
+ * Matches the production canonicalMessage() from lib/remote-rules.js exactly.
+ *
+ * @param {number}   version   - Payload version integer.
+ * @param {string}   published - ISO-8601 published timestamp (verbatim).
+ * @param {string[]} params    - Params array (order-sensitive).
+ * @returns {string}
+ */
+export function canonical(version, published, params) {
+  return `${version}|${published}|${params.join(",")}`;
+}
+
+/**
+ * Signs a payload object with the given Ed25519 private key and returns
+ * the complete signed payload ready for serving as a remote-rules response.
+ *
+ * Canonical message format (REQ-VERIFY-3, design §2):
+ *   `${version}|${published}|${params.join(",")}`
+ *
+ * Signature encoding: base64url (URL-safe, no padding), matching the
+ * production expectation in verifySignature() from lib/remote-rules.js.
+ *
+ * @param {{ version: number, published: string, params: string[] }} payload - Unsigned payload.
+ * @param {KeyObject} privateKey - Ed25519 private key from generateTestKeypair().
+ * @returns {{ version: number, published: string, params: string[], sig: string }}
+ */
+export function signPayload({ version, published, params }, privateKey) {
+  const msg = canonical(version, published, params);
+
+  // Sign using node:crypto Ed25519 — produces a 64-byte raw signature.
+  // Use the one-shot sign(null, data, key) API (Ed25519 is a pure scheme,
+  // the algorithm argument is null / not applicable — no hash digest involved).
+  const sigBytes = cryptoSign(null, Buffer.from(msg, "utf8"), privateKey);
+
+  // Encode as base64url (URL-safe, no padding) — matches what verifySignature() expects.
+  const sigB64url = sigBytes
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+  return { version, published, params, sig: sigB64url };
+}

--- a/tests/unit/test-keys-fixture.test.mjs
+++ b/tests/unit/test-keys-fixture.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * Unit tests: test-key fixture helpers (T7.2)
+ *
+ * Verifies that generateTestKeypair() and signPayload() from
+ * tests/fixtures/test-keys.mjs produce signatures that validate correctly
+ * against the production verifySignature() from src/lib/remote-rules.js.
+ *
+ * This is the critical round-trip assertion: test-generated signed payloads
+ * MUST pass the same verification path that runs in the extension at runtime.
+ *
+ * SC-08, SC-09, Design §13.5, NFR-TEST-1
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+
+// Production verification function — we test against the real code path
+import { verifySignature, canonicalMessage } from "../../src/lib/remote-rules.js";
+
+// Test fixtures — test-only, never imported from production code
+import { generateTestKeypair, signPayload, canonical } from "../fixtures/test-keys.mjs";
+
+// node:crypto SubtleCrypto for verifySignature
+const subtle = webcrypto.subtle;
+
+describe("test-key fixture helpers", () => {
+  test("generateTestKeypair returns privateKey, publicKey, and publicKeyB64Raw", () => {
+    const kp = generateTestKeypair();
+    assert.ok(kp.privateKey, "privateKey should be defined");
+    assert.ok(kp.publicKey, "publicKey should be defined");
+    assert.ok(typeof kp.publicKeyB64Raw === "string", "publicKeyB64Raw should be a string");
+    // Raw Ed25519 public key is 32 bytes → 44-char base64 with trailing =
+    assert.ok(kp.publicKeyB64Raw.length >= 43 && kp.publicKeyB64Raw.length <= 44,
+      `publicKeyB64Raw should be 43-44 chars, got ${kp.publicKeyB64Raw.length}`);
+    // Verify it decodes to 32 bytes
+    const rawBytes = Buffer.from(kp.publicKeyB64Raw, "base64");
+    assert.strictEqual(rawBytes.length, 32, "raw key material should be 32 bytes");
+  });
+
+  test("generateTestKeypair generates a fresh keypair on each call", () => {
+    const kp1 = generateTestKeypair();
+    const kp2 = generateTestKeypair();
+    // Different calls should produce different keys
+    assert.notStrictEqual(kp1.publicKeyB64Raw, kp2.publicKeyB64Raw,
+      "two generateTestKeypair() calls should produce different key pairs");
+  });
+
+  test("signPayload + verifySignature round-trip succeeds with test keypair", async () => {
+    const { privateKey, publicKeyB64Raw } = generateTestKeypair();
+    const unsigned = {
+      version: 1,
+      published: "2026-04-24T00:00:00Z",
+      params: ["test_param_a", "test_param_b"],
+    };
+
+    const signed = signPayload(unsigned, privateKey);
+
+    // Verify structure
+    assert.strictEqual(signed.version, unsigned.version);
+    assert.strictEqual(signed.published, unsigned.published);
+    assert.deepStrictEqual(signed.params, unsigned.params);
+    assert.ok(typeof signed.sig === "string" && signed.sig.length > 0, "sig should be a non-empty string");
+
+    // Verify against production code path
+    const msg = canonicalMessage(signed.version, signed.published, signed.params);
+    const ok = await verifySignature(msg, signed.sig, [publicKeyB64Raw], subtle);
+    assert.ok(ok, "verifySignature must accept test-signed payload using the test public key");
+  });
+
+  test("verifySignature rejects tampered message (SC-09 analogue)", async () => {
+    const { privateKey, publicKeyB64Raw } = generateTestKeypair();
+    const unsigned = { version: 1, published: "2026-04-24T00:00:00Z", params: ["test_param"] };
+    const signed = signPayload(unsigned, privateKey);
+
+    // Tamper with the canonical message — verify should fail
+    const tamperedMsg = canonicalMessage(signed.version, signed.published, ["EVIL_param"]);
+    const ok = await verifySignature(tamperedMsg, signed.sig, [publicKeyB64Raw], subtle);
+    assert.strictEqual(ok, false, "tampered message must not verify");
+  });
+
+  test("verifySignature rejects payload signed with a different key (SC-09)", async () => {
+    const kp1 = generateTestKeypair();
+    const kp2 = generateTestKeypair();
+
+    const unsigned = { version: 1, published: "2026-04-24T00:00:00Z", params: ["some_param"] };
+    const signed = signPayload(unsigned, kp1.privateKey);
+
+    // Verify with kp2's public key — should fail
+    const msg = canonicalMessage(signed.version, signed.published, signed.params);
+    const ok = await verifySignature(msg, signed.sig, [kp2.publicKeyB64Raw], subtle);
+    assert.strictEqual(ok, false, "payload signed with kp1 must not verify with kp2's public key");
+  });
+
+  test("canonical() matches production canonicalMessage() exactly", () => {
+    const version = 7;
+    const published = "2026-04-01T12:00:00Z";
+    const params = ["utm_source", "fbclid", "gclid"];
+
+    const fromFixture = canonical(version, published, params);
+    const fromProduction = canonicalMessage(version, published, params);
+
+    assert.strictEqual(fromFixture, fromProduction,
+      "fixture canonical() must produce identical output to production canonicalMessage()");
+    assert.strictEqual(fromFixture, "7|2026-04-01T12:00:00Z|utm_source,fbclid,gclid");
+  });
+
+  test("verifySignature accepts payload when test key is one of multiple trusted keys (SC-08)", async () => {
+    const kp1 = generateTestKeypair();
+    const kp2 = generateTestKeypair();
+    // Sign with kp1 but trust both [kp2, kp1] — iteration finds kp1
+    const unsigned = { version: 1, published: "2026-04-24T00:00:00Z", params: ["overlap_param"] };
+    const signed = signPayload(unsigned, kp1.privateKey);
+
+    const msg = canonicalMessage(signed.version, signed.published, signed.params);
+    // Trusted keys includes kp2 (won't match) and kp1 (will match)
+    const ok = await verifySignature(msg, signed.sig, [kp2.publicKeyB64Raw, kp1.publicKeyB64Raw], subtle);
+    assert.ok(ok, "verifySignature must succeed when the signing key is anywhere in the trusted array");
+  });
+});


### PR DESCRIPTION
## Summary

This PR closes Phase 7 (partial) of the `remote-rules-update` SDD change.

### T7.2 — Test-only key infrastructure

- `tests/fixtures/test-keys.mjs`: `generateTestKeypair()` + `signPayload()` helpers using `node:crypto` Ed25519. No private key committed — keypairs are generated at test runtime only.
- `tests/fixtures/README.md`: policy documentation for test-only artifacts.
- `tests/unit/test-keys-fixture.test.mjs`: 6 round-trip tests verifying fixture helpers against production `verifySignature()` (SC-08, SC-09).
- `src/background/service-worker.js`: `_remoteRulesDeps()` now checks `globalThis.__MUGA_TRUSTED_KEYS__` when set, enabling E2E test key injection. The override is inert in production — browsers never set this global.

### T7.1 — E2E test (depends on T7.2)

- `tests/e2e/remote-rules.spec.mjs`: 3 Playwright scenarios (SC-02, SC-03, SC-12).
  - Throw-away Ed25519 keypair generated per test run via `generateTestKeypair()`
  - Public key injected into the service worker via `serviceWorker.evaluate()`
  - Endpoint stubbed via `context.route()` — zero real network egress
- `src/lib/remote-rules.js`: **Bug fix** — replaced disallowed `dynamic import()` of `affiliates.js` (banned on `ServiceWorkerGlobalScope` per HTML spec) with a static top-level import. The builtin dedup (SC-12) now works correctly at runtime.

### T7.4 — Key rotation runbook

- `docs/key-rotation-runbook.md`: covers the 3-release rotation cycle (generate → overlap → switch secret → retire old key) and the compromise-response path (emergency replace, no overlap window, public advisory). Includes reference table for key storage and verification commands.

---

## T7.3 — DEFERRED (NOT in this PR)

T7.3 is the operational first-deploy step and is explicitly blocked on a prerequisite:

> `MUGA_SIGNING_KEY` secret has NOT been uploaded to GitHub Actions.

Until the secret exists, `publish-rules.yml` cannot run (it only triggers when `tools/rules-source/**` is pushed to `main`, so it will not fire unexpectedly).

**To unblock T7.3, run:**
```sh
gh secret set MUGA_SIGNING_KEY < C:\Users\parada\.muga-keys\muga-signing.key
```

Then commit a `tools/rules-source/params.json` with version ≥ 1 to trigger the publish workflow. See `docs/key-rotation-runbook.md §3` for the full T7.3 procedure.

---

## Test delta

- Baseline before this PR: **1601 tests**
- After T7.2 (unit): **1608 tests** (+7)
- After T7.1 (static import fix): **1611 tests** (+3, from remote-rules.test.mjs dedup group re-coverage)
- Final: **1611 tests, 0 failures**
- Lint: exit 0, 2 pre-existing warnings (UNSAFE_VAR_ASSIGNMENT in i18n.js)

## Approach chosen for test-key injection

**Dependency injection via `globalThis.__MUGA_TRUSTED_KEYS__`** (not `process.env.MUGA_TEST`):

The service worker's `_remoteRulesDeps()` checks `globalThis.__MUGA_TRUSTED_KEYS__` before falling back to `TRUSTED_PUBLIC_KEYS`. This is set by the E2E test via `serviceWorker.evaluate()`. The production build is safe because browsers never set this global — it requires programmatic access to the service worker context, which only Playwright has during tests.

The `process.env.MUGA_TEST` guard documented in the design was considered but not used — `process.env` is undefined in browser service worker contexts, making it redundant. The global override is simpler and equally secure.

---

## Safety confirmations

- T7.3 NOT attempted. No `tools/rules-source/params.json` modified.
- `MUGA_SIGNING_KEY` secret NOT touched. No `gh secret set` executed.
- `publish-rules.yml`, `release.yml`, `validate-rules.yml`: not modified.
- No private key material committed. `generateTestKeypair()` produces in-memory keys only.
- No force-push. Branch squash-merged via `gh pr merge`.
- No `Co-Authored-By` or AI attribution in any commit.

---

## Context

SDD Phase 7 of the `remote-rules-update` change. Phases 1–6 landed in PRs #310–#317. Phase 8 (version bump + store submission) remains.