### PR TITLE
chore(release): bump version to 1.10.0 for remote-rules release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-04-24
+
 ### Added
 - Optional weekly updates for the tracking parameter list, off by default. Ed25519-signed payloads fetched from a public GitHub Pages endpoint (`https://yocreoquesi.github.io/muga/rules/v1/params.json`). Enable in Settings → Remote rule updates. Zero outbound requests on a default install. See `docs/transparency.html`. (#270)
 
@@ -516,7 +518,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.9.10...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/yocreoquesi/muga/compare/v1.9.10...v1.10.0
 [1.9.10]: https://github.com/yocreoquesi/muga/compare/v1.9.9...v1.9.10
 [1.9.9]: https://github.com/yocreoquesi/muga/compare/v1.9.8...v1.9.9
 [1.9.8]: https://github.com/yocreoquesi/muga/compare/v1.9.7...v1.9.8

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.9.10-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-1471_pass-brightgreen)](#development)
+[![Version](https://img.shields.io/badge/version-1.10.0-blue)](#)
+[![Tests](https://img.shields.io/badge/tests-1611_pass-brightgreen)](#development)
 # MUGA: Clean URLs, Fair to Every Click
 
 ### Install now

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://yocreoquesi.github.io/muga/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.9.10"
+    "softwareVersion": "1.10.0"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.9.10 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 1.9.10
+> Version: 1.10.0
 > Last updated: 2026-04-13
 > Status: Final listing for Chrome Web Store and Firefox AMO. 450+ tracking params, 150+ domain rules, 6 categories, 2 active affiliate programs, MV3 native.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.9.10 &nbsp;&middot;&nbsp; 2026-04-13 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.10.0 &nbsp;&middot;&nbsp; 2026-04-24 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.9.10</span>
+      <span class="at-a-glance-value">1.10.0</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.9.10",
+  "version": "1.10.0",
   "description": "Fair to every click. Strips 450+ tracking params, respects affiliate links. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.9.10",
+  "version": "1.10.0",
   "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.9.10",
+  "version": "1.10.0",
   "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.9.10 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.


### PR DESCRIPTION
## Summary

Version bump to 1.10.0 for the remote-rules-update release (SDD Phase 8, T8.1).

## Files changed

- `package.json` — `"version": "1.10.0"`
- `src/manifest.json` — `"version": "1.10.0"`
- `src/manifest.v2.json` — `"version": "1.10.0"`
- `README.md` — version badge → `1.10.0`, tests badge → `1611_pass`
- `CHANGELOG.md` — `[Unreleased]` renamed to `[1.10.0] - 2026-04-24`; fresh empty `[Unreleased]` added; `[1.10.0]` compare link added; `[Unreleased]` link updated to `v1.10.0...HEAD`
- `docs/index.html` — `softwareVersion` → `1.10.0`
- `docs/store-listing.md` — `> Version:` → `1.10.0`
- `docs/transparency.html` — Version stamp + at-a-glance cell → `1.10.0`
- `src/privacy/privacy.html` — Version stamp → `1.10.0`
- `docs/privacy-page.html` — Version stamp → `1.10.0`

## CI

All 1611 tests pass. `npm run lint` exits 0.

## Tag push (after this merges)

After this PR merges to main, trigger the release workflow by pushing the tag:

```sh
git checkout main && git pull
git tag v1.10.0
git push origin v1.10.0
```

## Pre-release checklist

- [ ] Upload `MUGA_SIGNING_KEY` secret if not already done:
  `gh secret set MUGA_SIGNING_KEY < C:\Users\parada\.muga-keys\muga-signing.key`
- [ ] Commit `tools/rules-source/params.json` with empty params (T7.3) once secret is uploaded
- [ ] After tag push: verify published URL returns HTTP 200 (`https://yocreoquesi.github.io/muga/rules/v1/params.json`)
- [ ] Review PT/DE i18n FIXME comments before store submission

---

Audit Wave 3 long closed; this is the final SDD phase task for remote-rules-update. No AI attribution.