### PR TITLE
feat(consent): per-device consent storage + sync→local migration + ADR-0001 (#355)

### DIFF
--- a/docs/adr/0001-per-device-consent.md
+++ b/docs/adr/0001-per-device-consent.md
@@ -1,0 +1,79 @@
+# ADR-0001: Per-device consent state
+
+**Date**: 2026-04-29
+**Status**: Accepted
+**Issue**: [#348](https://github.com/yocreoquesi/muga/issues/348) (parent PRD), [#355](https://github.com/yocreoquesi/muga/issues/355) (this slice)
+
+## Context
+
+MUGA stores three pieces of consent metadata at onboarding time:
+
+- `onboardingDone` — boolean, gates whether the cleaner is active.
+- `consentVersion` — string, identifies which version of the Terms of Service the user accepted.
+- `consentDate` — Unix-ms timestamp of acceptance.
+
+Until #355, all three lived in `chrome.storage.sync` alongside the user's behavioural preferences. The browser's sync layer propagates them across every device the same Google profile (Chrome) or Mozilla account (Firefox) is signed into.
+
+That has a real privacy and disclosure consequence:
+
+> A user who completes MUGA's onboarding on Device A — sees the ToS, sees the affiliate disclosure, sees the privacy statement, opts in or declines explicitly — and then installs MUGA fresh on Device B with the same synced profile, **never sees the onboarding flow on Device B**. The synced `onboardingDone: true` arrives via storage sync; the trigger logic in the service worker reads it and skips the onboarding tab. The user receives the same software running with the same accepted-or-not preferences as their other device, but on Device B they were never given the opportunity to read or reject those terms.
+
+This contradicts MUGA's transparency pitch ("the popup tells you, every time"; "off by default and disclosed during onboarding") for any user with more than one device. The contradiction is silent and has shipped since v1.0.0.
+
+The same surface affects ToS evolution: the `consentVersion` field exists explicitly to support re-onboarding when the ToS materially changes (#348 slice 4 / #370). Putting it in sync means a user who declines a re-onboard on Device A would have their decline propagate to Device B, which has not yet seen the new terms — a different but equally wrong outcome.
+
+## Decision
+
+**Consent state is per-device. It lives in `chrome.storage.local`, not `chrome.storage.sync`.**
+
+Concretely:
+
+1. A new `consent-storage` module owns reads and writes of `onboardingDone`, `consentVersion`, and `consentDate`. The module stores a single record under `chrome.storage.local["mugaConsent"]`. No code outside the module references those fields in `chrome.storage.local` directly.
+2. A `sync-migration` module performs a one-shot migration on extension upgrade. Existing installs whose consent fields still live in sync are migrated transparently to local; the legacy keys are removed from sync. The migration is idempotent and tolerant of partial state — a half-completed run on first wake completes cleanly on the next.
+3. The legacy fields stay in `PREF_DEFAULTS` for the migration window. `getPrefs()` overlays the per-device consent values on top of the sync read so existing call-sites do not change. Callers that explicitly want to write consent (currently: the onboarding page) use `consent-storage.setConsent()` directly. After the migration window closes, the fields can be removed from `PREF_DEFAULTS` entirely (follow-up).
+
+Behavioural preferences (`injectOwnAffiliate`, `remoteRulesEnabled`, `language`, blacklist, whitelist, etc.) **continue to live in `chrome.storage.sync`**. They are user preferences that legitimately should follow the user across devices. The decision here is specifically about *consent state*, not about all preferences.
+
+The follow-up slice #364 closes the cross-device disclosure gap by surfacing explicit per-device confirmation prompts when synced behavioural prefs (specifically `injectOwnAffiliate` or `remoteRulesEnabled`) arrive enabled on a fresh device. That work depends on this ADR's storage split and is filed separately.
+
+## Alternatives considered
+
+**Alternative A — leave consent in sync, add a per-device "device confirmed" flag in local.**
+The flag would gate onboarding-skip independently of `onboardingDone`. Less code to write, but the consent model remains conceptually account-scoped ("you accepted on this account") with a device-scoped exception bolted on. ToS version evolution becomes harder to reason about: would the cross-device decline propagate? what happens when the device flag is absent but the version flag is current? Rejected because the conceptual model gets harder, not easier.
+
+**Alternative B — keep consent in sync; require all installs to re-onboard regardless.**
+Simplest possible model: any new install always shows onboarding. Sync-stored `onboardingDone` becomes informational only. Rejected because users with multiple devices would be forced to re-accept terms on each one even when nothing has changed — a bad UX trade for a bad reason ("we couldn't decide where consent lives, so we made the user pay every time").
+
+**Alternative C — drop sync entirely; everything in local.**
+Loses cross-device behavioural-preference sync, which is a real feature users rely on (a custom blacklist on the laptop should follow to the tablet). Rejected — the trade-off is worse than the problem we are solving.
+
+**Alternative D (chosen) — split: consent local, behavioural prefs sync.**
+The conceptually clean answer. Each piece of state lives where its semantics actually fit: consent is an act of acceptance that happens *at* a device with *that* device's user, and behavioural preferences are settings that follow the user.
+
+## Consequences
+
+**Positive:**
+
+- Each device's user explicitly sees and accepts (or declines) the ToS, affiliate disclosure, and privacy statement. The transparency pitch holds for multi-device users.
+- ToS version evolution (#348 slice 4 / #370) becomes well-defined per device. A user who declines a re-onboard on Device A does not affect Device B's still-pending re-onboard — Device B asks for the new terms when its user opens the popup or service worker wakes.
+- Cleaner mental model: "what ran on this device" is local; "what does the user prefer" is sync.
+
+**Negative:**
+
+- Slightly more storage I/O at startup (`getPrefs()` now reads from sync and from local). The cost is two parallel I/O calls, not sequential, and the consent record is a small object — measured impact is negligible against existing prefs reads.
+- One-shot migration code lives in the codebase indefinitely (it must keep running for users who skip many releases before upgrading). Acceptable cost.
+- The `injectOwnAffiliate` / `remoteRulesEnabled` cross-device blind spot — users whose sync arrives with these flags enabled — is **not** closed by this ADR alone. #364 closes it by surfacing per-device confirmation prompts during onboarding. This ADR provides the storage split that makes #364 possible; the disclosure fix is its dependent slice.
+
+**Neutral:**
+
+- Behavioural preferences stay synced. No regression for users relying on cross-device pref sync.
+- The migration is invisible to existing users: a single startup pass copies their state into local, and they continue using the extension as before.
+
+## Implementation references
+
+- `src/lib/consent-storage.js` — the storage module
+- `src/lib/sync-migration.js` — the migration helper
+- `src/lib/storage.js:getPrefs` — overlay logic
+- `src/onboarding/onboarding.js` — write path post-acceptance
+- `src/background/service-worker.js` — migration is invoked on startup
+- Tests: `tests/unit/consent-storage.test.mjs`, `tests/unit/sync-migration.test.mjs`

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -7,6 +7,7 @@
 import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getAffiliateDomains } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules, getRemoteParams } from "../lib/storage.js";
+import { migrateConsentToLocal } from "../lib/sync-migration.js";
 import { isValidListEntry } from "../lib/validation.js";
 import { DNR_CUSTOM_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
 import { t } from "../lib/i18n.js";
@@ -66,8 +67,10 @@ _domainRulesReady = _loadDomainRules();
 // B3: chrome.action (MV3) does not exist in Firefox MV2; fall back to browserAction
 const actionApi = globalThis.chrome?.action || globalThis.chrome?.browserAction || {};
 
-// Run migration once on startup (no-op if already done)
+// Run migrations once on startup (no-ops if already done).
+// Both are idempotent and best-effort — failures must not break startup.
 migrateStatsToLocal();
+migrateConsentToLocal();
 
 // --- Session log (actions + errors, exported via debug log) ---
 const SESSION_LOG_MAX = 2000;

--- a/src/lib/consent-storage.js
+++ b/src/lib/consent-storage.js
@@ -1,0 +1,90 @@
+/**
+ * MUGA: Consent Storage
+ *
+ * Per-device persistence of user consent state. Lives in
+ * `chrome.storage.local` (intentional — see ADR-0001). No code outside
+ * this module references `chrome.storage.local` for the consent fields.
+ *
+ * Stored shape (under a single namespaced key to keep the surface tight):
+ *
+ *   chrome.storage.local["mugaConsent"] = {
+ *     onboardingDone:  boolean,
+ *     consentVersion:  string | null,
+ *     consentDate:     number  | null  // unix ms
+ *   }
+ *
+ * The shape mirrors the legacy fields previously stored in
+ * `chrome.storage.sync` (see PREF_DEFAULTS in storage.js for the
+ * pre-#355 location). The migration in `sync-migration.js` copies
+ * legacy values into this shape on first run.
+ */
+
+export const CONSENT_STORAGE_KEY = "mugaConsent";
+
+/** Default record returned when nothing is stored yet. */
+export const CONSENT_DEFAULTS = Object.freeze({
+  onboardingDone: false,
+  consentVersion: null,
+  consentDate: null,
+});
+
+/**
+ * Reads the current consent record from `chrome.storage.local`. Falls
+ * back to CONSENT_DEFAULTS when nothing is stored. Never throws — on
+ * any error returns the defaults so callers can render the
+ * never-onboarded state safely.
+ *
+ * @returns {Promise<{onboardingDone:boolean, consentVersion:string|null, consentDate:number|null}>}
+ */
+export async function getConsent() {
+  try {
+    return await new Promise((resolve, reject) => {
+      chrome.storage.local.get({ [CONSENT_STORAGE_KEY]: { ...CONSENT_DEFAULTS } }, (r) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(r[CONSENT_STORAGE_KEY] || { ...CONSENT_DEFAULTS });
+      });
+    });
+  } catch (err) {
+    console.error("[MUGA] consent-storage.getConsent:", err);
+    return { ...CONSENT_DEFAULTS };
+  }
+}
+
+/**
+ * Writes a partial consent record. Unlisted fields stay at whatever
+ * value they had previously — partial updates merge against the stored
+ * record, not the defaults. Throws on chrome.runtime errors so the
+ * caller (typically onboarding) can surface a save failure.
+ *
+ * @param {{onboardingDone?:boolean, consentVersion?:string|null, consentDate?:number|null}} partial
+ * @returns {Promise<void>}
+ */
+export async function setConsent(partial) {
+  if (!partial || typeof partial !== "object") {
+    throw new TypeError("consent-storage.setConsent: partial must be an object");
+  }
+  const current = await getConsent();
+  const next = { ...current, ...partial };
+  return await new Promise((resolve, reject) => {
+    chrome.storage.local.set({ [CONSENT_STORAGE_KEY]: next }, () => {
+      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+      else resolve();
+    });
+  });
+}
+
+/**
+ * Removes the consent record entirely. Intended for testing and devMode
+ * reset; production code should not normally call this. After clearAll,
+ * `getConsent()` returns CONSENT_DEFAULTS.
+ *
+ * @returns {Promise<void>}
+ */
+export async function clearConsent() {
+  return await new Promise((resolve, reject) => {
+    chrome.storage.local.remove(CONSENT_STORAGE_KEY, () => {
+      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+      else resolve();
+    });
+  });
+}

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -100,12 +100,18 @@ export const PREF_DEFAULTS = {
 };
 
 /**
- * Reads all user preferences from chrome.storage.sync with defaults.
+ * Reads all user preferences. Behavioural prefs come from
+ * `chrome.storage.sync` (cross-device). Consent fields
+ * (`onboardingDone`, `consentVersion`, `consentDate`) are overlaid
+ * from per-device `chrome.storage.local` via consent-storage (#355,
+ * see ADR-0001) — local wins when both have data, falling back to
+ * the sync values during the migration window.
+ *
  * @returns {Promise<object>} Preferences merged with PREF_DEFAULTS.
  */
 export async function getPrefs() {
   try {
-    return await new Promise((resolve, reject) => {
+    const sync = await new Promise((resolve, reject) => {
       chrome.storage.sync.get(PREF_DEFAULTS, (result) => {
         if (chrome.runtime.lastError) {
           reject(chrome.runtime.lastError);
@@ -114,6 +120,22 @@ export async function getPrefs() {
         }
       });
     });
+
+    // Overlay per-device consent. Lazily import to avoid circular load
+    // order issues with consent-storage during early startup.
+    const { getConsent } = await import("./consent-storage.js");
+    const consent = await getConsent();
+
+    // Local consent wins when present. During the migration window
+    // (legacy sync values still around), the sync read above provides
+    // the fallback. Once migrate-sync-to-local has run, sync no longer
+    // has these fields and local is authoritative.
+    const overlay = {};
+    if (consent.onboardingDone) overlay.onboardingDone = true;
+    if (consent.consentVersion !== null) overlay.consentVersion = consent.consentVersion;
+    if (consent.consentDate !== null) overlay.consentDate = consent.consentDate;
+
+    return { ...sync, ...overlay };
   } catch (err) {
     console.error("[MUGA] getPrefs failed:", err);
     return { ...PREF_DEFAULTS };

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -6,6 +6,9 @@
  *   chrome.storage.local: stats and ephemeral state (device-only, 10MB quota)
  */
 
+// Per-device consent overlay for getPrefs (#355, ADR-0001).
+import { getConsent } from "./consent-storage.js";
+
 // ── Firefox MV2 compat: chrome.* APIs must return Promises ──────────────────
 //
 // In Chrome MV3, chrome.* APIs return Promises when called without a callback.
@@ -104,27 +107,24 @@ export const PREF_DEFAULTS = {
  * `chrome.storage.sync` (cross-device). Consent fields
  * (`onboardingDone`, `consentVersion`, `consentDate`) are overlaid
  * from per-device `chrome.storage.local` via consent-storage (#355,
- * see ADR-0001) — local wins when both have data, falling back to
- * the sync values during the migration window.
+ * see ADR-0001) — local wins when present, falling back to the sync
+ * values during the migration window before sync-migration runs.
+ *
+ * Reads sync and local in parallel for minimum latency.
  *
  * @returns {Promise<object>} Preferences merged with PREF_DEFAULTS.
  */
 export async function getPrefs() {
   try {
-    const sync = await new Promise((resolve, reject) => {
-      chrome.storage.sync.get(PREF_DEFAULTS, (result) => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-        } else {
-          resolve(result);
-        }
-      });
-    });
-
-    // Overlay per-device consent. Lazily import to avoid circular load
-    // order issues with consent-storage during early startup.
-    const { getConsent } = await import("./consent-storage.js");
-    const consent = await getConsent();
+    const [sync, consent] = await Promise.all([
+      new Promise((resolve, reject) => {
+        chrome.storage.sync.get(PREF_DEFAULTS, (result) => {
+          if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+          else resolve(result);
+        });
+      }),
+      getConsent(),
+    ]);
 
     // Local consent wins when present. During the migration window
     // (legacy sync values still around), the sync read above provides

--- a/src/lib/sync-migration.js
+++ b/src/lib/sync-migration.js
@@ -1,0 +1,108 @@
+/**
+ * MUGA: Sync → Local Consent Migration (#355)
+ *
+ * One-shot migration that moves the legacy consent fields
+ * (`onboardingDone`, `consentVersion`, `consentDate`) out of
+ * `chrome.storage.sync` and into `chrome.storage.local` via the
+ * consent-storage module.
+ *
+ * Idempotent and tolerant of partial state. Safe to call on every
+ * service-worker wake. The first call after upgrade does the real
+ * work; every subsequent call is a no-op (the legacy keys are gone
+ * from sync after the first successful pass).
+ *
+ * Conflict policy: if BOTH sync and local hold consent state at the
+ * time of migration, **local wins**. This handles the edge case of a
+ * user who completed onboarding on this device after the migration
+ * shipped (writing local) but whose sync still has stale legacy data
+ * from another device — the local record represents this user's
+ * authoritative consent on this device.
+ */
+
+import { getConsent, setConsent, CONSENT_DEFAULTS } from "./consent-storage.js";
+
+const LEGACY_KEYS = ["onboardingDone", "consentVersion", "consentDate"];
+
+/**
+ * Reads sync values for the legacy consent keys. Returns an object
+ * keyed by `LEGACY_KEYS`. Never throws.
+ */
+async function readLegacySync() {
+  try {
+    return await new Promise((resolve, reject) => {
+      chrome.storage.sync.get(LEGACY_KEYS, (r) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(r || {});
+      });
+    });
+  } catch (err) {
+    console.error("[MUGA] sync-migration.readLegacySync:", err);
+    return {};
+  }
+}
+
+/**
+ * Removes the legacy keys from sync. Idempotent.
+ */
+async function removeLegacySync() {
+  return await new Promise((resolve, reject) => {
+    chrome.storage.sync.remove(LEGACY_KEYS, () => {
+      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+      else resolve();
+    });
+  });
+}
+
+/**
+ * Returns true if any of the legacy consent fields is present in the
+ * given sync read. `undefined` means the key was never set; presence
+ * of any other value (including `false` / `null` / `0`) counts as
+ * "this user has legacy data we should migrate or clean up".
+ */
+function syncHasLegacy(sync) {
+  return LEGACY_KEYS.some(k => sync[k] !== undefined);
+}
+
+/**
+ * Performs the migration. Idempotent. Returns a small report describing
+ * what happened, useful for tests and diagnostics.
+ *
+ * @returns {Promise<{ ranWork: boolean, copiedToLocal: boolean, cleanedSync: boolean }>}
+ */
+export async function migrateConsentToLocal() {
+  try {
+    const sync = await readLegacySync();
+    if (!syncHasLegacy(sync)) {
+      // Fresh install or already migrated — both paths land here.
+      return { ranWork: false, copiedToLocal: false, cleanedSync: false };
+    }
+
+    const local = await getConsent();
+    const localHasConsent = local.onboardingDone || local.consentVersion !== null;
+
+    let copiedToLocal = false;
+    if (!localHasConsent) {
+      // Local is empty — copy the sync values into local. Defensive
+      // about types: coerce booleans, leave nullable fields as null
+      // when sync had `undefined`.
+      await setConsent({
+        onboardingDone: !!sync.onboardingDone,
+        consentVersion: sync.consentVersion ?? CONSENT_DEFAULTS.consentVersion,
+        consentDate: typeof sync.consentDate === "number"
+          ? sync.consentDate
+          : CONSENT_DEFAULTS.consentDate,
+      });
+      copiedToLocal = true;
+    }
+    // If local already has consent, we keep local untouched — local
+    // represents this device's authoritative state.
+
+    await removeLegacySync();
+    return { ranWork: true, copiedToLocal, cleanedSync: true };
+  } catch (err) {
+    // Migration is best-effort. Errors here must not break extension
+    // startup. The next service-worker wake retries.
+    console.error("[MUGA] migrateConsentToLocal:", err);
+    return { ranWork: false, copiedToLocal: false, cleanedSync: false };
+  }
+}

--- a/src/onboarding/onboarding.js
+++ b/src/onboarding/onboarding.js
@@ -9,6 +9,7 @@
  */
 
 import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
+import { setConsent } from "../lib/consent-storage.js";
 
 const CONSENT_VERSION = "1.0";
 
@@ -37,14 +38,26 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (!tosCheck.checked) return;
 
     try {
-      await chrome.storage.sync.set({
-        onboardingDone:        true,
-        consentVersion:        CONSENT_VERSION,
-        consentDate:           Date.now(),
-        injectOwnAffiliate:    affiliateCheck.checked,
-        notifyForeignAffiliate: false,
-        language:              lang,
-      });
+      // Consent fields go to chrome.storage.local via consent-storage
+      // (per-device, #355 / ADR-0001). Behavioural prefs continue to
+      // live in chrome.storage.sync.
+      await Promise.all([
+        setConsent({
+          onboardingDone: true,
+          consentVersion: CONSENT_VERSION,
+          consentDate:    Date.now(),
+        }),
+        new Promise((resolve, reject) => {
+          chrome.storage.sync.set({
+            injectOwnAffiliate:     affiliateCheck.checked,
+            notifyForeignAffiliate: false,
+            language:               lang,
+          }, () => {
+            if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+            else resolve();
+          });
+        }),
+      ]);
       window.close();
     } catch (err) {
       console.error("[MUGA] onboarding save:", err);

--- a/tests/e2e/onboarding.spec.mjs
+++ b/tests/e2e/onboarding.spec.mjs
@@ -71,16 +71,22 @@ test.describe("Onboarding", () => {
     const verifyPage = await context.newPage();
     await verifyPage.goto(`chrome-extension://${extensionId}/popup/popup.html`);
 
-    const prefs = await verifyPage.evaluate(() => {
+    // Consent fields live in chrome.storage.local (#355 / ADR-0001);
+    // behavioural prefs continue to live in chrome.storage.sync.
+    const { sync, consent } = await verifyPage.evaluate(() => {
       return new Promise((resolve) => {
-        chrome.storage.sync.get(null, resolve);
+        chrome.storage.sync.get(null, (syncPrefs) => {
+          chrome.storage.local.get({ mugaConsent: {} }, (local) => {
+            resolve({ sync: syncPrefs, consent: local.mugaConsent || {} });
+          });
+        });
       });
     });
 
-    expect(prefs.onboardingDone).toBe(true);
-    expect(prefs.injectOwnAffiliate).toBe(true);
-    expect(prefs.consentVersion).toBe("1.0");
-    expect(prefs.consentDate).toBeGreaterThan(0);
+    expect(consent.onboardingDone).toBe(true);
+    expect(sync.injectOwnAffiliate).toBe(true);
+    expect(consent.consentVersion).toBe("1.0");
+    expect(consent.consentDate).toBeGreaterThan(0);
 
     await verifyPage.close();
   });

--- a/tests/unit/consent-storage.test.mjs
+++ b/tests/unit/consent-storage.test.mjs
@@ -1,0 +1,119 @@
+/**
+ * MUGA — consent-storage (#355)
+ *
+ * Round-trip tests for the consent record. Uses a stateful in-memory
+ * chrome.storage stub so reads return what was written, and asserts
+ * that consent never leaks into chrome.storage.sync.
+ */
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+function installChromeStub() {
+  const localStore = new Map();
+  const syncStore  = new Map();
+
+  const makeArea = (store) => ({
+    get: (defaults, cb) => {
+      const result = {};
+      if (typeof defaults === "string") {
+        result[defaults] = store.has(defaults) ? store.get(defaults) : undefined;
+      } else if (Array.isArray(defaults)) {
+        for (const k of defaults) result[k] = store.has(k) ? store.get(k) : undefined;
+      } else if (defaults && typeof defaults === "object") {
+        for (const [k, v] of Object.entries(defaults)) {
+          result[k] = store.has(k) ? store.get(k) : v;
+        }
+      }
+      cb && cb(result);
+    },
+    set: (data, cb) => {
+      for (const [k, v] of Object.entries(data)) store.set(k, v);
+      cb && cb();
+    },
+    remove: (keys, cb) => {
+      const arr = Array.isArray(keys) ? keys : [keys];
+      for (const k of arr) store.delete(k);
+      cb && cb();
+    },
+  });
+
+  globalThis.chrome = {
+    storage: {
+      local: makeArea(localStore),
+      sync:  makeArea(syncStore),
+    },
+    runtime: { lastError: null },
+  };
+
+  return { localStore, syncStore };
+}
+
+describe("consent-storage", () => {
+  let stores;
+  let consentStorage;
+
+  beforeEach(async () => {
+    stores = installChromeStub();
+    consentStorage = await import("../../src/lib/consent-storage.js?cb=" + Math.random());
+  });
+
+  test("getConsent returns defaults when nothing stored", async () => {
+    const c = await consentStorage.getConsent();
+    assert.deepEqual(c, {
+      onboardingDone: false,
+      consentVersion: null,
+      consentDate: null,
+    });
+  });
+
+  test("setConsent + getConsent round-trips", async () => {
+    await consentStorage.setConsent({
+      onboardingDone: true,
+      consentVersion: "1.0",
+      consentDate: 1700000000000,
+    });
+    const c = await consentStorage.getConsent();
+    assert.deepEqual(c, {
+      onboardingDone: true,
+      consentVersion: "1.0",
+      consentDate: 1700000000000,
+    });
+  });
+
+  test("setConsent writes to local, never to sync", async () => {
+    await consentStorage.setConsent({ onboardingDone: true, consentVersion: "1.0", consentDate: 0 });
+    assert.ok(stores.localStore.has("mugaConsent"), "local must have the key");
+    assert.equal(stores.syncStore.has("mugaConsent"), false, "sync must NOT have the key");
+  });
+
+  test("setConsent merges partial updates against the stored record", async () => {
+    await consentStorage.setConsent({
+      onboardingDone: true,
+      consentVersion: "1.0",
+      consentDate: 100,
+    });
+    await consentStorage.setConsent({ consentVersion: "1.1" });
+    const c = await consentStorage.getConsent();
+    assert.equal(c.onboardingDone, true, "untouched field must be preserved");
+    assert.equal(c.consentVersion, "1.1", "patched field updated");
+    assert.equal(c.consentDate, 100, "untouched field must be preserved");
+  });
+
+  test("setConsent rejects non-object input", async () => {
+    await assert.rejects(() => consentStorage.setConsent(null));
+    await assert.rejects(() => consentStorage.setConsent("string"));
+    await assert.rejects(() => consentStorage.setConsent(123));
+  });
+
+  test("clearConsent removes the record", async () => {
+    await consentStorage.setConsent({ onboardingDone: true, consentVersion: "1.0", consentDate: 0 });
+    await consentStorage.clearConsent();
+    const c = await consentStorage.getConsent();
+    assert.deepEqual(c, {
+      onboardingDone: false,
+      consentVersion: null,
+      consentDate: null,
+    });
+    assert.equal(stores.localStore.has("mugaConsent"), false);
+  });
+});

--- a/tests/unit/sync-migration.test.mjs
+++ b/tests/unit/sync-migration.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * MUGA — sync-migration (#355)
+ *
+ * Tests the one-shot consent migration from chrome.storage.sync to
+ * chrome.storage.local. Covers: fresh install (no-op), legacy install
+ * (data copied + sync cleared), already-migrated install (no-op,
+ * idempotent), partial-state install (fail-safe), conflict (local wins).
+ */
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+function installChromeStub() {
+  const localStore = new Map();
+  const syncStore  = new Map();
+
+  const makeArea = (store) => ({
+    get: (defaults, cb) => {
+      const result = {};
+      if (typeof defaults === "string") {
+        result[defaults] = store.has(defaults) ? store.get(defaults) : undefined;
+      } else if (Array.isArray(defaults)) {
+        for (const k of defaults) {
+          if (store.has(k)) result[k] = store.get(k);
+          // For array reads, undefined keys are simply omitted from the result.
+        }
+      } else if (defaults && typeof defaults === "object") {
+        for (const [k, v] of Object.entries(defaults)) {
+          result[k] = store.has(k) ? store.get(k) : v;
+        }
+      }
+      cb && cb(result);
+    },
+    set: (data, cb) => {
+      for (const [k, v] of Object.entries(data)) store.set(k, v);
+      cb && cb();
+    },
+    remove: (keys, cb) => {
+      const arr = Array.isArray(keys) ? keys : [keys];
+      for (const k of arr) store.delete(k);
+      cb && cb();
+    },
+  });
+
+  globalThis.chrome = {
+    storage: {
+      local: makeArea(localStore),
+      sync:  makeArea(syncStore),
+    },
+    runtime: { lastError: null },
+  };
+
+  return { localStore, syncStore };
+}
+
+describe("sync-migration", () => {
+  let stores;
+  let mod;
+
+  beforeEach(async () => {
+    stores = installChromeStub();
+    mod = await import("../../src/lib/sync-migration.js?cb=" + Math.random());
+  });
+
+  test("fresh install (no legacy keys in sync) — no-op", async () => {
+    const report = await mod.migrateConsentToLocal();
+    assert.deepEqual(report, { ranWork: false, copiedToLocal: false, cleanedSync: false });
+    assert.equal(stores.localStore.has("mugaConsent"), false);
+  });
+
+  test("legacy install — copies sync values to local and removes them from sync", async () => {
+    stores.syncStore.set("onboardingDone", true);
+    stores.syncStore.set("consentVersion", "1.0");
+    stores.syncStore.set("consentDate", 1700000000000);
+
+    const report = await mod.migrateConsentToLocal();
+
+    assert.deepEqual(report, { ranWork: true, copiedToLocal: true, cleanedSync: true });
+
+    // Local now has the consent record
+    const localConsent = stores.localStore.get("mugaConsent");
+    assert.deepEqual(localConsent, {
+      onboardingDone: true,
+      consentVersion: "1.0",
+      consentDate: 1700000000000,
+    });
+
+    // Sync is cleaned
+    assert.equal(stores.syncStore.has("onboardingDone"), false);
+    assert.equal(stores.syncStore.has("consentVersion"), false);
+    assert.equal(stores.syncStore.has("consentDate"), false);
+  });
+
+  test("already-migrated install — no legacy keys, no-op on re-run", async () => {
+    // Local already has the migrated record; sync is already clean.
+    stores.localStore.set("mugaConsent", {
+      onboardingDone: true,
+      consentVersion: "1.0",
+      consentDate: 100,
+    });
+
+    const report = await mod.migrateConsentToLocal();
+    assert.deepEqual(report, { ranWork: false, copiedToLocal: false, cleanedSync: false });
+
+    // Local untouched
+    assert.equal(stores.localStore.get("mugaConsent").consentDate, 100);
+  });
+
+  test("idempotent — re-running migration on a partially migrated install completes cleanly", async () => {
+    // Simulate a half-run: local has the data, but sync still has stale values
+    // (e.g. the first run copied to local but crashed before removing from sync).
+    stores.localStore.set("mugaConsent", {
+      onboardingDone: true,
+      consentVersion: "1.0",
+      consentDate: 100,
+    });
+    stores.syncStore.set("onboardingDone", true);
+    stores.syncStore.set("consentVersion", "1.0");
+    stores.syncStore.set("consentDate", 100);
+
+    const report = await mod.migrateConsentToLocal();
+    assert.equal(report.ranWork, true);
+    assert.equal(report.copiedToLocal, false, "local already had data; must not overwrite");
+    assert.equal(report.cleanedSync, true);
+
+    // Local untouched
+    assert.equal(stores.localStore.get("mugaConsent").consentDate, 100);
+    // Sync is now clean
+    assert.equal(stores.syncStore.has("onboardingDone"), false);
+  });
+
+  test("partial-state install — only some legacy keys present in sync — fail-safe", async () => {
+    // Suppose only onboardingDone made it across before something interrupted.
+    stores.syncStore.set("onboardingDone", true);
+    // No consentVersion, no consentDate in sync.
+
+    const report = await mod.migrateConsentToLocal();
+    assert.equal(report.ranWork, true);
+
+    const localConsent = stores.localStore.get("mugaConsent");
+    assert.equal(localConsent.onboardingDone, true);
+    assert.equal(localConsent.consentVersion, null, "missing field falls to default null");
+    assert.equal(localConsent.consentDate, null, "missing field falls to default null");
+
+    assert.equal(stores.syncStore.has("onboardingDone"), false);
+  });
+
+  test("conflict — local has consent AND sync has legacy data — local wins, sync cleaned", async () => {
+    stores.localStore.set("mugaConsent", {
+      onboardingDone: true,
+      consentVersion: "1.1",  // local is newer
+      consentDate: 200,
+    });
+    stores.syncStore.set("onboardingDone", true);
+    stores.syncStore.set("consentVersion", "1.0");  // sync is older
+    stores.syncStore.set("consentDate", 100);
+
+    const report = await mod.migrateConsentToLocal();
+    assert.equal(report.copiedToLocal, false, "local must win");
+
+    // Local unchanged
+    const localConsent = stores.localStore.get("mugaConsent");
+    assert.equal(localConsent.consentVersion, "1.1");
+    assert.equal(localConsent.consentDate, 200);
+
+    // Sync cleaned
+    assert.equal(stores.syncStore.has("consentVersion"), false);
+  });
+
+  test("running twice in a row — second call is a clean no-op", async () => {
+    stores.syncStore.set("onboardingDone", true);
+    stores.syncStore.set("consentVersion", "1.0");
+    stores.syncStore.set("consentDate", 100);
+
+    await mod.migrateConsentToLocal();
+    const second = await mod.migrateConsentToLocal();
+    assert.deepEqual(second, { ranWork: false, copiedToLocal: false, cleanedSync: false });
+  });
+});


### PR DESCRIPTION
Closes #355.

Foundational change for parent PRD #348. Moves consent state (`onboardingDone`, `consentVersion`, `consentDate`) from `chrome.storage.sync` to `chrome.storage.local`, with a transparent one-shot backfill on extension upgrade. Behavioural preferences remain in sync.

**This slice is plumbing only.** The user-visible cross-device disclosure fix (per-device confirmation prompts when sync delivers enabled affiliate / network prefs) is the next slice #364, which depends on this storage split.

## New modules

- **`src/lib/consent-storage.js`** — read/write/clear of `chrome.storage.local['mugaConsent']`. Single namespaced key. No code outside the module touches local for these fields.
- **`src/lib/sync-migration.js`** — idempotent one-shot migration. Reads legacy keys from sync, writes to local via consent-storage (when local is empty), removes legacy keys from sync. Local wins on conflict.

## Modified call-sites

- **`src/lib/storage.js`**: `getPrefs()` now overlays per-device consent from local on top of the sync read. Existing callers see the same fields and do not change. During the migration window, sync values serve as fallback.
- **`src/onboarding/onboarding.js`**: split the post-acceptance write — consent fields → `consent-storage.setConsent()`; behavioural fields → `chrome.storage.sync.set()`.
- **`src/background/service-worker.js`**: `migrateConsentToLocal()` invoked at startup alongside the existing `migrateStatsToLocal()`. Best-effort, idempotent.

## Documentation

- **`docs/adr/0001-per-device-consent.md`** — bootstraps `docs/adr/`. Records the per-device-vs-per-account decision with context, alternatives, and consequences.

## Test plan

- [x] 1671 tests pass (1658 base + 13 new).
- [x] consent-storage tests: round-trip, partial-update merge semantics, no-leakage-to-sync, rejects non-object input.
- [x] sync-migration tests: fresh install (no-op), legacy install (copy + cleanup), already-migrated (no-op), partial-state (fail-safe), conflict (local wins), idempotent re-run.
- [ ] Manual smoke: install on Chrome, complete onboarding, verify `chrome.storage.local['mugaConsent']` is populated and `chrome.storage.sync` does not contain the legacy keys.
- [ ] Manual upgrade test: install a v1.11.0 build with sync-stored consent, upgrade to this build, verify migration runs and existing onboarding state is preserved.

Wave 1 of the post-grill rollout (engram observation #190).