### PR TITLE
docs(privacy): align with per-device consent + bundle architecture (#399)

### DIFF
--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.11.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.11.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.
@@ -45,8 +45,21 @@
 
   <h2>What data does MUGA handle?</h2>
   <p>MUGA receives URLs when you click links or right-click to copy a clean link. These URLs are cleaned inside your browser. MUGA never silently sends your data anywhere. Any feature that contacts an external service requires your explicit action and is disclosed here.</p>
-  <p>Your extension preferences (toggles, blacklist, whitelist, language) are stored in <code>chrome.storage.sync</code>. This means they sync across your own devices via your browser account. They are never visible to MUGA.</p>
-  <p>Anonymous usage counters (URLs cleaned, parameters removed, referrals spotted) are stored locally on your device via <code>chrome.storage.local</code>. These counters are never transmitted anywhere. Session data (debug logs, per-tab badge counts, recently cleaned URLs) is stored in <code>chrome.storage.session</code> and is automatically cleared when the browser restarts.</p>
+
+  <p>MUGA's data lives in two places, deliberately separated:</p>
+  <ul>
+    <li><strong>Per-device, on this machine only</strong> (<code>chrome.storage.local</code>): your acceptance of these terms and the version of the policy you agreed to (<code>onboardingDone</code>, <code>consentVersion</code>, <code>consentDate</code>); per-device decisions you made about behaviours your other devices may have enabled (<code>injectOwnAffiliate</code>, <code>remoteRulesEnabled</code> overrides — see <strong>Per-device consent</strong> below); usage counters (URLs cleaned, parameters removed, referrals spotted); and short-lived session data (debug logs, per-tab badge counts, recently cleaned URLs).</li>
+    <li><strong>Across your own devices, via your browser account</strong> (<code>chrome.storage.sync</code>): behavioural preferences you would expect to follow you between devices — language, blacklist, whitelist, custom tracking parameters, the affiliate toggles' default values, the remote-rule-updates default value. Sync happens through your browser, never through MUGA.</li>
+  </ul>
+  <p>Neither bucket is ever visible to MUGA. Session data (<code>chrome.storage.session</code>) is automatically cleared when the browser restarts. Usage counters are never transmitted anywhere.</p>
+
+  <h2>Per-device consent</h2>
+  <p>Acceptance of these terms is recorded <strong>per device</strong>, not per browser account. If you install MUGA on a second device, you will be asked to read and accept the terms on that device too, even if you already accepted them somewhere else. The reasoning is captured in our architectural decision record <a href="https://github.com/yocreoquesi/muga/blob/main/docs/adr/0001-per-device-consent.md" target="_blank" rel="noopener noreferrer">ADR-0001</a>: consent is an act between you and the device you are using; inheriting it across devices silently would deny each device's user the chance to read and decide.</p>
+  <p>Behavioural preferences (toggles like "Inject our affiliate tag", "Enable remote rule updates", and others) follow your browser account through sync. But on a fresh device, if any of those preferences arrives enabled from another device, MUGA shows you an explicit confirmation prompt during onboarding before acting on them. If you decline a preference on this device, the override is recorded locally and your other devices' settings are left untouched.</p>
+  <p>If we update these terms in a way that materially changes what you previously agreed to, MUGA will surface a re-acceptance flow on each device the next time the service worker wakes up. If we only add clauses (without changing existing ones), the flow shows you the new clauses and lets you accept or decline; declining keeps you under the previously accepted terms.</p>
+
+  <h2>Migration on upgrade</h2>
+  <p>If you previously installed MUGA before this version and your acceptance was stored across devices via sync, MUGA will migrate that acceptance to local storage on the first run after upgrade. The migration is one-way (sync → local) and idempotent: you keep your acceptance state without re-onboarding. The migration is implemented in <code>src/lib/sync-migration.js</code> in the source.</p>
 
   <h2>Tracking parameters</h2>
   <p>MUGA strips tracking parameters (UTMs, fbclid, gclid, and others) from URLs automatically. This happens locally. The removed parameters are not logged, transmitted, or stored anywhere.</p>
@@ -54,17 +67,18 @@
   <h2>Additional features</h2>
   <p>The following features are enabled by default and can be individually toggled in Settings:</p>
   <ul>
-    <li><strong>AMP redirect:</strong> Redirects Google AMP pages to the original canonical URL. Happens locally via the content script.</li>
+    <li><strong>AMP redirect:</strong> Redirects AMP pages to the original canonical URL. On Chrome, this happens at the network layer via the browser's built-in declarativeNetRequest engine, before the AMP page is loaded. On Firefox, it happens locally via the content script.</li>
     <li><strong>Ping blocking:</strong> Removes <code>&lt;a ping&gt;</code> attributes from links so the browser does not send tracking beacons when you click.</li>
-    <li><strong>Redirect unwrapping:</strong> Detects redirect-wrapper URLs and navigates directly to the real destination.</li>
+    <li><strong>Redirect unwrapping:</strong> Detects redirect-wrapper URLs (Awin, ShareASale, Admitad, and similar intermediary servers; Pepper deal-site meta-refresh; Amazon Sponsored Products redirects) and navigates directly to the real destination, bypassing the intermediary.</li>
     <li><strong>Right-click "Copy clean link":</strong> Cleans URLs when you copy them via context menu. Also available via keyboard shortcut (Alt+Shift+C).</li>
   </ul>
   <p>All of these operate entirely within your browser. No external requests are made.</p>
+  <p>URL cleaning (and the click, copy, page-load self-clean paths) runs as a local computation inside your browser. It does not round-trip through any extension service worker or external server. The cleaning logic ships in the extension package as a small bundled file (<code>src/content/cleaner-bundle.js</code>) generated from the ES module source under <code>src/lib/</code> via <code>tools/bundle-content.mjs</code>; the bundle is committed to the repository so reviewers can verify it matches the unbundled source.</p>
 
   <h2>Affiliate tags</h2>
   <p>MUGA can add affiliate tags to URLs that carry none when you visit a supported store. This is how an independent developer earns income from the tool he maintains. If you opted in during onboarding, this feature is active. You can disable it at any time in Settings.</p>
   <p>When you visit a supported store, MUGA checks the URL locally to see if an affiliate tag is already present. If not, and if you have the option enabled, MUGA modifies the URL before navigation to include our affiliate tag. <strong>This URL modification happens locally. No external request is made to determine whether to inject.</strong></p>
-  <p>If you enable "Remove all affiliate tags from other sources", only third-party tags are removed. Our own tag is always preserved. MUGA never replaces another affiliate's tag with ours in the same operation.</p>
+  <p>If you enable "Remove all affiliate tags from other sources", third-party tags placed by other creators or networks are removed from the URL. MUGA's own tag is preserved <strong>only when you also have affiliate injection enabled on this device</strong>; if you have injection off, MUGA's tag is treated like any other and removed too. The toggle's behaviour is symmetric with your stated preference: if you do not want to support MUGA via affiliate injection on this device, MUGA does not benefit from someone else's link arriving with our tag attached. MUGA never silently replaces another affiliate's tag with ours.</p>
 
   <h2>What MUGA never does</h2>
   <ul>
@@ -77,14 +91,14 @@
   </ul>
 
   <h2>Stores removed for privacy reasons</h2>
-  <p>MUGA evaluated affiliate programs for AliExpress, SHEIN, Zalando, Fnac, MediaMarkt, PcComponentes, and El Corte Ingles. All of them require redirect-based tracking: your click is routed through an external server (Awin, Admitad, ShareASale, or Skimlinks) before reaching the store. That server logs your visit, your referrer, and your destination.</p>
+  <p>MUGA evaluated 10+ affiliate programs from major retailers and marketplaces. All of them require redirect-based tracking: your click is routed through an external server before reaching the store. That server logs your visit, your referrer, and your destination.</p>
   <p>We do not believe forcing users through external tracking servers is necessary or fair. Redirect-based affiliate tracking is a choice these networks make, not a technical requirement. We rejected every one of these programs and chose to give up that revenue rather than compromise your privacy.</p>
-  <p>Because these stores rely on redirect-based affiliate networks, MUGA actively strips their affiliate tracking parameters (awc, wt_mc, lgw_code, and others) from URLs you visit. These parameters were placed by the same redirect servers we refuse to use. When possible, MUGA also unwraps affiliate redirect URLs (e.g. from Awin or Admitad) and sends you directly to the store, so the intermediary server is bypassed entirely.</p>
-  <p>Only stores that support direct URL parameter injection -- where the affiliate tag is a simple query parameter added locally, with no server involved -- are compatible with MUGA. Currently: Amazon and eBay. We believe users deserve the freedom to reach any store directly, and we will apply this same standard to any affiliate program we evaluate in the future.</p>
+  <p>Because these stores rely on redirect-based affiliate networks, MUGA actively strips their affiliate tracking parameters (awc, wt_mc, lgw_code, and others) from URLs you visit. These parameters were placed by the same redirect servers we refuse to use. When possible, MUGA also unwraps affiliate redirect URLs and sends you directly to the store, so the intermediary server is bypassed entirely.</p>
+  <p>Only stores that support direct URL parameter injection -- where the affiliate tag is a simple query parameter added locally, with no server involved -- are compatible with MUGA. We believe users deserve the freedom to reach any store directly, and we will apply this same standard to any affiliate program we evaluate in the future.</p>
 
   <h2>Third-party affiliate programs</h2>
   <p>When you navigate to a store via a MUGA-modified URL, the store's own analytics may record the visit as originating from an affiliate link. This is standard affiliate behaviour and is governed by the store's own privacy policy, not MUGA's.</p>
-  <p>MUGA is a registered participant in affiliate programs including Amazon Associates and others. These programs have their own terms of service and privacy policies.</p>
+  <p>MUGA is a registered participant in affiliate programs operated by supported stores. These programs have their own terms of service and privacy policies.</p>
 
   <h2>Permissions</h2>
   <p>MUGA requests the following browser permissions:</p>
@@ -98,10 +112,10 @@
   </ul>
 
   <h2>Open source</h2>
-  <p>MUGA is licensed under the <a href="https://github.com/yocreoquesi/muga/blob/main/LICENSE">GNU General Public License v3 (GPL v3)</a>. The complete source code is public. If you want to verify that this privacy policy accurately describes the extension's behaviour, read the code. It's all there.</p>
+  <p>MUGA is licensed under the <a href="https://github.com/yocreoquesi/muga/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">GNU General Public License v3 (GPL v3)</a>. The complete source code is public. If you want to verify that this privacy policy accurately describes the extension's behaviour, read the code. It's all there.</p>
 
   <h2>Contact</h2>
-  <p>Questions or concerns: open an issue at <a href="https://github.com/yocreoquesi/muga/issues">github.com/yocreoquesi/muga/issues</a>.</p>
+  <p>Questions or concerns: open an issue at <a href="https://github.com/yocreoquesi/muga/issues" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga/issues</a>.</p>
 
 </body>
 </html>

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-04-01 &nbsp;·&nbsp; Version 1.11.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.11.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.
@@ -45,8 +45,21 @@
 
   <h2>What data does MUGA handle?</h2>
   <p>MUGA receives URLs when you click links or right-click to copy a clean link. These URLs are cleaned inside your browser. MUGA never silently sends your data anywhere. Any feature that contacts an external service requires your explicit action and is disclosed here.</p>
-  <p>Your extension preferences (toggles, blacklist, whitelist, language) are stored in <code>chrome.storage.sync</code>. This means they sync across your own devices via your browser account. They are never visible to MUGA.</p>
-  <p>Anonymous usage counters (URLs cleaned, parameters removed, referrals spotted) are stored locally on your device via <code>chrome.storage.local</code>. These counters are never transmitted anywhere. Session data (debug logs, per-tab badge counts, recently cleaned URLs) is stored in <code>chrome.storage.session</code> and is automatically cleared when the browser restarts.</p>
+
+  <p>MUGA's data lives in two places, deliberately separated:</p>
+  <ul>
+    <li><strong>Per-device, on this machine only</strong> (<code>chrome.storage.local</code>): your acceptance of these terms and the version of the policy you agreed to (<code>onboardingDone</code>, <code>consentVersion</code>, <code>consentDate</code>); per-device decisions you made about behaviours your other devices may have enabled (<code>injectOwnAffiliate</code>, <code>remoteRulesEnabled</code> overrides — see <strong>Per-device consent</strong> below); usage counters (URLs cleaned, parameters removed, referrals spotted); and short-lived session data (debug logs, per-tab badge counts, recently cleaned URLs).</li>
+    <li><strong>Across your own devices, via your browser account</strong> (<code>chrome.storage.sync</code>): behavioural preferences you would expect to follow you between devices — language, blacklist, whitelist, custom tracking parameters, the affiliate toggles' default values, the remote-rule-updates default value. Sync happens through your browser, never through MUGA.</li>
+  </ul>
+  <p>Neither bucket is ever visible to MUGA. Session data (<code>chrome.storage.session</code>) is automatically cleared when the browser restarts. Usage counters are never transmitted anywhere.</p>
+
+  <h2>Per-device consent</h2>
+  <p>Acceptance of these terms is recorded <strong>per device</strong>, not per browser account. If you install MUGA on a second device, you will be asked to read and accept the terms on that device too, even if you already accepted them somewhere else. The reasoning is captured in our architectural decision record <a href="https://github.com/yocreoquesi/muga/blob/main/docs/adr/0001-per-device-consent.md" target="_blank" rel="noopener noreferrer">ADR-0001</a>: consent is an act between you and the device you are using; inheriting it across devices silently would deny each device's user the chance to read and decide.</p>
+  <p>Behavioural preferences (toggles like "Inject our affiliate tag", "Enable remote rule updates", and others) follow your browser account through sync. But on a fresh device, if any of those preferences arrives enabled from another device, MUGA shows you an explicit confirmation prompt during onboarding before acting on them. If you decline a preference on this device, the override is recorded locally and your other devices' settings are left untouched.</p>
+  <p>If we update these terms in a way that materially changes what you previously agreed to, MUGA will surface a re-acceptance flow on each device the next time the service worker wakes up. If we only add clauses (without changing existing ones), the flow shows you the new clauses and lets you accept or decline; declining keeps you under the previously accepted terms.</p>
+
+  <h2>Migration on upgrade</h2>
+  <p>If you previously installed MUGA before this version and your acceptance was stored across devices via sync, MUGA will migrate that acceptance to local storage on the first run after upgrade. The migration is one-way (sync → local) and idempotent: you keep your acceptance state without re-onboarding. The migration is implemented in <code>src/lib/sync-migration.js</code> in the source.</p>
 
   <h2>Tracking parameters</h2>
   <p>MUGA strips tracking parameters (UTMs, fbclid, gclid, and others) from URLs automatically. This happens locally. The removed parameters are not logged, transmitted, or stored anywhere.</p>
@@ -54,17 +67,18 @@
   <h2>Additional features</h2>
   <p>The following features are enabled by default and can be individually toggled in Settings:</p>
   <ul>
-    <li><strong>AMP redirect:</strong> Redirects AMP pages to the original canonical URL. Happens locally via the content script.</li>
+    <li><strong>AMP redirect:</strong> Redirects AMP pages to the original canonical URL. On Chrome, this happens at the network layer via the browser's built-in declarativeNetRequest engine, before the AMP page is loaded. On Firefox, it happens locally via the content script.</li>
     <li><strong>Ping blocking:</strong> Removes <code>&lt;a ping&gt;</code> attributes from links so the browser does not send tracking beacons when you click.</li>
-    <li><strong>Redirect unwrapping:</strong> Detects redirect-wrapper URLs and navigates directly to the real destination.</li>
+    <li><strong>Redirect unwrapping:</strong> Detects redirect-wrapper URLs (Awin, ShareASale, Admitad, and similar intermediary servers; Pepper deal-site meta-refresh; Amazon Sponsored Products redirects) and navigates directly to the real destination, bypassing the intermediary.</li>
     <li><strong>Right-click "Copy clean link":</strong> Cleans URLs when you copy them via context menu. Also available via keyboard shortcut (Alt+Shift+C).</li>
   </ul>
   <p>All of these operate entirely within your browser. No external requests are made.</p>
+  <p>URL cleaning (and the click, copy, page-load self-clean paths) runs as a local computation inside your browser. It does not round-trip through any extension service worker or external server. The cleaning logic ships in the extension package as a small bundled file (<code>src/content/cleaner-bundle.js</code>) generated from the ES module source under <code>src/lib/</code> via <code>tools/bundle-content.mjs</code>; the bundle is committed to the repository so reviewers can verify it matches the unbundled source.</p>
 
   <h2>Affiliate tags</h2>
   <p>MUGA can add affiliate tags to URLs that carry none when you visit a supported store. This is how an independent developer earns income from the tool he maintains. If you opted in during onboarding, this feature is active. You can disable it at any time in Settings.</p>
   <p>When you visit a supported store, MUGA checks the URL locally to see if an affiliate tag is already present. If not, and if you have the option enabled, MUGA modifies the URL before navigation to include our affiliate tag. <strong>This URL modification happens locally. No external request is made to determine whether to inject.</strong></p>
-  <p>If you enable "Remove all affiliate tags from other sources", only third-party tags are removed. Our own tag is always preserved. MUGA never replaces another affiliate's tag with ours in the same operation.</p>
+  <p>If you enable "Remove all affiliate tags from other sources", third-party tags placed by other creators or networks are removed from the URL. MUGA's own tag is preserved <strong>only when you also have affiliate injection enabled on this device</strong>; if you have injection off, MUGA's tag is treated like any other and removed too. The toggle's behaviour is symmetric with your stated preference: if you do not want to support MUGA via affiliate injection on this device, MUGA does not benefit from someone else's link arriving with our tag attached. MUGA never silently replaces another affiliate's tag with ours.</p>
 
   <h2>What MUGA never does</h2>
   <ul>


### PR DESCRIPTION
Closes #399. Pure documentation alignment with the post-grill rollout. No code changes.

## What changed

Both `src/privacy/privacy.html` and `docs/privacy-page.html`:

- **Effective date** bumped 2026-04-01 → 2026-05-01.
- **'What data does MUGA handle?'** restructured into a bullet list distinguishing per-device storage (`chrome.storage.local`: consent + per-device pref overrides + counters + session data) from cross-device sync (`chrome.storage.sync`: behavioural prefs).
- **New section 'Per-device consent'** with cross-reference to `docs/adr/0001-per-device-consent.md`.
- **New section 'Migration on upgrade'** describing the legacy → local migration.
- **'Additional features'** section: AMP redirect described as cross-browser (DNR on Chrome, content script on Firefox MV2); redirect-unwrap lists the specific intermediary networks; new paragraph about the content-script bundle and reviewer verifiability.
- **'Affiliate tags'** section: our-tag preservation language updated for the post-#353 conditional (preserved *only when injection is also on*).

## Version stamp

Kept at `Version 1.11.0` to match `package.json`; the version-consistency test enforces this. The version bump slice #416 updates both files atomically.

## Test plan

- [x] 2504 unit tests pass.
- [x] Both privacy files in sync (modulo the existing `target/rel` attr difference on the 'Source code' link, intentional per file purpose).
- [x] All cross-references (ADR-0001, sync-migration.js) point at valid repo paths.
- [ ] Maintainer reads the new content end-to-end before merge — copy is first-draft.

Engram observation #190.