### PR TITLE
feat(consent): version-comparison foundation — ConsentPolicy + Manifest (#365)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -8,6 +8,7 @@ import { processUrl, parseListEntry } from "../lib/cleaner.js";
 import { getAffiliateDomains } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules, getRemoteParams } from "../lib/storage.js";
 import { migrateConsentToLocal } from "../lib/sync-migration.js";
+import { evaluate as evaluateConsent } from "../lib/consent-policy.js";
 import { isValidListEntry } from "../lib/validation.js";
 import { DNR_CUSTOM_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
 import { t } from "../lib/i18n.js";
@@ -748,6 +749,27 @@ function openOnboardingOnce() {
   chrome.tabs.create({ url: chrome.runtime.getURL("onboarding/onboarding.html") });
 }
 
+/**
+ * Single decision function consulted by both the onInstalled and the
+ * background-load fallback paths (#365). Returns true when the
+ * onboarding tab should be opened — either because the user has never
+ * accepted, or because the required ToS version has advanced past
+ * what they accepted (soft or hard re-onboard).
+ *
+ * Today the manifest holds only "1.0" so this is functionally
+ * equivalent to the prior `!prefs.onboardingDone` check; the gate is
+ * in place for slice #370 which adds the delta / material rendering
+ * modes that consume the policy's `soft-reonboard` / `hard-reonboard`
+ * statuses.
+ *
+ * @param {object} prefs - Merged prefs (consent overlay applied by getPrefs).
+ * @returns {boolean}
+ */
+function shouldOpenOnboarding(prefs) {
+  const result = evaluateConsent({ stored: prefs });
+  return result.status !== "valid";
+}
+
 // --- On install: open onboarding on first run, sync DNR + maybe fetch rules ---
 chrome.runtime.onInstalled.addListener(async (details) => {
   const prefs = await getPrefsWithCache();
@@ -762,20 +784,21 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
   if (details.reason === "install") {
     const installPrefs = await getPrefs();
-    if (!installPrefs.onboardingDone) {
+    if (shouldOpenOnboarding(installPrefs)) {
       openOnboardingOnce();
     }
   }
 });
 
 // --- Fallback: onInstalled is unreliable in Firefox MV2 temporary add-ons ---
-// If onboarding was never completed, open it on background load. This also
-// covers edge cases where onInstalled fires before the module registers its
-// listener. The dedup flag ensures only one tab opens even if both paths fire.
+// If onboarding was never completed (or required ToS version has advanced),
+// open it on background load. This also covers edge cases where onInstalled
+// fires before the module registers its listener. The dedup flag ensures
+// only one tab opens even if both paths fire.
 (async () => {
   try {
     const prefs = await getPrefs();
-    if (!prefs.onboardingDone) {
+    if (shouldOpenOnboarding(prefs)) {
       openOnboardingOnce();
     }
     // Also ensure context menus are registered on first load

--- a/src/lib/consent-policy.js
+++ b/src/lib/consent-policy.js
@@ -1,0 +1,127 @@
+/**
+ * MUGA: Consent Policy (#365)
+ *
+ * Pure function. Given the user's stored consent record and the
+ * current required version (with its manifest), returns one of four
+ * statuses describing what onboarding flow (if any) the user should
+ * see.
+ *
+ * No I/O. No storage access. The caller (typically the service
+ * worker's onboarding-trigger logic) reads the consent record from
+ * `consent-storage` and passes it in.
+ *
+ * Statuses:
+ *
+ *   never-accepted  — onboarding was never completed on this device.
+ *                     Show the full onboarding flow (`fresh` mode in #370).
+ *   valid           — accepted version >= required version. No prompt.
+ *   soft-reonboard  — accepted version is older than required, AND every
+ *                     intermediate version (after accepted, up to and
+ *                     including required) is `additive: true`. Show
+ *                     the delta clauses only (#370).
+ *   hard-reonboard  — accepted version is older than required, AND at
+ *                     least one intermediate version is `additive: false`
+ *                     (material change). Gate features and show full
+ *                     re-acceptance flow (#370).
+ *
+ * Edge cases:
+ *
+ *   - A consent record with `onboardingDone: true` but no
+ *     `consentVersion` is treated as `valid`. Such records may exist
+ *     from before consentVersion was wired (legacy, pre-#355).
+ *   - If `requiredVersion` is not present in the manifest, the policy
+ *     fails open to `valid` rather than locking the user out — a
+ *     malformed manifest must not break the extension.
+ *   - If `acceptedVersion` is not present in the manifest (e.g. user
+ *     accepted a version that has since been retired), the policy
+ *     fails open to `valid`.
+ */
+
+import { compareVersions } from "./migration-evaluator.js";
+import {
+  CONSENT_VERSION_MANIFEST,
+  REQUIRED_CONSENT_VERSION,
+} from "./consent-version-manifest.js";
+
+/**
+ * @typedef {"never-accepted" | "valid" | "soft-reonboard" | "hard-reonboard"} ConsentStatus
+ */
+
+/**
+ * Evaluates whether the user's stored consent matches what the running
+ * code requires.
+ *
+ * @param {object} args
+ * @param {object} args.stored - Consent record from consent-storage.
+ *   Expected shape: `{ onboardingDone, consentVersion, consentDate }`.
+ *   Missing fields are tolerated.
+ * @param {string} [args.requiredVersion] - Override the required version
+ *   (testing). Defaults to REQUIRED_CONSENT_VERSION.
+ * @param {ReadonlyArray<object>} [args.manifest] - Override the manifest
+ *   (testing). Defaults to CONSENT_VERSION_MANIFEST.
+ * @returns {{
+ *   status: ConsentStatus,
+ *   requiredVersion: string,
+ *   acceptedVersion: string | null,
+ * }}
+ */
+export function evaluate({
+  stored,
+  requiredVersion = REQUIRED_CONSENT_VERSION,
+  manifest = CONSENT_VERSION_MANIFEST,
+}) {
+  // Never accepted: no record at all, or onboardingDone is false.
+  if (!stored || !stored.onboardingDone) {
+    return { status: "never-accepted", requiredVersion, acceptedVersion: null };
+  }
+
+  const acceptedVersion = stored.consentVersion || null;
+
+  // Legacy install with no consentVersion — treat as valid (fail-open).
+  // Such records exist from before the version field was wired.
+  if (!acceptedVersion) {
+    return { status: "valid", requiredVersion, acceptedVersion: null };
+  }
+
+  // Already at or past required — no prompt.
+  if (compareVersions(acceptedVersion, requiredVersion) >= 0) {
+    return { status: "valid", requiredVersion, acceptedVersion };
+  }
+
+  // Behind. Walk the manifest to determine soft vs hard.
+  const requiredIdx = manifest.findIndex(m => m.version === requiredVersion);
+  if (requiredIdx === -1) {
+    // Required version not in the manifest — malformed config. Fail
+    // open: do not punish the user for our config bug.
+    return { status: "valid", requiredVersion, acceptedVersion };
+  }
+
+  const acceptedIdx = manifest.findIndex(m => m.version === acceptedVersion);
+  if (acceptedIdx === -1) {
+    // User accepted a version not in the current manifest (e.g. a
+    // retired entry). Fail open.
+    return { status: "valid", requiredVersion, acceptedVersion };
+  }
+
+  if (acceptedIdx >= requiredIdx) {
+    // Defensive: catches the case where compareVersions said "behind"
+    // but manifest order says otherwise (mis-ordered manifest).
+    return { status: "valid", requiredVersion, acceptedVersion };
+  }
+
+  // Walk every intermediate version from accepted+1 to required
+  // (inclusive). If any is material, the cumulative result is hard.
+  let hasMaterial = false;
+  for (let i = acceptedIdx + 1; i <= requiredIdx; i++) {
+    if (manifest[i].additive === false) {
+      hasMaterial = true;
+      break;
+    }
+  }
+
+  return {
+    status: hasMaterial ? "hard-reonboard" : "soft-reonboard",
+    requiredVersion,
+    acceptedVersion,
+  };
+}

--- a/src/lib/consent-version-manifest.js
+++ b/src/lib/consent-version-manifest.js
@@ -1,0 +1,52 @@
+/**
+ * MUGA: Consent Version Manifest (#365)
+ *
+ * Append-only declarative list of all known Terms of Service versions.
+ * Each entry describes one version and whether the change since the
+ * prior version was *additive* (new clauses on top of existing ones,
+ * eligible for soft re-onboard) or *material* (changes existing terms,
+ * requires hard re-onboard).
+ *
+ * **Append-only invariant**: never delete or edit a published entry.
+ * Once shipped in a release, an entry must remain so a user upgrading
+ * across many versions encounters a coherent history of decisions.
+ *
+ * Adding a new version:
+ *
+ *   1. Append a new entry at the end with the next version string.
+ *   2. Set `additive: true` if the change only adds clauses; `false` if
+ *      it modifies or removes existing terms (material change).
+ *   3. Bump REQUIRED_CONSENT_VERSION below to match the new entry.
+ *   4. Update the onboarding page's CONSENT_VERSION constant to match.
+ *   5. Update the user-visible ToS document.
+ *
+ * Once REQUIRED_CONSENT_VERSION points at the new entry, ConsentPolicy
+ * will fire `soft-reonboard` or `hard-reonboard` on the next service
+ * worker wake for users who accepted an earlier version.
+ */
+
+/**
+ * @typedef {Object} ConsentVersionEntry
+ * @property {string} version - Semver-like "x.y.z" version string.
+ * @property {boolean} additive - True if the change since the prior
+ *   entry only added new clauses (eligible for soft re-onboard); false
+ *   if existing terms were modified or removed (hard re-onboard).
+ *   The first (baseline) entry's value is meaningless and conventionally
+ *   set to `false` so a missing manifest cannot accidentally trigger
+ *   soft re-onboard.
+ */
+
+/** @type {ReadonlyArray<ConsentVersionEntry>} */
+export const CONSENT_VERSION_MANIFEST = Object.freeze([
+  Object.freeze({
+    version: "1.0",
+    additive: false, // baseline; flag is meaningless for the first entry
+  }),
+]);
+
+/**
+ * The version of the ToS the running code requires. Set during release
+ * to the latest entry in CONSENT_VERSION_MANIFEST. ConsentPolicy uses
+ * this to decide whether a stored consent record is still current.
+ */
+export const REQUIRED_CONSENT_VERSION = "1.0";

--- a/tests/unit/consent-policy.test.mjs
+++ b/tests/unit/consent-policy.test.mjs
@@ -1,0 +1,162 @@
+/**
+ * MUGA — consent-policy (#365)
+ *
+ * Pure-logic tests for the version-comparison gate. Every status branch
+ * covered: never-accepted, valid, soft-reonboard, hard-reonboard, plus
+ * the fail-open edge cases (legacy install with no version, malformed
+ * manifest, retired accepted version).
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { evaluate } from "../../src/lib/consent-policy.js";
+import { CONSENT_VERSION_MANIFEST } from "../../src/lib/consent-version-manifest.js";
+
+// Fixture manifests for testing scenarios beyond the current single-entry baseline.
+const MANIFEST_TWO_ADDITIVE = Object.freeze([
+  Object.freeze({ version: "1.0", additive: false }),
+  Object.freeze({ version: "1.1", additive: true }),
+]);
+
+const MANIFEST_TWO_MATERIAL = Object.freeze([
+  Object.freeze({ version: "1.0", additive: false }),
+  Object.freeze({ version: "2.0", additive: false }),
+]);
+
+const MANIFEST_THREE_MIXED = Object.freeze([
+  Object.freeze({ version: "1.0", additive: false }),
+  Object.freeze({ version: "1.1", additive: true }),  // additive
+  Object.freeze({ version: "2.0", additive: false }), // material
+]);
+
+describe("consent-policy — never-accepted", () => {
+  test("no stored record at all", () => {
+    const r = evaluate({ stored: null, requiredVersion: "1.0", manifest: CONSENT_VERSION_MANIFEST });
+    assert.equal(r.status, "never-accepted");
+    assert.equal(r.acceptedVersion, null);
+  });
+
+  test("stored record with onboardingDone false", () => {
+    const r = evaluate({
+      stored: { onboardingDone: false, consentVersion: null, consentDate: null },
+      requiredVersion: "1.0",
+      manifest: CONSENT_VERSION_MANIFEST,
+    });
+    assert.equal(r.status, "never-accepted");
+  });
+
+  test("undefined stored", () => {
+    const r = evaluate({ stored: undefined });
+    assert.equal(r.status, "never-accepted");
+  });
+});
+
+describe("consent-policy — valid", () => {
+  test("accepted version equals required version", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "1.0" },
+      requiredVersion: "1.0",
+      manifest: CONSENT_VERSION_MANIFEST,
+    });
+    assert.equal(r.status, "valid");
+    assert.equal(r.acceptedVersion, "1.0");
+  });
+
+  test("accepted version greater than required (defensive)", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "2.0" },
+      requiredVersion: "1.0",
+      manifest: CONSENT_VERSION_MANIFEST,
+    });
+    assert.equal(r.status, "valid");
+  });
+
+  test("legacy record with onboardingDone but no consentVersion → fail-open valid", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: null, consentDate: null },
+      requiredVersion: "1.0",
+      manifest: CONSENT_VERSION_MANIFEST,
+    });
+    assert.equal(r.status, "valid");
+    assert.equal(r.acceptedVersion, null);
+  });
+});
+
+describe("consent-policy — soft-reonboard (additive bump)", () => {
+  test("user at 1.0, required 1.1 with additive: true", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "1.0" },
+      requiredVersion: "1.1",
+      manifest: MANIFEST_TWO_ADDITIVE,
+    });
+    assert.equal(r.status, "soft-reonboard");
+    assert.equal(r.acceptedVersion, "1.0");
+    assert.equal(r.requiredVersion, "1.1");
+  });
+});
+
+describe("consent-policy — hard-reonboard (material bump)", () => {
+  test("user at 1.0, required 2.0 with additive: false", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "1.0" },
+      requiredVersion: "2.0",
+      manifest: MANIFEST_TWO_MATERIAL,
+    });
+    assert.equal(r.status, "hard-reonboard");
+  });
+
+  test("user at 1.0, required 2.0 with one additive and one material in between → hard wins", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "1.0" },
+      requiredVersion: "2.0",
+      manifest: MANIFEST_THREE_MIXED,
+    });
+    // Path: 1.0 → 1.1 (additive) → 2.0 (material). Material along the way → hard.
+    assert.equal(r.status, "hard-reonboard");
+  });
+
+  test("user at 1.1 (additive), required 2.0 (material) — material gate", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "1.1" },
+      requiredVersion: "2.0",
+      manifest: MANIFEST_THREE_MIXED,
+    });
+    assert.equal(r.status, "hard-reonboard");
+  });
+});
+
+describe("consent-policy — fail-open edge cases", () => {
+  test("required version not in manifest → valid (config bug, do not punish user)", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "1.0" },
+      requiredVersion: "9.9", // not in manifest
+      manifest: CONSENT_VERSION_MANIFEST,
+    });
+    assert.equal(r.status, "valid");
+  });
+
+  test("accepted version retired from manifest → valid", () => {
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "0.5" }, // not in current manifest
+      requiredVersion: "1.0",
+      manifest: CONSENT_VERSION_MANIFEST,
+    });
+    assert.equal(r.status, "valid");
+  });
+});
+
+describe("consent-policy — defaults from CONSENT_VERSION_MANIFEST", () => {
+  test("called with only stored (uses default required + manifest)", () => {
+    // The default manifest currently has only "1.0". A user accepted at
+    // "1.0" should be valid against the default.
+    const r = evaluate({
+      stored: { onboardingDone: true, consentVersion: "1.0" },
+    });
+    assert.equal(r.status, "valid");
+    assert.equal(r.requiredVersion, "1.0");
+  });
+
+  test("never-accepted with defaults", () => {
+    const r = evaluate({ stored: null });
+    assert.equal(r.status, "never-accepted");
+  });
+});

--- a/tests/unit/consent-version-manifest.test.mjs
+++ b/tests/unit/consent-version-manifest.test.mjs
@@ -1,0 +1,74 @@
+/**
+ * MUGA — consent-version-manifest schema (#365)
+ *
+ * Validates the manifest's append-only invariant and shape. Runs
+ * against the live manifest so any future addition is checked
+ * automatically.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CONSENT_VERSION_MANIFEST,
+  REQUIRED_CONSENT_VERSION,
+} from "../../src/lib/consent-version-manifest.js";
+import { compareVersions } from "../../src/lib/migration-evaluator.js";
+
+const SEMVER_RE = /^\d+(\.\d+){0,2}$/;
+
+describe("consent-version-manifest — shape", () => {
+  test("CONSENT_VERSION_MANIFEST is a frozen array", () => {
+    assert.ok(Array.isArray(CONSENT_VERSION_MANIFEST));
+    assert.ok(Object.isFrozen(CONSENT_VERSION_MANIFEST));
+  });
+
+  test("manifest has at least one entry", () => {
+    assert.ok(CONSENT_VERSION_MANIFEST.length >= 1);
+  });
+
+  test("REQUIRED_CONSENT_VERSION is a non-empty string", () => {
+    assert.equal(typeof REQUIRED_CONSENT_VERSION, "string");
+    assert.ok(REQUIRED_CONSENT_VERSION.length > 0);
+  });
+
+  test("REQUIRED_CONSENT_VERSION is present in the manifest", () => {
+    const found = CONSENT_VERSION_MANIFEST.find(m => m.version === REQUIRED_CONSENT_VERSION);
+    assert.ok(found, `REQUIRED_CONSENT_VERSION "${REQUIRED_CONSENT_VERSION}" must be a manifest entry`);
+  });
+});
+
+describe("consent-version-manifest — entry validation", () => {
+  for (const entry of CONSENT_VERSION_MANIFEST) {
+    describe(`entry "${entry.version}"`, () => {
+      test("is frozen", () => {
+        assert.ok(Object.isFrozen(entry), "entries must be Object.freeze()'d for the append-only invariant");
+      });
+
+      test("version is well-formed semver", () => {
+        assert.match(entry.version, SEMVER_RE);
+      });
+
+      test("additive is a boolean", () => {
+        assert.equal(typeof entry.additive, "boolean");
+      });
+    });
+  }
+});
+
+describe("consent-version-manifest — global invariants", () => {
+  test("versions are unique", () => {
+    const versions = CONSENT_VERSION_MANIFEST.map(m => m.version);
+    const uniq = new Set(versions);
+    assert.equal(versions.length, uniq.size, "duplicate version detected in manifest");
+  });
+
+  test("manifest is in ascending version order", () => {
+    for (let i = 1; i < CONSENT_VERSION_MANIFEST.length; i++) {
+      const prev = CONSENT_VERSION_MANIFEST[i - 1].version;
+      const curr = CONSENT_VERSION_MANIFEST[i].version;
+      assert.ok(
+        compareVersions(curr, prev) > 0,
+        `manifest must be ascending; found ${curr} after ${prev}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #365.

Adds the version-comparison gate that #348 needs to support re-onboarding when the ToS changes. **Dormant in this slice** — the manifest holds only `1.0` so user-visible behaviour is unchanged. Slice #370 builds the delta / material rendering modes that consume the new statuses.

## New modules

- **`src/lib/consent-version-manifest.js`** — append-only declarative list of ToS versions. Each entry: `{ version, additive }`. Frozen for the invariant. Also exports `REQUIRED_CONSENT_VERSION`.
- **`src/lib/consent-policy.js`** — pure `evaluate({ stored })` function. Returns one of four statuses:
  - `never-accepted` — no record / onboardingDone false
  - `valid` — accepted >= required
  - `soft-reonboard` — accepted older, every intermediate entry is `additive: true`
  - `hard-reonboard` — accepted older, at least one intermediate entry is material

  Fail-open on edge cases (legacy records with no consentVersion; required version missing from manifest; accepted version retired) — never punish the user for a config bug.

## Service worker

- New `shouldOpenOnboarding(prefs)` helper consults `ConsentPolicy`. Both `onInstalled` and the background-load fallback now call this single decision function. Behaviour today: identical to before (manifest at `1.0` only).

## Test plan

- [x] 2382 tests pass (2349 base + 33 new).
- [x] Every status branch covered: `never-accepted`, `valid` (×3 variants including legacy fail-open), `soft-reonboard`, `hard-reonboard` (single material + mixed additive+material), and fail-open edges (required missing, accepted retired).
- [x] Manifest schema test enforces frozen entries + version uniqueness + ascending order + `REQUIRED_CONSENT_VERSION` validity.
- [ ] Manual smoke: load extension with `consentVersion: '1.0'` and confirm no re-onboarding fires.

Wave 2 of the post-grill rollout (engram observation #190).