### PR TITLE
test(unit): ops-docs sync checks (#414)

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,42 @@
+# Ops docs — index
+
+Three runbooks for the maintainer running MUGA in production. Read in this order on first encounter; jump to the one you need on subsequent visits.
+
+## Read in this order
+
+### 1. [health-signals.md](./health-signals.md)
+
+What to watch after a release, how loud each channel is, and when a blip becomes a regression. Documents the GitHub-issues stream, AMO + CWS reviews, the in-extension `Report unclean URL` and `Report a problem` channels, and direct email — with latency, baseline, and signal-to-noise per source. Includes a threshold table (watch / investigate / confirmed regression), an explicit T+0/+6/+24/+48/+72 checklist for the first 72 hours after release, and the quiet-period cadence after that.
+
+**Consult when:** triaging signals after a release; deciding whether a one-star review or a cluster of GitHub issues warrants action.
+
+### 2. [rollback-playbook.md](./rollback-playbook.md)
+
+Incident response runbook. The calm, decisive doc for the maintainer mid-incident. Covers the revert vs forward-fix decision tree, three paths for identifying the bad commit (`git log` review, `git bisect`, in-extension report cross-reference), copy-pasteable commands for cutting a PATCH release, a fill-in-the-blank communication template, the re-validation window post-patch, and the explicit list of cases where you **do not** roll back (cosmetic, sub-1% impact, intentional behavior).
+
+**Consult when:** a regression has been confirmed (per `health-signals.md` thresholds) and you need to act.
+
+### 3. [staged-release.md](./staged-release.md)
+
+Decision doc for whether a release ships staged on Chrome or full. Covers the asymmetry between CWS (granular % rollouts) and AMO (always 100% on publish), the pros and cons of staging, the explicit "stage when X / skip when Y" criteria, the default 1% → 10% → 50% → 100% ramp schedule with hold rules tied to `health-signals.md`, the available tooling, and a per-release decision log.
+
+**Consult when:** at release time, choosing whether this build ships staged or full; or planning the AMO synchronize / stagger / accept-asymmetry option.
+
+## When to consult each — quick reference
+
+| Situation | Doc |
+|---|---|
+| Picked up a one-star review, not sure if it's actionable | `health-signals.md` |
+| Three users reported the same broken site in 24h | `health-signals.md` (confirmation) → `rollback-playbook.md` (action) |
+| Confirmed regression, deciding revert vs fix | `rollback-playbook.md` |
+| Cutting v1.X.Y patch | `rollback-playbook.md` §3 |
+| About to tag v1.13.0, deciding rollout strategy | `staged-release.md` |
+| Mid-rollout, deciding whether to ramp from 10% to 50% | `health-signals.md` thresholds + `staged-release.md` ramp rules |
+
+## Format and tone
+
+All three docs are plain markdown, runbook-style, calm and direct. They are not packed into the AMO/CWS extension bundle (web-ext uses `--source-dir src/` so anything outside `src/` stays out of the package). Edit them like you would edit a runbook for yourself in 6 months.
+
+## Last reviewed
+
+The per-release decision log in `staged-release.md` §7 is the canonical "is this still current" indicator. If the most recent decision-log entry is older than the most recent release, give the index a re-read pass.

--- a/tests/unit/ops-docs-sync.test.mjs
+++ b/tests/unit/ops-docs-sync.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * MUGA: Ops-docs sync test (#414)
+ *
+ * Mechanical drift checks for the runbooks under docs/ops/. Catches
+ * the obvious sync failures without trying to evaluate substance.
+ *
+ * Substance review (does the runbook describe the current process)
+ * stays a human task. This file enforces:
+ *
+ *   1. Every doc in docs/ops/ is referenced from docs/ops/README.md
+ *      so the index does not silently drift out of sync with the
+ *      sibling files.
+ *
+ *   2. The rollback playbook references at least one CHANGELOG entry
+ *      version (e.g. "v1.12.0"), keeping the playbook's example
+ *      version connected to the actual codebase. If a future release
+ *      cycle bumps the major version and the playbook stays on the
+ *      old example, this catches it.
+ *
+ * Run with: npm test
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "../..");
+const opsDir = join(root, "docs/ops");
+
+function read(relPath) {
+  return readFileSync(join(root, relPath), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// 1. Every doc in docs/ops/ must be referenced from docs/ops/README.md
+// ---------------------------------------------------------------------------
+describe("Ops-docs sync — every doc is indexed", () => {
+  test("docs/ops/README.md references every sibling .md file", () => {
+    const readme = read("docs/ops/README.md");
+    const siblings = readdirSync(opsDir).filter(
+      (f) => f.endsWith(".md") && f !== "README.md"
+    );
+
+    assert.ok(siblings.length > 0, "docs/ops/ has no runbooks (expected at least one)");
+
+    for (const sibling of siblings) {
+      const isReferenced =
+        readme.includes(`(${sibling})`) ||
+        readme.includes(`(./${sibling})`) ||
+        readme.includes(`/${sibling}`);
+      assert.ok(
+        isReferenced,
+        [
+          `docs/ops/README.md does not reference ${sibling}.`,
+          "Either link the doc from the index or remove it from docs/ops/.",
+        ].join(" ")
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Rollback playbook references a CHANGELOG version
+// ---------------------------------------------------------------------------
+describe("Ops-docs sync — rollback playbook references CHANGELOG versions", () => {
+  test("docs/ops/rollback-playbook.md cites at least one v1.X.Y version", () => {
+    const playbook = read("docs/ops/rollback-playbook.md");
+    const changelog = read("CHANGELOG.md");
+
+    // Pull every version stamp from the CHANGELOG.
+    const changelogVersions = new Set(
+      [...changelog.matchAll(/v?(\d+\.\d+\.\d+)/g)].map((m) => m[1])
+    );
+    assert.ok(
+      changelogVersions.size > 0,
+      "CHANGELOG.md has no v X.Y.Z entries (expected at least one)"
+    );
+
+    // The playbook should reference at least ONE version that also
+    // appears in the CHANGELOG. This keeps the example stay connected
+    // to the actual release line.
+    const playbookVersions = [...playbook.matchAll(/v?(\d+\.\d+\.\d+)/g)].map((m) => m[1]);
+    const intersection = playbookVersions.filter((v) => changelogVersions.has(v));
+
+    assert.ok(
+      intersection.length > 0,
+      [
+        "docs/ops/rollback-playbook.md does not cite any version that appears",
+        "in CHANGELOG.md. The playbook example versions should be drawn from",
+        "the actual release line, not invented numbers.",
+        `Playbook versions: ${playbookVersions.join(", ") || "(none)"}`,
+        `CHANGELOG versions: ${[...changelogVersions].slice(0, 5).join(", ")}…`,
+      ].join("\n  ")
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #414. (#476 was auto-closed when its base branch \`docs/413-ops-readme\` was deleted upon merge of #475; this is the rebase-onto-main reopen.)

New \`tests/unit/ops-docs-sync.test.mjs\` with two mechanical drift checks for \`docs/ops/\` runbooks:

1. Every sibling \`.md\` is referenced from \`docs/ops/README.md\`.
2. \`rollback-playbook.md\` cites at least one version that appears in \`CHANGELOG.md\`.

## Test plan

- [x] 2 new unit tests green locally.
- [x] No code changes.
- [ ] CI green.