### PR TITLE
feat(brand): rewrite store listing to lead with the wedge (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Store listing rewritten to lead with the differentiator: "Privacy Without Breaking Creator Links". The "fair to creators" wedge — the one MUGA-only behavior that no other URL cleaner can copy without contradicting their own pitch — is now the headline of both Chrome Web Store and Firefox AMO listings, plus README.md and the manifest descriptions. The listing example now shows a third-party reviewer's `?tag=reviewer-21` being preserved while 7 tracking params are removed, so the value proposition is visible in the first 5 seconds of reading. Section ordering reworked: wedge → before/after → param coverage → why we rejected 10+ networks → privacy. New CWS short description (118 chars): "Strip tracking. Keep creator referrals. 450+ params removed automatically. Open source, MV3 native, zero data sent." Strategic review consensus, 2026-04-26 (internal + ChatGPT + Gemini). (#328)
+
 ### Added
 - Popup now headlines a count celebration when MUGA cleans a URL: "MUGA removed N trackers from this URL", with a one-shot pulse animation on the digits (gated by `prefers-reduced-motion: no-preference`). Pluralized via `Intl.PluralRules` so the en/es/pt/de variants stay grammatical. When MUGA evaluates a URL and finds nothing to clean, a quieter "URL was already clean" line surfaces instead — a positive signal that MUGA *checked*, not silence. Built via DOM nodes (no `innerHTML`) so the i18n template stays injection-proof. Three new keys: `preview_count_one`, `preview_count_other`, `preview_count_clean`. (#326)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.11.0-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-1624_pass-brightgreen)](#development)
-# MUGA: Clean URLs, Fair to Every Click
+[![Tests](https://img.shields.io/badge/tests-1658_pass-brightgreen)](#development)
+# MUGA: Privacy Without Breaking Creator Links
 
 ### Install now
 
@@ -12,7 +12,9 @@
 
 ---
 
-URLs arrive pre-loaded with `utm_source`, `fbclid`, `gclid`, e-commerce noise, share tokens, and 450+ more. MUGA strips them automatically, before the page renders. **We clean tracking, but we respect referrals. By default, we never touch what isn't ours.** On stores whose affiliate model forces your clicks through external tracking servers, we strip their tracking parameters too -- we do not believe that forcing redirects on users is necessary or fair, and we refuse to collaborate with networks that do.
+**MUGA strips tracking from every URL — without breaking the affiliate links of the creators who recommended you.** Every other URL cleaner removes `utm_source`, `fbclid`, `gclid`, and the rest. So does MUGA. But every other URL cleaner also strips the affiliate tag of the YouTuber whose video you came from, the newsletter that shared the link, the reviewer who took the time to write the comparison. That tag is how independent creators get paid for the recommendation. **MUGA leaves it alone** — and the popup tells you so, every time, with a "Creator referral preserved" badge. No other URL cleaner does this. None of them can without contradicting their own pitch.
+
+On stores whose affiliate model forces your clicks through external tracking servers, MUGA strips their tracking parameters anyway — we do not believe forcing redirects on users is necessary or fair, and we refuse to collaborate with networks that do.
 
 > **MUGA?** Most URLs Get Abused. **MUGA.** Mercilessly Undoing Garbage Attachments. **MUGA!** Make URLs Genuine Again.
 

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,8 +1,8 @@
 # MUGA: Store Listings
 
 > Version: 1.11.0
-> Last updated: 2026-04-25
-> Status: Final listing for Chrome Web Store and Firefox AMO. 450+ tracking params, 150+ domain rules, 6 categories, 2 active affiliate programs, MV3 native.
+> Last updated: 2026-04-26
+> Status: Final listing for Chrome Web Store and Firefox AMO. Lead headline rewritten to surface the "fair to creators" wedge per the 2026-04-26 strategic review (consensus across three independent analyses).
 
 ---
 
@@ -10,35 +10,43 @@
 
 ### Extension name
 
-MUGA: Clean URLs, Fair to Every Click
+MUGA: Privacy Without Breaking Creator Links
 
 ### Short description (132 chars max)
 
-URL cleaner: strips utm, fbclid, gclid and 450+ tracking params automatically. Respects creator affiliates. Open source, MV3 native.
+Strip tracking. Keep creator referrals. 450+ params removed automatically. Open source, MV3 native, zero data sent.
 
-*(130 chars)*
+*(118 chars)*
 
 ---
 
 ### Detailed description
 
-MUGA is a URL cleaner and tracking remover. It strips utm_source, utm_medium, utm_campaign, fbclid, gclid, msclkid, and 450+ more tracking parameters from every URL you visit, automatically, before the page loads. No buttons. No setup. No permission popups. Built natively for Manifest V3 on Chrome. Available for Firefox via Manifest V2.
+MUGA strips tracking from every URL — without breaking the affiliate links of the creators who recommended you.
 
-By default, MUGA never touches what isn't ours. If a link already has a creator's affiliate tag, we leave it alone. That is the "fair to every click" part, and what makes MUGA different from every other URL cleaner out there.
+That sentence is the whole pitch. Every other URL cleaner removes utm_source, fbclid, gclid, and the rest. So does MUGA. But every other URL cleaner also strips the affiliate tag of the YouTuber whose video you came from, the newsletter that shared the link, the reviewer who took the time to write the comparison. That tag is how independent creators get paid for the recommendation. MUGA leaves it alone.
+
+When MUGA preserves a creator's referral on the current page, the popup tells you so — a small green badge ("Creator referral preserved") appears with the tag that was kept. No other URL cleaner does this. None of them can without contradicting their own pitch.
 
 
 ======================================
-BEFORE / AFTER
+WHAT MUGA DOES, IN ONE EXAMPLE
 ======================================
 
-Store link from a video review:
+A friend sends you a product link from a YouTube reviewer:
 
 Before: amazon.es/dp/B00EXAMPLE?tag=reviewer-21&linkCode=ll1&linkId=abc123&pd_rd_r=xyz&pf_rd_p=def&utm_source=youtube&utm_medium=video
+
 After:  amazon.es/dp/B00EXAMPLE?tag=reviewer-21
 
-The reviewer's affiliate tag stays. The 7 tracking params are gone.
+The reviewer's affiliate tag stays. The 7 tracking params are gone. You support the creator. The tracking platforms get nothing.
 
-Video link shared from mobile:
+
+======================================
+MORE BEFORE/AFTER
+======================================
+
+Video link from mobile share:
 
 Before: youtube.com/watch?v=dQw4w9WgXcQ&si=abc123trackingtoken456789
 After:  youtube.com/watch?v=dQw4w9WgXcQ
@@ -71,6 +79,7 @@ WHAT GETS STRIPPED
 MORE THAN PARAM STRIPPING
 ======================================
 
+. Visible feedback: when MUGA cleans a URL, the popup shows "MUGA removed N trackers from this URL". When MUGA preserves a creator's affiliate tag, the popup says so. You see the value, every time.
 . AMP redirect: AMP pages redirect to the canonical article URL
 . Block <a ping> beacons: suppresses background tracking requests on click
 . Redirect unwrapping: detects and bypasses intermediary redirect wrappers so you land on the real URL
@@ -81,16 +90,23 @@ MORE THAN PARAM STRIPPING
 
 
 ======================================
+WHY "FAIR TO CREATORS" IS NOT MARKETING TALK
+======================================
+
+We evaluated 10+ affiliate programs from major retailers (Zalando, SHEIN, MediaMarkt, Walmart, Target, AliExpress, and others) and rejected every one of them. They all require redirect-based tracking — your click passes through an external server before reaching the store. We refuse to route your clicks through external surveillance just to earn a commission.
+
+So when MUGA gives credit to a creator, it is to a creator who chose a clean affiliate model that does not redirect or track you. When you enable MUGA's optional affiliate injection, you are doing the same. The price you pay is the same. No redirects. No surveillance. No middleman.
+
+Two active programs across multiple markets: Amazon (ES, DE, FR, IT, UK, US), eBay (US, ES, DE, UK, FR, IT). Programs that meet the privacy bar — direct parameter injection, no redirect through external servers.
+
+
+======================================
 THE AFFILIATE MODEL: OPT-IN, HONEST, AUDITABLE
 ======================================
 
-MUGA has an affiliate feature. Here is exactly how it works.
-
-Affiliate injection is off by default. You choose to enable it during onboarding, or manually in Settings at any time.
+Affiliate injection is OFF by default. You choose to enable it during onboarding, or manually in Settings at any time.
 
 When enabled: if you navigate to a supported store and the link has no affiliate tag at all, MUGA adds ours. The price you pay is exactly the same. The store just knows you arrived via MUGA. That is how you support an independent developer at zero cost to you.
-
-Not every store is compatible. We evaluated 10 stores and rejected all of them because they require redirect-based tracking that forces your clicks through external servers. We do not believe that is necessary or fair. We chose to give up that revenue rather than compromise your privacy.
 
 What MUGA does NOT do by default:
 . It never replaces an existing affiliate tag on compatible stores. If someone's tag is already in the link, MUGA leaves it alone.
@@ -98,21 +114,21 @@ What MUGA does NOT do by default:
 . You can turn affiliate injection off at any time in Settings, globally or per domain.
 . On stores with redirect-based affiliate models, MUGA strips their tracking parameters and unwraps redirect URLs when possible.
 
-This is disclosed during setup, in the privacy policy, and in the source code. You can read every line.
+This is disclosed during setup, in the privacy policy, and in the source code. Every line is public.
 
 
 ======================================
 PRIVATE. REALLY.
 ======================================
 
-Every URL is processed entirely inside your browser. MUGA never sends data anywhere.
+Every URL is processed entirely inside your browser. MUGA never sends data anywhere on a default install.
 
 . Zero analytics, zero telemetry, zero data collection
 . No account, no sign-in, no cloud
 . Core permissions: storage, activeTab, contextMenus, declarativeNetRequestWithHostAccess, clipboardWrite
-. optional_host_permissions https://yocreoquesi.github.io/*: granted only when the user enables Remote rule updates. Used to fetch the signed tracking-parameter payload — a single HTTPS GET check at most once per 7 days, piggybacked on natural service-worker wake events (no chrome.alarms permission). Credentials-omit, no user data transmitted. Revocable at any time via browser settings.
+. Optional host permission yocreoquesi.github.io/*: granted only when you enable "Remote rule updates" in Settings. Used to fetch a signed tracking-parameter payload over HTTPS — a single GET check at most once per 7 days, piggybacked on natural service-worker wake events (no chrome.alarms permission). Credentials-omit, no user data transmitted, Ed25519-signed payload verified against a public key shipped with the extension. Off by default. Revocable at any time via browser settings.
 
-We evaluated 10+ affiliate programs from major retailers and marketplaces. All of them require redirect-based tracking that routes your clicks through external servers before reaching the store. We rejected every one of them and gave up that revenue rather than compromise your privacy. On those stores, MUGA actively strips the affiliate tracking parameters that redirect networks leave behind, and unwraps redirect URLs when possible so you go straight to the store.
+We rejected 10+ affiliate networks because they require redirect-based tracking. On those stores, MUGA actively strips the affiliate tracking parameters that redirect networks leave behind, and unwraps redirect URLs when possible so you go straight to the store.
 
 
 ======================================
@@ -126,19 +142,8 @@ YOUR RULES
 . Strip all third-party affiliates: one toggle to remove every affiliate tag globally
 . Per-domain disable: opt entire domains out of MUGA
 . Export / Import settings as JSON: back up or move your config across devices
-. Language: English and Espanol, switchable any time
+. Language: English, Spanish, Portuguese, German — switchable any time
 . Settings sync across Chrome devices automatically
-
-
-======================================
-SUPPORTED STORES (affiliate features, opt-in only)
-======================================
-
-Active: Amazon (ES, DE, FR, IT, UK, US), eBay (US, ES, DE, UK, FR, IT).
-
-Only stores that support direct URL parameter injection are compatible with MUGA. We evaluated and rejected 10+ stores whose affiliate programs require redirect-based tracking, because routing your clicks through external servers would violate our privacy policy.
-
-Tracking removal works on every site on the web, not just these stores. If you find a tracker MUGA misses, open an issue on GitHub. We fix them.
 
 
 ======================================
@@ -153,7 +158,7 @@ https://github.com/yocreoquesi/muga
 
 ### Keywords (Chrome Web Store, max 5)
 
-privacy, URL cleaner, tracking remover, affiliate, UTM
+privacy, URL cleaner, creator-friendly, tracking remover, UTM
 
 ---
 
@@ -161,21 +166,32 @@ privacy, URL cleaner, tracking remover, affiliate, UTM
 
 ### Extension name
 
-MUGA: Clean URLs, Fair to Every Click
+MUGA: Privacy Without Breaking Creator Links
 
 ### Summary (250 chars max)
 
-URL cleaner and tracking remover. Strips 450+ tracking params (utm, fbclid, gclid) before the page loads. Respects creator affiliates. Rejects redirect-based tracking. 100% local, open source, GPL v3. Nothing leaves your browser.
+Strip tracking from every URL while preserving the affiliate referrals of creators who recommended you. 450+ params removed automatically. 100% local. Zero data sent. Open source, GPL v3. The only URL cleaner that respects creators.
 
-*(243 chars)*
+*(238 chars)*
 
 ---
 
 ### Detailed description
 
-MUGA is a URL cleaner built for people who care about what happens to their clicks.
+MUGA strips tracking from every URL — without breaking the affiliate links of the creators who recommended you.
 
-Every URL you visit arrives loaded with tracking parameters -- utm_source, fbclid, gclid, msclkid, share tokens, e-commerce session noise, and hundreds more. MUGA strips them automatically, before the page renders. No buttons to press. No configuration needed. No data leaves your browser. Ever.
+Every other URL cleaner removes utm_source, fbclid, gclid, and the rest. So does MUGA. But every other URL cleaner also strips the affiliate tag of the YouTuber whose video you came from, the newsletter that shared the link, the reviewer who took the time to write the comparison. That tag is how independent creators get paid for the recommendation. MUGA leaves it alone.
+
+When MUGA preserves a creator's referral on the current page, the popup tells you so — a green badge appears with the tag that was kept. No other URL cleaner does this. None of them can without contradicting their own pitch.
+
+
+One example, the whole pitch:
+
+Before: amazon.es/dp/B00EXAMPLE?tag=reviewer-21&linkCode=ll1&pd_rd_r=xyz&utm_source=youtube&utm_medium=video
+
+After:  amazon.es/dp/B00EXAMPLE?tag=reviewer-21
+
+The reviewer's affiliate tag stays. The tracking params are gone. The creator gets paid. The tracking platforms get nothing.
 
 
 450+ tracking parameters. 150+ domain-specific rulesets. Zero data collection.
@@ -193,6 +209,7 @@ What gets stripped:
 
 More than param stripping
 
+. Visible feedback: when MUGA cleans a URL, the popup shows "MUGA removed N trackers". When MUGA preserves a creator's tag, the popup says so. You see the value, every time.
 . AMP redirect: AMP pages redirect to the canonical article URL
 . Block <a ping> beacons: suppresses background tracking requests on click
 . Redirect unwrapping: detects and bypasses intermediary redirect wrappers so you land on the real URL
@@ -202,30 +219,29 @@ More than param stripping
 . Popup preview: before/after view for the current page
 
 
+Why "fair to creators" is not marketing talk
+
+We evaluated 10+ affiliate programs from major retailers (Zalando, SHEIN, MediaMarkt, Walmart, Target, AliExpress, and others) and rejected every one of them. They all require redirect-based tracking — your click passes through an external server before reaching the store. We refuse to route your clicks through external surveillance just to earn a commission.
+
+So when MUGA gives credit to a creator, it is to a creator who chose a clean affiliate model that does not redirect or track you. When you enable MUGA's optional affiliate injection, you are doing the same. No redirects. No surveillance. No middleman.
+
+Two active programs across multiple markets: Amazon (ES, DE, FR, IT, UK, US), eBay (US, ES, DE, UK, FR, IT).
+
+
 Fair to every click
 
-By default, MUGA never touches what is not ours. If a link already has a creator's affiliate tag, we leave it alone. A reviewer links to a product with their tag -- it stays. That is what "fair to every click" means.
+By default, MUGA never touches what is not ours. If a link already has a creator's affiliate tag, we leave it alone. A reviewer links to a product with their tag — it stays.
 
 MUGA has an optional affiliate feature (off by default). When enabled: if you navigate to a supported store and the link has no affiliate tag at all, MUGA adds ours. The price you pay is exactly the same. You can turn it off any time, globally or per domain.
 
 
-We rejected 10+ stores to protect your privacy
-
-We evaluated 10+ affiliate programs from major retailers and marketplaces. Every one of them requires redirect-based tracking -- your click passes through an external server before reaching the store. We do not believe forcing users through external tracking servers is necessary or fair. We rejected all of them and gave up that revenue.
-
-On those stores, MUGA actively strips the affiliate tracking parameters that redirect networks leave behind, and unwraps redirect URLs when possible so you go straight to the store.
-
-Supported stores (affiliate features, opt-in only):
-2 active programs across multiple markets (ES, DE, FR, IT, UK, US).
-
-
 Private by design
 
-Every URL is processed entirely inside your browser. MUGA never sends data anywhere.
+Every URL is processed entirely inside your browser. MUGA never sends data anywhere on a default install.
 . Zero analytics, zero telemetry, zero data collection
 . No account, no sign-in, no cloud
 . Core permissions: storage, activeTab, contextMenus, declarativeNetRequest, clipboardWrite
-. optional_permissions https://yocreoquesi.github.io/*: granted only when you enable Remote rule updates. Used to fetch the signed tracking-parameter payload — a single HTTPS GET check at most once per 7 days, piggybacked on natural browser activity (no chrome.alarms permission). Credentials-omit, no user data transmitted. Revocable at any time.
+. Optional permission yocreoquesi.github.io/*: granted only when you enable "Remote rule updates". Used to fetch a signed tracking-parameter payload — a single HTTPS GET check at most once per 7 days, piggybacked on natural browser activity (no chrome.alarms permission). Credentials-omit, no user data transmitted, Ed25519-signed payload verified against a public key shipped with the extension. Off by default. Revocable at any time.
 
 
 Your rules
@@ -236,12 +252,12 @@ Your rules
 . Strip all third-party affiliates: one toggle to remove every affiliate tag globally
 . Per-domain disable: opt entire domains out of MUGA
 . Export/Import settings as JSON
-. English and Spanish, switchable any time
+. English, Spanish, Portuguese, German — switchable any time
 
 
 Open source. GPL v3. Read every line.
 
-The entire codebase is public on GitHub under the GPL v3 license. Read it. Audit it. Fork it. If anything looks wrong, open an issue. We built MUGA to be the URL cleaner we wanted to use ourselves -- transparent, honest, and built to last.
+The entire codebase is public on GitHub under the GPL v3 license. Read it. Audit it. Fork it. If anything looks wrong, open an issue. We built MUGA to be the URL cleaner we wanted to use ourselves — transparent, honest, built to last, and fair to the creators who keep the open web running.
 
 https://github.com/yocreoquesi/muga
 
@@ -249,9 +265,9 @@ https://github.com/yocreoquesi/muga
 
 ### AMO metadata
 
-- Extension name: MUGA: Clean URLs, Fair to Every Click
+- Extension name: MUGA: Privacy Without Breaking Creator Links
 - License: GPL v3
 - Primary category: Privacy & Security
 - Secondary category: Shopping
-- Tags: privacy, tracking, url-cleaner, affiliate
+- Tags: privacy, tracking, url-cleaner, affiliate, creator-friendly
 - Website: https://github.com/yocreoquesi/muga

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muga",
   "version": "1.11.0",
-  "description": "Fair to every click. Strips 450+ tracking params, respects affiliate links. Open source.",
+  "description": "Privacy without breaking creator links. Strips 450+ tracking params, preserves creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {
     "dev:chrome": "web-ext run --source-dir src/ --target chromium",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
   "version": "1.11.0",
-  "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
+  "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [
     "storage",

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -3,7 +3,7 @@
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
   "version": "1.11.0",
-  "description": "Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source.",
+  "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary

Closes #328. Repositions MUGA from "another URL cleaner" to "the only URL cleaner that respects creator referrals" across Chrome Web Store, Firefox AMO, README, and the manifest descriptions.

## Why

Strategic review consensus (2026-04-26): the differentiator that no competitor can copy without contradicting their own pitch is "fair to creators". The current listing buries this in the middle of a generic "URL cleaner that strips utm, fbclid, gclid" pitch — every other tool says the same thing. The new listing leads with the distinguishing claim and proves it with one example.

> "Rewrite store listing with the wedge as headline." — ChatGPT
> "You must market it as 'ethical' or 'creator-friendly' cleaner, not just another URL cleaner." — Gemini
> "The wedge is buried." — internal review

## Headline copy progression

| Field | Old | New |
|---|---|---|
| Extension name (listing) | MUGA: Clean URLs, Fair to Every Click | **MUGA: Privacy Without Breaking Creator Links** |
| CWS short desc (132 max) | URL cleaner: strips utm, fbclid, gclid and 450+ tracking params automatically. Respects creator affiliates. Open source, MV3 native. | **Strip tracking. Keep creator referrals. 450+ params removed automatically. Open source, MV3 native, zero data sent.** |
| AMO summary (250 max) | URL cleaner and tracking remover. Strips 450+ tracking params... | **Strip tracking from every URL while preserving the affiliate referrals of creators who recommended you. 450+ params removed automatically. 100% local. Zero data sent. Open source, GPL v3. The only URL cleaner that respects creators.** |
| Manifest description | Automatically cleans URLs by removing 450+ tracking params (utm, fbclid, gclid). AMP redirect, ping blocking. Open source. | **Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.** |

## Section reordering in detailed description

1. Wedge headline (the hook)
2. Before/after example showing a YouTube reviewer's `tag=reviewer-21` preserved while 7 tracking params are stripped (the whole pitch in one screenshot)
3. More before/after (video, newsletter)
4. Param coverage (demoted from headline to detail)
5. **Visible feedback features (NEW)** — references the v1.11.0 popup count celebration and the "Creator referral preserved" badge
6. Why "fair to creators" is not marketing talk (rejected 10+ networks)
7. Affiliate model (opt-in, honest, auditable)
8. Privacy
9. Custom rules
10. Open source / GPL v3

## Manifest `name` field intentionally NOT changed

Renaming the technical `name` triggers a "product rename" review path on both stores. The display name in the public listing updates on next submission via the rewritten listing copy. We change the brand-facing copy now and let the listing-vs-manifest divergence resolve naturally through normal release cycles.

## Sync touchpoints

- `docs/store-listing.md` — full rewrite, both CWS and AMO blocks
- `README.md` — title + opening paragraph + tests badge bumped to 1658 (post-#345)
- `package.json` — description field
- `src/manifest.json` — description field
- `src/manifest.v2.json` — description field
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [x] `npm test` — 1648 passing (no code touched).
- [x] `npm run lint` — exit 0.
- [x] `version-consistency` test green.
- [ ] Post-merge: maintainer re-submits the new listing copy to CWS and AMO via the developer dashboards. Submission is manual on both stores; this PR ships the source of truth (`docs/store-listing.md`) but does NOT auto-publish to the storefronts. Plan to coordinate the re-submit alongside the next release that ships further Wave 1 features.

## Strategic context

Part of the 2026-04-26 strategic review → Wave 1: Wedge Visible. Companion to #326 (count celebration, PR #345) and #327 (preserved-creator badge, shipped in v1.11.0). Together: the wedge is now visible in the **product** AND in the **listing**.