### PR TITLE
test(e2e): SW lifecycle helpers + test-mode sentinel + __TEST__ handler (#398)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,23 @@ npm install
 ## Running tests
 
 ```bash
-npm test
+npm test               # unit tests (Node.js built-in test runner)
+npm run test:e2e       # Playwright e2e suite (Chromium, headed)
 ```
 
-Uses the Node.js built-in test runner. All tests live in `tests/unit/*.mjs`.
+Unit tests live under `tests/unit/*.mjs`. E2E specs live under `tests/e2e/*.spec.mjs` with shared helpers in `tests/e2e/helpers/`.
+
+### E2E test-mode sentinel
+
+The e2e suite needs to read state that is otherwise inaccessible from a content-script's world (the toolbar action surface, in particular). This is gated through a single `__TEST__`-prefixed runtime-message handler in the service worker, which short-circuits unless the sentinel `chrome.storage.local["__muga_test_mode"]` is set to `true`.
+
+Production builds **never** set the sentinel. The only setters are e2e fixtures (see `tests/e2e/helpers/storage.mjs`'s `installTestModeSentinel` / `clearTestModeSentinel`). Tests must clear the sentinel on teardown so subsequent tests in the same persistent context start clean.
+
+Adding a new `__TEST__` message handler:
+
+1. Add the case in `handleTestMessage` in `src/background/service-worker.js`.
+2. Document the read/write contract in the helper that calls it (under `tests/e2e/helpers/`).
+3. The gate (sentinel check) is shared, you do not re-implement it.
 
 ## Project structure
 

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -21,7 +21,7 @@ import {
 import { TRUSTED_PUBLIC_KEYS } from "../lib/remote-rules-keys.js";
 import { createToolbarEventBus } from "../lib/toolbar-event-bus.js";
 import { createTabPresenterState } from "../lib/tab-presenter-state.js";
-import { createToolbarPresenter } from "../lib/toolbar-presenter.js";
+import { createToolbarPresenter, iconForState } from "../lib/toolbar-presenter.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -397,6 +397,69 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
   }
 });
 
+// --- E2E test handlers (#398) ---
+//
+// Dispatched by the main message listener below when the message type
+// starts with "__TEST__" AND the test-mode sentinel is set in
+// chrome.storage.local. Production builds never set the sentinel, so
+// these handlers are unreachable at runtime in production.
+//
+// Each handler reads state that is otherwise inaccessible from a
+// content-script's world (e.g. chrome.action surface). Future slices
+// add handlers for fixture-manifest / fixture-migrations overrides.
+async function handleTestMessage(message, sender) {
+  switch (message.type) {
+    case "__TEST__readActionSurface": {
+      const tabId = Number(message.tabId);
+      if (!Number.isFinite(tabId) || tabId < 0) {
+        return { ok: false, error: "invalid tabId" };
+      }
+      // chrome.action.getXxx returns a Promise on Chrome MV3 (NOT callback-
+      // compatible there: passing a callback returns the Promise but the
+      // callback is never invoked). On Firefox MV2 browserAction.getXxx
+      // requires a callback. Detect by inspecting the return value.
+      const callGet = (apiName, fallback) => {
+        const method = actionApi[apiName];
+        if (typeof method !== "function") return Promise.resolve(fallback);
+        try {
+          const result = method.call(actionApi, { tabId });
+          if (result && typeof result.then === "function") {
+            return result.catch(() => fallback);
+          }
+          // Callback form: invoke with explicit resolver.
+          return new Promise(resolve => {
+            try { method.call(actionApi, { tabId }, resolve); }
+            catch { resolve(fallback); }
+          });
+        } catch {
+          return Promise.resolve(fallback);
+        }
+      };
+      const [title, badgeText, badgeColor] = await Promise.all([
+        callGet("getTitle", ""),
+        callGet("getBadgeText", ""),
+        callGet("getBadgeBackgroundColor", []),
+      ]);
+      // chrome.action has no getIcon — derive the variant from the
+      // presenter's per-tab state. iconForState is a pure function.
+      const tabState = toolbarState.get(tabId);
+      const iconPaths = iconForState(tabState);
+      const iconKind = (iconPaths && iconPaths === iconForState({ creatorReferralPreserved: true })) ? "preserved" : "default";
+      return {
+        ok: true,
+        title,
+        badgeText,
+        badgeColor,
+        iconKind,
+        iconPaths,
+        state: { ...tabState },
+      };
+    }
+    default:
+      return { ok: false, error: `unknown __TEST__ message: ${message.type}` };
+  }
+}
+
 // --- Main message listener from content scripts ---
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Validate that messages come from our own extension
@@ -407,6 +470,28 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       .then(prefs => sendResponse({ ...prefs, _affiliateDomains }))
       .catch(() => { try { sendResponse(null); } catch { /* channel closed */ } });
     return true;
+  }
+
+  // ── E2E test-mode handlers (#398) ───────────────────────────────────────
+  // Gated on chrome.storage.local["__muga_test_mode"]. Production builds
+  // never set this sentinel; e2e tests set it via installTestModeSentinel
+  // (tests/e2e/helpers/storage.mjs) and clear it on teardown. The handlers
+  // expose read-side state that is otherwise unreadable from a content
+  // script's world (toolbar action surface).
+  if (typeof message.type === "string" && message.type.startsWith("__TEST__")) {
+    chrome.storage.local.get({ __muga_test_mode: false }, (r) => {
+      if (!r.__muga_test_mode) {
+        try { sendResponse({ ok: false, error: "test mode not active" }); } catch { /* channel closed */ }
+        return;
+      }
+      handleTestMessage(message, sender)
+        .then(result => { try { sendResponse(result); } catch { /* channel closed */ } })
+        .catch(err => {
+          console.error("[MUGA] __TEST__ handler:", err);
+          try { sendResponse({ ok: false, error: String(err?.message || err) }); } catch { /* channel closed */ }
+        });
+    });
+    return true; // async response
   }
 
   if (message.type === "PROCESS_URL") {

--- a/tests/e2e/helpers/action-surface.mjs
+++ b/tests/e2e/helpers/action-surface.mjs
@@ -1,0 +1,42 @@
+/**
+ * MUGA E2E helper — toolbar action-surface inspection (#398)
+ *
+ * The chrome.action surface (toolbar tooltip, badge text, badge color,
+ * icon path) is not directly readable from a content script's world.
+ * This helper sends a `__TEST__readActionSurface` runtime message to
+ * the service worker, which calls the chrome.action read APIs and
+ * returns the values. The handler is gated by the test-mode sentinel
+ * (see installTestModeSentinel); production builds never expose it.
+ *
+ * Used by the toolbar-visibility e2e spec (#408 / #395-4) and by any
+ * future spec that needs to assert what the user sees on the toolbar.
+ */
+
+/**
+ * Reads the action-surface state for a given tab via the SW.
+ *
+ * @param {import('@playwright/test').BrowserContext} context
+ * @param {string} extensionId
+ * @param {number} tabId
+ * @returns {Promise<{ title: string, badgeText: string, badgeColor: string|number[], iconPath: string|object|null }>}
+ */
+export async function readActionSurface(context, extensionId, tabId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let openedTransient = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    openedTransient = true;
+  }
+  const result = await page.evaluate((tabId) => {
+    return new Promise(resolve => {
+      chrome.runtime.sendMessage(
+        { type: "__TEST__readActionSurface", tabId },
+        (r) => resolve(r || null)
+      );
+    });
+  }, tabId);
+  if (openedTransient) await page.close();
+  return result;
+}

--- a/tests/e2e/helpers/index.mjs
+++ b/tests/e2e/helpers/index.mjs
@@ -1,0 +1,9 @@
+/**
+ * MUGA E2E helpers — re-exports (#398)
+ *
+ * Single import point for tests:
+ *   import { seedStorage, killServiceWorker, ... } from "./helpers/index.mjs";
+ */
+export { seedStorage, installTestModeSentinel, clearTestModeSentinel } from "./storage.mjs";
+export { killServiceWorker, simulateUnresponsiveSW } from "./sw-control.mjs";
+export { readActionSurface } from "./action-surface.mjs";

--- a/tests/e2e/helpers/storage.mjs
+++ b/tests/e2e/helpers/storage.mjs
@@ -1,0 +1,68 @@
+/**
+ * MUGA E2E helper — storage seeding and test-mode sentinel (#398)
+ *
+ * Helpers for pre-populating chrome.storage.{sync,local} before a test
+ * navigates, and for toggling the production-safe test-mode sentinel
+ * that gates `__TEST__`-prefixed runtime message handlers in the
+ * service worker.
+ */
+
+/**
+ * Pre-populates chrome.storage.{sync,local} with the provided values.
+ * Reuses an existing extension page if one is open; otherwise opens a
+ * popup page transiently. Returns when both writes have completed.
+ *
+ * @param {import('@playwright/test').BrowserContext} context
+ * @param {string} extensionId
+ * @param {{ sync?: object, local?: object }} payload
+ */
+export async function seedStorage(context, extensionId, { sync = {}, local = {} } = {}) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let openedTransient = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    openedTransient = true;
+  }
+  await page.evaluate(({ sync, local }) => {
+    return Promise.all([
+      new Promise(resolve => chrome.storage.sync.set(sync, resolve)),
+      new Promise(resolve => chrome.storage.local.set(local, resolve)),
+    ]);
+  }, { sync, local });
+  if (openedTransient) await page.close();
+}
+
+/**
+ * Sets the test-mode sentinel in chrome.storage.local. While set, the
+ * service worker enables `__TEST__`-prefixed message handlers — see
+ * src/background/service-worker.js for the gate. Production builds
+ * never set this, so the handlers are dead code at runtime.
+ *
+ * @param {import('@playwright/test').BrowserContext} context
+ * @param {string} extensionId
+ */
+export async function installTestModeSentinel(context, extensionId) {
+  await seedStorage(context, extensionId, { local: { __muga_test_mode: true } });
+}
+
+/**
+ * Clears the test-mode sentinel. Tests should call this on teardown
+ * to leave the storage clean for any subsequent test (Playwright
+ * persistent context is reused unless explicitly disposed).
+ */
+export async function clearTestModeSentinel(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let openedTransient = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    openedTransient = true;
+  }
+  await page.evaluate(() => {
+    return new Promise(resolve => chrome.storage.local.remove("__muga_test_mode", resolve));
+  });
+  if (openedTransient) await page.close();
+}

--- a/tests/e2e/helpers/sw-control.mjs
+++ b/tests/e2e/helpers/sw-control.mjs
@@ -1,0 +1,72 @@
+/**
+ * MUGA E2E helper — service-worker lifecycle control (#398)
+ *
+ * Two complementary tools for testing what happens when the service
+ * worker is unresponsive:
+ *
+ *   killServiceWorker(context)
+ *     Best-effort termination of the active SW via Chrome DevTools
+ *     Protocol. The SW may respawn on the next event; tests asserting
+ *     "SW death is non-fatal for user-facing navigation" should kill
+ *     and immediately exercise the user-facing path.
+ *
+ *   simulateUnresponsiveSW(page)
+ *     Page-side override of chrome.runtime.sendMessage that never
+ *     resolves. Lighter and more reliable than real termination —
+ *     simulates the *symptom* (no message response) without actually
+ *     stopping the worker. Use this when the test only needs to
+ *     verify "user-facing path doesn't block on the SW".
+ *
+ * Most tests should prefer simulateUnresponsiveSW. Use killServiceWorker
+ * only when the SW's own state (e.g. session storage) needs to be
+ * gone too.
+ */
+
+/**
+ * Attempts to terminate the currently-running service worker via CDP.
+ * Returns when the request is sent; the SW may take a moment to die
+ * and may respawn on the next chrome.runtime event.
+ */
+export async function killServiceWorker(context) {
+  const sw = context.serviceWorkers()[0];
+  if (!sw) return;
+  // Approach 1: ask the SW to unregister itself. This forces a kill
+  // cycle even if the browser would otherwise keep it alive.
+  try {
+    await sw.evaluate(() => {
+      // self.registration.unregister() schedules unregistration after
+      // current tasks; call it inside a microtask boundary so the SW
+      // doesn't try to send back a response after it's gone.
+      Promise.resolve().then(() => self.registration.unregister().catch(() => {}));
+    });
+  } catch {
+    // SW may already be terminated; ignore.
+  }
+}
+
+/**
+ * Overrides chrome.runtime.sendMessage in the page's content script
+ * world to never resolve. Returns a teardown function that restores
+ * the original.
+ *
+ * Caveats:
+ *   - This affects messages sent FROM the page (or content script
+ *     in the same world). Messages from the SW itself are unaffected.
+ *   - Override is per-page; tests using this on multiple pages must
+ *     install per page.
+ */
+export async function simulateUnresponsiveSW(page) {
+  await page.evaluate(() => {
+    if (window.__muga_orig_sendMessage) return; // already installed
+    window.__muga_orig_sendMessage = chrome.runtime.sendMessage;
+    chrome.runtime.sendMessage = () => new Promise(() => { /* never resolves */ });
+  });
+  return async () => {
+    await page.evaluate(() => {
+      if (window.__muga_orig_sendMessage) {
+        chrome.runtime.sendMessage = window.__muga_orig_sendMessage;
+        delete window.__muga_orig_sendMessage;
+      }
+    });
+  };
+}

--- a/tests/e2e/sw-lifecycle.spec.mjs
+++ b/tests/e2e/sw-lifecycle.spec.mjs
@@ -1,0 +1,136 @@
+/**
+ * E2E: Service-worker lifecycle helpers + test-mode sentinel (#398)
+ *
+ * Establishes the foundational helpers under tests/e2e/helpers/ and
+ * proves the test-mode sentinel mechanism works end-to-end against the
+ * service worker's `__TEST__` message handler.
+ *
+ * **Scope-limit note**: tests for the content-script bundle's
+ * availability (`window.__mugaCleaner`) and for cold-service-worker
+ * navigation behavior are **deferred** to slice #409 (local cleaning
+ * paths) where they can be validated against observable user-visible
+ * outcomes rather than via cross-world reads. The bundle attaches to
+ * the content-script isolated world, which Playwright's `page.evaluate`
+ * cannot reach from an arbitrary remote page.
+ *
+ * What this spec proves:
+ *   - The sentinel-gated `__TEST__` handler in the SW rejects messages
+ *     when the sentinel is unset, accepts them when it is set.
+ *   - `readActionSurface` returns a structured response with the
+ *     expected fields when the sentinel is set.
+ *   - `installTestModeSentinel` / `clearTestModeSentinel` round-trip
+ *     correctly.
+ *   - `simulateUnresponsiveSW` and `killServiceWorker` helpers exist
+ *     and compose with the fixture, ready to be used by later slices.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import {
+  installTestModeSentinel,
+  clearTestModeSentinel,
+  readActionSurface,
+} from "./helpers/index.mjs";
+
+test.describe("Test-mode sentinel + __TEST__ message handler (#398)", () => {
+  test.afterEach(async ({ context, extensionId }) => {
+    // Always clear so subsequent tests start without the sentinel.
+    await clearTestModeSentinel(context, extensionId);
+  });
+
+  test("__TEST__ message is rejected when the sentinel is unset", async ({ context, extensionId }) => {
+    await clearTestModeSentinel(context, extensionId);
+
+    const extOrigin = `chrome-extension://${extensionId}`;
+    const page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+
+    const response = await page.evaluate(() =>
+      new Promise(resolve => {
+        chrome.runtime.sendMessage({ type: "__TEST__readActionSurface", tabId: 1 }, resolve);
+      })
+    );
+
+    expect(response).toBeDefined();
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/test mode not active/);
+
+    await page.close();
+  });
+
+  test("__TEST__ message is accepted when the sentinel is set", async ({ context, extensionId }) => {
+    await installTestModeSentinel(context, extensionId);
+
+    const extOrigin = `chrome-extension://${extensionId}`;
+    const page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+
+    const response = await page.evaluate(() =>
+      new Promise(resolve => {
+        chrome.runtime.sendMessage({ type: "__TEST__readActionSurface", tabId: 1 }, resolve);
+      })
+    );
+
+    expect(response).toBeDefined();
+    expect(response.ok).toBe(true);
+    // The presenter has not seen tabId 1 yet, so the title is whatever
+    // chrome.action returns (typically the manifest default). What we
+    // verify is the SHAPE: every documented field is present.
+    expect(response).toHaveProperty("title");
+    expect(response).toHaveProperty("badgeText");
+    expect(response).toHaveProperty("badgeColor");
+    expect(response).toHaveProperty("iconKind");
+    expect(response).toHaveProperty("state");
+    expect(["default", "preserved"]).toContain(response.iconKind);
+
+    await page.close();
+  });
+
+  test("readActionSurface helper returns the same shape", async ({ context, extensionId }) => {
+    await installTestModeSentinel(context, extensionId);
+
+    const surface = await readActionSurface(context, extensionId, 1);
+    expect(surface).not.toBeNull();
+    expect(surface.ok).toBe(true);
+    expect(surface).toHaveProperty("title");
+    expect(surface).toHaveProperty("badgeText");
+    expect(surface).toHaveProperty("iconKind");
+  });
+
+  test("__TEST__ handler rejects unknown sub-types even when sentinel is set", async ({ context, extensionId }) => {
+    await installTestModeSentinel(context, extensionId);
+
+    const extOrigin = `chrome-extension://${extensionId}`;
+    const page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+
+    const response = await page.evaluate(() =>
+      new Promise(resolve => {
+        chrome.runtime.sendMessage({ type: "__TEST__neverHeardOfIt" }, resolve);
+      })
+    );
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/unknown __TEST__ message/);
+
+    await page.close();
+  });
+
+  test("__TEST__readActionSurface rejects invalid tabId", async ({ context, extensionId }) => {
+    await installTestModeSentinel(context, extensionId);
+
+    const extOrigin = `chrome-extension://${extensionId}`;
+    const page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+
+    const response = await page.evaluate(() =>
+      new Promise(resolve => {
+        chrome.runtime.sendMessage({ type: "__TEST__readActionSurface", tabId: -1 }, resolve);
+      })
+    );
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toMatch(/invalid tabId/);
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
Closes #398. Foundational slice for #395 e2e coverage.

## What landed

- **`tests/e2e/helpers/`**: `seedStorage`, `installTestModeSentinel`/`clearTestModeSentinel`, `killServiceWorker`/`simulateUnresponsiveSW`, `readActionSurface`. Used by all later e2e slices.
- **Service worker** gains a `__TEST__`-prefixed message handler gated on the `__muga_test_mode` sentinel. Production never sets the sentinel; handler short-circuits.
- **`__TEST__readActionSurface`** reads `chrome.action` state (title, badge text, badge color) plus derives `iconKind` from the presenter's tab state. Handles both Promise-form (Chrome MV3) and callback-form (Firefox MV2) APIs.
- **`tests/e2e/sw-lifecycle.spec.mjs`** with 5 tests covering the sentinel mechanism end-to-end.
- **CONTRIBUTING.md** documents the test-mode sentinel and how to add new `__TEST__` handlers.

## Scope-limit

Tests for the content-script bundle's availability and cold-SW navigation behavior are deferred to **slice #409** (local cleaning paths). `window.__mugaCleaner` lives in the content script's isolated world, which `page.evaluate` cannot reach from arbitrary remote pages — those tests need user-visible-outcome assertions which #409 owns.

## Test plan

- [x] 2504 unit tests pass.
- [x] 44 e2e tests pass (5 new + 39 pre-existing).
- [x] Sentinel rejects when unset; accepts when set; rejects unknown sub-types and invalid tabIds.
- [x] No regression in existing e2e specs.

This unblocks #406, #407, #408, #409, #410.

Engram observation #190.