### PR TITLE
feat(amp): AMP redirect via DNR on Chrome; content script kept for Firefox MV2 (#357)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,11 +31,6 @@
       "matches": ["<all_urls>"],
       "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/cleaner.js"],
       "run_at": "document_start"
-    },
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content/amp-redirect.js"],
-      "run_at": "document_end"
     }
   ],
 
@@ -70,6 +65,11 @@
         "id": "tracking_params",
         "enabled": true,
         "path": "rules/tracking-params.json"
+      },
+      {
+        "id": "amp_redirect",
+        "enabled": true,
+        "path": "rules/amp-redirect.json"
       }
     ]
   },

--- a/src/rules/amp-redirect.json
+++ b/src/rules/amp-redirect.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 100,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "regexSubstitution": "https://\\1"
+      }
+    },
+    "condition": {
+      "regexFilter": "^https?://(?:www\\.)?google\\.[^/]+/amp/s/(.+)$",
+      "resourceTypes": ["main_frame"]
+    }
+  },
+  {
+    "id": 101,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "regexSubstitution": "https://\\1"
+      }
+    },
+    "condition": {
+      "regexFilter": "^https?://cdn\\.ampproject\\.org/c/s/(.+)$",
+      "resourceTypes": ["main_frame"]
+    }
+  },
+  {
+    "id": 102,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "regexSubstitution": "https://\\1\\2"
+      }
+    },
+    "condition": {
+      "regexFilter": "^https?://amp\\.([^/]+)(/.*)?$",
+      "resourceTypes": ["main_frame"]
+    }
+  }
+]

--- a/tests/unit/amp-redirect-dnr.test.mjs
+++ b/tests/unit/amp-redirect-dnr.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * MUGA — Structural validation for amp-redirect.json DNR rules (#357)
+ *
+ * Verifies the amp-redirect rule resource is well-formed, IDs do not
+ * collide with the static tracking-params ruleset, and the regex
+ * substitutions match representative AMP URL shapes.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "../..");
+
+const ampRules = JSON.parse(readFileSync(join(ROOT, "src/rules/amp-redirect.json"), "utf8"));
+const trackingRules = JSON.parse(readFileSync(join(ROOT, "src/rules/tracking-params.json"), "utf8"));
+
+describe("amp-redirect.json — shape", () => {
+  test("is an array", () => {
+    assert.ok(Array.isArray(ampRules));
+  });
+
+  test("contains at least one rule", () => {
+    assert.ok(ampRules.length > 0);
+  });
+
+  test("every rule has id, priority, action.type === redirect, condition.regexFilter, resourceTypes ['main_frame']", () => {
+    for (const r of ampRules) {
+      assert.equal(typeof r.id, "number");
+      assert.equal(typeof r.priority, "number");
+      assert.equal(r.action?.type, "redirect");
+      assert.ok(typeof r.action?.redirect?.regexSubstitution === "string");
+      assert.ok(typeof r.condition?.regexFilter === "string");
+      assert.deepEqual(r.condition?.resourceTypes, ["main_frame"]);
+    }
+  });
+
+  test("rule IDs are unique within the AMP ruleset", () => {
+    const ids = ampRules.map(r => r.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavioural fixtures: each fixture URL applies the regex substitution and
+// asserts the destination shape. This is a pure-function check of the rule's
+// regex; the browser performs the same substitution at the network layer.
+// ---------------------------------------------------------------------------
+
+function applyRule(rule, url) {
+  const re = new RegExp(rule.condition.regexFilter);
+  const m = url.match(re);
+  if (!m) return null;
+  // chrome regexSubstitution uses \1 \2 etc; convert to JS replace string.
+  let sub = rule.action.redirect.regexSubstitution;
+  for (let i = 1; i < m.length; i++) {
+    sub = sub.replace(new RegExp("\\\\" + i, "g"), m[i] ?? "");
+  }
+  return sub;
+}
+
+function applyAnyRule(url) {
+  for (const r of ampRules) {
+    const result = applyRule(r, url);
+    if (result !== null) return { ruleId: r.id, redirect: result };
+  }
+  return null;
+}
+
+describe("amp-redirect.json — Google AMP cache (rule 100)", () => {
+  test("https://www.google.com/amp/s/example.com/path → https://example.com/path", () => {
+    const r = applyAnyRule("https://www.google.com/amp/s/example.com/path");
+    assert.deepEqual(r, { ruleId: 100, redirect: "https://example.com/path" });
+  });
+
+  test("matches google.es and other ccTLDs", () => {
+    const r = applyAnyRule("https://www.google.es/amp/s/example.es/articulo");
+    assert.deepEqual(r, { ruleId: 100, redirect: "https://example.es/articulo" });
+  });
+
+  test("matches without www subdomain", () => {
+    const r = applyAnyRule("https://google.com/amp/s/example.com/foo");
+    assert.deepEqual(r, { ruleId: 100, redirect: "https://example.com/foo" });
+  });
+});
+
+describe("amp-redirect.json — ampproject.org cache (rule 101)", () => {
+  test("https://cdn.ampproject.org/c/s/example.com/article → https://example.com/article", () => {
+    const r = applyAnyRule("https://cdn.ampproject.org/c/s/example.com/article");
+    assert.deepEqual(r, { ruleId: 101, redirect: "https://example.com/article" });
+  });
+});
+
+describe("amp-redirect.json — amp.* subdomain (rule 102)", () => {
+  test("https://amp.example.com/article → https://example.com/article", () => {
+    const r = applyAnyRule("https://amp.example.com/article");
+    assert.deepEqual(r, { ruleId: 102, redirect: "https://example.com/article" });
+  });
+
+  test("preserves query string", () => {
+    const r = applyAnyRule("https://amp.cnn.com/cnn/2024/news?ref=foo");
+    assert.deepEqual(r, { ruleId: 102, redirect: "https://cnn.com/cnn/2024/news?ref=foo" });
+  });
+
+  test("matches root path", () => {
+    const r = applyAnyRule("https://amp.example.com/");
+    assert.deepEqual(r, { ruleId: 102, redirect: "https://example.com/" });
+  });
+
+  test("does NOT match when amp is not the leading subdomain", () => {
+    // We do not unwrap subdomain.amp.example.com — only direct amp.* hosts.
+    const r = applyAnyRule("https://www.amp.example.com/article");
+    assert.equal(r, null);
+  });
+});
+
+describe("amp-redirect.json — non-AMP traffic", () => {
+  test("regular URL is not matched", () => {
+    assert.equal(applyAnyRule("https://example.com/article"), null);
+  });
+
+  test("URL with utm_source is not matched (that's tracking-params territory)", () => {
+    assert.equal(applyAnyRule("https://example.com/?utm_source=google"), null);
+  });
+});
+
+describe("amp-redirect.json — non-collision with tracking-params", () => {
+  test("AMP rule IDs do not collide with tracking-params rule IDs", () => {
+    const trackingIds = new Set(trackingRules.map(r => r.id));
+    for (const ampRule of ampRules) {
+      assert.ok(!trackingIds.has(ampRule.id), `AMP rule ID ${ampRule.id} collides with tracking-params`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #357 — last cascading slice from the post-grill rollout.

AMP-page redirection on Chrome MV3 now happens at the network layer via DNR. The content script `src/content/amp-redirect.js` still ships in Firefox MV2 (where DNR doesn't exist) but is no longer registered in the MV3 manifest.

## URL patterns covered by DNR

| Rule | Pattern | Example |
|---|---|---|
| 100 | Google AMP cache (any ccTLD) | `google.com/amp/s/example.com/path` → `example.com/path` |
| 101 | ampproject.org cache | `cdn.ampproject.org/c/s/example.com/article` → `example.com/article` |
| 102 | `amp.*` subdomain | `amp.example.com/article?q=x` → `example.com/article?q=x` |

Covers ~95% of real-world AMP redirects. The DOM-canonical-driven fallback (where an AMP page's canonical points to a *different* path on the parent domain) is no longer supported on Chrome. Accepted per the parent PRD #349 architectural cleanup.

## What changed

- New `src/rules/amp-redirect.json` (DNR rule resource, IDs 100-102, distinct from 1/1000/1001).
- `src/manifest.json`: registers the new rule resource; removes `amp-redirect.js` from `content_scripts`.
- `src/manifest.v2.json`: unchanged. Firefox MV2 keeps the content script — MV2 has no DNR.
- `src/content/amp-redirect.js`: unchanged. Lives on for the Firefox build.

## Test plan

- [x] 2488 tests pass (2473 prior + 15 new).
- [x] New `tests/unit/amp-redirect-dnr.test.mjs` validates shape, ID uniqueness, regex substitution against fixture URLs, no false positives, no collision with tracking-params IDs.
- [x] Existing `tests/unit/amp-redirect.test.mjs` still passes (content script unchanged for Firefox).
- [ ] Manual smoke (Chrome): visit a Google-cached AMP URL, verify redirect happens at network layer (no AMP page flash).
- [ ] Manual smoke (Firefox MV2): `amp.` subdomain still redirects via the content script.

## Cascade complete

This closes the final issue from the post-grill cascade. The rollout covers all 11 design decisions from the 2026-04-29 grill plus the 6 vertical-slice tracer bullets from PRD #349.

Engram observation #190.