### PR TITLE
fix(remote-rules): address verify warnings blocking v1.10.0 (W-1, W-2, W-3)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -6,7 +6,7 @@
 
 import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getAffiliateDomains } from "../lib/affiliates.js";
-import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules } from "../lib/storage.js";
+import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules, getRemoteParams } from "../lib/storage.js";
 import { isValidListEntry } from "../lib/validation.js";
 import { DNR_CUSTOM_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
 import { t } from "../lib/i18n.js";
@@ -126,7 +126,11 @@ function getPrefsWithCache() {
   if (cachedPrefs) return Promise.resolve(cachedPrefs);
   if (!prefsFetchPromise) {
     const versionAtStart = _cacheVersion;
-    prefsFetchPromise = getPrefs().then(prefs => {
+    // Fetch sync prefs and local remoteParams together so the cleaner sees
+    // remote params on the copy/context-menu/selection paths (REQ-MERGE-5).
+    // Without this, processUrl() gets prefs.remoteParams === undefined and
+    // remote params are only stripped via DNR (navigation), not the content-script copy path.
+    prefsFetchPromise = Promise.all([getPrefs(), getRemoteParams()]).then(([prefs, remote]) => {
       if (_cacheVersion !== versionAtStart) {
         // Cache was invalidated while fetching — discard stale result
         prefsFetchPromise = null;
@@ -135,6 +139,7 @@ function getPrefsWithCache() {
       // Pre-parse blacklist/whitelist once so processUrl doesn't re-parse on every call
       prefs._parsedBlacklist = (prefs.blacklist || []).map(parseListEntry);
       prefs._parsedWhitelist = (prefs.whitelist || []).map(parseListEntry);
+      prefs.remoteParams = remote.remoteParams || [];
       cachedPrefs = prefs;
       prefsFetchPromise = null;
       return prefs;
@@ -320,6 +325,12 @@ async function appendHistory(original, clean, removedTracking = []) {
 
 // --- Storage change listener: invalidate cache and re-apply DNR state ---
 chrome.storage.onChanged.addListener(async (changes, area) => {
+  // Invalidate the prefs cache on both sync changes (disabledCategories, customParams, etc.)
+  // and local changes that affect the merged cache (remoteParams — REQ-MERGE-5).
+  if (area === "local") {
+    if (changes.remoteParams) _invalidatePrefsCache();
+    return;
+  }
   if (area !== "sync") return;
   // Any sync storage change (including disabledCategories, contextMenuEnabled, etc.)
   // must invalidate the prefs cache so the next getPrefsWithCache() reads fresh data.

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -608,7 +608,7 @@ export async function runRemoteRulesFetch(deps = {}) {
         fetchImpl,
       });
     } catch (err) {
-      const code = err.code === ERR.OVER_CAP ? ERR.NETWORK_ERROR : ERR.NETWORK_ERROR;
+      const code = err.code || ERR.NETWORK_ERROR;
       await _writeError(code, storage);
       console.error("[MUGA] remote-rules:", code, err.message);
       return;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1047,7 +1047,7 @@ async function initRemoteRules() {
   let status = { enabled: false, fetchedAt: null, paramCount: 0, lastError: null, source: REMOTE_RULES_URL };
   try {
     const resp = await chrome.runtime.sendMessage({ type: "GET_REMOTE_RULES_STATUS" });
-    if (resp) status = { ...status, ...resp };
+    if (resp) status = { ...status, ...resp, ...(resp.meta || {}) };
   } catch (err) {
     console.error("[MUGA] GET_REMOTE_RULES_STATUS:", err);
   }
@@ -1113,7 +1113,7 @@ async function initRemoteRules() {
       // Re-query status and render updated state
       const statusResp = await chrome.runtime.sendMessage({ type: "GET_REMOTE_RULES_STATUS" });
       if (statusResp) {
-        renderRemoteRulesStatus({ source: REMOTE_RULES_URL, ...statusResp });
+        renderRemoteRulesStatus({ source: REMOTE_RULES_URL, ...statusResp, ...(statusResp.meta || {}) });
       }
     } catch (err) {
       console.error("[MUGA] ENABLE_REMOTE_RULES:", err);

--- a/tests/e2e/remote-rules.spec.mjs
+++ b/tests/e2e/remote-rules.spec.mjs
@@ -173,27 +173,12 @@ test.describe("Remote rules — E2E", () => {
       const result = await enableRemoteRules(page);
       expect(result?.ok).toBe(true);
 
-      // Reload the status by sending GET_REMOTE_RULES_STATUS and updating the DOM
-      // (The options page renders on init; to test the UI update, we trigger a DOM refresh)
-      await page.evaluate(async () => {
-        // Trigger a GET_REMOTE_RULES_STATUS and manually update the DOM elements
-        // that renderRemoteRulesStatus() would normally update via the toggle handler
-        const resp = await new Promise(resolve =>
-          chrome.runtime.sendMessage({ type: "GET_REMOTE_RULES_STATUS" }, resolve)
-        );
-        if (resp?.enabled) {
-          const statusBlock = document.getElementById("remote-rules-status");
-          if (statusBlock) statusBlock.hidden = false;
-
-          const fetchEl = document.getElementById("remote-rules-last-fetch");
-          if (fetchEl && resp.meta?.fetchedAt) {
-            fetchEl.textContent = new Date(resp.meta.fetchedAt).toLocaleString("en");
-          }
-
-          const countEl = document.getElementById("remote-rules-param-count");
-          if (countEl) countEl.textContent = String(resp.meta?.paramCount ?? 0);
-        }
-      });
+      // Reload the options page so initRemoteRules() fires again and calls
+      // renderRemoteRulesStatus() via the real code path. This ensures that if
+      // renderRemoteRulesStatus() is broken the test will fail — not silently pass
+      // because the DOM was written directly (S-1 fix).
+      await page.reload();
+      await page.waitForLoadState("domcontentloaded");
 
       // Status block should now be visible
       await expect(page.locator("#remote-rules-status")).not.toBeHidden();

--- a/tests/unit/verify-warnings-regression.test.mjs
+++ b/tests/unit/verify-warnings-regression.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Regression guards for `sdd-verify` warnings on the remote-rules-update change.
+ *
+ * Each test pins a specific past defect so it cannot silently return.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "../..");
+
+const swSource = readFileSync(join(ROOT, "src/background/service-worker.js"), "utf8");
+const optionsSource = readFileSync(join(ROOT, "src/options/options.js"), "utf8");
+const remoteRulesSource = readFileSync(join(ROOT, "src/lib/remote-rules.js"), "utf8");
+
+describe("W-1 regression: GET_STATUS meta is flattened in options.js", () => {
+  test("options.js un-nests resp.meta when merging into status", () => {
+    // If the spread is just `{ ...status, ...resp }` then `meta` is an opaque
+    // object and `status.fetchedAt` / `status.paramCount` stay null.
+    // The fix splats `resp.meta` alongside `resp`.
+    assert.ok(
+      /\.\.\.resp\.meta|\.\.\.\(resp\.meta[^}]*\}\)/.test(optionsSource) ||
+        /\.\.\.meta(?:\b|[^.])/.test(optionsSource),
+      "options.js should spread resp.meta (or an equivalent flattening) into the status object"
+    );
+  });
+
+  test("renderRemoteRulesStatus reads fetchedAt/paramCount/lastError at the top level", () => {
+    // If the render function reads from a nested .meta path, W-1 is back.
+    const renderFn = optionsSource.match(/function renderRemoteRulesStatus[\s\S]+?^\}/m);
+    assert.ok(renderFn, "renderRemoteRulesStatus function should exist");
+    const body = renderFn[0];
+    assert.ok(
+      /status\.fetchedAt|status\.paramCount|status\.lastError/.test(body),
+      "render should read fetchedAt/paramCount/lastError at top level"
+    );
+    assert.ok(
+      !/status\.meta\.(fetchedAt|paramCount|lastError)/.test(body),
+      "render must NOT read status.meta.* — that reintroduces W-1"
+    );
+  });
+});
+
+describe("W-2 regression: fetchWithCap error code preserved", () => {
+  test("runRemoteRulesFetch does not coerce all errors to NETWORK_ERROR", () => {
+    // The original defect: `err.code === ERR.OVER_CAP ? ERR.NETWORK_ERROR : ERR.NETWORK_ERROR`
+    // (identical branches) hid OVER_CAP from the user-visible meta.lastError.
+    const badTernary = /err\.code\s*===\s*ERR\.OVER_CAP\s*\?\s*ERR\.NETWORK_ERROR\s*:\s*ERR\.NETWORK_ERROR/;
+    assert.ok(
+      !badTernary.test(remoteRulesSource),
+      "remote-rules.js must not map OVER_CAP to NETWORK_ERROR via identical ternary branches (W-2)"
+    );
+  });
+
+  test("error code falls back to NETWORK_ERROR only when code is absent", () => {
+    // The fix pattern: `err.code || ERR.NETWORK_ERROR`. Any specific code
+    // from fetchWithCap (OVER_CAP) or other throws is preserved.
+    assert.ok(
+      /err\.code\s*\|\|\s*ERR\.NETWORK_ERROR/.test(remoteRulesSource),
+      "remote-rules.js should use `err.code || ERR.NETWORK_ERROR` so OVER_CAP survives"
+    );
+  });
+});
+
+describe("W-3 regression: remoteParams merged into prefs cache", () => {
+  test("getPrefsWithCache fetches both sync prefs and local remoteParams", () => {
+    // If the cache only reads sync storage, processUrl() on the copy/context-menu
+    // path sees prefs.remoteParams === undefined and the cleaner falls back to [].
+    // Remote params would then only strip on DNR (navigation), violating REQ-MERGE-5.
+    assert.ok(
+      /getRemoteParams/.test(swSource),
+      "service-worker.js should import and call getRemoteParams to merge remote rules into the prefs cache (REQ-MERGE-5)"
+    );
+    // The merge happens inside getPrefsWithCache's fetch promise.
+    const cacheFn = swSource.match(/function getPrefsWithCache[\s\S]+?^\}/m);
+    assert.ok(cacheFn, "getPrefsWithCache should exist");
+    assert.ok(
+      /remote(Params|\.remoteParams)/.test(cacheFn[0]),
+      "getPrefsWithCache body must assign remoteParams onto the cached prefs object"
+    );
+  });
+
+  test("storage.onChanged invalidates the cache on local remoteParams writes", () => {
+    // Without this, a remote-rules fetch updates local.remoteParams but the
+    // still-cached prefs keep the stale [] — copy-clean strips nothing.
+    const listener = swSource.match(/chrome\.storage\.onChanged\.addListener[\s\S]+?^\}\);/m);
+    assert.ok(listener, "storage.onChanged listener should exist");
+    const body = listener[0];
+    assert.ok(
+      /area\s*===\s*["']local["']/.test(body) && /remoteParams/.test(body),
+      "storage listener must handle local area changes to remoteParams and invalidate the cache"
+    );
+  });
+});
+
+describe("S-3 regression: REMOTE_ERR_KEYS covers NETWORK_ERROR", () => {
+  test("options.js REMOTE_ERR_KEYS maps NETWORK_ERROR to an i18n key", () => {
+    const map = optionsSource.match(/const REMOTE_ERR_KEYS\s*=\s*Object\.freeze\(\{[\s\S]+?\}\)/);
+    assert.ok(map, "REMOTE_ERR_KEYS map should exist");
+    assert.ok(
+      /NETWORK_ERROR\s*:\s*["']optionsRemoteRulesErrNetwork["']/.test(map[0]),
+      "REMOTE_ERR_KEYS must include NETWORK_ERROR so W-2 surfaces with the right i18n message"
+    );
+  });
+
+  test("REMOTE_ERR_KEYS covers every ERR code from remote-rules.js", () => {
+    const errBlock = remoteRulesSource.match(/export const ERR\s*=\s*Object\.freeze\(\{([\s\S]+?)\}\)/);
+    assert.ok(errBlock, "ERR constants should exist in remote-rules.js");
+    const errNames = Array.from(errBlock[1].matchAll(/^\s*([A-Z_]+)\s*:/gm), m => m[1]);
+    assert.ok(errNames.length >= 8, `expected ≥8 error codes, found ${errNames.length}`);
+    const map = optionsSource.match(/const REMOTE_ERR_KEYS\s*=\s*Object\.freeze\(\{([\s\S]+?)\}\)/);
+    for (const code of errNames) {
+      assert.ok(
+        new RegExp(`${code}\\s*:\\s*["']`).test(map[1]),
+        `REMOTE_ERR_KEYS must include ${code} (found in ERR) so the UI surfaces it with a translated message`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the three `sdd-verify` warnings that were blocking the v1.10.0 release (report: engram `sdd/remote-rules-update/verify-report`).

- **W-1** *(blocking)* — Options UI `renderRemoteRulesStatus` reads `status.fetchedAt` / `status.paramCount` at the top level, but the `GET_REMOTE_RULES_STATUS` handler replied with `{ meta: { fetchedAt, paramCount } }`. The spread `{ ...status, ...resp }` left `meta` nested, so after a successful fetch the UI showed "Never checked" and `0` params. **Fixed** by un-nesting `resp.meta` in the merge + the E2E test now exercises `renderRemoteRulesStatus` instead of bypassing it (S-1). *(Committed earlier in this branch by the prior agent.)*

- **W-2** *(polish)* — `runRemoteRulesFetch` mapped every `fetchWithCap` failure to `NETWORK_ERROR` via identical ternary branches, so `OVER_CAP` never surfaced in the UI. **Fixed** with `err.code || ERR.NETWORK_ERROR` so any specific error code survives. The i18n map already covers every ERR code.

- **W-3** *(blocking, REQ-MERGE-5)* — `getPrefsWithCache()` read only `chrome.storage.sync`. `processUrl()` called from copy-clean-URL / context-menu / selection paths saw `prefs.remoteParams === undefined`. Remote params were only stripped on navigation (DNR rule 1001), not on copy. **Fixed** by fetching sync + local in parallel and merging `remoteParams` into the cached prefs object + extending `storage.onChanged` to invalidate on `local.remoteParams` writes.

## Regression tests

`tests/unit/verify-warnings-regression.test.mjs` — 8 source-string assertions pinning the specific fix patterns for W-1 (flattened spread + render reads top-level), W-2 (no identical ternary + fallback pattern), W-3 (getRemoteParams imported/called, local storage invalidation), S-3 (every ERR code appears in REMOTE_ERR_KEYS).

## Delta

- Tests: 1611 → **1619** (+8), all green
- Lint: 0 errors, 4 pre-existing warnings, unchanged

## After merge

v1.10.0 is ready to tag. User command:

```sh
git checkout main && git pull
git tag v1.10.0
git push origin v1.10.0
```

The remaining operational items (T7.3 first rules-source publish, T8.3 monitoring) are documented in the Phase 8 PR body and `docs/key-rotation-runbook.md`.