### PR TITLE
test(e2e): re-onboard rendering + migration banner round-trip (#407)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -379,6 +379,13 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
   // and local changes that affect the merged cache (remoteParams — REQ-MERGE-5).
   if (area === "local") {
     if (changes.remoteParams) _invalidatePrefsCache();
+    // E2E fixture overrides (#407): when fixtures change, prefs may
+    // produce a different effective onboardingDone (hard-reonboard
+    // gate) — drop the cache so the next read picks up the fixture.
+    // The sentinel + fixture keys are never written in production.
+    if (changes.__muga_test_mode || changes.__muga_test_fixtures) {
+      _invalidatePrefsCache();
+    }
     return;
   }
   if (area !== "sync") return;

--- a/src/lib/migration-prompt.js
+++ b/src/lib/migration-prompt.js
@@ -55,6 +55,7 @@ export function createMigrationPrompt({
   readState,
   applyPrefs,
   t,
+  migrations,  // optional override; defaults to MIGRATIONS via evaluateMigrations
 }) {
   // The migration currently being shown. Updated on every refresh.
   let active = null;
@@ -91,6 +92,7 @@ export function createMigrationPrompt({
         currentVersion: state.currentVersion,
         responses,
         prefs: state.prefs,
+        ...(migrations ? { migrations } : {}),
       });
       if (pending.length === 0) { hide(); return; }
       render(pending[0], pending.length);

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -12,6 +12,8 @@ import { getConsent } from "./consent-storage.js";
 import { getOverrides as getPerDeviceOverrides } from "./per-device-prefs.js";
 // Consent version-comparison for feature gating during hard re-onboard (#370).
 import { evaluate as evaluateConsentPolicy } from "./consent-policy.js";
+// E2E fixture overrides (#407). Returns null in production.
+import { getTestFixtures } from "./test-fixtures.js";
 
 // ── Firefox MV2 compat: chrome.* APIs must return Promises ──────────────────
 //
@@ -121,7 +123,7 @@ export const PREF_DEFAULTS = {
  */
 export async function getPrefs() {
   try {
-    const [sync, consent, overrides] = await Promise.all([
+    const [sync, consent, overrides, fixtures] = await Promise.all([
       new Promise((resolve, reject) => {
         chrome.storage.sync.get(PREF_DEFAULTS, (result) => {
           if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
@@ -130,6 +132,7 @@ export async function getPrefs() {
       }),
       getConsent(),
       getPerDeviceOverrides(),
+      getTestFixtures(),
     ]);
 
     // Consent overlay (#355). Local wins over sync.
@@ -143,7 +146,13 @@ export async function getPrefs() {
     // (`if (!prefs.onboardingDone) return`) bail until the user re-accepts.
     // Soft re-onboard does NOT gate features — the user's prior consent
     // remains valid for previously accepted behaviour.
-    const policy = evaluateConsentPolicy({ stored: consent });
+    // Under e2e fixtures (#407), the gate fires against the fixture
+    // manifest + required version so tests can drive the dormant path.
+    const policy = evaluateConsentPolicy({
+      stored: consent,
+      ...(fixtures?.requiredConsentVersion ? { requiredVersion: fixtures.requiredConsentVersion } : {}),
+      ...(fixtures?.consentManifest ? { manifest: fixtures.consentManifest } : {}),
+    });
     if (policy.status === "hard-reonboard") {
       overlay.onboardingDone = false;
     }

--- a/src/lib/test-fixtures.js
+++ b/src/lib/test-fixtures.js
@@ -1,0 +1,50 @@
+/**
+ * MUGA: Test fixtures (#407)
+ *
+ * Reads runtime overrides for the consent-version manifest, the
+ * migration spec, and i18n keys from `chrome.storage.local` — but ONLY
+ * when the test-mode sentinel is set (see #398).
+ *
+ * Production builds never set the sentinel, so every accessor in this
+ * module returns null at runtime in production and the code paths
+ * that read them fall through to the static module-level constants
+ * unchanged. The fixtures exist solely to let the e2e suite drive
+ * dormant rendering paths (re-onboard delta / material, migration
+ * banner) deterministically without shipping fixture data into the
+ * release artifact.
+ *
+ * Storage shape (set via the `withFixtureManifest` e2e helper):
+ *
+ *   chrome.storage.local["__muga_test_fixtures"] = {
+ *     consentManifest:        Array<{version, additive}> | null,
+ *     requiredConsentVersion: string                     | null,
+ *     consentClausesByVersion: Record<string, string[]>  | null,
+ *     migrations:             Array<MigrationSpec>       | null,
+ *     i18nOverrides:          Record<string, string>     | null,
+ *   }
+ */
+
+const SENTINEL_KEY = "__muga_test_mode";
+const FIXTURES_KEY = "__muga_test_fixtures";
+
+async function readLocal(key, fallback) {
+  return await new Promise((resolve) => {
+    try {
+      chrome.storage.local.get({ [key]: fallback }, (r) => resolve(r?.[key] ?? fallback));
+    } catch {
+      resolve(fallback);
+    }
+  });
+}
+
+/**
+ * Returns the fixtures object when the test sentinel is set, else null.
+ * Cheap to call repeatedly — no caching, since fixtures may change
+ * between tests.
+ */
+export async function getTestFixtures() {
+  const sentinel = await readLocal(SENTINEL_KEY, false);
+  if (!sentinel) return null;
+  const fixtures = await readLocal(FIXTURES_KEY, null);
+  return fixtures || null;
+}

--- a/src/onboarding/onboarding.js
+++ b/src/onboarding/onboarding.js
@@ -28,7 +28,8 @@ import {
   CONSENT_VERSION_MANIFEST,
   REQUIRED_CONSENT_VERSION,
 } from "../lib/consent-version-manifest.js";
-import { clausesForDelta } from "../lib/consent-clauses.js";
+import { clausesForDelta, CONSENT_CLAUSES_BY_VERSION } from "../lib/consent-clauses.js";
+import { getTestFixtures } from "../lib/test-fixtures.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
   const tosCheck         = document.getElementById("tos-check");
@@ -48,7 +49,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   applyTranslations(lang);
 
   // --- Read state ----------------------------------------------------------
-  const [syncPrefs, localConsent, existingOverrides] = await Promise.all([
+  const [syncPrefs, localConsent, existingOverrides, fixtures] = await Promise.all([
     new Promise((resolve) => {
       chrome.storage.sync.get(
         { injectOwnAffiliate: false, remoteRulesEnabled: false },
@@ -57,10 +58,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     }),
     getConsent(),
     getOverrides(),
+    getTestFixtures(),
   ]);
 
+  // Test-only overrides (#407). Fixtures are null in production.
+  const activeManifest = fixtures?.consentManifest || CONSENT_VERSION_MANIFEST;
+  const activeRequiredVersion = fixtures?.requiredConsentVersion || REQUIRED_CONSENT_VERSION;
+  const activeClausesByVersion = fixtures?.consentClausesByVersion || CONSENT_CLAUSES_BY_VERSION;
+
   // --- Re-onboard mode dispatch (#370) ------------------------------------
-  const policy = evaluateConsent({ stored: localConsent });
+  const policy = evaluateConsent({
+    stored: localConsent,
+    requiredVersion: activeRequiredVersion,
+    manifest: activeManifest,
+  });
   const mode = policy.status === "soft-reonboard"
     ? "delta"
     : policy.status === "hard-reonboard"
@@ -76,7 +87,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       const clauseKeys = clausesForDelta({
         acceptedVersion: policy.acceptedVersion,
         requiredVersion: policy.requiredVersion,
-        manifest: CONSENT_VERSION_MANIFEST,
+        manifest: activeManifest,
+        clausesByVersion: activeClausesByVersion,
       });
       if (reonboardDeltaClauses) {
         // Build the clause list with createElement + textContent (no innerHTML).
@@ -144,12 +156,14 @@ document.addEventListener("DOMContentLoaded", async () => {
         syncWrites.injectOwnAffiliate = affiliateCheck.checked;
       }
 
-      // Consent record carries REQUIRED_CONSENT_VERSION — moves the user
-      // forward whether this is fresh, delta, or material acceptance.
+      // Consent record carries the active required version — moves the
+      // user forward whether this is fresh, delta, or material acceptance.
+      // Under test fixtures (#407), activeRequiredVersion may differ from
+      // the static REQUIRED_CONSENT_VERSION export.
       const ops = [
         setConsent({
           onboardingDone: true,
-          consentVersion: REQUIRED_CONSENT_VERSION,
+          consentVersion: activeRequiredVersion,
           consentDate:    Date.now(),
         }),
         new Promise((resolve, reject) => {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -9,6 +9,7 @@ import { getPrefs, sessionStorage, getDomainStats } from "../lib/storage.js";
 import { TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
 import { isFirefox as detectFirefox } from "../lib/browser-detect.js";
 import { createMigrationPrompt } from "../lib/migration-prompt.js";
+import { getTestFixtures } from "../lib/test-fixtures.js";
 
 /** Creates a clipboard SVG icon (12x12) via createElementNS. */
 function _createClipboardSvg() {
@@ -336,6 +337,18 @@ async function init() {
 async function wireMigrationPrompt(lang) {
   const root = document.getElementById("migration-banner");
   if (!root) return; // popup variant without the banner — nothing to do
+
+  // E2E fixtures (#407): null in production. Lets tests inject a
+  // fixture migration spec + i18n keys so the dormant banner path
+  // can be exercised end-to-end.
+  const fixtures = await getTestFixtures();
+  const fixtureMigrations = fixtures?.migrations || null;
+  const fixtureI18n = fixtures?.i18nOverrides || null;
+  const tWithFixtures = fixtureI18n
+    ? (key) => (fixtureI18n[key] != null ? fixtureI18n[key] : t(key, lang))
+    : (key) => t(key, lang);
+  const currentVersionOverride = fixtures?.currentVersion || null;
+
   const prompt = createMigrationPrompt({
     root,
     titleEl:    document.getElementById("migration-banner-title"),
@@ -350,7 +363,7 @@ async function wireMigrationPrompt(lang) {
       // could persist the previous-installed version separately, but
       // that requires a SW write on update which is its own slice.
       const manifest = chrome.runtime.getManifest?.() || {};
-      const currentVersion = manifest.version || "0.0.0";
+      const currentVersion = currentVersionOverride || manifest.version || "0.0.0";
       const stored = await new Promise((resolve) => {
         chrome.storage.local.get({ mugaPrevVersion: currentVersion }, (r) => resolve(r));
       });
@@ -368,7 +381,8 @@ async function wireMigrationPrompt(lang) {
         });
       });
     },
-    t: (key) => t(key, lang),
+    t: tWithFixtures,
+    ...(fixtureMigrations ? { migrations: fixtureMigrations } : {}),
   });
   await prompt.refresh();
 }

--- a/tests/e2e/helpers/fixtures.mjs
+++ b/tests/e2e/helpers/fixtures.mjs
@@ -1,0 +1,57 @@
+/**
+ * MUGA E2E helper — runtime fixture overrides (#407)
+ *
+ * Drives the dormant re-onboard rendering modes (#370) and the
+ * migration banner UI (#369) by writing fixture overrides into
+ * `chrome.storage.local` under the key read by `src/lib/test-fixtures.js`.
+ *
+ * Fixtures only take effect when the test-mode sentinel is set (see
+ * `installTestModeSentinel`). Production builds never set the
+ * sentinel, so the static module-level constants always win at
+ * runtime.
+ */
+
+import { seedStorage } from "./storage.mjs";
+
+const FIXTURES_KEY = "__muga_test_fixtures";
+
+/**
+ * Writes a fixture overrides bundle to chrome.storage.local. The shape
+ * matches what `getTestFixtures()` returns:
+ *
+ *   {
+ *     consentManifest:        Array<{version, additive}> | null,
+ *     requiredConsentVersion: string                     | null,
+ *     consentClausesByVersion: Record<string, string[]>  | null,
+ *     migrations:             Array<MigrationSpec>       | null,
+ *     i18nOverrides:          Record<string, string>     | null,
+ *     currentVersion:         string                     | null,
+ *   }
+ *
+ * Caller is responsible for installing the test-mode sentinel before
+ * the fixtures will be honoured. Caller is also responsible for
+ * clearing fixtures on teardown via `clearFixtures`.
+ */
+export async function withFixtureManifest(context, extensionId, fixtures) {
+  await seedStorage(context, extensionId, {
+    local: { [FIXTURES_KEY]: fixtures },
+  });
+}
+
+/**
+ * Removes any fixture overrides. Tests should call this on teardown.
+ */
+export async function clearFixtures(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  await page.evaluate((key) =>
+    new Promise(resolve => chrome.storage.local.remove(key, resolve)), FIXTURES_KEY
+  );
+  if (opened) await page.close();
+}

--- a/tests/e2e/helpers/index.mjs
+++ b/tests/e2e/helpers/index.mjs
@@ -7,3 +7,4 @@
 export { seedStorage, installTestModeSentinel, clearTestModeSentinel } from "./storage.mjs";
 export { killServiceWorker, simulateUnresponsiveSW } from "./sw-control.mjs";
 export { readActionSurface } from "./action-surface.mjs";
+export { withFixtureManifest, clearFixtures } from "./fixtures.mjs";

--- a/tests/e2e/migration-banner.spec.mjs
+++ b/tests/e2e/migration-banner.spec.mjs
@@ -1,0 +1,185 @@
+/**
+ * E2E: Migration banner round-trip (#407)
+ *
+ * Drives the dormant migration-banner UI from #369 by injecting a
+ * fixture migration spec + fixture i18n keys via `withFixtureManifest`
+ * (gated on the test-mode sentinel from #398).
+ *
+ * Fixture migration:
+ *   id              = "fixture-flip"
+ *   fromVersion     = "1.0.0"
+ *   toVersion       = "2.0.0"
+ *   prefs           = ["fixturePref"]
+ *   proposedValue   = { fixturePref: true }
+ *   networkRelated  = false
+ *   bannerCopyKey   = "fixture_banner"
+ *
+ * Fixture i18n:
+ *   fixture_banner_title = "Fixture migration"
+ *   fixture_banner_body  = "We'd like to enable a fixture pref. Confirm?"
+ *
+ * Storage seed: `mugaPrevVersion = "1.0.0"`, fixture currentVersion =
+ * "2.0.0", so the upgrade window matches.
+ *
+ * Cases: accept (writes pref + records "accept"), decline (no pref,
+ * records "decline"), dismiss (no pref, records "dismiss", banner
+ * does not re-show on next popup open within the same session).
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import {
+  seedStorage,
+  installTestModeSentinel,
+  clearTestModeSentinel,
+  withFixtureManifest,
+  clearFixtures,
+} from "./helpers/index.mjs";
+
+const FIXTURE = {
+  migrations: [
+    {
+      id: "fixture-flip",
+      fromVersion: "1.0.0",
+      toVersion: "2.0.0",
+      prefs: ["fixturePref"],
+      proposedValue: { fixturePref: true },
+      networkRelated: false,
+      bannerCopyKey: "fixture_banner",
+    },
+  ],
+  i18nOverrides: {
+    fixture_banner_title: "Fixture migration",
+    fixture_banner_body: "We'd like to enable a fixture pref. Confirm?",
+  },
+  currentVersion: "2.0.0",
+};
+
+async function clearAll(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  await page.evaluate(() =>
+    Promise.all([
+      new Promise(r => chrome.storage.sync.clear(r)),
+      new Promise(r => chrome.storage.local.clear(r)),
+    ])
+  );
+  if (opened) await page.close();
+}
+
+async function seedConsentAndPrev(context, extensionId) {
+  await seedStorage(context, extensionId, {
+    sync: {
+      onboardingDone: true,  // legacy sync (will overlay-lose to local consent)
+    },
+    local: {
+      mugaConsent: { onboardingDone: true, consentVersion: "1.0", consentDate: 1700000000000 },
+      mugaPrevVersion: "1.0.0",
+    },
+  });
+}
+
+async function readState(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const state = await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.storage.sync.get(["fixturePref"], sync => {
+        chrome.storage.local.get({ migrationResponses: {} }, local =>
+          resolve({ sync, local })
+        );
+      });
+    })
+  );
+  if (opened) await page.close();
+  return state;
+}
+
+test.describe("Migration banner round-trip (#407)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await clearAll(context, extensionId);
+    await installTestModeSentinel(context, extensionId);
+    await seedConsentAndPrev(context, extensionId);
+    await withFixtureManifest(context, extensionId, FIXTURE);
+  });
+
+  test.afterEach(async ({ context, extensionId }) => {
+    await clearFixtures(context, extensionId);
+    await clearTestModeSentinel(context, extensionId);
+  });
+
+  test("banner renders with fixture copy when the fixture migration is pending", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+    const banner = page.locator("#migration-banner");
+    await expect(banner).toBeVisible();
+    await expect(page.locator("#migration-banner-title")).toHaveText("Fixture migration");
+    await expect(page.locator("#migration-banner-body")).toHaveText("We'd like to enable a fixture pref. Confirm?");
+
+    await page.close();
+  });
+
+  test("accept writes the pref + records 'accept' + hides the banner", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+    await expect(page.locator("#migration-banner")).toBeVisible();
+    await page.locator("#migration-banner-accept").click();
+    await expect(page.locator("#migration-banner")).toBeHidden();
+
+    await page.close();
+
+    const { sync, local } = await readState(context, extensionId);
+    expect(sync.fixturePref).toBe(true);
+    expect(local.migrationResponses["fixture-flip"]).toBe("accept");
+  });
+
+  test("decline leaves the pref untouched + records 'decline' + hides the banner", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+    await expect(page.locator("#migration-banner")).toBeVisible();
+    await page.locator("#migration-banner-decline").click();
+    await expect(page.locator("#migration-banner")).toBeHidden();
+
+    await page.close();
+
+    const { sync, local } = await readState(context, extensionId);
+    expect(sync.fixturePref).toBeUndefined();
+    expect(local.migrationResponses["fixture-flip"]).toBe("decline");
+  });
+
+  test("dismiss leaves the pref untouched + records 'dismiss' + banner does not re-show on next popup open", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+    await expect(page.locator("#migration-banner")).toBeVisible();
+    await page.locator("#migration-banner-dismiss").click();
+    await expect(page.locator("#migration-banner")).toBeHidden();
+
+    await page.close();
+
+    const { sync, local } = await readState(context, extensionId);
+    expect(sync.fixturePref).toBeUndefined();
+    expect(local.migrationResponses["fixture-flip"]).toBe("dismiss");
+
+    // Re-open popup — banner should stay hidden (response recorded, the
+    // evaluator skips migrations with any recorded response).
+    const page2 = await context.newPage();
+    await page2.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+    await expect(page2.locator("#migration-banner")).toBeHidden();
+    await page2.close();
+  });
+});

--- a/tests/e2e/reonboard-rendering.spec.mjs
+++ b/tests/e2e/reonboard-rendering.spec.mjs
@@ -1,0 +1,181 @@
+/**
+ * E2E: Re-onboard rendering — delta + material modes (#407)
+ *
+ * Drives the dormant rendering paths from #370 by injecting fixture
+ * overrides for `CONSENT_VERSION_MANIFEST` and `REQUIRED_CONSENT_VERSION`
+ * via `withFixtureManifest` (gated on the test-mode sentinel from #398).
+ *
+ * Three scenarios:
+ *
+ *   delta:    accepted 1.0, manifest [1.0, 1.1 additive], required 1.1
+ *             → mugaReonboardMode === "delta"
+ *             → features section hidden, delta banner visible
+ *             → clicking Start writes consent.consentVersion === "1.1"
+ *
+ *   material: accepted 1.0, manifest [1.0, 1.1 material], required 1.1
+ *             → mugaReonboardMode === "material"
+ *             → material banner visible, features section hidden
+ *             → getPrefs() onboardingDone falls back to false (gate
+ *               fires) — verified by reading prefs from the SW.
+ *
+ *   fresh:    no fixture; default behaviour stays "fresh".
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import {
+  seedStorage,
+  installTestModeSentinel,
+  clearTestModeSentinel,
+  withFixtureManifest,
+  clearFixtures,
+} from "./helpers/index.mjs";
+
+async function clearAll(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  await page.evaluate(() =>
+    Promise.all([
+      new Promise(r => chrome.storage.sync.clear(r)),
+      new Promise(r => chrome.storage.local.clear(r)),
+    ])
+  );
+  if (opened) await page.close();
+}
+
+async function readPrefsViaSW(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const prefs = await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "getPrefs" }, resolve);
+    })
+  );
+  if (opened) await page.close();
+  return prefs;
+}
+
+test.describe("Re-onboard rendering: delta + material (#407)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await clearAll(context, extensionId);
+    await installTestModeSentinel(context, extensionId);
+  });
+
+  test.afterEach(async ({ context, extensionId }) => {
+    await clearFixtures(context, extensionId);
+    await clearTestModeSentinel(context, extensionId);
+  });
+
+  test("delta mode: additive bump renders soft re-onboard banner", async ({ context, extensionId }) => {
+    // Local consent: user accepted 1.0 previously.
+    await seedStorage(context, extensionId, {
+      local: {
+        mugaConsent: {
+          onboardingDone: true,
+          consentVersion: "1.0",
+          consentDate: 1700000000000,
+        },
+      },
+    });
+
+    // Manifest fixture: 1.0 baseline + 1.1 additive. Required is 1.1.
+    await withFixtureManifest(context, extensionId, {
+      consentManifest: [
+        { version: "1.0", additive: false },
+        { version: "1.1", additive: true },
+      ],
+      requiredConsentVersion: "1.1",
+      consentClausesByVersion: { "1.0": [], "1.1": [] }, // empty clauses ok
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    expect(await page.evaluate(() => document.body.dataset.mugaReonboardMode)).toBe("delta");
+    await expect(page.locator("#features-section")).toBeHidden();
+    await expect(page.locator("#reonboard-delta")).toBeVisible();
+    await expect(page.locator("#reonboard-material")).toBeHidden();
+
+    // Click Start — writes consent.consentVersion === "1.1" against the
+    // fixture's required version.
+    await page.locator("#tos-check").check();
+    await page.locator("#start-btn").click();
+    await page.waitForEvent("close", { timeout: 5000 }).catch(() => {});
+
+    const verifyPage = await context.newPage();
+    await verifyPage.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+    const consent = await verifyPage.evaluate(() =>
+      new Promise(resolve =>
+        chrome.storage.local.get({ mugaConsent: null }, r => resolve(r.mugaConsent))
+      )
+    );
+    expect(consent.onboardingDone).toBe(true);
+    expect(consent.consentVersion).toBe("1.1");
+    await verifyPage.close();
+  });
+
+  test("material mode: non-additive bump renders hard re-onboard banner", async ({ context, extensionId }) => {
+    await seedStorage(context, extensionId, {
+      local: {
+        mugaConsent: {
+          onboardingDone: true,
+          consentVersion: "1.0",
+          consentDate: 1700000000000,
+        },
+      },
+    });
+
+    await withFixtureManifest(context, extensionId, {
+      consentManifest: [
+        { version: "1.0", additive: false },
+        { version: "1.1", additive: false }, // material change
+      ],
+      requiredConsentVersion: "1.1",
+      consentClausesByVersion: { "1.0": [], "1.1": [] },
+    });
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    expect(await page.evaluate(() => document.body.dataset.mugaReonboardMode)).toBe("material");
+    await expect(page.locator("#features-section")).toBeHidden();
+    await expect(page.locator("#reonboard-material")).toBeVisible();
+    await expect(page.locator("#reonboard-delta")).toBeHidden();
+
+    await page.close();
+
+    // Hard-reonboard gate (#370) — getPrefs() forces onboardingDone:false
+    // when the consent policy says material change pending. Verify by
+    // reading prefs through the SW message handler.
+    const prefs = await readPrefsViaSW(context, extensionId);
+    expect(prefs.onboardingDone).toBe(false);
+  });
+
+  test("fresh mode: no fixtures means default rendering", async ({ context, extensionId }) => {
+    // No consent stored, no fixtures applied beyond the sentinel —
+    // onboarding renders the standard fresh flow.
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding/onboarding.html`);
+    await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
+
+    expect(await page.evaluate(() => document.body.dataset.mugaReonboardMode)).toBe("fresh");
+    await expect(page.locator("#features-section")).toBeVisible();
+    await expect(page.locator("#reonboard-delta")).toBeHidden();
+    await expect(page.locator("#reonboard-material")).toBeHidden();
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #407. Drives the dormant rendering paths from #370 (re-onboard delta / material) and #369 (migration banner) using fixture overrides gated on the test-mode sentinel (#398).

**New e2e specs**

- \`tests/e2e/reonboard-rendering.spec.mjs\` (3 tests): delta mode, material mode (with hard-reonboard gate verification via SW \`getPrefs\` message), fresh mode regression guard.
- \`tests/e2e/migration-banner.spec.mjs\` (4 tests): banner renders with fixture copy, accept (writes pref + records response), decline (no pref + records), dismiss (no pref + records + does not re-show on next popup open).

**Infrastructure**

- New module \`src/lib/test-fixtures.js\` — single accessor returning null in production, fixture bundle when the test sentinel is set.
- New helper \`tests/e2e/helpers/fixtures.mjs\` — \`withFixtureManifest\` / \`clearFixtures\`. Re-exported from \`helpers/index.mjs\`.

**Production code touched (all sentinel-gated, no-op without fixtures)**

- \`src/onboarding/onboarding.js\` — threads override manifest / requiredVersion / clausesByVersion through \`evaluate()\` + \`clausesForDelta()\`; acceptance writes the active required version.
- \`src/lib/storage.js\` — \`getPrefs\` threads fixture overrides into the hard-reonboard gate's \`evaluate()\` call.
- \`src/popup/popup.js\` — \`wireMigrationPrompt\` reads fixtures, overrides the migrations array + the \`t\` callback for banner copy.
- \`src/lib/migration-prompt.js\` — \`createMigrationPrompt\` accepts an optional \`migrations\` override.
- \`src/background/service-worker.js\` — \`storage.onChanged\` invalidates the prefs cache on sentinel / fixture-key writes (both never written in production).

## Test plan

- [x] 7 new e2e tests green locally on Chromium.
- [x] Full e2e suite (62 tests) green locally.
- [x] Unit suite (2516 tests) green locally.
- [ ] CI green.