### PR TITLE
feat(migration): foundation modules for pref-default migration prompts (#363)

### DIFF
--- a/src/lib/migration-evaluator.js
+++ b/src/lib/migration-evaluator.js
@@ -1,0 +1,89 @@
+/**
+ * MUGA: Migration Evaluator
+ *
+ * Pure function. Given the user's previous version, current version, prior
+ * responses to migrations, and current pref state, returns the ordered list
+ * of migrations that need to be presented to the user this run.
+ *
+ * No I/O. No storage access. Caller is responsible for fetching responses
+ * (via migration-storage) and prefs (via storage), and applying accepted
+ * migrations.
+ *
+ * @see migration-spec.js for entry shape.
+ */
+
+import { MIGRATIONS } from "./migration-spec.js";
+
+/**
+ * Compares two "x.y.z" semver-ish version strings.
+ * Returns negative when a < b, zero when equal, positive when a > b.
+ * Missing components are treated as zero ("1.2" === "1.2.0").
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function compareVersions(a, b) {
+  const pa = String(a).split(".").map(n => parseInt(n, 10) || 0);
+  const pb = String(b).split(".").map(n => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const ai = pa[i] || 0;
+    const bi = pb[i] || 0;
+    if (ai !== bi) return ai - bi;
+  }
+  return 0;
+}
+
+/**
+ * Returns the migrations that should be presented to the user this run.
+ *
+ * A migration fires when:
+ *   - The user is upgrading across it: previousVersion <= entry.fromVersion
+ *     AND currentVersion >= entry.toVersion.
+ *   - The user has not already responded (accept | decline | dismiss).
+ *   - The user's current pref state does not already match the proposed
+ *     value (i.e. they have not manually opted in already).
+ *
+ * Returns entries in declared order so multiple-upgrade paths surface them
+ * the same way every time.
+ *
+ * @param {object}   args
+ * @param {string}   args.previousVersion - The version the user was on before this upgrade.
+ * @param {string}   args.currentVersion  - The currently running extension version.
+ * @param {Record<string, "accept"|"decline"|"dismiss">} args.responses - Per-id responses.
+ * @param {object}   args.prefs           - The user's current preferences.
+ * @param {Array}    [args.migrations]    - Override the spec (testing). Defaults to MIGRATIONS.
+ * @returns {Array<object>} Pending migrations to present, in declared order.
+ */
+export function evaluateMigrations({
+  previousVersion,
+  currentVersion,
+  responses = {},
+  prefs = {},
+  migrations = MIGRATIONS,
+}) {
+  if (!previousVersion || !currentVersion) return [];
+  const pending = [];
+  for (const m of migrations) {
+    // Upgrade window check: must be crossing this migration.
+    if (compareVersions(previousVersion, m.fromVersion) > 0) continue;
+    if (compareVersions(currentVersion, m.toVersion) < 0) continue;
+
+    // Already responded? Skip.
+    if (responses[m.id]) continue;
+
+    // Pref state already matches the proposed value? Skip — nothing to ask.
+    let alreadyMatches = true;
+    for (const key of Object.keys(m.proposedValue)) {
+      if (prefs[key] !== m.proposedValue[key]) {
+        alreadyMatches = false;
+        break;
+      }
+    }
+    if (alreadyMatches) continue;
+
+    pending.push(m);
+  }
+  return pending;
+}

--- a/src/lib/migration-spec.js
+++ b/src/lib/migration-spec.js
@@ -1,0 +1,45 @@
+/**
+ * MUGA: Migration Spec
+ *
+ * Append-only declarative list of all known pref-default migrations. Each
+ * entry describes a moment where a user-observable preference default
+ * changed between two extension versions, and what banner the user should
+ * see post-upgrade so they can opt in or decline explicitly.
+ *
+ * **Append-only invariant**: never delete or edit a published entry. Once
+ * shipped in a release, an entry must remain readable so a user upgrading
+ * across many versions encounters a coherent history of decisions. To
+ * supersede a past migration, append a new entry — do not mutate the old.
+ *
+ * The list ships empty. Future additions land here as the project flips
+ * pref defaults (e.g. `remoteRulesEnabled` from off to on once the signing
+ * infrastructure stabilizes — see #352, #362).
+ *
+ * Entry shape (all fields required unless noted):
+ *
+ *   id              — stable string identifier, unique across the spec.
+ *   fromVersion     — semver-like "x.y.z" of the LAST version where the
+ *                     prior default was authoritative.
+ *   toVersion       — semver-like "x.y.z" introducing the new default.
+ *                     The migration fires when the user upgrades from a
+ *                     version <= fromVersion to a version >= toVersion.
+ *   prefs           — array of pref keys the migration touches.
+ *   proposedValue   — object mapping pref keys to their new accepted value.
+ *                     Applied verbatim on user accept.
+ *   networkRelated  — boolean. If true, the static schema test requires
+ *                     bannerCopyKey to be non-empty (silent migration of
+ *                     network-related prefs is forbidden by policy).
+ *   bannerCopyKey   — i18n key for the banner copy. Required when
+ *                     networkRelated is true; may be empty otherwise.
+ *
+ * @type {Array<{
+ *   id: string,
+ *   fromVersion: string,
+ *   toVersion: string,
+ *   prefs: string[],
+ *   proposedValue: Record<string, unknown>,
+ *   networkRelated: boolean,
+ *   bannerCopyKey: string,
+ * }>}
+ */
+export const MIGRATIONS = Object.freeze([]);

--- a/src/lib/migration-storage.js
+++ b/src/lib/migration-storage.js
@@ -1,0 +1,99 @@
+/**
+ * MUGA: Migration Storage
+ *
+ * Per-device persistence of user responses to migration prompts. Stored in
+ * `chrome.storage.local` (intentional — a migration confirms intent on
+ * THIS device; inheriting acceptance via sync would defeat the point,
+ * mirroring the per-device consent model in the parent PRD #348).
+ *
+ * Responses are keyed by migration id and take one of three values:
+ *   "accept"  — user opted into the proposed change.
+ *   "decline" — user explicitly rejected the change.
+ *   "dismiss" — user closed the banner without choosing; treated as
+ *               "not now". Pref state stays unchanged.
+ */
+
+const STORAGE_KEY = "migrationResponses";
+
+/**
+ * Returns the stored response for a migration id, or null if none.
+ * @param {string} migrationId
+ * @returns {Promise<"accept"|"decline"|"dismiss"|null>}
+ */
+export async function getResponse(migrationId) {
+  try {
+    const result = await new Promise((resolve, reject) => {
+      chrome.storage.local.get({ [STORAGE_KEY]: {} }, (r) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(r);
+      });
+    });
+    const responses = result[STORAGE_KEY] || {};
+    return responses[migrationId] || null;
+  } catch (err) {
+    console.error("[MUGA] migration-storage.getResponse:", err);
+    return null;
+  }
+}
+
+/**
+ * Returns the full map of stored responses.
+ * @returns {Promise<Record<string, "accept"|"decline"|"dismiss">>}
+ */
+export async function getAllResponses() {
+  try {
+    const result = await new Promise((resolve, reject) => {
+      chrome.storage.local.get({ [STORAGE_KEY]: {} }, (r) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(r);
+      });
+    });
+    return result[STORAGE_KEY] || {};
+  } catch (err) {
+    console.error("[MUGA] migration-storage.getAllResponses:", err);
+    return {};
+  }
+}
+
+/**
+ * Records a user's response to a migration.
+ * @param {string} migrationId
+ * @param {"accept"|"decline"|"dismiss"} response
+ * @returns {Promise<void>}
+ */
+export async function recordResponse(migrationId, response) {
+  if (!migrationId || !["accept", "decline", "dismiss"].includes(response)) {
+    throw new Error(`migration-storage: invalid response ${JSON.stringify({migrationId, response})}`);
+  }
+  try {
+    const current = await getAllResponses();
+    const updated = { ...current, [migrationId]: response };
+    await new Promise((resolve, reject) => {
+      chrome.storage.local.set({ [STORAGE_KEY]: updated }, () => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve();
+      });
+    });
+  } catch (err) {
+    console.error("[MUGA] migration-storage.recordResponse:", err);
+    throw err;
+  }
+}
+
+/**
+ * Clears all stored responses. Intended for testing and devMode only.
+ * @returns {Promise<void>}
+ */
+export async function clearAll() {
+  try {
+    await new Promise((resolve, reject) => {
+      chrome.storage.local.remove(STORAGE_KEY, () => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve();
+      });
+    });
+  } catch (err) {
+    console.error("[MUGA] migration-storage.clearAll:", err);
+    throw err;
+  }
+}

--- a/tests/unit/migration-evaluator.test.mjs
+++ b/tests/unit/migration-evaluator.test.mjs
@@ -1,0 +1,233 @@
+/**
+ * MUGA — migration evaluator (#363)
+ *
+ * Pure-logic tests for evaluateMigrations. No I/O, no chrome stub needed.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { evaluateMigrations, compareVersions } from "../../src/lib/migration-evaluator.js";
+
+const FIXTURE = {
+  id: "fixture-pref-flip",
+  fromVersion: "1.0.0",
+  toVersion: "2.0.0",
+  prefs: ["fixturePref"],
+  proposedValue: { fixturePref: true },
+  networkRelated: false,
+  bannerCopyKey: "fixture_banner",
+};
+
+const FIXTURE_NETWORK = {
+  id: "fixture-network-flip",
+  fromVersion: "1.5.0",
+  toVersion: "2.5.0",
+  prefs: ["fixtureNetworkPref"],
+  proposedValue: { fixtureNetworkPref: true },
+  networkRelated: true,
+  bannerCopyKey: "fixture_network_banner",
+};
+
+describe("compareVersions", () => {
+  test("returns negative for a < b", () => {
+    assert.ok(compareVersions("1.0.0", "1.0.1") < 0);
+    assert.ok(compareVersions("1.0.0", "2.0.0") < 0);
+    assert.ok(compareVersions("1.9.9", "1.10.0") < 0);
+  });
+  test("returns zero for equal", () => {
+    assert.equal(compareVersions("1.0.0", "1.0.0"), 0);
+    assert.equal(compareVersions("1.0", "1.0.0"), 0);
+  });
+  test("returns positive for a > b", () => {
+    assert.ok(compareVersions("2.0.0", "1.0.0") > 0);
+    assert.ok(compareVersions("1.10.0", "1.9.9") > 0);
+  });
+  test("treats missing components as zero", () => {
+    assert.equal(compareVersions("1", "1.0.0"), 0);
+    assert.equal(compareVersions("1.0", "1.0.0"), 0);
+  });
+});
+
+describe("evaluateMigrations — empty / no-op cases", () => {
+  test("empty migrations list returns []", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: {},
+      prefs: {},
+      migrations: [],
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("default MIGRATIONS list (which ships empty) returns []", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: {},
+      prefs: {},
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("missing previousVersion returns []", () => {
+    const result = evaluateMigrations({
+      previousVersion: "",
+      currentVersion: "2.0.0",
+      responses: {},
+      prefs: {},
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("missing currentVersion returns []", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "",
+      responses: {},
+      prefs: {},
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+});
+
+describe("evaluateMigrations — upgrade window", () => {
+  test("user crossing the migration window sees it", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: {},
+      prefs: { fixturePref: false },
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, [FIXTURE]);
+  });
+
+  test("user already past the migration window does not see it", () => {
+    const result = evaluateMigrations({
+      previousVersion: "2.0.1",
+      currentVersion: "2.1.0",
+      responses: {},
+      prefs: { fixturePref: false },
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("user not yet at toVersion does not see it", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "1.9.0",
+      responses: {},
+      prefs: { fixturePref: false },
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("fresh install (previousVersion < fromVersion) does see it", () => {
+    // First install at v2.0.0 of an extension whose migration spec has
+    // fromVersion 1.0.0 — the user IS upgrading across the window.
+    const result = evaluateMigrations({
+      previousVersion: "0.9.0",
+      currentVersion: "2.0.0",
+      responses: {},
+      prefs: { fixturePref: false },
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, [FIXTURE]);
+  });
+});
+
+describe("evaluateMigrations — response gating", () => {
+  test("accepted migration is not re-presented", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: { "fixture-pref-flip": "accept" },
+      prefs: { fixturePref: false },
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("declined migration is not re-presented", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: { "fixture-pref-flip": "decline" },
+      prefs: { fixturePref: false },
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("dismissed migration is not re-presented", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: { "fixture-pref-flip": "dismiss" },
+      prefs: { fixturePref: false },
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+});
+
+describe("evaluateMigrations — pref state already matches", () => {
+  test("user with pref already set to proposedValue does not see banner", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: {},
+      prefs: { fixturePref: true }, // already matches proposedValue
+      migrations: [FIXTURE],
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("user with one of two prefs not matching still sees banner", () => {
+    const multi = {
+      id: "multi",
+      fromVersion: "1.0.0",
+      toVersion: "2.0.0",
+      prefs: ["a", "b"],
+      proposedValue: { a: true, b: true },
+      networkRelated: false,
+      bannerCopyKey: "",
+    };
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "2.0.0",
+      responses: {},
+      prefs: { a: true, b: false },
+      migrations: [multi],
+    });
+    assert.deepEqual(result, [multi]);
+  });
+});
+
+describe("evaluateMigrations — multiple stacked migrations", () => {
+  test("returns all unresolved migrations in declared order", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "3.0.0",
+      responses: {},
+      prefs: { fixturePref: false, fixtureNetworkPref: false },
+      migrations: [FIXTURE, FIXTURE_NETWORK],
+    });
+    assert.deepEqual(result, [FIXTURE, FIXTURE_NETWORK]);
+  });
+
+  test("returns only the unresolved subset when one was already accepted", () => {
+    const result = evaluateMigrations({
+      previousVersion: "1.0.0",
+      currentVersion: "3.0.0",
+      responses: { "fixture-pref-flip": "accept" },
+      prefs: { fixturePref: true, fixtureNetworkPref: false },
+      migrations: [FIXTURE, FIXTURE_NETWORK],
+    });
+    assert.deepEqual(result, [FIXTURE_NETWORK]);
+  });
+});

--- a/tests/unit/migration-spec.test.mjs
+++ b/tests/unit/migration-spec.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * MUGA — migration spec schema (#363)
+ *
+ * Validates that every entry in MIGRATIONS has the documented shape, that
+ * ids are unique, that version pairs are well-formed, and — critically —
+ * that any entry tagged `networkRelated: true` has a non-empty
+ * `bannerCopyKey`. The last check is the silent-migration prevention guard:
+ * a network-related pref default cannot flip without a user-visible banner.
+ *
+ * The spec ships empty (#363) — these assertions run against the empty list
+ * cleanly, and protect every future entry that lands in the spec.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { MIGRATIONS } from "../../src/lib/migration-spec.js";
+import { compareVersions } from "../../src/lib/migration-evaluator.js";
+
+const REQUIRED_FIELDS = [
+  "id",
+  "fromVersion",
+  "toVersion",
+  "prefs",
+  "proposedValue",
+  "networkRelated",
+  "bannerCopyKey",
+];
+
+const SEMVER_RE = /^\d+(\.\d+){0,2}$/;
+
+describe("migration-spec — shape", () => {
+  test("MIGRATIONS is an array", () => {
+    assert.ok(Array.isArray(MIGRATIONS), "MIGRATIONS must be an array");
+  });
+
+  test("MIGRATIONS is frozen (append-only invariant — entries cannot be mutated)", () => {
+    assert.ok(Object.isFrozen(MIGRATIONS), "MIGRATIONS must be Object.freeze()'d");
+  });
+});
+
+describe("migration-spec — entry validation", () => {
+  for (const m of MIGRATIONS) {
+    describe(`entry "${m?.id || "(missing id)"}"`, () => {
+      for (const field of REQUIRED_FIELDS) {
+        test(`has required field "${field}"`, () => {
+          assert.ok(field in m, `Missing field: ${field}`);
+        });
+      }
+
+      test("id is a non-empty string", () => {
+        assert.equal(typeof m.id, "string");
+        assert.ok(m.id.length > 0);
+      });
+
+      test("fromVersion is well-formed semver", () => {
+        assert.match(m.fromVersion, SEMVER_RE);
+      });
+
+      test("toVersion is well-formed semver", () => {
+        assert.match(m.toVersion, SEMVER_RE);
+      });
+
+      test("toVersion > fromVersion", () => {
+        assert.ok(
+          compareVersions(m.toVersion, m.fromVersion) > 0,
+          `toVersion (${m.toVersion}) must be greater than fromVersion (${m.fromVersion})`
+        );
+      });
+
+      test("prefs is a non-empty array of strings", () => {
+        assert.ok(Array.isArray(m.prefs));
+        assert.ok(m.prefs.length > 0);
+        m.prefs.forEach(p => assert.equal(typeof p, "string"));
+      });
+
+      test("proposedValue is an object covering every entry in prefs", () => {
+        assert.equal(typeof m.proposedValue, "object");
+        for (const key of m.prefs) {
+          assert.ok(key in m.proposedValue, `proposedValue missing pref "${key}"`);
+        }
+      });
+
+      test("networkRelated is a boolean", () => {
+        assert.equal(typeof m.networkRelated, "boolean");
+      });
+
+      test("bannerCopyKey is required and non-empty when networkRelated is true", () => {
+        if (m.networkRelated) {
+          assert.equal(typeof m.bannerCopyKey, "string");
+          assert.ok(
+            m.bannerCopyKey.length > 0,
+            "Network-related migrations MUST have a non-empty bannerCopyKey. " +
+            "Silent migration of network-related prefs is forbidden."
+          );
+        } else {
+          assert.equal(typeof m.bannerCopyKey, "string");
+        }
+      });
+    });
+  }
+});
+
+describe("migration-spec — global invariants", () => {
+  test("ids are unique across the spec", () => {
+    const ids = MIGRATIONS.map(m => m.id);
+    const uniq = new Set(ids);
+    assert.equal(ids.length, uniq.size, "Duplicate id detected in MIGRATIONS");
+  });
+});

--- a/tests/unit/migration-storage.test.mjs
+++ b/tests/unit/migration-storage.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * MUGA — migration storage (#363)
+ *
+ * Round-trip tests for migration response persistence. Uses a stateful
+ * in-memory chrome.storage.local stub so reads return what was written.
+ * Asserts that responses go to local — never sync.
+ */
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Stateful in-memory chrome.storage stub. Installed before each test.
+function installChromeStub() {
+  const localStore = new Map();
+  const syncStore  = new Map();
+
+  const makeArea = (store) => ({
+    get: (defaults, cb) => {
+      const result = {};
+      if (typeof defaults === "string") {
+        result[defaults] = store.has(defaults) ? store.get(defaults) : undefined;
+      } else if (Array.isArray(defaults)) {
+        for (const k of defaults) result[k] = store.has(k) ? store.get(k) : undefined;
+      } else if (defaults && typeof defaults === "object") {
+        for (const [k, v] of Object.entries(defaults)) {
+          result[k] = store.has(k) ? store.get(k) : v;
+        }
+      }
+      cb && cb(result);
+    },
+    set: (data, cb) => {
+      for (const [k, v] of Object.entries(data)) store.set(k, v);
+      cb && cb();
+    },
+    remove: (keys, cb) => {
+      const arr = Array.isArray(keys) ? keys : [keys];
+      for (const k of arr) store.delete(k);
+      cb && cb();
+    },
+  });
+
+  globalThis.chrome = {
+    storage: {
+      local: makeArea(localStore),
+      sync:  makeArea(syncStore),
+    },
+    runtime: { lastError: null },
+  };
+
+  return { localStore, syncStore };
+}
+
+describe("migration-storage — round-trip", () => {
+  let stores;
+  let migrationStorage;
+
+  beforeEach(async () => {
+    stores = installChromeStub();
+    // Re-import each test to bypass module caching of chrome refs.
+    migrationStorage = await import("../../src/lib/migration-storage.js?cb=" + Math.random());
+  });
+
+  test("getResponse returns null when nothing stored", async () => {
+    const r = await migrationStorage.getResponse("any-id");
+    assert.equal(r, null);
+  });
+
+  test("recordResponse + getResponse round-trips", async () => {
+    await migrationStorage.recordResponse("mig-1", "accept");
+    const r = await migrationStorage.getResponse("mig-1");
+    assert.equal(r, "accept");
+  });
+
+  test("recordResponse stores in local, never in sync", async () => {
+    await migrationStorage.recordResponse("mig-2", "decline");
+    assert.ok(stores.localStore.has("migrationResponses"), "local must have the key");
+    assert.equal(stores.syncStore.has("migrationResponses"), false, "sync must NOT have the key");
+  });
+
+  test("multiple responses coexist", async () => {
+    await migrationStorage.recordResponse("mig-a", "accept");
+    await migrationStorage.recordResponse("mig-b", "decline");
+    await migrationStorage.recordResponse("mig-c", "dismiss");
+    const all = await migrationStorage.getAllResponses();
+    assert.deepEqual(all, { "mig-a": "accept", "mig-b": "decline", "mig-c": "dismiss" });
+  });
+
+  test("recordResponse overwrites a prior response for the same id", async () => {
+    await migrationStorage.recordResponse("mig-x", "dismiss");
+    await migrationStorage.recordResponse("mig-x", "accept");
+    const r = await migrationStorage.getResponse("mig-x");
+    assert.equal(r, "accept");
+  });
+
+  test("clearAll removes all responses", async () => {
+    await migrationStorage.recordResponse("mig-y", "accept");
+    await migrationStorage.clearAll();
+    const all = await migrationStorage.getAllResponses();
+    assert.deepEqual(all, {});
+  });
+
+  test("recordResponse rejects invalid response value", async () => {
+    await assert.rejects(
+      () => migrationStorage.recordResponse("mig-z", "ignore"),
+      /invalid response/
+    );
+  });
+
+  test("recordResponse rejects empty migrationId", async () => {
+    await assert.rejects(
+      () => migrationStorage.recordResponse("", "accept"),
+      /invalid response/
+    );
+  });
+});


### PR DESCRIPTION
Closes #363.

Phase 2 of the parent PRD #352. The static + pure-logic + storage plumbing for the migration-banner mechanism. **No UI in this slice** — the banner ships in #369. The MIGRATIONS list ships empty.

## Modules

- **`src/lib/migration-spec.js`** — append-only `MIGRATIONS` list. Object.freeze'd to enforce the invariant.
- **`src/lib/migration-evaluator.js`** — pure `evaluateMigrations()` function. No I/O. Given previousVersion + currentVersion + responses + prefs + spec, returns ordered list of pending migrations.
- **`src/lib/migration-storage.js`** — per-device response persistence in `chrome.storage.local` (intentional — mirrors the per-device model in #348). Surface: `getResponse`, `getAllResponses`, `recordResponse`, `clearAll`.

## Tests

- **migration-evaluator** — fresh install, upgrade-window, accept/decline/dismiss gating, pref-already-matches skip, multiple stacked migrations.
- **migration-storage** — round-trip with a stateful in-memory chrome.storage stub. Asserts local-only, never sync.
- **migration-spec** — schema validation. **Critical guard**: any `networkRelated: true` entry must have a non-empty `bannerCopyKey` (silent-migration prevention).

## Test plan

- [x] 1688 tests pass (1658 base + 30 new across the 3 suites).
- [x] Schema test runs cleanly against the empty initial list.
- [x] No UI changes; no manifest changes; no runtime impact (the empty MIGRATIONS list means `evaluateMigrations` always returns []).

Wave 1 of the post-grill rollout (engram observation #190).