### PR TITLE
feat(toolbar): presenter scaffold + per-tab dynamic tooltip (#358)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -17,6 +17,9 @@ import {
   REMOTE_RULE_ID,
 } from "../lib/remote-rules.js";
 import { TRUSTED_PUBLIC_KEYS } from "../lib/remote-rules-keys.js";
+import { createToolbarEventBus } from "../lib/toolbar-event-bus.js";
+import { createTabPresenterState } from "../lib/tab-presenter-state.js";
+import { createToolbarPresenter } from "../lib/toolbar-presenter.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -65,6 +68,23 @@ _domainRulesReady = _loadDomainRules();
 
 // B3: chrome.action (MV3) does not exist in Firefox MV2; fall back to browserAction
 const actionApi = globalThis.chrome?.action || globalThis.chrome?.browserAction || {};
+
+// --- Toolbar presenter (#358) ---
+// All toolbar surface mutations (tooltip, badge text, badge color, icon) flow
+// through this presenter via the event bus. No code outside the presenter calls
+// chrome.action.set* directly.
+const toolbarBus   = createToolbarEventBus();
+const toolbarState = createTabPresenterState();
+createToolbarPresenter({
+  bus: toolbarBus,
+  state: toolbarState,
+  actionApi,
+  // The presenter calls t(key) without a lang. Resolve from cachedPrefs at
+  // call time so the user's current language is used. Defaults to "en"
+  // before the cache is warm, which is fine — tooltip update fires after
+  // URL processing, by which point prefs are loaded.
+  t: (key) => t(key, cachedPrefs?.language || "en"),
+});
 
 // Run migration once on startup (no-op if already done)
 migrateStatsToLocal();
@@ -305,10 +325,14 @@ async function syncContextMenus(enabled) {
   });
 }
 
-// Set badge appearance once on startup
-actionApi.setBadgeBackgroundColor?.({ color: "#2563eb" });
+// Badge background color is set by the toolbar presenter at startup (#358).
 
 // --- Badge helpers ---
+//
+// The badge text and tooltip are now driven by the ToolbarPresenter (#358).
+// updateTabBadge emits a urlCleaned event; the presenter accumulates the
+// count and writes the badge text. Session storage is still used so the
+// count survives service-worker termination across the same tab lifecycle.
 
 async function updateTabBadge(tabId, junkRemoved) {
   if (!tabId || junkRemoved <= 0) return;
@@ -316,20 +340,21 @@ async function updateTabBadge(tabId, junkRemoved) {
   const data = await sessionStorage.get({ [key]: 0 });
   const newCount = data[key] + junkRemoved;
   await sessionStorage.set({ [key]: newCount });
-  actionApi.setBadgeText?.({ text: String(newCount), tabId });
+  toolbarBus.emit({ type: "urlCleaned", tabId, paramsRemoved: junkRemoved });
 }
 
 // Clear badge when a tab starts navigating to a new page
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === "loading") {
     sessionStorage.remove(`tab_${tabId}`);
-    actionApi.setBadgeText?.({ text: "", tabId });
+    toolbarBus.emit({ type: "navigationStarted", tabId });
   }
 });
 
 // Clean up session data when a tab closes
 chrome.tabs.onRemoved.addListener((tabId) => {
   sessionStorage.remove(`tab_${tabId}`);
+  toolbarBus.emit({ type: "tabClosed", tabId });
 });
 
 // --- Session history helpers ---
@@ -393,6 +418,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     handleProcessUrl(message.url, { skipNotify: message.skipNotify, source: message.skipNotify ? "copy_selection" : "navigation", skipStats: !!message.skipStats })
       .then(result => {
         updateTabBadge(tabId, result.junkRemoved ?? 0);
+        if (typeof tabId === "number" && result.preservedAffiliate) {
+          toolbarBus.emit({ type: "creatorReferralPreserved", tabId });
+        }
         sendResponse(result);
       })
       .catch(err => {

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -240,6 +240,12 @@ export const TRANSLATIONS = {
   ctx_copy_clean_link:      { en: "Copy clean link",                       es: "Copiar enlace limpio",                       pt: "Copiar link limpo",                       de: "Bereinigten Link kopieren" },
   ctx_copy_clean_selection: { en: "Copy clean links in selection",         es: "Copiar enlaces limpios de la selección",         pt: "Copiar links limpos da seleção",         de: "Bereinigte Links in Auswahl kopieren" },
 
+  // ── Toolbar tooltips (#358) ──────────────────────────────────────────────
+  tooltip_default:                { en: "MUGA",                                                  es: "MUGA",                                                  pt: "MUGA",                                                  de: "MUGA" },
+  tooltip_cleaned:                { en: "MUGA — tracking removed",                               es: "MUGA — rastreo eliminado",                              pt: "MUGA — rastreamento removido",                          de: "MUGA — Tracking entfernt" },
+  tooltip_preserved:              { en: "MUGA — creator referral preserved",                     es: "MUGA — referido del creador preservado",                pt: "MUGA — indicação do criador preservada",                de: "MUGA — Creator-Empfehlung erhalten" },
+  tooltip_cleaned_and_preserved:  { en: "MUGA — tracking removed, creator referral preserved",   es: "MUGA — rastreo eliminado, referido del creador preservado", pt: "MUGA — rastreamento removido, indicação do criador preservada", de: "MUGA — Tracking entfernt, Creator-Empfehlung erhalten" },
+
   // ── Content script toast ──────────────────────────────────────────────────
   toast_title:   { en: "MUGA found someone else's affiliate tag", es: "MUGA encontró el tag de afiliado de otro", pt: "MUGA encontrou a tag de afiliado de outra pessoa", de: "MUGA hat ein fremdes Affiliate-Tag gefunden" },
   toast_tag_msg: { en: "has an affiliate tag that isn't ours:", es: "tiene un tag de afiliado que no es nuestro:", pt: "tem uma tag de afiliado que não é nossa:", de: "hat ein Affiliate-Tag, das nicht unseres ist:" },

--- a/src/lib/tab-presenter-state.js
+++ b/src/lib/tab-presenter-state.js
@@ -1,0 +1,84 @@
+/**
+ * MUGA: Tab Presenter State
+ *
+ * In-memory record of what each tab's toolbar currently shows. Keyed by
+ * tabId. Reset on navigation start; evicted on tab close. Consulted by
+ * the toolbar presenter whenever it has to compute the next surface
+ * state for a tab.
+ *
+ * State per tab:
+ *   {
+ *     paramsRemoved: number,         // count strip events accumulated
+ *     creatorReferralPreserved: bool,
+ *     foreignAffiliateDetected: bool,
+ *   }
+ */
+
+const EMPTY = Object.freeze({
+  paramsRemoved: 0,
+  creatorReferralPreserved: false,
+  foreignAffiliateDetected: false,
+});
+
+export function createTabPresenterState() {
+  const byTab = new Map();
+
+  return {
+    /**
+     * Returns the current state for a tab. Never throws; missing tabs
+     * return a frozen empty record so callers can read fields safely.
+     * @param {number} tabId
+     * @returns {object}
+     */
+    get(tabId) {
+      return byTab.get(tabId) || EMPTY;
+    },
+
+    /**
+     * Returns the previous state (for diff comparisons) and applies a
+     * partial update. Numeric fields like `paramsRemoved` accumulate.
+     * @param {number} tabId
+     * @param {object} patch
+     * @returns {{ prev: object, next: object }}
+     */
+    update(tabId, patch) {
+      const prev = byTab.get(tabId) || EMPTY;
+      const next = { ...prev };
+      if (typeof patch.paramsRemoved === "number") {
+        next.paramsRemoved = prev.paramsRemoved + patch.paramsRemoved;
+      }
+      if (patch.creatorReferralPreserved === true) {
+        next.creatorReferralPreserved = true;
+      }
+      if (patch.foreignAffiliateDetected === true) {
+        next.foreignAffiliateDetected = true;
+      }
+      byTab.set(tabId, next);
+      return { prev, next };
+    },
+
+    /**
+     * Resets a tab's state to empty (used on navigation start).
+     * @param {number} tabId
+     */
+    reset(tabId) {
+      byTab.delete(tabId);
+    },
+
+    /**
+     * Evicts a tab from the state map (used on tab close).
+     * @param {number} tabId
+     */
+    evict(tabId) {
+      byTab.delete(tabId);
+    },
+
+    /**
+     * Number of tracked tabs. Exposed for tests and diagnostics.
+     * @returns {number}
+     */
+    size() {
+      return byTab.size;
+    },
+  };
+}

--- a/src/lib/toolbar-event-bus.js
+++ b/src/lib/toolbar-event-bus.js
@@ -1,0 +1,53 @@
+/**
+ * MUGA: Toolbar Event Bus
+ *
+ * Thin internal pub/sub. The URL-processing path emits semantic events
+ * (urlCleaned, creatorReferralPreserved, foreignAffiliateDetected,
+ * navigationStarted, tabClosed); the toolbar presenter subscribes and
+ * translates them into chrome.action.* calls.
+ *
+ * Decoupling matters: the URL pipeline does not call browser APIs
+ * directly, and the presenter does not know about URL cleaning. This is
+ * what keeps the presenter testable and the cleaning code free of
+ * presentation concerns.
+ *
+ * Event shapes:
+ *   { type: "urlCleaned",                tabId: number, paramsRemoved: number }
+ *   { type: "creatorReferralPreserved",  tabId: number }
+ *   { type: "foreignAffiliateDetected",  tabId: number }
+ *   { type: "navigationStarted",         tabId: number }
+ *   { type: "tabClosed",                 tabId: number }
+ */
+
+export function createToolbarEventBus() {
+  const listeners = [];
+  return {
+    /**
+     * Subscribes a listener to all events.
+     * @param {(event: object) => void} fn
+     * @returns {() => void} Unsubscribe function.
+     */
+    subscribe(fn) {
+      listeners.push(fn);
+      return () => {
+        const i = listeners.indexOf(fn);
+        if (i !== -1) listeners.splice(i, 1);
+      };
+    },
+
+    /**
+     * Emits an event to all subscribers. Listener errors are isolated —
+     * a throwing listener does not break delivery to subsequent ones.
+     * @param {object} event
+     */
+    emit(event) {
+      for (const fn of listeners.slice()) {
+        try {
+          fn(event);
+        } catch (err) {
+          console.error("[MUGA] toolbar bus listener error:", err);
+        }
+      }
+    },
+  };
+}

--- a/src/lib/toolbar-presenter.js
+++ b/src/lib/toolbar-presenter.js
@@ -1,0 +1,115 @@
+/**
+ * MUGA: Toolbar Presenter
+ *
+ * Single point of design control over the browser-action toolbar surface
+ * (tooltip via setTitle, badge text via setBadgeText, badge color via
+ * setBadgeBackgroundColor, icon via setIcon). No code outside this module
+ * may call those APIs directly.
+ *
+ * Subscribes to a ToolbarEventBus and translates semantic events into
+ * the right per-tab surface state. State is cached in TabPresenterState
+ * so the same surface call is not issued twice for the same value.
+ *
+ * This slice (#358) wires:
+ *   - The dynamic per-tab tooltip via setTitle.
+ *   - The existing badge text behavior, preserved unchanged (count of
+ *     params stripped on this tab; cleared on navigation; cleared on
+ *     tab close; fixed blue background — semantic colors arrive in #367).
+ *
+ * Subsequent slices add semantic badge color (#367) and icon variant (#368).
+ */
+
+const DEFAULT_BADGE_COLOR = "#2563eb";
+
+/**
+ * Creates a toolbar presenter and wires it to the bus. Returns the
+ * presenter for testing / direct calls (not generally needed in
+ * production — the bus is the entry point).
+ *
+ * @param {object} args
+ * @param {object} args.bus       - ToolbarEventBus (subscribe/emit).
+ * @param {object} args.state     - TabPresenterState (get/update/reset/evict).
+ * @param {object} args.actionApi - chrome.action / browserAction shim.
+ * @param {(key: string) => string} args.t - i18n lookup. Returns the
+ *   localized string for the user's current language.
+ * @returns {object} Presenter with introspection helpers.
+ */
+export function createToolbarPresenter({ bus, state, actionApi, t }) {
+  // Set the default badge background color once. Future slices (#367) replace
+  // this with semantic colors driven by tab state.
+  actionApi.setBadgeBackgroundColor?.({ color: DEFAULT_BADGE_COLOR });
+
+  function tooltipFor(s) {
+    const cleaned   = s.paramsRemoved > 0;
+    const preserved = s.creatorReferralPreserved;
+    if (cleaned && preserved) return t("tooltip_cleaned_and_preserved");
+    if (preserved)            return t("tooltip_preserved");
+    if (cleaned)              return t("tooltip_cleaned");
+    return t("tooltip_default");
+  }
+
+  function applyTab(tabId, prev, next) {
+    // Tooltip. Only call setTitle if the resolved string changed.
+    const prevTitle = tooltipFor(prev);
+    const nextTitle = tooltipFor(next);
+    if (prevTitle !== nextTitle) {
+      actionApi.setTitle?.({ tabId, title: nextTitle });
+    }
+
+    // Badge text. Mirrors the pre-existing behavior: numeric count of
+    // params removed on this tab; empty when zero.
+    if (next.paramsRemoved !== prev.paramsRemoved) {
+      const text = next.paramsRemoved > 0 ? String(next.paramsRemoved) : "";
+      actionApi.setBadgeText?.({ tabId, text });
+    }
+  }
+
+  function clearTab(tabId) {
+    state.reset(tabId);
+    actionApi.setBadgeText?.({ tabId, text: "" });
+    actionApi.setTitle?.({ tabId, title: t("tooltip_default") });
+  }
+
+  bus.subscribe((event) => {
+    if (!event || typeof event !== "object" || !event.type) return;
+    const tabId = event.tabId;
+    if (typeof tabId !== "number" || tabId < 0) return;
+
+    switch (event.type) {
+      case "urlCleaned": {
+        const count = Math.max(0, Number(event.paramsRemoved) || 0);
+        if (count === 0) return;
+        const { prev, next } = state.update(tabId, { paramsRemoved: count });
+        applyTab(tabId, prev, next);
+        return;
+      }
+      case "creatorReferralPreserved": {
+        const { prev, next } = state.update(tabId, { creatorReferralPreserved: true });
+        applyTab(tabId, prev, next);
+        return;
+      }
+      case "foreignAffiliateDetected": {
+        const { prev, next } = state.update(tabId, { foreignAffiliateDetected: true });
+        applyTab(tabId, prev, next);
+        return;
+      }
+      case "navigationStarted": {
+        clearTab(tabId);
+        return;
+      }
+      case "tabClosed": {
+        state.evict(tabId);
+        return;
+      }
+      default:
+        return;
+    }
+  });
+
+  return {
+    // Test/introspection: returns the tooltip string the presenter would
+    // show for a given state. Useful for unit tests without mocking
+    // setTitle round-trips.
+    _tooltipFor: tooltipFor,
+  };
+}

--- a/tests/unit/toolbar-presenter.test.mjs
+++ b/tests/unit/toolbar-presenter.test.mjs
@@ -1,0 +1,245 @@
+/**
+ * MUGA — toolbar presenter (#358)
+ *
+ * Verifies the contract: given an event sequence, the presenter writes
+ * the right per-tab tooltip and badge state. Tests assert the API calls
+ * the presenter would make against a recording stub — not screenshots,
+ * not real chrome APIs.
+ */
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { createToolbarEventBus } from "../../src/lib/toolbar-event-bus.js";
+import { createTabPresenterState } from "../../src/lib/tab-presenter-state.js";
+import { createToolbarPresenter } from "../../src/lib/toolbar-presenter.js";
+
+function makeRecordingActionApi() {
+  const calls = [];
+  return {
+    calls,
+    setBadgeBackgroundColor(arg) { calls.push(["setBadgeBackgroundColor", arg]); },
+    setBadgeText(arg)            { calls.push(["setBadgeText", arg]); },
+    setTitle(arg)                { calls.push(["setTitle", arg]); },
+    setIcon(arg)                 { calls.push(["setIcon", arg]); },
+  };
+}
+
+const STRINGS = {
+  tooltip_default:               "MUGA",
+  tooltip_cleaned:               "MUGA — tracking removed",
+  tooltip_preserved:             "MUGA — creator referral preserved",
+  tooltip_cleaned_and_preserved: "MUGA — tracking removed, creator referral preserved",
+};
+const t = (key) => STRINGS[key] ?? key;
+
+function setup() {
+  const bus = createToolbarEventBus();
+  const state = createTabPresenterState();
+  const actionApi = makeRecordingActionApi();
+  const presenter = createToolbarPresenter({ bus, state, actionApi, t });
+  return { bus, state, actionApi, presenter };
+}
+
+describe("toolbar-presenter — startup", () => {
+  test("sets the default badge background color once at construction", () => {
+    const { actionApi } = setup();
+    const colorCalls = actionApi.calls.filter(([k]) => k === "setBadgeBackgroundColor");
+    assert.equal(colorCalls.length, 1);
+    assert.deepEqual(colorCalls[0][1], { color: "#2563eb" });
+  });
+});
+
+describe("toolbar-presenter — urlCleaned", () => {
+  test("first cleaning sets the badge to count and tooltip to cleaned", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    assert.deepEqual(
+      actionApi.calls.find(([k]) => k === "setBadgeText")?.[1],
+      { tabId: 7, text: "3" }
+    );
+    assert.deepEqual(
+      actionApi.calls.find(([k]) => k === "setTitle")?.[1],
+      { tabId: 7, title: "MUGA — tracking removed" }
+    );
+  });
+
+  test("subsequent cleaning accumulates the count", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 2 });
+    const last = actionApi.calls.filter(([k]) => k === "setBadgeText").pop();
+    assert.deepEqual(last?.[1], { tabId: 7, text: "5" });
+  });
+
+  test("zero or negative paramsRemoved is a no-op", () => {
+    const { bus, actionApi } = setup();
+    actionApi.calls.length = 0; // discard startup call
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 0 });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: -5 });
+    assert.equal(actionApi.calls.length, 0);
+  });
+});
+
+describe("toolbar-presenter — creatorReferralPreserved", () => {
+  test("on a clean tab, sets tooltip to preserved (no badge change)", () => {
+    const { bus, actionApi } = setup();
+    actionApi.calls.length = 0;
+    bus.emit({ type: "creatorReferralPreserved", tabId: 9 });
+    const titleCall = actionApi.calls.find(([k]) => k === "setTitle");
+    assert.deepEqual(titleCall?.[1], { tabId: 9, title: "MUGA — creator referral preserved" });
+    // No badge text call because paramsRemoved is unchanged at zero
+    assert.equal(actionApi.calls.find(([k]) => k === "setBadgeText"), undefined);
+  });
+
+  test("after a cleaning event, sets tooltip to combined", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 9, paramsRemoved: 4 });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "creatorReferralPreserved", tabId: 9 });
+    const titleCall = actionApi.calls.find(([k]) => k === "setTitle");
+    assert.deepEqual(
+      titleCall?.[1],
+      { tabId: 9, title: "MUGA — tracking removed, creator referral preserved" }
+    );
+  });
+});
+
+describe("toolbar-presenter — navigationStarted", () => {
+  test("clears badge text and resets tooltip to default", () => {
+    const { bus, state, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 5, paramsRemoved: 2 });
+    bus.emit({ type: "creatorReferralPreserved", tabId: 5 });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "navigationStarted", tabId: 5 });
+    assert.deepEqual(
+      actionApi.calls.find(([k]) => k === "setBadgeText")?.[1],
+      { tabId: 5, text: "" }
+    );
+    assert.deepEqual(
+      actionApi.calls.find(([k]) => k === "setTitle")?.[1],
+      { tabId: 5, title: "MUGA" }
+    );
+    // State for the tab is reset
+    assert.equal(state.get(5).paramsRemoved, 0);
+    assert.equal(state.get(5).creatorReferralPreserved, false);
+  });
+});
+
+describe("toolbar-presenter — tabClosed", () => {
+  test("evicts the tab from state without writing to the action surface", () => {
+    const { bus, state, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 3, paramsRemoved: 1 });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "tabClosed", tabId: 3 });
+    // No setBadgeText / setTitle on close — the browser handles tab teardown
+    assert.equal(actionApi.calls.find(([k]) => k === "setBadgeText"), undefined);
+    assert.equal(actionApi.calls.find(([k]) => k === "setTitle"), undefined);
+    // State map no longer holds the tab
+    assert.equal(state.size(), 0);
+  });
+
+  test("reused tabId does not see stale state", () => {
+    const { bus, state } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 11, paramsRemoved: 7 });
+    bus.emit({ type: "tabClosed", tabId: 11 });
+    // Browser reuses tabId 11 for a new tab later
+    assert.equal(state.get(11).paramsRemoved, 0);
+    assert.equal(state.get(11).creatorReferralPreserved, false);
+  });
+});
+
+describe("toolbar-presenter — robustness", () => {
+  test("ignores events without a valid tabId", () => {
+    const { bus, actionApi } = setup();
+    actionApi.calls.length = 0;
+    bus.emit({ type: "urlCleaned", paramsRemoved: 2 }); // missing tabId
+    bus.emit({ type: "urlCleaned", tabId: -1, paramsRemoved: 2 });
+    bus.emit({ type: "urlCleaned", tabId: "x", paramsRemoved: 2 });
+    assert.equal(actionApi.calls.length, 0);
+  });
+
+  test("ignores unknown event types", () => {
+    const { bus, actionApi } = setup();
+    actionApi.calls.length = 0;
+    bus.emit({ type: "neverHeardOfIt", tabId: 1 });
+    assert.equal(actionApi.calls.length, 0);
+  });
+
+  test("does not call setTitle redundantly when state-equivalent updates land", () => {
+    const { bus, actionApi } = setup();
+    // Two cleanings on the same tab. Tooltip stays at "tracking removed"
+    // both times — setTitle should only be called once.
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 1 });
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 1 });
+    const titleCalls = actionApi.calls.filter(([k]) => k === "setTitle");
+    assert.equal(titleCalls.length, 1);
+  });
+});
+
+describe("toolbar-event-bus", () => {
+  test("subscribers receive events", () => {
+    const bus = createToolbarEventBus();
+    const events = [];
+    bus.subscribe(e => events.push(e));
+    bus.emit({ type: "ping" });
+    assert.deepEqual(events, [{ type: "ping" }]);
+  });
+
+  test("unsubscribe stops further delivery", () => {
+    const bus = createToolbarEventBus();
+    const events = [];
+    const unsub = bus.subscribe(e => events.push(e));
+    bus.emit({ type: "a" });
+    unsub();
+    bus.emit({ type: "b" });
+    assert.deepEqual(events, [{ type: "a" }]);
+  });
+
+  test("a throwing listener does not break delivery to others", () => {
+    const bus = createToolbarEventBus();
+    const events = [];
+    bus.subscribe(() => { throw new Error("boom"); });
+    bus.subscribe(e => events.push(e));
+    bus.emit({ type: "ok" });
+    assert.deepEqual(events, [{ type: "ok" }]);
+  });
+});
+
+describe("tab-presenter-state", () => {
+  test("get on unknown tab returns empty record", () => {
+    const state = createTabPresenterState();
+    const s = state.get(42);
+    assert.equal(s.paramsRemoved, 0);
+    assert.equal(s.creatorReferralPreserved, false);
+    assert.equal(s.foreignAffiliateDetected, false);
+  });
+
+  test("update accumulates paramsRemoved", () => {
+    const state = createTabPresenterState();
+    state.update(1, { paramsRemoved: 3 });
+    state.update(1, { paramsRemoved: 2 });
+    assert.equal(state.get(1).paramsRemoved, 5);
+  });
+
+  test("update sets boolean flags monotonically", () => {
+    const state = createTabPresenterState();
+    state.update(1, { creatorReferralPreserved: true });
+    assert.equal(state.get(1).creatorReferralPreserved, true);
+  });
+
+  test("reset clears state for a tab", () => {
+    const state = createTabPresenterState();
+    state.update(1, { paramsRemoved: 5, creatorReferralPreserved: true });
+    state.reset(1);
+    assert.equal(state.get(1).paramsRemoved, 0);
+    assert.equal(state.get(1).creatorReferralPreserved, false);
+  });
+
+  test("evict removes the tab from the map", () => {
+    const state = createTabPresenterState();
+    state.update(1, { paramsRemoved: 5 });
+    state.update(2, { paramsRemoved: 5 });
+    state.evict(1);
+    assert.equal(state.size(), 1);
+    assert.equal(state.get(1).paramsRemoved, 0);
+  });
+});


### PR DESCRIPTION
Closes #358.

Foundational tracer bullet for parent PRD #350. Introduces `ToolbarEventBus`, `TabPresenterState`, and `ToolbarPresenter` modules, and wires the dynamic per-tab tooltip end-to-end. Badge color (#367) and icon variant (#368) ride on top in subsequent slices.

Hover the toolbar icon on a tab where MUGA acted: tooltip now describes what happened (`MUGA — tracking removed`, `MUGA — creator referral preserved`, or both). Tabs where MUGA did nothing notable show `MUGA`.

## What changed

- 3 new modules under `src/lib/` (event bus, tab state, presenter).
- 4 new i18n keys (tooltip variants), all locales: en/es/pt/de.
- `service-worker.js`: direct `chrome.action.set*` calls replaced with `bus.emit()`. Existing badge-text behavior preserved (count, cleared on nav, evicted on tab close). Default blue color preserved — semantic colors are #367.
- New emission of `creatorReferralPreserved` when `result.preservedAffiliate` is non-null.

## Test plan

- [x] 1682 tests pass (1658 base + 24 new).
- [x] Cleaned/preserved/combined tooltip cases covered.
- [x] Navigation reset + tab-close eviction covered (no stale state on reused tabIds).
- [x] Presenter does not call `setTitle` redundantly when state-equivalent updates land.
- [x] Robustness: malformed events (missing tabId, unknown type) do not crash.
- [ ] Manual smoke: load extension on Chrome, navigate to a creator-affiliated URL, hover the icon, verify tooltip text.

Wave 1 of the post-grill rollout (engram observation #190).