### PR TITLE
ci: weekly auto-importer for AdGuard Filter 17 tracking params (#459)

### DIFF
--- a/.github/workflows/import-upstream.yml
+++ b/.github/workflows/import-upstream.yml
@@ -1,0 +1,137 @@
+name: Import upstream tracking params
+
+on:
+  schedule:
+    # Sunday 04:00 UTC. Off-peak so the PR notification arrives at the start
+    # of the maintainer's week without competing with weekday CI traffic.
+    - cron: "0 4 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Concurrency: only one importer in flight; queued, no cancellation.
+concurrency:
+  group: import-upstream
+  cancel-in-progress: false
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch upstream and diff
+        id: diff
+        run: |
+          set -eo pipefail
+          IMPORT_REPORT_PATH="$GITHUB_WORKSPACE/import-report.json" \
+            node tools/import-upstream.mjs
+          COUNT=$(jq -r '.new_candidates_count' "$GITHUB_WORKSPACE/import-report.json")
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Candidates discovered: $COUNT"
+
+      - name: Exit early if no new candidates
+        if: steps.diff.outputs.count == '0'
+        run: echo "No new candidates from upstream this week. Exiting cleanly."
+
+      - name: Configure git for the bot commit
+        if: steps.diff.outputs.count != '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create branch and commit candidates
+        if: steps.diff.outputs.count != '0'
+        id: branch
+        run: |
+          set -eo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="auto-import/$DATE"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+
+          # If a branch from a previous failed run exists, recreate from main.
+          git checkout -B "$BRANCH"
+
+          mkdir -p tools/import-candidates
+          cp "$GITHUB_WORKSPACE/import-report.json" "tools/import-candidates/report-$DATE.json"
+
+          git add tools/import-candidates/
+          COUNT=${{ steps.diff.outputs.count }}
+          git commit -m "auto-import: $COUNT tracking-param candidates from AdGuard Filter 17 ($DATE)"
+          git push -u origin "$BRANCH" --force-with-lease
+
+      - name: Open or update pull request
+        if: steps.diff.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eo pipefail
+          DATE="${{ steps.branch.outputs.date }}"
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          COUNT="${{ steps.diff.outputs.count }}"
+          REPORT="$GITHUB_WORKSPACE/import-report.json"
+
+          # Build the candidate list as a markdown bulleted block.
+          CANDIDATES=$(jq -r '.new_candidates[] | "- `" + . + "`"' "$REPORT")
+
+          BODY=$(cat <<EOF
+          Weekly automated diff against [AdGuard URL Tracking Protection (Filter 17)](https://filters.adtidy.org/extension/safari/filters/17.txt).
+
+          **Source:** AdGuard Filter 17
+          **Fetched at:** $(jq -r '.fetched_at' "$REPORT")
+          **Params in upstream:** $(jq -r '.total_in_source' "$REPORT")
+          **Params in MUGA:** $(jq -r '.total_in_muga' "$REPORT")
+          **New candidates (not in MUGA):** $COUNT
+
+          ## Candidates
+
+          $CANDIDATES
+
+          ## Reviewer checklist
+
+          - [ ] Each candidate is a real tracking parameter (not a functional or affiliate one for any host MUGA already preserves)
+          - [ ] Categorize each candidate into the appropriate \`TRACKING_PARAM_CATEGORIES\` group in \`src/lib/affiliates.js\`
+          - [ ] Append to \`TRACKING_PARAMS\` array in the same file
+          - [ ] Run \`npm run build:rules\` to regenerate the DNR ruleset
+          - [ ] Run \`npm run build:content\` to regenerate the content-script bundle
+          - [ ] Add unit tests for any candidate with non-trivial behaviour
+          - [ ] Once all candidates are triaged, delete \`tools/import-candidates/report-$DATE.json\`
+
+          **DO NOT auto-merge.** Each candidate requires human judgment to confirm
+          it is not a functional parameter on some site and to assign it to the
+          right category. Marketers occasionally add their own tracking under
+          parameter names that look ambiguous.
+
+          The raw import report is committed to this branch at
+          \`tools/import-candidates/report-$DATE.json\` for archival.
+          EOF
+          )
+
+          # Re-use existing PR if one is already open against this branch.
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "[auto-import] $COUNT tracking-param candidates from AdGuard Filter 17 ($DATE)" --body "$BODY"
+            echo "Updated existing PR #$EXISTING"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "[auto-import] $COUNT tracking-param candidates from AdGuard Filter 17 ($DATE)" \
+              --body "$BODY" \
+              --label "needs-triage,category:ops"
+          fi

--- a/tests/unit/import-upstream.test.mjs
+++ b/tests/unit/import-upstream.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * MUGA — Unit tests for tools/import-upstream.mjs
+ *
+ * Run with: npm test
+ *
+ * Coverage:
+ *   - parseRemoveparamRules extracts param names from removeparam rules
+ *   - Pipe-separated multi-param rules split correctly
+ *   - Regex specs (starting with /) are skipped
+ *   - Negation specs (starting with ~) are skipped
+ *   - Comments (!) and section headers ([) are ignored
+ *   - Param names are lowercased and validated
+ *   - Empty input returns an empty set
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { parseRemoveparamRules } from "../../tools/import-upstream.mjs";
+
+describe("parseRemoveparamRules", () => {
+  test("extracts a simple removeparam rule", () => {
+    const text = "*$removeparam=fbclid";
+    const result = parseRemoveparamRules(text);
+    assert.deepEqual([...result], ["fbclid"]);
+  });
+
+  test("splits pipe-separated multi-param rules", () => {
+    const text = "*$removeparam=fbclid|gclid|msclkid";
+    const result = parseRemoveparamRules(text);
+    assert.deepEqual([...result].sort(), ["fbclid", "gclid", "msclkid"]);
+  });
+
+  test("handles host-scoped rules (||example.com^)", () => {
+    const text = "||example.com^$removeparam=utm_source";
+    const result = parseRemoveparamRules(text);
+    assert.deepEqual([...result], ["utm_source"]);
+  });
+
+  test("skips regex specs that start with /", () => {
+    const text = "*$removeparam=/^utm_/";
+    const result = parseRemoveparamRules(text);
+    assert.equal(result.size, 0);
+  });
+
+  test("skips negation specs that start with ~", () => {
+    const text = "*$removeparam=~tag";
+    const result = parseRemoveparamRules(text);
+    assert.equal(result.size, 0);
+  });
+
+  test("ignores comment lines starting with !", () => {
+    const text = "! this is a comment\n*$removeparam=fbclid";
+    const result = parseRemoveparamRules(text);
+    assert.deepEqual([...result], ["fbclid"]);
+  });
+
+  test("ignores section header lines starting with [", () => {
+    const text = "[Adblock Plus 2.0]\n*$removeparam=fbclid";
+    const result = parseRemoveparamRules(text);
+    assert.deepEqual([...result], ["fbclid"]);
+  });
+
+  test("lowercases all param names", () => {
+    const text = "*$removeparam=FBclid|GCLID";
+    const result = parseRemoveparamRules(text);
+    assert.deepEqual([...result].sort(), ["fbclid", "gclid"]);
+  });
+
+  test("returns an empty set for empty input", () => {
+    assert.equal(parseRemoveparamRules("").size, 0);
+    assert.equal(parseRemoveparamRules("\n\n").size, 0);
+  });
+
+  test("handles realistic AdGuard Filter 17 sample correctly", () => {
+    const text = `[Adblock Plus 2.0]
+! Title: AdGuard URL Tracking Protection
+! Description: example
+||example.com^$removeparam=utm_source
+||example.com^$removeparam=utm_medium
+*$removeparam=fbclid
+*$removeparam=gclid|gclsrc|dclid
+! comment
+*$removeparam=/^_branch_/
+*$removeparam=~important_tag`;
+    const result = parseRemoveparamRules(text);
+    assert.deepEqual(
+      [...result].sort(),
+      ["dclid", "fbclid", "gclid", "gclsrc", "utm_medium", "utm_source"]
+    );
+  });
+
+  test("rejects malformed param names containing illegal characters", () => {
+    const text = "*$removeparam=foo bar|baz<script>";
+    const result = parseRemoveparamRules(text);
+    // Neither matches the conservative validator regex; both are rejected.
+    assert.equal(result.size, 0);
+  });
+
+  test("ignores lines with no $removeparam modifier", () => {
+    const text = "||tracker.example.com^\n*$third-party";
+    const result = parseRemoveparamRules(text);
+    assert.equal(result.size, 0);
+  });
+});

--- a/tools/import-upstream.mjs
+++ b/tools/import-upstream.mjs
@@ -1,0 +1,115 @@
+/**
+ * MUGA: Auto-importer for upstream tracking parameter sources.
+ *
+ * Fetches AdGuard Filter 17 (URL Tracking Protection) and diffs the parsed
+ * removeparam rules against MUGA's TRACKING_PARAMS list. Writes a JSON report
+ * to /tmp/import-report.json with the new candidates that a human reviewer
+ * should triage into the appropriate TRACKING_PARAM_CATEGORIES group.
+ *
+ * Run with: node tools/import-upstream.mjs
+ *
+ * Designed to run from a GitHub Actions cron. The workflow is responsible for:
+ *   - reading /tmp/import-report.json
+ *   - opening a PR with the candidates if any are present
+ *   - never auto-merging — every change requires human judgment
+ *
+ * Why AdGuard Filter 17 only (in this initial version):
+ *   - It is the most actively maintained upstream URL-tracking list at the
+ *     scale MUGA cares about (verified by millions of users via AdGuard).
+ *   - License (GPL-3.0) is compatible with MUGA's GPL v3.
+ *   - Format is well-documented and stable (Adblock Plus syntax with
+ *     $removeparam modifier).
+ *
+ * ClearURLs is intentionally NOT imported here:
+ *   - License (LGPL-3.0+) would be technically compatible, but ClearURLs
+ *     uses a JSON ruleset with regex per provider rather than a flat param
+ *     list; the import shape does not fit MUGA's TRACKING_PARAMS array.
+ *   - Adding ClearURLs support is a follow-up if reviewer demand justifies it.
+ */
+
+import { TRACKING_PARAMS } from "../src/lib/affiliates.js";
+import { writeFileSync } from "node:fs";
+
+const ADGUARD_FILTER_17_URL =
+  "https://filters.adtidy.org/extension/safari/filters/17.txt";
+
+/**
+ * Parses an Adblock Plus filter list and extracts every removeparam parameter
+ * name. Pipe-separated multi-param rules are split. Regex-based removeparam
+ * rules (those starting with `/` or `~`) are skipped — those need different
+ * handling than a flat name list.
+ *
+ * @param {string} text The raw filter list contents.
+ * @returns {Set<string>} Lowercased parameter names found in $removeparam rules.
+ */
+export function parseRemoveparamRules(text) {
+  const params = new Set();
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith("!")) continue; // comment
+    if (line.startsWith("[")) continue; // section header
+
+    // Find the $removeparam modifier; multiple modifiers may be present so we
+    // search anywhere on the line and stop at the next `,` or end-of-line.
+    const match = /\$.*?removeparam=([^,$]+)/i.exec(line);
+    if (!match) continue;
+
+    const spec = match[1].trim();
+    if (!spec) continue;
+
+    // Skip regex specs and negations: those need rule-by-rule handling.
+    if (spec.startsWith("/") || spec.startsWith("~")) continue;
+
+    for (const piece of spec.split("|")) {
+      const name = piece.trim().toLowerCase();
+      if (!name) continue;
+      // Conservative param-name validation: alphanumeric + _ - . only.
+      if (!/^[a-z0-9_\-.]{1,64}$/.test(name)) continue;
+      params.add(name);
+    }
+  }
+  return params;
+}
+
+async function main() {
+  const response = await fetch(ADGUARD_FILTER_17_URL, {
+    headers: { "User-Agent": "muga-import-upstream/1.0 (+https://github.com/yocreoquesi/muga)" },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch AdGuard Filter 17: ${response.status} ${response.statusText}`);
+  }
+  const text = await response.text();
+
+  const upstreamParams = parseRemoveparamRules(text);
+  const existing = new Set(TRACKING_PARAMS.map((p) => p.toLowerCase()));
+
+  const candidates = [...upstreamParams].filter((p) => !existing.has(p));
+  candidates.sort();
+
+  const report = {
+    source: "AdGuard Filter 17 (URL Tracking Protection)",
+    source_url: ADGUARD_FILTER_17_URL,
+    fetched_at: new Date().toISOString(),
+    total_in_source: upstreamParams.size,
+    total_in_muga: existing.size,
+    new_candidates_count: candidates.length,
+    new_candidates: candidates,
+  };
+
+  const outPath = process.env.IMPORT_REPORT_PATH || "/tmp/import-report.json";
+  writeFileSync(outPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+  console.log(`AdGuard Filter 17: ${upstreamParams.size} params parsed`);
+  console.log(`MUGA TRACKING_PARAMS: ${existing.size} entries`);
+  console.log(`New candidates: ${candidates.length}`);
+  console.log(`Report written: ${outPath}`);
+}
+
+// Only run when invoked directly (not when imported by tests). Guard is
+// defensive against process.argv[1] being undefined (node -e, REPL, etc.).
+if (process.argv[1]?.endsWith("import-upstream.mjs")) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs every Sunday at 04:00 UTC, fetches AdGuard URL Tracking Protection (Filter 17), diffs the parsed `$removeparam` rules against MUGA's `TRACKING_PARAMS` array, and opens (or updates) a PR with any new candidates for human review.
- Cuts the maintenance burden of keeping the tracking-params list current without ever auto-merging — every candidate goes through human triage to confirm category and avoid false positives.
- 12 new unit tests covering the parser; full suite stays green.

Closes #459.

## What ships

- `tools/import-upstream.mjs` — pure-function parser of Adblock Plus `$removeparam` rules. Handles pipe-separated multi-param specs, skips regex (`/^utm_/`) and negation (`~tag`) specs, validates param names against a conservative charset, lowercases output. Writes a JSON report to `$IMPORT_REPORT_PATH` (default `/tmp/import-report.json`).
- `tests/unit/import-upstream.test.mjs` — 12 unit tests including a realistic AdGuard sample fragment regression.
- `.github/workflows/import-upstream.yml` — cron + manual dispatch. Idempotent (re-uses the same `auto-import/<date>` branch on re-runs and updates the existing PR instead of opening duplicates). Labels `needs-triage` + `category:ops`. Never auto-merges.

## Why AdGuard Filter 17 only at this stage

- Most actively maintained upstream URL-tracking list at MUGA scale (verified at scale by AdGuard's user base).
- License GPL-3.0 — compatible with MUGA's GPL v3.
- Stable Adblock Plus syntax with `$removeparam` modifier.

ClearURLs is **intentionally excluded for now**: its JSON ruleset uses per-provider regex rather than a flat param list, so the import shape does not fit `TRACKING_PARAMS`. Adding ClearURLs is a follow-up if reviewer demand justifies the additional adapter complexity.

## Test plan

- [x] `npm test` — 12 new unit tests pass; full suite remains green
- [x] Manual smoke test against a synthetic Filter 17 fragment — parser correctly extracts params, skips regex / negation, ignores comments and headers
- [ ] Reviewer manually triggers `workflow_dispatch` once to confirm end-to-end flow against the live AdGuard URL (will produce the first real `[auto-import]` PR)

## Reviewer checklist (when this lands)

- [ ] On the first generated PR, sanity-check the candidate list — most should land in `TRACKING_PARAM_CATEGORIES.ads` or `.email`
- [ ] Confirm the bot's commit signature (`github-actions[bot]`) matches expectation
- [ ] Confirm the workflow's idempotency by manually triggering it twice in a row — second run should update the existing PR, not open a duplicate

## Notes

- No new permissions on the extension manifest.
- No new runtime dependencies.
- The workflow uses `permissions: contents: write, pull-requests: write` (minimum needed to push the auto-import branch and open a PR).