### PR TITLE
test(e2e): consent migration + per-device confirmation prompts (#406)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -455,6 +455,14 @@ async function handleTestMessage(message, sender) {
         state: { ...tabState },
       };
     }
+    case "__TEST__runConsentMigration": {
+      // Force a re-run of the sync→local consent migration. Production
+      // calls this once on service-worker startup; the e2e suite needs
+      // to call it on demand AFTER seeding sync so it can assert the
+      // observable end-state (local populated, sync cleaned).
+      const report = await migrateConsentToLocal();
+      return { ok: true, ...report };
+    }
     default:
       return { ok: false, error: `unknown __TEST__ message: ${message.type}` };
   }

--- a/tests/e2e/consent-migration.spec.mjs
+++ b/tests/e2e/consent-migration.spec.mjs
@@ -1,0 +1,202 @@
+/**
+ * E2E: Consent migration sync → local (#406)
+ *
+ * Exercises the migration introduced by #355 in a real browser:
+ *   - Legacy consent fields live in chrome.storage.sync (`onboardingDone`,
+ *     `consentVersion`, `consentDate`).
+ *   - On first SW wake post-upgrade, those fields are copied into
+ *     chrome.storage.local under `mugaConsent` and removed from sync.
+ *
+ * The unit suite in tests/unit/sync-migration.test.mjs already covers
+ * the pure logic exhaustively. This spec verifies the integration:
+ * the SW exposes a __TEST__runConsentMigration handler (gated on the
+ * test-mode sentinel) that drives the same migrateConsentToLocal()
+ * production calls on startup, and the chrome.storage APIs in a real
+ * browser produce the expected end-state.
+ *
+ * Each test seeds storage from a known clean slate, runs the migration
+ * via the test-mode handler, and asserts on storage afterwards.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import {
+  seedStorage,
+  installTestModeSentinel,
+  clearTestModeSentinel,
+} from "./helpers/index.mjs";
+
+const LEGACY_KEYS = ["onboardingDone", "consentVersion", "consentDate"];
+
+async function runMigration(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const result = await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "__TEST__runConsentMigration" }, resolve);
+    })
+  );
+  if (opened) await page.close();
+  return result;
+}
+
+async function readStorage(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const result = await page.evaluate((legacyKeys) =>
+    new Promise(resolve => {
+      chrome.storage.sync.get(legacyKeys, sync => {
+        chrome.storage.local.get({ mugaConsent: null }, local => {
+          resolve({ sync, local });
+        });
+      });
+    }), LEGACY_KEYS
+  );
+  if (opened) await page.close();
+  return result;
+}
+
+async function clearAllStorage(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  await page.evaluate(() =>
+    Promise.all([
+      new Promise(resolve => chrome.storage.sync.clear(resolve)),
+      new Promise(resolve => chrome.storage.local.clear(resolve)),
+    ])
+  );
+  if (opened) await page.close();
+}
+
+test.describe("Consent migration: sync → local (#406)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await clearAllStorage(context, extensionId);
+    await installTestModeSentinel(context, extensionId);
+  });
+
+  test.afterEach(async ({ context, extensionId }) => {
+    await clearTestModeSentinel(context, extensionId);
+  });
+
+  test("legacy sync state migrates to local on first run", async ({ context, extensionId }) => {
+    const ts = Date.now();
+    await seedStorage(context, extensionId, {
+      sync: { onboardingDone: true, consentVersion: "1.0", consentDate: ts },
+    });
+
+    const report = await runMigration(context, extensionId);
+    expect(report.ok).toBe(true);
+    expect(report.ranWork).toBe(true);
+    expect(report.copiedToLocal).toBe(true);
+    expect(report.cleanedSync).toBe(true);
+
+    const { sync, local } = await readStorage(context, extensionId);
+    expect(local.mugaConsent).toMatchObject({
+      onboardingDone: true,
+      consentVersion: "1.0",
+      consentDate: ts,
+    });
+    for (const key of LEGACY_KEYS) {
+      expect(sync[key]).toBeUndefined();
+    }
+  });
+
+  test("fresh install (no legacy sync) is a no-op", async ({ context, extensionId }) => {
+    const report = await runMigration(context, extensionId);
+    expect(report.ok).toBe(true);
+    expect(report.ranWork).toBe(false);
+    expect(report.copiedToLocal).toBe(false);
+    expect(report.cleanedSync).toBe(false);
+
+    const { local } = await readStorage(context, extensionId);
+    expect(local.mugaConsent).toBeNull();
+  });
+
+  test("idempotent: running twice leaves the same end state", async ({ context, extensionId }) => {
+    const ts = Date.now();
+    await seedStorage(context, extensionId, {
+      sync: { onboardingDone: true, consentVersion: "1.0", consentDate: ts },
+    });
+
+    const first = await runMigration(context, extensionId);
+    expect(first.ranWork).toBe(true);
+
+    const second = await runMigration(context, extensionId);
+    expect(second.ok).toBe(true);
+    expect(second.ranWork).toBe(false);
+    expect(second.copiedToLocal).toBe(false);
+
+    const { sync, local } = await readStorage(context, extensionId);
+    expect(local.mugaConsent.onboardingDone).toBe(true);
+    expect(local.mugaConsent.consentVersion).toBe("1.0");
+    expect(local.mugaConsent.consentDate).toBe(ts);
+    for (const key of LEGACY_KEYS) {
+      expect(sync[key]).toBeUndefined();
+    }
+  });
+
+  test("conflict: local wins when both stores hold consent state", async ({ context, extensionId }) => {
+    const localTs = 1700000000000;
+    const syncTs = 1600000000000;
+    // Seed local with this device's authoritative state.
+    await seedStorage(context, extensionId, {
+      local: {
+        mugaConsent: { onboardingDone: true, consentVersion: "1.0", consentDate: localTs },
+      },
+      sync: { onboardingDone: true, consentVersion: "0.9", consentDate: syncTs },
+    });
+
+    const report = await runMigration(context, extensionId);
+    expect(report.ok).toBe(true);
+    expect(report.ranWork).toBe(true);
+    expect(report.copiedToLocal).toBe(false);  // local was already populated
+    expect(report.cleanedSync).toBe(true);
+
+    const { sync, local } = await readStorage(context, extensionId);
+    expect(local.mugaConsent.consentVersion).toBe("1.0");
+    expect(local.mugaConsent.consentDate).toBe(localTs);
+    for (const key of LEGACY_KEYS) {
+      expect(sync[key]).toBeUndefined();
+    }
+  });
+
+  test("partial sync state migrates with sensible defaults", async ({ context, extensionId }) => {
+    // Only onboardingDone present in sync — older legacy installs that
+    // never wrote consentVersion / consentDate.
+    await seedStorage(context, extensionId, {
+      sync: { onboardingDone: true },
+    });
+
+    const report = await runMigration(context, extensionId);
+    expect(report.ok).toBe(true);
+    expect(report.ranWork).toBe(true);
+    expect(report.copiedToLocal).toBe(true);
+    expect(report.cleanedSync).toBe(true);
+
+    const { sync, local } = await readStorage(context, extensionId);
+    expect(local.mugaConsent.onboardingDone).toBe(true);
+    // Defaults from CONSENT_DEFAULTS — null, not undefined.
+    expect(local.mugaConsent.consentVersion).toBeNull();
+    expect(local.mugaConsent.consentDate).toBeNull();
+    for (const key of LEGACY_KEYS) {
+      expect(sync[key]).toBeUndefined();
+    }
+  });
+});

--- a/tests/e2e/per-device-confirmation.spec.mjs
+++ b/tests/e2e/per-device-confirmation.spec.mjs
@@ -1,0 +1,197 @@
+/**
+ * E2E: Per-device confirmation prompts (#406)
+ *
+ * Exercises the per-device override flow introduced by #364.
+ *
+ * Setup. The user installed MUGA on Device A and enabled
+ * `injectOwnAffiliate` and/or `remoteRulesEnabled`. Those prefs live in
+ * chrome.storage.sync and propagate. Device B starts with the prefs
+ * arriving as `true` from sync but with no local consent yet.
+ *
+ * Expected onboarding behaviour:
+ *   - The affiliate checkbox is pre-checked AND the synced-from-other-
+ *     device note is visible.
+ *   - The remote-rules section (hidden by default) is revealed AND the
+ *     remote-rules checkbox is pre-checked.
+ *   - Unchecking the box and clicking Start writes a per-device
+ *     override (`mugaPerDevicePrefs.<key> = false`) without touching
+ *     the sync value.
+ *
+ * The unit suite covers the pure pendingConfirmations() logic. This
+ * spec proves the onboarding page wires the inputs correctly and the
+ * Start handler writes the correct overrides.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { seedStorage } from "./helpers/index.mjs";
+
+async function clearAllStorage(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  await page.evaluate(() =>
+    Promise.all([
+      new Promise(resolve => chrome.storage.sync.clear(resolve)),
+      new Promise(resolve => chrome.storage.local.clear(resolve)),
+    ])
+  );
+  if (opened) await page.close();
+}
+
+async function readPostOnboardingState(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const result = await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.storage.sync.get(
+        ["injectOwnAffiliate", "remoteRulesEnabled"],
+        sync => {
+          chrome.storage.local.get(
+            { mugaConsent: null, mugaPerDevicePrefs: null },
+            local => resolve({ sync, local })
+          );
+        }
+      );
+    })
+  );
+  if (opened) await page.close();
+  return result;
+}
+
+test.describe("Per-device confirmation prompts (#406)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await clearAllStorage(context, extensionId);
+  });
+
+  test("affiliate prompt: pre-checked + synced-note visible when sync has injectOwnAffiliate=true", async ({ context, extensionId }) => {
+    await seedStorage(context, extensionId, {
+      sync: { injectOwnAffiliate: true },
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    await expect(page.locator("#affiliate-check")).toBeChecked();
+    await expect(page.locator("#affiliate-synced-note")).toBeVisible();
+
+    await page.close();
+  });
+
+  test("remote-rules prompt: section revealed + checkbox pre-checked when sync has remoteRulesEnabled=true", async ({ context, extensionId }) => {
+    await seedStorage(context, extensionId, {
+      sync: { remoteRulesEnabled: true },
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    await expect(page.locator("#remote-rules-section")).toBeVisible();
+    await expect(page.locator("#remote-rules-check")).toBeChecked();
+
+    await page.close();
+  });
+
+  test("declining the affiliate prompt writes a per-device override without touching sync", async ({ context, extensionId }) => {
+    await seedStorage(context, extensionId, {
+      sync: { injectOwnAffiliate: true },
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    await page.locator("#affiliate-check").uncheck();
+    await page.locator("#tos-check").check();
+    await page.locator("#start-btn").click();
+    await page.waitForEvent("close", { timeout: 5000 }).catch(() => {});
+
+    const { sync, local } = await readPostOnboardingState(context, extensionId);
+
+    // Sync still says true — declining on this device must NOT mutate
+    // the value that other devices share.
+    expect(sync.injectOwnAffiliate).toBe(true);
+
+    // Local override records the decline for this device only.
+    expect(local.mugaPerDevicePrefs).toMatchObject({ injectOwnAffiliate: false });
+
+    // Onboarding completed.
+    expect(local.mugaConsent.onboardingDone).toBe(true);
+  });
+
+  test("declining the remote-rules prompt writes a per-device override without touching sync", async ({ context, extensionId }) => {
+    await seedStorage(context, extensionId, {
+      sync: { remoteRulesEnabled: true },
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    await page.locator("#remote-rules-check").uncheck();
+    await page.locator("#tos-check").check();
+    await page.locator("#start-btn").click();
+    await page.waitForEvent("close", { timeout: 5000 }).catch(() => {});
+
+    const { sync, local } = await readPostOnboardingState(context, extensionId);
+
+    expect(sync.remoteRulesEnabled).toBe(true);
+    expect(local.mugaPerDevicePrefs).toMatchObject({ remoteRulesEnabled: false });
+    expect(local.mugaConsent.onboardingDone).toBe(true);
+  });
+
+  test("confirming a synced pref leaves no override (sync drives effective value)", async ({ context, extensionId }) => {
+    await seedStorage(context, extensionId, {
+      sync: { injectOwnAffiliate: true },
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    // Box is already checked; just accept ToS and click Start.
+    await page.locator("#tos-check").check();
+    await page.locator("#start-btn").click();
+    await page.waitForEvent("close", { timeout: 5000 }).catch(() => {});
+
+    const { sync, local } = await readPostOnboardingState(context, extensionId);
+
+    expect(sync.injectOwnAffiliate).toBe(true);
+    // No override recorded for confirmed prefs — sync stays the source
+    // of truth on this device too.
+    if (local.mugaPerDevicePrefs) {
+      expect(local.mugaPerDevicePrefs.injectOwnAffiliate).toBeUndefined();
+    }
+    expect(local.mugaConsent.onboardingDone).toBe(true);
+  });
+
+  test("no prompts when sync has neither pref enabled", async ({ context, extensionId }) => {
+    // Seed sync with the prefs explicitly OFF — pendingConfirmations
+    // should be empty, no synced-note, no remote-rules section.
+    await seedStorage(context, extensionId, {
+      sync: { injectOwnAffiliate: false, remoteRulesEnabled: false },
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    await expect(page.locator("#affiliate-synced-note")).toBeHidden();
+    await expect(page.locator("#remote-rules-section")).toBeHidden();
+    await expect(page.locator("#affiliate-check")).not.toBeChecked();
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #406. Adds two e2e specs that exercise #355 (sync→local consent migration) and #364 (per-device override prompts during onboarding) in a real browser.

**\`tests/e2e/consent-migration.spec.mjs\`** (5 tests)
- legacy sync state migrates to local on first run
- fresh install (no legacy sync) is a no-op
- idempotent: running twice leaves the same end state
- conflict: local wins when both stores hold consent state
- partial sync state migrates with sensible defaults

**\`tests/e2e/per-device-confirmation.spec.mjs\`** (6 tests)
- affiliate prompt pre-checked + synced-note visible
- remote-rules prompt: section revealed + checkbox pre-checked
- declining affiliate writes per-device override without touching sync
- declining remote-rules writes per-device override without touching sync
- confirming a synced pref leaves no override
- no prompts when sync has neither pref enabled

The unit suite already covers the pure logic. These specs verify the integration in a real browser.

To make migration deterministically observable from the e2e suite, adds a \`__TEST__runConsentMigration\` handler in \`src/background/service-worker.js\`, gated on the existing test-mode sentinel (#398). Production builds never set the sentinel, so the handler is unreachable at runtime in production.

## Test plan

- [x] 11 new e2e tests green locally on Chromium.
- [x] Existing \`onboarding.spec.mjs\` (5 tests) still green.
- [x] Existing \`sw-lifecycle.spec.mjs\` (5 tests) still green.
- [x] Unit suite (2510 tests) still green.
- [ ] CI green.