### PR TITLE
chore(rules): publish utm_b64url to remote rules catalog (v3)

### DIFF
--- a/tools/rules-source/params.json
+++ b/tools/rules-source/params.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
-  "published": "2026-04-24T19:24:54Z",
-  "params": []
+  "version": 3,
+  "published": "2026-04-26T14:31:20Z",
+  "params": ["utm_b64url"]
 }


### PR DESCRIPTION
## Summary

First real param shipped through the signed remote-rules pipeline since the empty seed deploy in v1.10.0.

`utm_b64url` is a tracking param observed on email campaigns and ad redirects — base64url-encoded campaign metadata. Adding it to `tools/rules-source/params.json` triggers the `publish-rules` workflow on merge to main, which signs and writes the artifact to `docs/rules/v1/params.json`.

## Source change

```diff
- "version": 2, "published": "...", "params": []
+ "version": 3, "published": "2026-04-26T14:31:20Z", "params": ["utm_b64url"]
```

## Post-merge

The `publish-rules` workflow runs automatically and produces a `[skip ci]` commit with the signed artifact. Users with Remote rule updates enabled will pick up `utm_b64url` on their next on-wake fetch (max ~7 days).