### PR TITLE
feat(remote-rules): drop alarms permission for v1.10.1 (on-wake time-gated fetch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-04-25
+
+### Changed
+- Remote rule updates no longer require the `alarms` permission. The weekly refresh now piggybacks on natural service-worker wake events (browser startup, page visits, popup messages) and is throttled by a stored `fetchedAt` timestamp — at most one fetch per 7 days, short-circuited immediately when the feature is off. This drops one permission from the manifest without changing the opt-in default or the privacy posture.
+
+### Removed
+- `alarms` permission from `manifest.json` and `manifest.v2.json`.
+
 ## [1.10.0] - 2026-04-24
 
 ### Added
@@ -518,7 +526,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.10.1...HEAD
+[1.10.1]: https://github.com/yocreoquesi/muga/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/yocreoquesi/muga/compare/v1.9.10...v1.10.0
 [1.9.10]: https://github.com/yocreoquesi/muga/compare/v1.9.9...v1.9.10
 [1.9.9]: https://github.com/yocreoquesi/muga/compare/v1.9.8...v1.9.9

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.10.0-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-1611_pass-brightgreen)](#development)
+[![Version](https://img.shields.io/badge/version-1.10.1-blue)](#)
+[![Tests](https://img.shields.io/badge/tests-1615_pass-brightgreen)](#development)
 # MUGA: Clean URLs, Fair to Every Click
 
 ### Install now

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://yocreoquesi.github.io/muga/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.10.0"
+    "softwareVersion": "1.10.1"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,7 +1,7 @@
 # MUGA: Store Listings
 
-> Version: 1.10.0
-> Last updated: 2026-04-13
+> Version: 1.10.1
+> Last updated: 2026-04-25
 > Status: Final listing for Chrome Web Store and Firefox AMO. 450+ tracking params, 150+ domain rules, 6 categories, 2 active affiliate programs, MV3 native.
 
 ---
@@ -110,8 +110,7 @@ Every URL is processed entirely inside your browser. MUGA never sends data anywh
 . Zero analytics, zero telemetry, zero data collection
 . No account, no sign-in, no cloud
 . Core permissions: storage, activeTab, contextMenus, declarativeNetRequestWithHostAccess, clipboardWrite
-. alarms: used to schedule a weekly background check for signed tracking-parameter updates when the user enables Remote rule updates in Settings. No alarm fires if the feature is disabled (off by default).
-. optional_host_permissions https://yocreoquesi.github.io/*: granted only when the user enables Remote rule updates. Used to fetch the signed tracking-parameter payload — single HTTPS GET per week, credentials-omit, no user data transmitted. Revocable at any time via browser settings.
+. optional_host_permissions https://yocreoquesi.github.io/*: granted only when the user enables Remote rule updates. Used to fetch the signed tracking-parameter payload — a single HTTPS GET check at most once per 7 days, piggybacked on natural service-worker wake events (no chrome.alarms permission). Credentials-omit, no user data transmitted. Revocable at any time via browser settings.
 
 We evaluated 10+ affiliate programs from major retailers and marketplaces. All of them require redirect-based tracking that routes your clicks through external servers before reaching the store. We rejected every one of them and gave up that revenue rather than compromise your privacy. On those stores, MUGA actively strips the affiliate tracking parameters that redirect networks leave behind, and unwraps redirect URLs when possible so you go straight to the store.
 
@@ -226,8 +225,7 @@ Every URL is processed entirely inside your browser. MUGA never sends data anywh
 . Zero analytics, zero telemetry, zero data collection
 . No account, no sign-in, no cloud
 . Core permissions: storage, activeTab, contextMenus, declarativeNetRequest, clipboardWrite
-. alarms: used to schedule a weekly background check for signed tracking-parameter updates when you enable Remote rule updates in Settings. No alarm fires on a default install.
-. optional_permissions https://yocreoquesi.github.io/*: granted only when you enable Remote rule updates. Used to fetch the signed tracking-parameter payload — single HTTPS GET per week, credentials-omit, no user data transmitted. Revocable at any time.
+. optional_permissions https://yocreoquesi.github.io/*: granted only when you enable Remote rule updates. Used to fetch the signed tracking-parameter payload — a single HTTPS GET check at most once per 7 days, piggybacked on natural browser activity (no chrome.alarms permission). Credentials-omit, no user data transmitted. Revocable at any time.
 
 
 Your rules

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.10.0 &nbsp;&middot;&nbsp; 2026-04-24 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.10.1 &nbsp;&middot;&nbsp; 2026-04-25 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.10.0</span>
+      <span class="at-a-glance-value">1.10.1</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -165,13 +165,8 @@
   </div>
 
   <div class="permission-block">
-    <div class="permission-name">alarms</div>
-    <div class="permission-why">Used to schedule a weekly background check for signed tracking-parameter updates when you have enabled Remote rule updates in Settings. No alarm fires on a default install — the alarm handler reads your preference on every tick and returns immediately if the feature is off. This permission cannot be withheld; it is always declared so the alarm infrastructure is ready if you opt in.</div>
-  </div>
-
-  <div class="permission-block">
     <div class="permission-name">optional_host_permissions: https://yocreoquesi.github.io/* <em>(Chrome MV3)</em> / optional_permissions <em>(Firefox MV2)</em></div>
-    <div class="permission-why">Granted only when you enable Remote rule updates. Used to perform one HTTPS GET per week to fetch the signed tracking-parameter list from the project's public GitHub Pages endpoint (<code>https://yocreoquesi.github.io/muga/rules/v1/params.json</code>). The request is sent with <code>credentials: "omit"</code> and <code>cache: "no-store"</code> — no cookies, no user identifiers, no POST body. The endpoint is open source and auditable. If you disable Remote rule updates, this permission remains granted but no code path uses it; you can revoke it at any time via your browser's extension settings.</div>
+    <div class="permission-why">Granted only when you enable Remote rule updates. Used to perform a single HTTPS GET — at most once per 7 days — to fetch the signed tracking-parameter list from the project's public GitHub Pages endpoint (<code>https://yocreoquesi.github.io/muga/rules/v1/params.json</code>). The request is sent with <code>credentials: "omit"</code> and <code>cache: "no-store"</code> — no cookies, no user identifiers, no POST body. The refresh is triggered by natural service-worker wake events (a page visit, a browser startup, a message from the popup) combined with a stored "last-fetched" timestamp; no background alarm permission is used. The endpoint is open source and auditable. You can revoke this permission at any time via your browser's extension settings.</div>
   </div>
 
   <h2>How to Verify</h2>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Fair to every click. Strips 450+ tracking params, respects affiliate links. Open source.",
   "type": "module",
   "scripts": {

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -11,9 +11,6 @@ import { isValidListEntry } from "../lib/validation.js";
 import { DNR_CUSTOM_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
 import { t } from "../lib/i18n.js";
 import {
-  REMOTE_ALARM_NAME,
-  ALARM_PERIOD_MIN,
-  ALARM_DELAY_MIN,
   runRemoteRulesFetch,
   clearRemoteCache,
   buildRemoteDnrRule,
@@ -148,26 +145,50 @@ function getPrefsWithCache() {
   return prefsFetchPromise;
 }
 
-// --- Remote-rules alarm helpers ---
-// Feature-detect chrome.alarms (absent in some stripped Firefox MV2 builds).
-const hasAlarms = typeof chrome.alarms !== "undefined";
+// --- Remote-rules opportunistic fetch ---
+// MV3 service workers wake on many events (navigation, message, onInstalled,
+// onStartup, etc.). Instead of using chrome.alarms — which requires a separate
+// permission and a Privacy-practices justification — we piggyback on those
+// natural wake-ups and throttle with a time-gate stored in remoteRulesMeta.
+// Users who never open the browser don't need fresh rules; users who do, get
+// one fetch per ~7 days as a side-effect of normal activity.
+
+// Target interval between successful remote-rules fetches (7 days).
+const REMOTE_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Module-level flag — checked once per SW lifetime so repeated wake events
+// (one per message, one per navigation, etc.) don't hit chrome.storage on
+// every call. Resets automatically when the SW dies and respawns.
+let _remoteRulesCheckedThisLifetime = false;
 
 /**
- * Registers the remote-rules weekly alarm idempotently.
- * Called on onInstalled and onStartup. The alarm handler short-circuits
- * if remoteRulesEnabled is false, so always registering is safe (REQ-OPT-6).
+ * Fires a remote-rules fetch iff (a) the user has opted in, (b) no fetch is
+ * currently in flight (enforced by runRemoteRulesFetch internally), and (c)
+ * the last successful fetch is older than REMOTE_REFRESH_INTERVAL_MS (or has
+ * never happened). Silent no-op on any failure to read state — this is a
+ * best-effort path that must never block callers.
  *
- * Pure helper — takes chrome.alarms as an injected dep for unit-testability.
- * No-op when the API is absent (feature-detect).
+ * Deduplicated per SW lifetime via `_remoteRulesCheckedThisLifetime` so
+ * hot paths (PROCESS_URL, message handlers) can call it freely without
+ * extra storage reads.
  *
- * @param {typeof chrome.alarms | undefined} alarms - chrome.alarms API (or undefined).
+ * @param {object} deps - Dependencies for runRemoteRulesFetch (same shape as Phase 2).
+ * @returns {Promise<void>}
  */
-function registerRemoteRulesAlarm(alarms) {
-  if (!alarms) return;
-  return alarms.create(REMOTE_ALARM_NAME, {
-    periodInMinutes: ALARM_PERIOD_MIN,
-    delayInMinutes: ALARM_DELAY_MIN,
-  });
+async function maybeFetchRemoteRules(deps) {
+  if (_remoteRulesCheckedThisLifetime) return;
+  _remoteRulesCheckedThisLifetime = true;
+  try {
+    const { remoteRulesEnabled } = await getPrefs();
+    if (!remoteRulesEnabled) return;
+    const { remoteRulesMeta } = await getRemoteParams();
+    const last = remoteRulesMeta?.fetchedAt ? Date.parse(remoteRulesMeta.fetchedAt) : 0;
+    if (Number.isFinite(last) && Date.now() - last < REMOTE_REFRESH_INTERVAL_MS) return;
+    await runRemoteRulesFetch(deps);
+  } catch (err) {
+    // Non-fatal: remote rules are optional. Leave built-in rules active.
+    console.warn("[MUGA] maybeFetchRemoteRules:", err?.message || err);
+  }
 }
 
 // --- DNR sync helpers ---
@@ -364,6 +385,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       try { sendResponse({ cleanUrl: null, action: "error", removedTracking: [], junkRemoved: 0, detectedAffiliate: null }); } catch { /* channel closed */ }
       return true;
     }
+    // Opportunistic remote-rules refresh — cheap no-op after the first call
+    // in each SW lifetime. Catches the "user never restarts browser" case
+    // that onStartup can't reach. Runs in parallel with URL processing.
+    maybeFetchRemoteRules(_remoteRulesDeps());
     const tabId = sender.tab?.id;
     handleProcessUrl(message.url, { skipNotify: message.skipNotify, source: message.skipNotify ? "copy_selection" : "navigation", skipStats: !!message.skipStats })
       .then(result => {
@@ -464,9 +489,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       try {
         await setPrefs({ remoteRulesEnabled: true });
         _invalidatePrefsCache();
-        // Re-register alarm idempotently (REQ-OPT-6)
-        registerRemoteRulesAlarm(hasAlarms ? chrome.alarms : undefined);
-        // Immediate first fetch (REQ-OPT-3, SC-02)
+        // Immediate first fetch (REQ-OPT-3, SC-02). Subsequent fetches happen
+        // opportunistically via maybeFetchRemoteRules on any SW wake once the
+        // 7-day interval has elapsed — no alarm required.
         await runRemoteRulesFetch(_remoteRulesDeps());
         try { sendResponse({ ok: true }); } catch { /* channel closed */ }
       } catch (err) {
@@ -511,8 +536,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           remoteParams: [],
           remoteRulesMeta: { version: 0, fetchedAt: null, paramCount: 0, lastError: null, published: null },
         });
-        // Feature-detect flags (REQ-UI-5)
-        const supportsAlarms = hasAlarms;
+        // Feature-detect flags (REQ-UI-5). Since v1.10.1 the feature no
+        // longer requires chrome.alarms — the only remaining runtime gate
+        // is DNR availability. `supportsAlarms` is kept as `true` for
+        // backwards compat with any cached UI bundle that still inspects it.
+        const supportsAlarms = true;
         const supportsDNR = hasDNR;
         try {
           sendResponse({
@@ -671,41 +699,14 @@ function _remoteRulesDeps() {
   };
 }
 
-// --- onAlarm: weekly remote-rules fetch ---
-// Registered after hasAlarms guard so we don't reference chrome.alarms in envs where it's absent.
-if (hasAlarms) {
-  chrome.alarms.onAlarm.addListener(async (alarm) => {
-    if (alarm.name !== REMOTE_ALARM_NAME) return;
-
-    // Re-read remoteRulesEnabled from storage on every fire (REQ-OPT-6, SC-01).
-    // Must NOT use the prefs cache — the alarm fires infrequently and re-reading
-    // is cheap. Using the cache here could silently leave the disabled state stale.
-    let enabled = false;
-    try {
-      const data = await chrome.storage.sync.get({ remoteRulesEnabled: false });
-      enabled = !!data.remoteRulesEnabled;
-    } catch (err) {
-      console.error("[MUGA] remote-rules: failed to read remoteRulesEnabled:", err);
-      return;
-    }
-
-    if (!enabled) return; // short-circuit: disabled (SC-01)
-
-    // runRemoteRulesFetch manages its own _remoteFetchInFlight dedup guard (REQ-FETCH-3, SC-11)
-    try {
-      await runRemoteRulesFetch(_remoteRulesDeps());
-    } catch (err) {
-      // runRemoteRulesFetch writes errors to meta itself; this catch is for unexpected throws
-      console.error("[MUGA] remote-rules: unexpected error in alarm handler:", err);
-    }
-  });
-}
-
-// --- On startup: apply DNR state + register remote-rules alarm ---
+// --- On startup: apply DNR state + opportunistic remote-rules fetch ---
 chrome.runtime.onStartup.addListener(async () => {
   const prefs = await getPrefsWithCache();
   await applyDnrState(prefs);
-  registerRemoteRulesAlarm(hasAlarms ? chrome.alarms : undefined);
+  // Opportunistic fetch: time-gated so it only fires if the stored fetchedAt
+  // is older than REMOTE_REFRESH_INTERVAL_MS or absent. Also short-circuits
+  // immediately if remoteRulesEnabled is false.
+  maybeFetchRemoteRules(_remoteRulesDeps());
 });
 
 // --- Dedup flag: prevent opening onboarding twice in the same background lifetime ---
@@ -716,11 +717,13 @@ function openOnboardingOnce() {
   chrome.tabs.create({ url: chrome.runtime.getURL("onboarding/onboarding.html") });
 }
 
-// --- On install: open onboarding on first run, register context menu + alarm ---
+// --- On install: open onboarding on first run, sync DNR + maybe fetch rules ---
 chrome.runtime.onInstalled.addListener(async (details) => {
   const prefs = await getPrefsWithCache();
   await applyDnrState(prefs);
-  registerRemoteRulesAlarm(hasAlarms ? chrome.alarms : undefined);
+  // Opportunistic fetch: fires on install/update if user had enabled remote rules
+  // before the update and the stored payload is stale (or absent).
+  maybeFetchRemoteRules(_remoteRulesDeps());
 
   if (prefs.contextMenuEnabled !== false) {
     await syncContextMenus(true);

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -23,9 +23,6 @@ import { TRACKING_PARAMS as _BUILTIN_TRACKING_PARAMS } from "./affiliates.js";
 export const REMOTE_RULES_URL =
   "https://yocreoquesi.github.io/muga/rules/v1/params.json";
 
-/** chrome.alarms name for the weekly fetch alarm (REQ-FETCH-1). */
-export const REMOTE_ALARM_NAME = "muga-remote-rules";
-
 /**
  * DNR rule ID for remote params. Re-exported from lib/dnr-ids.js for
  * backwards compatibility with callers that import it from this module.
@@ -38,12 +35,6 @@ export const MAX_PAYLOAD_BYTES = 50 * 1024; // 50 KB
 
 /** Fetch timeout in milliseconds (REQ-FETCH-5). */
 export const FETCH_TIMEOUT_MS = 15_000;
-
-/** Alarm period in minutes — 7 days (REQ-FETCH-1). */
-export const ALARM_PERIOD_MIN = 10_080;
-
-/** Alarm initial delay in minutes — 1 hour (REQ-FETCH-1). */
-export const ALARM_DELAY_MIN = 60;
 
 /** Maximum accepted remote params after filtering (REQ-VALIDATE-6). */
 export const MAX_PARAM_COUNT = 500;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
 
   "permissions": [
@@ -10,8 +10,7 @@
     "activeTab",
     "contextMenus",
     "clipboardWrite",
-    "declarativeNetRequestWithHostAccess",
-    "alarms"
+    "declarativeNetRequestWithHostAccess"
   ],
 
   "optional_host_permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
 
   "permissions": [
@@ -11,8 +11,7 @@
     "contextMenus",
     "clipboardWrite",
     "declarativeNetRequest",
-    "<all_urls>",
-    "alarms"
+    "<all_urls>"
   ],
 
   "optional_permissions": [

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1028,10 +1028,10 @@ function renderRemoteRulesStatus(status) {
  * user-gesture frame and the permission request silently returns false.
  */
 async function initRemoteRules() {
-  // REQ-UI-5: hide the section entirely on runtimes without alarms or DNR
-  const supportsRemote =
-    typeof chrome.alarms !== "undefined" &&
-    typeof chrome.declarativeNetRequest !== "undefined";
+  // REQ-UI-5: hide the section entirely on runtimes without DNR. v1.10.1
+  // removed the chrome.alarms dependency — the only remaining runtime gate
+  // is DNR availability.
+  const supportsRemote = typeof chrome.declarativeNetRequest !== "undefined";
 
   const section = document.getElementById("remote-rules-section");
   if (!section) return;

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/tests/unit/config-integrity.test.mjs
+++ b/tests/unit/config-integrity.test.mjs
@@ -232,18 +232,20 @@ describe("manifest.json integrity", () => {
     }
   });
 
-  // Remote rules update (T1.1) — REQ-MANIFEST-1, REQ-MANIFEST-2
-  test("MV3 permissions include alarms (required for weekly remote-rules fetch)", () => {
+  // Remote rules update — v1.10.1 removed chrome.alarms in favor of opportunistic
+  // on-wake time-gated fetch (maybeFetchRemoteRules in service-worker.js). Asserting
+  // the permission is absent prevents it from silently returning during future refactors.
+  test("MV3 permissions do NOT include alarms (v1.10.1 switched to on-wake fetch)", () => {
     assert.ok(
-      mv3.permissions.includes("alarms"),
-      'manifest.json must include "alarms" in permissions for chrome.alarms API'
+      !mv3.permissions.includes("alarms"),
+      'manifest.json must NOT include "alarms" — remote-rules refresh now piggybacks on natural SW wake events'
     );
   });
 
-  test("MV2 permissions include alarms (required for weekly remote-rules fetch)", () => {
+  test("MV2 permissions do NOT include alarms (v1.10.1 switched to on-wake fetch)", () => {
     assert.ok(
-      mv2.permissions.includes("alarms"),
-      'manifest.v2.json must include "alarms" in permissions for browser.alarms API'
+      !mv2.permissions.includes("alarms"),
+      'manifest.v2.json must NOT include "alarms" — remote-rules refresh now piggybacks on natural SW wake events'
     );
   });
 

--- a/tests/unit/options-patterns.test.mjs
+++ b/tests/unit/options-patterns.test.mjs
@@ -209,10 +209,11 @@ describe("T3.2 options.js remote-rules wiring", () => {
     );
   });
 
-  test("feature-detects chrome.alarms and chrome.declarativeNetRequest", () => {
+  test("feature-detects chrome.declarativeNetRequest (REQ-UI-5)", () => {
+    // v1.10.1 removed the alarms permission — only DNR is required now.
     assert.ok(
-      optionsJs.includes("chrome.alarms") && optionsJs.includes("chrome.declarativeNetRequest"),
-      "options.js must feature-detect chrome.alarms and chrome.declarativeNetRequest (REQ-UI-5)"
+      optionsJs.includes("chrome.declarativeNetRequest"),
+      "options.js must feature-detect chrome.declarativeNetRequest (REQ-UI-5)"
     );
   });
 

--- a/tests/unit/remote-rules.test.mjs
+++ b/tests/unit/remote-rules.test.mjs
@@ -67,7 +67,6 @@ import {
   buildRemoteDnrRule,
   runRemoteRulesFetch,
   REMOTE_RULE_ID,
-  REMOTE_ALARM_NAME,
   REMOTE_RULES_URL,
   MAX_PAYLOAD_BYTES,
   FETCH_TIMEOUT_MS,
@@ -137,10 +136,6 @@ function makePayload({
 describe("Constants — shape and values", () => {
   test("REMOTE_RULE_ID is 1001", () => {
     assert.strictEqual(REMOTE_RULE_ID, 1001);
-  });
-
-  test("REMOTE_ALARM_NAME is a non-empty string", () => {
-    assert.ok(typeof REMOTE_ALARM_NAME === "string" && REMOTE_ALARM_NAME.length > 0);
   });
 
   test("REMOTE_RULES_URL is the correct endpoint", () => {

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -314,196 +314,176 @@ describe("Security: debug log payload privacy (finding 1)", () => {
   });
 });
 
-// ── T2.1: Remote-rules alarm registration ────────────────────────────────────
+// ── Remote-rules refresh — on-wake time-gated (v1.10.1) ──────────────────────
+// Replaces chrome.alarms. No new permission required — the SW wakes on natural
+// events (onInstalled, onStartup, PROCESS_URL) and checks the stored fetchedAt
+// timestamp. One check per SW lifetime via a module-level flag.
 
-import {
-  REMOTE_ALARM_NAME,
-  ALARM_PERIOD_MIN,
-  ALARM_DELAY_MIN,
-} from "../../src/lib/remote-rules.js";
-
-/**
- * Pure alarm-registration helper extracted from the service worker.
- * Takes the chrome.alarms API as an injected dependency so it can be
- * unit-tested without a browser environment.
- *
- * Mirrors the production logic in service-worker.js:
- *   registerRemoteRulesAlarm(chrome.alarms)
- */
-function registerRemoteRulesAlarm(alarms) {
-  if (!alarms) return; // feature-detect: no-op if API absent
-  return alarms.create(REMOTE_ALARM_NAME, {
-    periodInMinutes: ALARM_PERIOD_MIN,
-    delayInMinutes: ALARM_DELAY_MIN,
-  });
-}
-
-describe("T2.1 — Remote-rules alarm registration helper", () => {
-  test("calls alarms.create with REMOTE_ALARM_NAME", () => {
-    const calls = [];
-    const fakeAlarms = {
-      create(name, opts) { calls.push({ name, opts }); },
-    };
-    registerRemoteRulesAlarm(fakeAlarms);
-    assert.strictEqual(calls.length, 1, "alarms.create must be called exactly once");
-    assert.strictEqual(calls[0].name, REMOTE_ALARM_NAME);
-  });
-
-  test("creates alarm with correct periodInMinutes (7 days = 10080)", () => {
-    const calls = [];
-    const fakeAlarms = { create(name, opts) { calls.push({ name, opts }); } };
-    registerRemoteRulesAlarm(fakeAlarms);
-    assert.strictEqual(calls[0].opts.periodInMinutes, 10_080);
-  });
-
-  test("creates alarm with correct delayInMinutes (1 hour = 60)", () => {
-    const calls = [];
-    const fakeAlarms = { create(name, opts) { calls.push({ name, opts }); } };
-    registerRemoteRulesAlarm(fakeAlarms);
-    assert.strictEqual(calls[0].opts.delayInMinutes, 60);
-  });
-
-  test("no-ops when alarms API is absent (feature-detect)", () => {
-    // Must not throw; just return without calling create
-    assert.doesNotThrow(() => registerRemoteRulesAlarm(undefined));
-    assert.doesNotThrow(() => registerRemoteRulesAlarm(null));
-  });
-
-  test("service worker source registers alarm on onInstalled", () => {
-    const onInstalledPos = swSource.indexOf("onInstalled.addListener");
-    assert.ok(onInstalledPos !== -1, "onInstalled.addListener must be present");
-    // The block from onInstalled to the next top-level chrome.runtime listener
-    const onInstalledBlock = swSource.slice(onInstalledPos, onInstalledPos + 600);
-    assert.ok(
-      onInstalledBlock.includes("registerRemoteRulesAlarm"),
-      "SW must call registerRemoteRulesAlarm inside the onInstalled listener"
-    );
-  });
-
-  test("service worker source registers alarm on onStartup", () => {
-    const onStartupPos = swSource.indexOf("onStartup.addListener");
-    assert.ok(onStartupPos !== -1, "onStartup.addListener must be present");
-    const onStartupBlock = swSource.slice(onStartupPos, onStartupPos + 300);
-    assert.ok(
-      onStartupBlock.includes("registerRemoteRulesAlarm"),
-      "SW must call registerRemoteRulesAlarm inside the onStartup listener"
-    );
-  });
-
-  test("service worker feature-detects chrome.alarms before registering", () => {
-    // The SW must guard alarms registration (same pattern as hasDNR / hasContextMenus)
-    assert.ok(
-      swSource.includes("chrome.alarms") && swSource.includes("typeof chrome.alarms"),
-      "SW must feature-detect chrome.alarms before registering"
-    );
-  });
-});
-
-// ── T2.2: onAlarm handler ────────────────────────────────────────────────────
+const REMOTE_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * Pure alarm-handler logic extracted from the service worker.
- * Tests the gate logic (disabled check, dedup guard) without needing a real browser.
- *
- * In production, the SW's chrome.alarms.onAlarm listener calls this function.
- * We extract it so it can be unit-tested with in-memory fakes.
+ * Pure extraction of maybeFetchRemoteRules for unit testing. Mirrors the
+ * production logic in service-worker.js.
  */
-async function handleRemoteRulesAlarm(alarmName, deps) {
-  // Only handle our alarm
-  if (alarmName !== REMOTE_ALARM_NAME) return "ignored";
-
-  // Re-read remoteRulesEnabled from storage — NOT a module cache (REQ-OPT-6, SC-01)
-  const syncData = await deps.syncStorage.get({ remoteRulesEnabled: false });
-  if (!syncData.remoteRulesEnabled) return "disabled";
-
-  // Dedup guard: delegate to runRemoteRulesFetch which manages _remoteFetchInFlight
-  await deps.runFetch(deps.fetchDeps);
-  return "ran";
+function makeMaybeFetchHelper() {
+  let _checked = false;
+  return async function maybeFetchRemoteRules(deps) {
+    if (_checked) return "skipped-dedup";
+    _checked = true;
+    const { remoteRulesEnabled } = await deps.getPrefs();
+    if (!remoteRulesEnabled) return "disabled";
+    const { remoteRulesMeta } = await deps.getRemoteParams();
+    const last = remoteRulesMeta?.fetchedAt ? Date.parse(remoteRulesMeta.fetchedAt) : 0;
+    if (Number.isFinite(last) && Date.now() - last < REMOTE_REFRESH_INTERVAL_MS) {
+      return "fresh";
+    }
+    await deps.runFetch(deps.fetchDeps);
+    return "ran";
+  };
 }
 
-describe("T2.2 — onAlarm handler logic", () => {
-  function makeSyncFake(data) {
-    return {
-      get(defaults) {
-        const result = { ...defaults };
-        for (const k of Object.keys(defaults)) {
-          if (Object.prototype.hasOwnProperty.call(data, k)) result[k] = data[k];
-        }
-        return Promise.resolve(result);
-      },
-    };
-  }
-
+describe("Remote-rules on-wake time-gated fetch (replaces alarms)", () => {
   test("short-circuits when remoteRulesEnabled is false (SC-01)", async () => {
     let fetchCalled = false;
-    const result = await handleRemoteRulesAlarm(REMOTE_ALARM_NAME, {
-      syncStorage: makeSyncFake({ remoteRulesEnabled: false }),
+    const maybe = makeMaybeFetchHelper();
+    const result = await maybe({
+      getPrefs: async () => ({ remoteRulesEnabled: false }),
+      getRemoteParams: async () => ({ remoteRulesMeta: { fetchedAt: null } }),
       runFetch: async () => { fetchCalled = true; },
       fetchDeps: {},
     });
     assert.strictEqual(result, "disabled");
-    assert.strictEqual(fetchCalled, false, "fetch must not be called when disabled");
+    assert.strictEqual(fetchCalled, false, "fetch must not fire when disabled");
   });
 
-  test("calls runFetch when enabled (happy path)", async () => {
+  test("short-circuits when last fetch is fresh (< 7 days)", async () => {
     let fetchCalled = false;
-    const result = await handleRemoteRulesAlarm(REMOTE_ALARM_NAME, {
-      syncStorage: makeSyncFake({ remoteRulesEnabled: true }),
+    const maybe = makeMaybeFetchHelper();
+    const recent = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+    const result = await maybe({
+      getPrefs: async () => ({ remoteRulesEnabled: true }),
+      getRemoteParams: async () => ({ remoteRulesMeta: { fetchedAt: recent } }),
+      runFetch: async () => { fetchCalled = true; },
+      fetchDeps: {},
+    });
+    assert.strictEqual(result, "fresh");
+    assert.strictEqual(fetchCalled, false);
+  });
+
+  test("fires fetch when last fetch is stale (> 7 days)", async () => {
+    let fetchCalled = false;
+    const maybe = makeMaybeFetchHelper();
+    const stale = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const result = await maybe({
+      getPrefs: async () => ({ remoteRulesEnabled: true }),
+      getRemoteParams: async () => ({ remoteRulesMeta: { fetchedAt: stale } }),
       runFetch: async () => { fetchCalled = true; },
       fetchDeps: {},
     });
     assert.strictEqual(result, "ran");
-    assert.strictEqual(fetchCalled, true, "runFetch must be called when enabled");
+    assert.strictEqual(fetchCalled, true);
   });
 
-  test("ignores alarm with different name", async () => {
+  test("fires fetch when fetchedAt is absent (first-time enable)", async () => {
     let fetchCalled = false;
-    const result = await handleRemoteRulesAlarm("other-alarm", {
-      syncStorage: makeSyncFake({ remoteRulesEnabled: true }),
+    const maybe = makeMaybeFetchHelper();
+    const result = await maybe({
+      getPrefs: async () => ({ remoteRulesEnabled: true }),
+      getRemoteParams: async () => ({ remoteRulesMeta: { fetchedAt: null } }),
       runFetch: async () => { fetchCalled = true; },
       fetchDeps: {},
     });
-    assert.strictEqual(result, "ignored");
-    assert.strictEqual(fetchCalled, false);
+    assert.strictEqual(result, "ran");
+    assert.strictEqual(fetchCalled, true);
+  });
+
+  test("dedupes subsequent calls in the same SW lifetime", async () => {
+    let fetchCount = 0;
+    const maybe = makeMaybeFetchHelper();
+    const deps = {
+      getPrefs: async () => ({ remoteRulesEnabled: true }),
+      getRemoteParams: async () => ({ remoteRulesMeta: { fetchedAt: null } }),
+      runFetch: async () => { fetchCount++; },
+      fetchDeps: {},
+    };
+    const first = await maybe(deps);
+    const second = await maybe(deps);
+    const third = await maybe(deps);
+    assert.strictEqual(first, "ran");
+    assert.strictEqual(second, "skipped-dedup");
+    assert.strictEqual(third, "skipped-dedup");
+    assert.strictEqual(fetchCount, 1, "runFetch must only be invoked once per SW lifetime");
   });
 
   test("passes fetchDeps to runFetch", async () => {
-    let receivedDeps = null;
-    const fakeDeps = { foo: "bar" };
-    await handleRemoteRulesAlarm(REMOTE_ALARM_NAME, {
-      syncStorage: makeSyncFake({ remoteRulesEnabled: true }),
-      runFetch: async (deps) => { receivedDeps = deps; },
+    let received = null;
+    const maybe = makeMaybeFetchHelper();
+    const fakeDeps = { marker: "xyz" };
+    await maybe({
+      getPrefs: async () => ({ remoteRulesEnabled: true }),
+      getRemoteParams: async () => ({ remoteRulesMeta: { fetchedAt: null } }),
+      runFetch: async (deps) => { received = deps; },
       fetchDeps: fakeDeps,
     });
-    assert.strictEqual(receivedDeps, fakeDeps);
+    assert.strictEqual(received, fakeDeps);
   });
 
-  test("service worker source registers onAlarm listener", () => {
+  test("service worker source defines maybeFetchRemoteRules", () => {
     assert.ok(
-      swSource.includes("alarms.onAlarm.addListener"),
-      "SW must register chrome.alarms.onAlarm listener"
-    );
-  });
-
-  test("service worker onAlarm handler re-reads remoteRulesEnabled from storage (SC-01)", () => {
-    const alarmBlock = swSource.slice(
-      swSource.indexOf("alarms.onAlarm.addListener"),
-      swSource.indexOf("alarms.onAlarm.addListener") + 800
-    );
-    assert.ok(
-      alarmBlock.includes("remoteRulesEnabled"),
-      "onAlarm handler must re-read remoteRulesEnabled from storage"
+      /function\s+maybeFetchRemoteRules|async\s+function\s+maybeFetchRemoteRules/.test(swSource),
+      "SW must define maybeFetchRemoteRules function"
     );
   });
 
-  test("service worker onAlarm handler calls runRemoteRulesFetch", () => {
-    const alarmBlock = swSource.slice(
-      swSource.indexOf("alarms.onAlarm.addListener"),
-      swSource.indexOf("alarms.onAlarm.addListener") + 800
+  test("service worker defines REMOTE_REFRESH_INTERVAL_MS as 7 days", () => {
+    const match = swSource.match(/REMOTE_REFRESH_INTERVAL_MS\s*=\s*([^;]+);/);
+    assert.ok(match, "SW must define REMOTE_REFRESH_INTERVAL_MS");
+    // eslint-disable-next-line no-eval
+    const value = Function(`"use strict"; return (${match[1]});`)();
+    assert.strictEqual(value, 7 * 24 * 60 * 60 * 1000, "must equal 7 days in ms");
+  });
+
+  test("service worker calls maybeFetchRemoteRules from onInstalled", () => {
+    const onInstalledPos = swSource.indexOf("onInstalled.addListener");
+    assert.ok(onInstalledPos !== -1, "onInstalled.addListener must be present");
+    const block = swSource.slice(onInstalledPos, onInstalledPos + 600);
+    assert.ok(
+      block.includes("maybeFetchRemoteRules"),
+      "onInstalled handler must call maybeFetchRemoteRules"
+    );
+  });
+
+  test("service worker calls maybeFetchRemoteRules from onStartup", () => {
+    const onStartupPos = swSource.indexOf("onStartup.addListener");
+    assert.ok(onStartupPos !== -1, "onStartup.addListener must be present");
+    const block = swSource.slice(onStartupPos, onStartupPos + 600);
+    assert.ok(
+      block.includes("maybeFetchRemoteRules"),
+      "onStartup handler must call maybeFetchRemoteRules"
+    );
+  });
+
+  test("service worker calls maybeFetchRemoteRules from PROCESS_URL handler", () => {
+    const processUrlPos = swSource.indexOf('message.type === "PROCESS_URL"');
+    assert.ok(processUrlPos !== -1, "PROCESS_URL handler must be present");
+    const block = swSource.slice(processUrlPos, processUrlPos + 800);
+    assert.ok(
+      block.includes("maybeFetchRemoteRules"),
+      "PROCESS_URL handler must call maybeFetchRemoteRules so users who never restart the browser still get refreshes"
+    );
+  });
+
+  test("service worker does NOT import chrome.alarms (permission removed)", () => {
+    // Regression guard: the alarms permission was removed in v1.10.1.
+    // If someone reintroduces chrome.alarms.create / onAlarm, the next build
+    // against the current manifest will fail at runtime.
+    assert.ok(
+      !swSource.includes("chrome.alarms.create"),
+      "SW must not reintroduce chrome.alarms.create — v1.10.1 removed the permission"
     );
     assert.ok(
-      alarmBlock.includes("runRemoteRulesFetch"),
-      "onAlarm handler must call runRemoteRulesFetch"
+      !swSource.includes("chrome.alarms.onAlarm"),
+      "SW must not reintroduce chrome.alarms.onAlarm — v1.10.1 removed the permission"
     );
   });
 });
@@ -570,18 +550,9 @@ describe("T2.3 — Message handler source patterns", () => {
     );
   });
 
-  test("ENABLE_REMOTE_RULES handler re-registers alarm idempotently", () => {
-    const enablePos = swSource.indexOf('"ENABLE_REMOTE_RULES"');
-    const enableBlock = swSource.slice(enablePos, enablePos + 600);
-    assert.ok(
-      enableBlock.includes("registerRemoteRulesAlarm"),
-      "ENABLE handler must re-register alarm idempotently (REQ-OPT-6)"
-    );
-  });
-
   test("GET_REMOTE_RULES_STATUS responds with enabled, meta, supportsAlarms, supportsDNR", () => {
     const statusPos = swSource.indexOf('"GET_REMOTE_RULES_STATUS"');
-    const statusBlock = swSource.slice(statusPos, statusPos + 800);
+    const statusBlock = swSource.slice(statusPos, statusPos + 1500);
     assert.ok(statusBlock.includes("supportsAlarms"), "status must include supportsAlarms (REQ-UI-5)");
     assert.ok(statusBlock.includes("supportsDNR"), "status must include supportsDNR (REQ-UI-5)");
     assert.ok(statusBlock.includes("enabled"), "status must include enabled flag");
@@ -589,12 +560,12 @@ describe("T2.3 — Message handler source patterns", () => {
 
   test("all remote-rules message handlers return true (keep channel open)", () => {
     // All three handlers must return true per the onMessage invariant.
-    // Each handler uses an IIFE pattern so return true is at the end of the block.
+    // Each handler uses an IIFE pattern; the status handler grew with v1.10.1
+    // explanatory comments so give the window enough headroom.
     for (const msgType of ["ENABLE_REMOTE_RULES", "DISABLE_REMOTE_RULES", "GET_REMOTE_RULES_STATUS"]) {
       const pos = swSource.indexOf(`"${msgType}"`);
       assert.ok(pos !== -1, `${msgType} handler must exist`);
-      // Find the return true within the next 1200 chars (IIFE pattern is ~900 chars)
-      const block = swSource.slice(pos, pos + 1200);
+      const block = swSource.slice(pos, pos + 1800);
       assert.ok(block.includes("return true"), `${msgType} handler must return true`);
     }
   });


### PR DESCRIPTION
## What

Swap the `chrome.alarms`-based weekly refresh for an on-wake time-gated fetch. The SW checks a stored `fetchedAt` timestamp on natural wake events (`onInstalled`, `onStartup`, `PROCESS_URL`) and fires the actual fetch only if the last successful pull was more than 7 days ago. A module-level flag deduplicates within a single SW lifetime.

## Why

CWS is currently blocking the v1.10.0 publish behind the new Privacy Practices form, and each declared permission requires a separate justification. Removing `alarms` takes one step out of that form permanently and cuts the store review surface.

Also improves behavior for:
- **Long-running browsers** (laptop sleep/resume): Chrome can throttle alarms for dormant extensions; on-wake fetch fires whenever the user is actually active.
- **Rarely-used extensions**: no more pointless weekly fetch on a user who hasn't opened the popup in months — next time they browse anywhere, the first PROCESS_URL triggers a refresh (single storage read, 7-day gate).

No behavioral change for typical users: `onStartup` still triggers the check on cold browser boot.

## Scope

- Drop `alarms` from `manifest.json` + `manifest.v2.json`
- Replace `registerRemoteRulesAlarm` + `onAlarm` listener with `maybeFetchRemoteRules(deps)`
- Invoke from `onInstalled`, `onStartup`, and `PROCESS_URL` handler
- Drop now-orphaned constants `REMOTE_ALARM_NAME`, `ALARM_PERIOD_MIN`, `ALARM_DELAY_MIN`
- Options UI feature-detect drops the `chrome.alarms` check (DNR is the only remaining gate)
- Test suite: replace T2.1/T2.2 alarm-specific tests with on-wake coverage + a regression guard that fails if `chrome.alarms.create` or `chrome.alarms.onAlarm` return to the SW
- Docs: `docs/store-listing.md` + `docs/transparency.html` refreshed to document the new mechanism

## Version bump

`1.10.0` → `1.10.1` across the 10 version-stamped files. CHANGELOG entry under `[1.10.1] - 2026-04-25`. `[Unreleased]` link updated to `compare/v1.10.1...HEAD`.

## Test + lint

- `npm test`: 1615/1615 passing (was 1611 — net +4 after swapping T2.1/T2.2 tests for the new on-wake coverage).
- `npm run lint`: exit 0, 4 pre-existing warnings, unchanged.

## After merge

Tag `v1.10.1` → `release.yml` via `workflow_dispatch` (tag-push trigger works too now that we have the `[skip ci]` fallback from PR #322). Privacy Practices form can be filled with **one fewer permission to justify**. See updated `docs/store-listing.md` for the canonical justification texts.