### PR TITLE
feat(i18n): missing-translations diff tool + CONTRIBUTING policy (#361)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,24 @@ Before adding to `preserveParams`, consider:
 
 The consistency test catches the rule-level violation. It does not catch poor judgment about scope. That is your call — this section exists so the call is made deliberately.
 
+## Translations
+
+MUGA ships UI in English, Spanish, Portuguese, and German. The maintainer is a native Spanish speaker (English fluent); PT and DE are best-effort. The project's policy is:
+
+- **Officially maintained**: `en` and `es`. Every translation key in `src/lib/i18n.js` must have a non-empty value in both. The completeness test in `tests/unit/i18n-completeness.test.mjs` enforces this floor — a PR that adds a key without an EN+ES pair fails CI.
+
+- **Community-maintained**: `pt` and `de`. New keys may ship without these initially; the runtime fallback chain at `i18n.js:281` lands missing entries on EN cleanly. PT and DE PRs do not require native-speaker review by the maintainer (the maintainer is not a native speaker of either) — the EN+ES floor is what gates a merge.
+
+To find which keys are missing in PT or DE, run:
+
+```bash
+node tools/missing-translations.mjs           # both languages
+node tools/missing-translations.mjs pt        # PT only
+node tools/missing-translations.mjs de        # DE only
+```
+
+The script's output is markdown suitable for pasting into the per-language tracking issues. Submit a PR editing the matching entries in `TRANSLATIONS` and the CI suite will validate the EN+ES floor for you.
+
 ## Adding affiliate stores
 
 Edit `src/lib/affiliates.js` and add an entry to `AFFILIATE_PATTERNS`:

--- a/tests/unit/missing-translations.test.mjs
+++ b/tests/unit/missing-translations.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * MUGA — missing-translations smoke test (#361)
+ *
+ * Validates the diff tool's output format. Uses the live TRANSLATIONS
+ * for the structural shape checks, not a fixture, because the tool's
+ * value is precisely about producing stable output for the live data.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { missingKeys, formatReport } from "../../tools/missing-translations.mjs";
+
+describe("missing-translations — missingKeys()", () => {
+  test("returns an array", () => {
+    assert.ok(Array.isArray(missingKeys("pt")));
+    assert.ok(Array.isArray(missingKeys("de")));
+  });
+
+  test("returns deterministically (idempotent — same input, same output)", () => {
+    const a = missingKeys("pt");
+    const b = missingKeys("pt");
+    assert.deepEqual(a, b);
+  });
+
+  test("returns no entries for the EN baseline (every key has en)", () => {
+    // Reuses the same logic but against EN — should never report missing.
+    // The completeness test (#359) enforces this floor; this is a
+    // double-check that missingKeys treats EN consistently.
+    const en = missingKeys("en");
+    assert.equal(en.length, 0);
+  });
+
+  test("unknown locale returns ALL keys (no entry for that locale anywhere)", () => {
+    const fake = missingKeys("xx");
+    // Must report every key, since no entry has an "xx" slot.
+    assert.ok(fake.length > 0);
+  });
+});
+
+describe("missing-translations — formatReport()", () => {
+  test("returns a non-empty markdown string for PT", () => {
+    const out = formatReport("pt");
+    assert.equal(typeof out, "string");
+    assert.ok(out.length > 0);
+    assert.ok(out.startsWith("# PT translations needed"));
+  });
+
+  test("returns a non-empty markdown string for DE", () => {
+    const out = formatReport("de");
+    assert.equal(typeof out, "string");
+    assert.ok(out.length > 0);
+    assert.ok(out.startsWith("# DE translations needed"));
+  });
+
+  test("output is deterministic across calls", () => {
+    const a = formatReport("pt");
+    const b = formatReport("pt");
+    assert.equal(a, b);
+  });
+
+  test("output mentions the regenerate command", () => {
+    const out = formatReport("pt");
+    assert.ok(out.includes("node tools/missing-translations.mjs pt"));
+  });
+
+  test("output does NOT contain unresolved template placeholders", () => {
+    const out = formatReport("pt");
+    assert.ok(!out.includes("${langLabel}"), "Found unresolved ${langLabel} placeholder");
+    assert.ok(!out.includes("${lang}"), "Found unresolved ${lang} placeholder");
+  });
+});

--- a/tools/missing-translations.mjs
+++ b/tools/missing-translations.mjs
@@ -1,0 +1,91 @@
+/**
+ * MUGA: Missing-translations diff tool (#361)
+ *
+ * Reads `src/lib/i18n.js` and produces, for each community-maintained
+ * language (PT, DE), a markdown bullet list of i18n keys that are
+ * missing or empty in that language. The output is suitable for
+ * pasting into the per-language tracking issues.
+ *
+ * Usage:
+ *   node tools/missing-translations.mjs           # both languages, stdout
+ *   node tools/missing-translations.mjs pt        # PT only
+ *   node tools/missing-translations.mjs de        # DE only
+ *
+ * Idempotent: same input → same output. Keys are emitted in the order
+ * they appear in TRANSLATIONS.
+ */
+import { TRANSLATIONS } from "../src/lib/i18n.js";
+
+const COMMUNITY_LOCALES = ["pt", "de"];
+
+/**
+ * Returns the list of keys missing in `lang`. A key is "missing" if
+ * its locale slot is undefined, null, or an empty string after trim.
+ *
+ * @param {string} lang - The locale code to check.
+ * @returns {string[]} Keys missing in this locale, in declaration order.
+ */
+export function missingKeys(lang) {
+  const out = [];
+  for (const [key, entry] of Object.entries(TRANSLATIONS)) {
+    const val = entry?.[lang];
+    if (typeof val !== "string" || val.trim() === "") out.push(key);
+  }
+  return out;
+}
+
+/**
+ * Produces a markdown report for one language. Suitable for direct
+ * paste into a GitHub issue body.
+ */
+export function formatReport(lang) {
+  const missing = missingKeys(lang);
+  const total = Object.keys(TRANSLATIONS).length;
+  const langLabel = lang.toUpperCase();
+
+  const lines = [];
+  lines.push(`# ${langLabel} translations needed`);
+  lines.push("");
+  if (missing.length === 0) {
+    lines.push(`All ${total} translation keys are present in ${langLabel}. Nothing to do at the moment.`);
+    lines.push("");
+    lines.push(`This issue is kept open as a tracking point. When new keys are added without a ${langLabel} value, regenerate this list with:`);
+    lines.push("");
+    lines.push("```bash");
+    lines.push(`node tools/missing-translations.mjs ${lang}`);
+    lines.push("```");
+    return lines.join("\n");
+  }
+
+  lines.push(`${missing.length} of ${total} keys missing in ${langLabel}. Each key below needs a translation in \`src/lib/i18n.js\`.`);
+  lines.push("");
+  lines.push("**Contribution flow:** edit the matching entry in `TRANSLATIONS`, run `npm test`, open a PR. PT and DE PRs do not need native-speaker review by the maintainer (the maintainer is not a native speaker of either) — the EN+ES floor enforced by the test suite is what gates a merge.");
+  lines.push("");
+  lines.push("## Missing keys");
+  lines.push("");
+  for (const key of missing) {
+    lines.push(`- [ ] \`${key}\``);
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push("Regenerate this list:");
+  lines.push("```bash");
+  lines.push(`node tools/missing-translations.mjs ${lang}`);
+  lines.push("```");
+  return lines.join("\n");
+}
+
+// CLI entry. Skipped when this module is imported (e.g. by the smoke test).
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, "/")}` || import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  const arg = (process.argv[2] || "").toLowerCase();
+  const targets = arg ? [arg] : COMMUNITY_LOCALES;
+  for (const lang of targets) {
+    if (!COMMUNITY_LOCALES.includes(lang)) {
+      console.error(`Unknown locale: ${lang}. Valid: ${COMMUNITY_LOCALES.join(", ")}`);
+      process.exit(1);
+    }
+    process.stdout.write(formatReport(lang));
+    process.stdout.write("\n\n");
+  }
+}


### PR DESCRIPTION
Closes #361. Last AFK leaf of the i18n PRD #351.

Adds `tools/missing-translations.mjs` — small node script that reads `src/lib/i18n.js` and outputs a markdown report of keys missing in PT or DE (the community-maintained locales). Output is deterministic and suitable for paste into per-language tracking issues.

`CONTRIBUTING.md` gains a 'Translations' section documenting the EN+ES official / PT+DE community policy, the runtime fallback contract, the relaxed PT/DE PR review policy, and the script.

Smoke test covers: deterministic output, EN baseline cross-check (no missing), unknown-locale reports all keys, formatReport produces well-formed markdown without unresolved template placeholders.

## Test plan

- [x] 2497 tests pass.
- [x] Output deterministic (verified by smoke test).
- [x] No unresolved template placeholders in output.
- [ ] Per-language tracking issues will be opened as a separate step (issue creation, not code).

Engram observation #190.