### PR TITLE
docs(i18n): public disclosure — EN+ES official, PT+DE community-maintained (#360)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The popup shows what MUGA cleaned on the current page: which parameters were rem
 
 ![Popup showing cleaned URL on a store page](docs/assets/screenshot-ss2-popup.png)
 
-Settings give you full control: affiliate behavior, per-domain rules, blacklists, whitelists, and advanced features. Available in English, Spanish, Portuguese, and German.
+Settings give you full control: affiliate behavior, per-domain rules, blacklists, whitelists, and advanced features. The UI ships in English and Spanish (officially maintained); Portuguese and German are community-contributed and may have gaps that fall back to English.
 
 ![Settings page](docs/assets/screenshot-ss3-options.png)
 
@@ -117,7 +117,7 @@ Settings give you full control: affiliate behavior, per-domain rules, blacklists
 - Toast notification when a third-party affiliate is detected (opt-in)
 - **Remote rule updates**: weekly signed updates to the tracking-param list from a public GitHub Pages endpoint. **Off by default while the signing infrastructure stabilizes** — the default may flip in a future release; the [CHANGELOG](CHANGELOG.md) will record the change when it happens. The fetch is a plain GET to a public URL — no user data is sent.
 - Export / Import settings as JSON
-- 4 languages: English, Spanish, Portuguese, German
+- Languages: English and Spanish (officially maintained), Portuguese and German (community-contributed; missing entries fall back to English)
 
 ---
 

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -142,7 +142,7 @@ YOUR RULES
 . Strip all third-party affiliates: one toggle to remove every affiliate tag globally
 . Per-domain disable: opt entire domains out of MUGA
 . Export / Import settings as JSON: back up or move your config across devices
-. Language: English, Spanish, Portuguese, German — switchable any time
+. Languages: English and Spanish (officially maintained), Portuguese and German (community-contributed; missing entries fall back to English) — switchable any time
 . Settings sync across Chrome devices automatically
 
 
@@ -254,7 +254,7 @@ Your rules
 . Strip all third-party affiliates: one toggle to remove every affiliate tag globally
 . Per-domain disable: opt entire domains out of MUGA
 . Export/Import settings as JSON
-. English, Spanish, Portuguese, German — switchable any time
+. Languages: English and Spanish (officially maintained), Portuguese and German (community-contributed; missing entries fall back to English) — switchable any time
 
 
 Open source. GPL v3. Read every line.

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -133,6 +133,9 @@ export const TRANSLATIONS = {
   section_language: { en: "Language", es: "Idioma", pt: "Idioma", de: "Sprache" },
   lang_label:  { en: "Display language", es: "Idioma de la interfaz", pt: "Idioma da interface", de: "Anzeigesprache" },
   lang_hint:   { en: "Affects the popup and settings page. Does not affect URL processing.", es: "Afecta al popup y a esta página. No afecta al procesamiento de URLs.", pt: "Afeta o popup e a página de configurações. Não afeta o processamento de URLs.", de: "Betrifft das Popup und die Einstellungsseite. Hat keinen Einfluss auf die URL-Verarbeitung." },
+  // Community-maintained note (#360). Surfaces when PT or DE is selected so
+  // users understand the support level they should expect for those locales.
+  lang_community_note: { en: "Community-maintained — contributions welcome.", es: "Mantenido por la comunidad — se aceptan contribuciones.", pt: "Mantido pela comunidade — contribuições são bem-vindas.", de: "Von der Community gepflegt — Beiträge willkommen." },
 
   row_dnr_label:         { en: "Strip tracking parameters before navigation", es: "Eliminar parámetros de rastreo antes de navegar", pt: "Remover parâmetros de rastreamento antes de navegar", de: "Tracking-Parameter vor der Navigation entfernen" },
   row_dnr_hint:          { en: "Cleans URLs as you type in the address bar, from bookmarks, and links from other apps. Before the page loads.", es: "Limpia URLs mientras escribes en la barra de direcciones, desde marcadores y enlaces de otras apps. Antes de que cargue la página.", pt: "Limpa URLs enquanto você digita na barra de endereços, de favoritos e links de outros apps. Antes de a página carregar.", de: "Bereinigt URLs während du in der Adressleiste tippst, aus Lesezeichen und Links aus anderen Apps. Vor dem Laden der Seite." },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -86,6 +86,7 @@
         <div class="row-label">
           <strong data-i18n="lang_label">Display language</strong>
           <small data-i18n="lang_hint">Affects the popup and settings page. Does not affect URL processing.</small>
+          <small id="lang-community-note" class="hint" data-i18n="lang_community_note" hidden>Community-maintained — contributions welcome.</small>
         </div>
         <select class="lang-select" id="lang-select" aria-label="Display language">
           <option value="en">English</option>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -402,9 +402,19 @@ function renderStores() {
 /** Initializes the language dropdown and binds change handler. */
 function initLanguageSelect() {
   const select = document.getElementById("lang-select");
+  const communityNote = document.getElementById("lang-community-note");
+  // Community-maintained languages (#360 / #351). Visible in the language
+  // section so users selecting PT or DE understand the support level they
+  // should expect.
+  const COMMUNITY_LANGS = new Set(["pt", "de"]);
+  function updateCommunityNote(lang) {
+    if (communityNote) communityNote.hidden = !COMMUNITY_LANGS.has(lang);
+  }
   select.value = _currentLang;
+  updateCommunityNote(_currentLang);
   select.addEventListener("change", async () => {
     _currentLang = select.value;
+    updateCommunityNote(_currentLang);
     try { await setPrefs({ language: _currentLang }); } catch (err) { console.error("[MUGA] save language:", err); }
     document.documentElement.lang = _currentLang;
     applyTranslations(_currentLang);


### PR DESCRIPTION
Closes #360. Last user-facing piece of the post-grill rollout.

Reframes the language-support claim across README, store-listing, and the Settings UI so users (and AMO/CWS reviewers) see the honest support level — matching the policy already in CONTRIBUTING.md and the completeness test from #359.

## What changed

- **README.md** — two language mentions reframed (lines 84 and 120). EN+ES officially maintained, PT+DE community-contributed with EN fallback.
- **`docs/store-listing.md`** — two language mentions reframed (lines 145 and 257). Store dashboard pulls from this at release time.
- **`src/options/options.html`** — Settings 'Language' section gains a small i18n note that surfaces only when PT or DE is the active language. Hidden by default.
- **`src/options/options.js`** — `initLanguageSelect()` toggles the note's hidden attribute on language change.
- **`src/lib/i18n.js`** — new key `lang_community_note` with all four locales. Tone: factual, not apologetic — "Community-maintained — contributions welcome."

## Test plan

- [x] 2492 tests pass. The new key satisfies the completeness floor (#359) — EN + ES non-empty, also PT + DE non-empty.
- [x] Tone reviewed (first-draft, please refine if you want a different voice).
- [ ] Manual smoke: open Settings, switch to PT or DE, verify note appears; switch back to EN/ES, verify note hides.
- [ ] Visual: verify the note placement on the Language card looks intentional (next to lang_hint, smaller text).

Engram observation #190.