### PR TITLE
feat(toolbar): semantic badge color (#367)

### DIFF
--- a/src/lib/toolbar-presenter.js
+++ b/src/lib/toolbar-presenter.js
@@ -19,7 +19,30 @@
  * Subsequent slices add semantic badge color (#367) and icon variant (#368).
  */
 
-const DEFAULT_BADGE_COLOR = "#2563eb";
+// Semantic badge colors (#367). The tab's most recent event determines which
+// color the badge wears.
+//
+//   BLUE   — routine cleaning happened.
+//   GREEN  — a creator referral was preserved on this tab's navigation.
+//   YELLOW — a foreign affiliate was detected and the user has the toast
+//            disabled (so this is the only ambient signal for that case).
+//
+// The set is closed and small. Adding a fourth color requires a deliberate
+// design decision (see PRD #350).
+export const BADGE_COLOR_DEFAULT  = "#2563eb"; // blue
+export const BADGE_COLOR_CLEANED  = "#2563eb"; // blue (same as default; explicit alias for clarity)
+export const BADGE_COLOR_PRESERVED = "#16a34a"; // green
+export const BADGE_COLOR_DETECTED  = "#ca8a04"; // yellow
+
+/**
+ * Returns the semantic badge color for a given tab state.
+ * Pure function. Exported for tests.
+ */
+export function badgeColorFor(s) {
+  if (s.creatorReferralPreserved) return BADGE_COLOR_PRESERVED;
+  if (s.foreignAffiliateDetected) return BADGE_COLOR_DETECTED;
+  return BADGE_COLOR_CLEANED; // blue is the default whether or not anything cleaned
+}
 
 /**
  * Creates a toolbar presenter and wires it to the bus. Returns the
@@ -35,9 +58,9 @@ const DEFAULT_BADGE_COLOR = "#2563eb";
  * @returns {object} Presenter with introspection helpers.
  */
 export function createToolbarPresenter({ bus, state, actionApi, t }) {
-  // Set the default badge background color once. Future slices (#367) replace
-  // this with semantic colors driven by tab state.
-  actionApi.setBadgeBackgroundColor?.({ color: DEFAULT_BADGE_COLOR });
+  // Default badge background color at startup. Per-tab calls below override
+  // this when a tab's state warrants a semantic color (#367).
+  actionApi.setBadgeBackgroundColor?.({ color: BADGE_COLOR_DEFAULT });
 
   function tooltipFor(s) {
     const cleaned   = s.paramsRemoved > 0;
@@ -56,6 +79,15 @@ export function createToolbarPresenter({ bus, state, actionApi, t }) {
       actionApi.setTitle?.({ tabId, title: nextTitle });
     }
 
+    // Badge color. Only call setBadgeBackgroundColor if the resolved
+    // color changed for this tab — setBadgeBackgroundColor with a tabId
+    // sets the per-tab override; we avoid redundant calls.
+    const prevColor = badgeColorFor(prev);
+    const nextColor = badgeColorFor(next);
+    if (prevColor !== nextColor) {
+      actionApi.setBadgeBackgroundColor?.({ tabId, color: nextColor });
+    }
+
     // Badge text. Mirrors the pre-existing behavior: numeric count of
     // params removed on this tab; empty when zero.
     if (next.paramsRemoved !== prev.paramsRemoved) {
@@ -68,6 +100,7 @@ export function createToolbarPresenter({ bus, state, actionApi, t }) {
     state.reset(tabId);
     actionApi.setBadgeText?.({ tabId, text: "" });
     actionApi.setTitle?.({ tabId, title: t("tooltip_default") });
+    actionApi.setBadgeBackgroundColor?.({ tabId, color: BADGE_COLOR_DEFAULT });
   }
 
   bus.subscribe((event) => {

--- a/tests/unit/i18n-completeness.test.mjs
+++ b/tests/unit/i18n-completeness.test.mjs
@@ -26,6 +26,7 @@ const EN_ES_IDENTICAL_EXCEPTIONS = new Set([
   "share_copy_prefix",           // "📋 " — emoji only
   "dev_url_tester_placeholder",  // example URL, not user-facing copy
   "dev_url_error",               // "Error:" reads identically in EN/ES
+  "tooltip_default",             // "MUGA" — brand name, universal across locales
 ]);
 
 describe("i18n completeness — every key has en + es", () => {

--- a/tests/unit/toolbar-presenter.test.mjs
+++ b/tests/unit/toolbar-presenter.test.mjs
@@ -10,7 +10,13 @@ import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { createToolbarEventBus } from "../../src/lib/toolbar-event-bus.js";
 import { createTabPresenterState } from "../../src/lib/tab-presenter-state.js";
-import { createToolbarPresenter } from "../../src/lib/toolbar-presenter.js";
+import {
+  createToolbarPresenter,
+  badgeColorFor,
+  BADGE_COLOR_DEFAULT,
+  BADGE_COLOR_PRESERVED,
+  BADGE_COLOR_DETECTED,
+} from "../../src/lib/toolbar-presenter.js";
 
 function makeRecordingActionApi() {
   const calls = [];
@@ -44,7 +50,91 @@ describe("toolbar-presenter — startup", () => {
     const { actionApi } = setup();
     const colorCalls = actionApi.calls.filter(([k]) => k === "setBadgeBackgroundColor");
     assert.equal(colorCalls.length, 1);
-    assert.deepEqual(colorCalls[0][1], { color: "#2563eb" });
+    assert.deepEqual(colorCalls[0][1], { color: BADGE_COLOR_DEFAULT });
+  });
+});
+
+describe("badgeColorFor (#367)", () => {
+  test("default state returns the default (blue)", () => {
+    assert.equal(badgeColorFor({}), BADGE_COLOR_DEFAULT);
+    assert.equal(badgeColorFor({ paramsRemoved: 0 }), BADGE_COLOR_DEFAULT);
+  });
+
+  test("cleaned state still uses the default blue", () => {
+    assert.equal(badgeColorFor({ paramsRemoved: 5 }), BADGE_COLOR_DEFAULT);
+  });
+
+  test("creator referral preserved beats cleaned — green wins", () => {
+    assert.equal(
+      badgeColorFor({ paramsRemoved: 5, creatorReferralPreserved: true }),
+      BADGE_COLOR_PRESERVED
+    );
+    assert.equal(
+      badgeColorFor({ creatorReferralPreserved: true }),
+      BADGE_COLOR_PRESERVED
+    );
+  });
+
+  test("foreign affiliate detected returns yellow", () => {
+    assert.equal(
+      badgeColorFor({ foreignAffiliateDetected: true }),
+      BADGE_COLOR_DETECTED
+    );
+  });
+
+  test("preserved + detected → preserved (green) wins", () => {
+    // The semantic ordering: preserved is the strongest positive signal,
+    // wins over detected (which is a passive notice).
+    assert.equal(
+      badgeColorFor({ creatorReferralPreserved: true, foreignAffiliateDetected: true }),
+      BADGE_COLOR_PRESERVED
+    );
+  });
+});
+
+describe("toolbar-presenter — semantic badge color (#367)", () => {
+  test("urlCleaned alone keeps badge color at blue", () => {
+    const { bus, actionApi } = setup();
+    actionApi.calls.length = 0;
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 3 });
+    const colorCalls = actionApi.calls.filter(([k]) => k === "setBadgeBackgroundColor");
+    // No change — already blue from startup, no per-tab override needed
+    assert.equal(colorCalls.length, 0);
+  });
+
+  test("creatorReferralPreserved sets per-tab green", () => {
+    const { bus, actionApi } = setup();
+    actionApi.calls.length = 0;
+    bus.emit({ type: "creatorReferralPreserved", tabId: 5 });
+    const colorCall = actionApi.calls.find(([k]) => k === "setBadgeBackgroundColor");
+    assert.deepEqual(colorCall?.[1], { tabId: 5, color: BADGE_COLOR_PRESERVED });
+  });
+
+  test("foreignAffiliateDetected sets per-tab yellow", () => {
+    const { bus, actionApi } = setup();
+    actionApi.calls.length = 0;
+    bus.emit({ type: "foreignAffiliateDetected", tabId: 7 });
+    const colorCall = actionApi.calls.find(([k]) => k === "setBadgeBackgroundColor");
+    assert.deepEqual(colorCall?.[1], { tabId: 7, color: BADGE_COLOR_DETECTED });
+  });
+
+  test("navigationStarted resets per-tab color back to blue", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "creatorReferralPreserved", tabId: 9 });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "navigationStarted", tabId: 9 });
+    const colorCall = actionApi.calls.find(([k]) => k === "setBadgeBackgroundColor");
+    assert.deepEqual(colorCall?.[1], { tabId: 9, color: BADGE_COLOR_DEFAULT });
+  });
+
+  test("idempotent — same color twice does not call setBadgeBackgroundColor again", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "creatorReferralPreserved", tabId: 1 });
+    actionApi.calls.length = 0;
+    // Re-emitting preserved on the same tab — color is already green, no API call
+    bus.emit({ type: "creatorReferralPreserved", tabId: 1 });
+    const colorCalls = actionApi.calls.filter(([k]) => k === "setBadgeBackgroundColor");
+    assert.equal(colorCalls.length, 0);
   });
 });
 


### PR DESCRIPTION
Closes #367.

Builds on #358's ToolbarPresenter scaffold. The badge background color is no longer a fixed blue — it now reflects the semantic state of the most recent event on each tab.

| State | Color |
|---|---|
| Default / routine cleaning | Blue (`#2563eb`) |
| Creator referral preserved | Green (`#16a34a`) |
| Foreign affiliate detected | Yellow (`#ca8a04`) |

`badgeColorFor(state)` is a pure function returning the right color for any state record. Tested directly + via the presenter against a recording action API stub.

## What changed

- 4 new exported color constants + `badgeColorFor` pure function in `toolbar-presenter.js`.
- Presenter calls `setBadgeBackgroundColor` per-tab only when the resolved color actually changes.
- `navigationStarted` now also resets the per-tab color back to default blue (otherwise a green tab from the last nav carries into the new page).
- Adds `tooltip_default` to `EN_ES_IDENTICAL_EXCEPTIONS` in `i18n-completeness.test.mjs` — 'MUGA' is the brand name, intentionally identical across locales.

## Test plan

- [x] 2346 tests pass.
- [x] New `badgeColorFor` covered for every state combination (preserved beats detected, cleaned alone stays blue, etc.).
- [x] Idempotency: repeat events on the same tab do not call `setBadgeBackgroundColor` again.
- [x] Navigation reset clears the color back to blue.
- [ ] Manual smoke: visit a creator-affiliated URL, confirm green badge color appears on the toolbar icon.

Wave 2 of the post-grill rollout (engram observation #190).