### PR TITLE
docs(affiliates): record A5 (#457) Shopify and AliExpress rejection findings

### DIFF
--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -886,6 +886,27 @@ export const AFFILIATE_PATTERNS = [
   //   - Linear: no public referral / affiliate program at the time of writing.
   //     "Linear for Startups" is a discount program, not a referral commission.
   //
+  // Programs evaluated in slice #457 and intentionally NOT added:
+  //   - Shopify "native" referral: there is no Shopify-native referral or
+  //     affiliate parameter at the platform level. Shopify documentation
+  //     and major Shopify-ecosystem sources (Yotpo, ReferralCandy, Rivo)
+  //     all confirm that referral tracking is delegated to third-party apps
+  //     (ReferralCandy, UpPromote, Refersion, GoAffPro, etc.), each using
+  //     its own parameter scheme. A wildcard ?ref= match across every
+  //     Shopify-hosted store would produce massive false positives — `ref`
+  //     is widely used for non-affiliate purposes (anchors, navigation
+  //     context). Per-shop entries are theoretically supportable but out
+  //     of scope for the current host-based matcher.
+  //   - AliExpress aff_short_key on direct URLs: AliExpress's affiliate
+  //     attribution requires the click to pass through s.click.aliexpress.com
+  //     where parameters like `af` (offer ID), `cn` (affiliate ID), `dp`
+  //     (tracking ID), and `aff_short_key` are processed. The same
+  //     parameters appearing on a clean aliexpress.com/item/* URL do NOT
+  //     attribute a sale; the redirect is the attribution mechanism, not
+  //     the URL parameter. AliExpress is therefore handled as a
+  //     network-redirect through muga-unwrap's allowlist (which includes
+  //     s.click.aliexpress.com), not as a direct-injection program here.
+  //
   // AWIN network removed: redirect-based tracking only (awin1.com/pclick.php).
   // Cannot inject awc parameter directly; requires redirecting through AWIN servers.
   //


### PR DESCRIPTION
Documentation-only PR closing #457 with rationale.

After investigation, both candidates from #457 are intentionally rejected. The reasoning is preserved inline in `src/lib/affiliates.js` so future contributors who wonder "why no Shopify? why no AliExpress aff_short_key?" find the answer next to the code that would have implemented them.

## Shopify native referral

Confirmed against Shopify's own docs and ecosystem sources (Yotpo, ReferralCandy, Rivo): **Shopify does not offer a native referral or affiliate parameter at the platform level.** Tracking is delegated to third-party apps (ReferralCandy, UpPromote, Refersion, GoAffPro), each with its own parameter scheme. A wildcard `?ref=` across every Shopify-hosted store would produce massive false positives — `ref` is widely used for non-affiliate purposes (anchor links, navigation context).

Per-shop entries are theoretically supportable but out of scope for the current host-based matcher.

## AliExpress aff_short_key

AliExpress's affiliate attribution requires the click to pass through `s.click.aliexpress.com`, where parameters like `af`, `cn`, `dp`, and `aff_short_key` are processed. The same parameters appearing on a clean `aliexpress.com/item/*` URL do NOT attribute a sale; **the redirect is the attribution mechanism, not the URL parameter**.

AliExpress is therefore handled as a network-redirect through muga-unwrap's allowlist (which already includes `s.click.aliexpress.com`), NOT as a direct-injection program here.

## Test plan

- [x] No behaviour change — documentation-only commit
- [x] `npm test` — full regression still passing (2585/2585)
- [x] `npm run build:content` — bundle output identical (comments stripped by esbuild minification)

Closes #457.
