### PR TITLE
chore(release): bump version to 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-04-26
+
 ### Added
-- New collaborative report link in the popup: "Still see tracking? Help us improve" (i18n key `report_unclean_url`). Visible only when MUGA modified the URL and `showReportButton` is on, alongside the existing "Report a problem with this URL" link. Opens a pre-filled GitHub issue tagged `unclean-url` with hostname, version, browser and the params MUGA already removed — never the full URL or query string. Same zero-network, no-new-permissions model as the broken-site report. Feeds the remote-rules catalog with real-world misses. (#271)
 - Popup now surfaces when MUGA preserved a third-party creator's affiliate tag on the current URL. New "Creator referral preserved" badge inside the preview section, with a tooltip explaining the policy. Fires regardless of whether the URL was otherwise modified — including on URLs MUGA leaves untouched. Wedge of "fair to creators" made tangible. New cleaner result field `preservedAffiliate` exposing `{ param, value, store, group }`. Independent of the existing `notifyForeignAffiliate` toast preference: this is a passive UI signal, not a notification. New i18n keys `preview_preserved_creator` and `preview_preserved_creator_hint` in en/es/pt/de. (#327)
+- New collaborative report link in the popup: "Still see tracking? Help us improve" (i18n key `report_unclean_url`). Visible only when MUGA modified the URL and `showReportButton` is on, alongside the existing "Report a problem with this URL" link. Opens a pre-filled GitHub issue tagged `unclean-url` with hostname, version, browser and the params MUGA already removed — never the full URL or query string. Same zero-network, no-new-permissions model as the broken-site report. Feeds the remote-rules catalog with real-world misses. (#271)
 
 ## [1.10.2] - 2026-04-25
 
@@ -540,7 +542,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.10.2...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/yocreoquesi/muga/compare/v1.10.2...v1.11.0
 [1.10.2]: https://github.com/yocreoquesi/muga/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/yocreoquesi/muga/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/yocreoquesi/muga/compare/v1.9.10...v1.10.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.10.2-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.11.0-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-1624_pass-brightgreen)](#development)
 # MUGA: Clean URLs, Fair to Every Click
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://yocreoquesi.github.io/muga/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.10.2"
+    "softwareVersion": "1.11.0"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.2 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.11.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 1.10.2
+> Version: 1.11.0
 > Last updated: 2026-04-25
 > Status: Final listing for Chrome Web Store and Firefox AMO. 450+ tracking params, 150+ domain rules, 6 categories, 2 active affiliate programs, MV3 native.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.10.2 &nbsp;&middot;&nbsp; 2026-04-25 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.11.0 &nbsp;&middot;&nbsp; 2026-04-26 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.10.2</span>
+      <span class="at-a-glance-value">1.11.0</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Fair to every click. Strips 450+ tracking params, respects affiliate links. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.10.2 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.11.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.


### PR DESCRIPTION
## Summary

Releases **v1.11.0** to Chrome Web Store and Firefox AMO.

Ships two user-visible features from the 2026-04-26 strategic review (Wave 1 — Wedge Visible):

- **"Creator referral preserved" badge** in the popup, surfacing the "fair to creators" wedge at the moment of value (#327, #342)
- **Collaborative "unclean URL" report channel** in the popup, feeding the remote-rules catalog with real-world misses (#271, #341)

Both ship with zero new permissions, zero outbound network calls, full i18n coverage in en/es/pt/de.

## Version sync

| File | Old | New |
|---|---|---|
| `package.json` | 1.10.2 | 1.11.0 |
| `src/manifest.json` | 1.10.2 | 1.11.0 |
| `src/manifest.v2.json` | 1.10.2 | 1.11.0 |
| `README.md` (badge) | 1.10.2 | 1.11.0 |
| `docs/store-listing.md` | 1.10.2 | 1.11.0 |
| `docs/transparency.html` | 1.10.2 | 1.11.0 |
| `docs/privacy-page.html` | 1.10.2 | 1.11.0 |
| `docs/index.html` (JSON-LD) | 1.10.2 | 1.11.0 |
| `src/privacy/privacy.html` | 1.10.2 | 1.11.0 |

CHANGELOG: `[Unreleased]` entries moved into `## [1.11.0] - 2026-04-26`. Compare-link references at the bottom updated.

## Test plan

- [x] `npm test` — 1648 passing.
- [x] `npm run lint` — exit 0.
- [x] `version-consistency` test green (catches any out-of-sync version reference).
- [ ] Merge → tag `v1.11.0` → push tag → GitHub Actions builds + auto-submits to CWS and AMO.

## Post-merge

```sh
git tag v1.11.0
git push origin v1.11.0
```

The `release.yml` workflow handles the rest.