### PR TITLE
chore(rules): T7.3 first signed deploy with empty param list

### DIFF
--- a/tools/rules-source/params.json
+++ b/tools/rules-source/params.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
-  "published": "2026-04-24T00:00:00Z",
+  "version": 2,
+  "published": "2026-04-24T19:24:54Z",
   "params": []
 }


### PR DESCRIPTION
Triggers publish-rules.yml. Smoke-test of the signing + GitHub Pages pipeline. Zero user-visible effect — empty params list.