### PR TITLE
feat(wrapper-engine): Skimlinks + ShareASale + Rakuten + TradeTracker (#438)

### DIFF
--- a/src/lib/wrapper-engine.js
+++ b/src/lib/wrapper-engine.js
@@ -55,24 +55,62 @@
  *   extract: (url: URL) => string|null,
  * }>}
  */
+/**
+ * Builds a generic extract() that pulls `paramName` from the URL's query
+ * string and validates the result is a well-formed HTTP(S) URL. Centralizes
+ * the try/catch + protocol guard so each network entry stays declarative.
+ * @param {string} paramName
+ * @returns {(url: URL) => string|null}
+ */
+function extractFromParam(paramName) {
+  return (url) => {
+    const value = url.searchParams.get(paramName);
+    if (!value) return null;
+    try {
+      const dest = new URL(value);
+      if (dest.protocol !== "https:" && dest.protocol !== "http:") return null;
+      return value;
+    } catch {
+      return null;
+    }
+  };
+}
+
 export const WRAPPERS = [
   {
     id: "awin",
     name: "Awin",
     hostPatterns: ["awin1.com", "www.awin1.com"],
     pathPatterns: ["/cread.php", "/awclick.php"],
-    extract: (url) => {
-      const p = url.searchParams.get("p");
-      if (!p) return null;
-      // The URL API has already URL-decoded p; verify it's a valid HTTP(S) URL.
-      try {
-        const dest = new URL(p);
-        if (dest.protocol !== "https:" && dest.protocol !== "http:") return null;
-        return p;
-      } catch {
-        return null;
-      }
-    },
+    extract: extractFromParam("p"),
+  },
+  {
+    id: "skimlinks",
+    name: "Skimlinks",
+    hostPatterns: ["go.redirectingat.com", "go.skimresources.com"],
+    pathPatterns: null,
+    extract: extractFromParam("url"),
+  },
+  {
+    id: "shareasale",
+    name: "ShareASale",
+    hostPatterns: ["shareasale.com", "www.shareasale.com"],
+    pathPatterns: ["/r.cfm"],
+    extract: extractFromParam("urllink"),
+  },
+  {
+    id: "rakuten",
+    name: "Rakuten LinkShare",
+    hostPatterns: ["click.linksynergy.com"],
+    pathPatterns: ["/deeplink"],
+    extract: extractFromParam("murl"),
+  },
+  {
+    id: "tradetracker",
+    name: "TradeTracker",
+    hostPatterns: ["tc.tradetracker.net"],
+    pathPatterns: null,
+    extract: extractFromParam("u"),
   },
 ];
 

--- a/tests/unit/wrapper-engine-affiliate-networks.test.mjs
+++ b/tests/unit/wrapper-engine-affiliate-networks.test.mjs
@@ -1,0 +1,310 @@
+/**
+ * MUGA — Unit tests for B2 affiliate-network wrappers (issue #438).
+ *
+ * Run with: npm test
+ *
+ * Networks covered (extending B1's WRAPPERS table):
+ *   - Skimlinks      (go.redirectingat.com, go.skimresources.com → url=)
+ *   - ShareASale     (shareasale.com /r.cfm → urllink=)
+ *   - Rakuten        (click.linksynergy.com /deeplink → murl=)
+ *   - TradeTracker   (tc.tradetracker.net → u=)
+ *
+ * Each network has at minimum one positive fixture (real-shaped affiliate URL
+ * extracts to expected destination) and one negative (same host but missing
+ * destination param). Edge cases — malformed encoding, extra surviving
+ * params, recursion across networks — covered in the dedicated suites below.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { unwrap, detectWrapper, WRAPPERS } from "../../src/lib/wrapper-engine.js";
+
+// ---------------------------------------------------------------------------
+// Skimlinks
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — Skimlinks", () => {
+  test("unwraps go.redirectingat.com with url= parameter", () => {
+    const dest = "https://merchant.com/product";
+    const input =
+      "https://go.redirectingat.com/?id=12345X&xs=1&url=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result, "expected an unwrap result");
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["skimlinks"]);
+  });
+
+  test("unwraps go.skimresources.com variant", () => {
+    const dest = "https://shop.example.com/item/42";
+    const input =
+      "https://go.skimresources.com/?id=99999X&url=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+    assert.deepEqual(result.networks, ["skimlinks"]);
+  });
+
+  test("returns null when Skimlinks URL has no url parameter", () => {
+    const input = "https://go.redirectingat.com/?id=12345X&xs=1";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when Skimlinks url= is empty", () => {
+    const input = "https://go.redirectingat.com/?id=12345X&url=";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when Skimlinks url= is malformed (not a URL)", () => {
+    const input = "https://go.redirectingat.com/?url=not-a-url";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when Skimlinks url= is non-HTTP(S)", () => {
+    const input =
+      "https://go.redirectingat.com/?url=" + encodeURIComponent("ftp://example.com/file");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("preserves query string on the unwrapped Skimlinks destination", () => {
+    const dest = "https://merchant.com/product?utm_source=skim&id=42";
+    const input =
+      "https://go.redirectingat.com/?id=1&url=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ShareASale
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — ShareASale", () => {
+  test("unwraps shareasale.com/r.cfm with urllink= parameter", () => {
+    const dest = "https://merchant.com/landing";
+    const input =
+      "https://shareasale.com/r.cfm?b=12345&u=67890&m=11111&urllink=" +
+      encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["shareasale"]);
+  });
+
+  test("returns null when ShareASale URL has no urllink parameter", () => {
+    const input = "https://shareasale.com/r.cfm?b=12345&u=67890&m=11111";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when ShareASale urllink= is empty", () => {
+    const input = "https://shareasale.com/r.cfm?b=1&urllink=";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when ShareASale urllink= is malformed", () => {
+    const input = "https://shareasale.com/r.cfm?urllink=not-a-url";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("does not match ShareASale paths other than /r.cfm", () => {
+    const input =
+      "https://shareasale.com/u.cfm?urllink=" + encodeURIComponent("https://merchant.com");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("preserves query string on the unwrapped ShareASale destination", () => {
+    const dest = "https://merchant.com/product?ref=sas&id=1";
+    const input =
+      "https://shareasale.com/r.cfm?b=1&u=2&m=3&urllink=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rakuten LinkShare
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — Rakuten LinkShare", () => {
+  test("unwraps click.linksynergy.com/deeplink with murl= parameter", () => {
+    const dest = "https://merchant.com/category/shoes";
+    const input =
+      "https://click.linksynergy.com/deeplink?id=AbCdEf&mid=12345&murl=" +
+      encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["rakuten"]);
+  });
+
+  test("returns null when Rakuten URL has no murl parameter", () => {
+    const input = "https://click.linksynergy.com/deeplink?id=AbCdEf&mid=12345";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when Rakuten murl= is empty", () => {
+    const input = "https://click.linksynergy.com/deeplink?murl=";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when Rakuten murl= is malformed", () => {
+    const input = "https://click.linksynergy.com/deeplink?murl=javascript%3Aalert(1)";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("does not match Rakuten paths other than /deeplink", () => {
+    const input =
+      "https://click.linksynergy.com/other-path?murl=" +
+      encodeURIComponent("https://merchant.com");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("preserves query string on the unwrapped Rakuten destination", () => {
+    const dest = "https://merchant.com/p?utm_source=rakuten&q=42";
+    const input =
+      "https://click.linksynergy.com/deeplink?id=1&mid=2&murl=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TradeTracker
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — TradeTracker", () => {
+  test("unwraps tc.tradetracker.net with u= parameter", () => {
+    const dest = "https://merchant.com/offer";
+    const input =
+      "https://tc.tradetracker.net/?c=12345&m=67890&a=11111&r=&u=" +
+      encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["tradetracker"]);
+  });
+
+  test("returns null when TradeTracker URL has no u parameter", () => {
+    const input = "https://tc.tradetracker.net/?c=12345&m=67890";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when TradeTracker u= is empty", () => {
+    const input = "https://tc.tradetracker.net/?u=";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when TradeTracker u= is malformed", () => {
+    const input = "https://tc.tradetracker.net/?u=not-a-url";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when TradeTracker u= is non-HTTP(S)", () => {
+    const input =
+      "https://tc.tradetracker.net/?u=" + encodeURIComponent("file:///etc/passwd");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("preserves query string on the unwrapped TradeTracker destination", () => {
+    const dest = "https://merchant.com/p?ref=tt&utm_source=tt";
+    const input = "https://tc.tradetracker.net/?u=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases shared across the new networks
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — B2 edge cases", () => {
+  test("Skimlinks: extra params after extraction survive on the destination", () => {
+    const dest = "https://merchant.com/p?id=42&color=red";
+    const input =
+      "https://go.redirectingat.com/?id=1&xs=1&url=" + encodeURIComponent(dest) +
+      "&extra=foo";
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+    // The wrapper's own params (id, xs, extra) must NOT leak onto the destination.
+    assert.ok(!result.unwrapped.includes("xs=1"));
+    assert.ok(!result.unwrapped.includes("extra=foo"));
+  });
+
+  test("ShareASale: malformed percent-encoding in urllink yields null gracefully", () => {
+    // %ZZ is not a valid percent escape — URL parser treats it literally and
+    // the resulting string fails to parse as a URL.
+    const input = "https://shareasale.com/r.cfm?urllink=https%3A%2F%2Fmerchant.com%2F%ZZbad";
+    // Should not throw; either returns null or a result whose destination is
+    // still a valid http(s) URL. The contract is "no throw, graceful null".
+    const result = unwrap(input);
+    if (result !== null) {
+      assert.ok(result.unwrapped.startsWith("http"));
+    }
+  });
+
+  test("Rakuten: a long but valid destination URL still extracts", () => {
+    // Long destination near (but under) the project-wide 2000-char cap that
+    // downstream stages enforce. The wrapper extractor itself is contract-free
+    // about length — it must simply return whatever the URL API parses.
+    const longPath = "/p/" + "a".repeat(1500);
+    const dest = "https://merchant.com" + longPath;
+    const input =
+      "https://click.linksynergy.com/deeplink?murl=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+
+  test("TradeTracker wrapping Skimlinks resolves through both networks", () => {
+    const merchant = "https://merchant.com/final";
+    const skim =
+      "https://go.redirectingat.com/?id=1&url=" + encodeURIComponent(merchant);
+    const outer = "https://tc.tradetracker.net/?u=" + encodeURIComponent(skim);
+    const result = unwrap(outer);
+    assert.ok(result);
+    assert.equal(result.unwrapped, merchant);
+    assert.equal(result.hops, 2);
+    assert.deepEqual(result.networks, ["tradetracker", "skimlinks"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema introspection — every new network is well-formed
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — B2 schema", () => {
+  for (const id of ["skimlinks", "shareasale", "rakuten", "tradetracker"]) {
+    test(`WRAPPERS contains ${id} with required schema fields`, () => {
+      const w = WRAPPERS.find((entry) => entry.id === id);
+      assert.ok(w, `${id} entry must exist in WRAPPERS`);
+      assert.ok(typeof w.name === "string" && w.name.length > 0);
+      assert.ok(Array.isArray(w.hostPatterns) && w.hostPatterns.length > 0);
+      assert.ok(typeof w.extract === "function");
+    });
+  }
+
+  test("detectWrapper resolves each new network correctly", () => {
+    assert.equal(
+      detectWrapper("https://go.redirectingat.com/?url=https%3A%2F%2Fx.com").id,
+      "skimlinks"
+    );
+    assert.equal(
+      detectWrapper("https://go.skimresources.com/?url=https%3A%2F%2Fx.com").id,
+      "skimlinks"
+    );
+    assert.equal(
+      detectWrapper("https://shareasale.com/r.cfm?urllink=https%3A%2F%2Fx.com").id,
+      "shareasale"
+    );
+    assert.equal(
+      detectWrapper("https://click.linksynergy.com/deeplink?murl=https%3A%2F%2Fx.com").id,
+      "rakuten"
+    );
+    assert.equal(
+      detectWrapper("https://tc.tradetracker.net/?u=https%3A%2F%2Fx.com").id,
+      "tradetracker"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #438 (B2). Extends the Wrapper Engine config table — built in B1 — with four affiliate-network wrappers, plus a shared extractor refactor.

## New networks

- **Skimlinks**: `go.redirectingat.com`, `go.skimresources.com` → `?url=`
- **ShareASale**: `shareasale.com/r.cfm` → `?urllink=`
- **Rakuten LinkShare**: `click.linksynergy.com/deeplink` → `?murl=`
- **TradeTracker**: `tc.tradetracker.net` → `?u=`

## Refactor

Extracted `extractFromParam(name)` so all five networks (including existing Awin) share one validated extractor: try/catch around `new URL()` + `http:`/`https:` protocol guard. Awin behavior unchanged — its 21 existing tests still pass.

## Test plan

- [x] `npm test` → **2674/2674** passing (+34 from baseline 2640)
- [x] `npm run lint` → 0 errors (only pre-existing i18n warnings)
- [x] No version bump (feature additive, no behavior change for existing URLs)
- [x] Coverage per network: positive + negative + edges (missing param, malformed encoding, non-HTTP scheme, wrong path)
- [x] Cross-network recursion test (TradeTracker → Skimlinks → merchant)

## Notes

The 2000-char destination cap lives in `cleaner.js`, not in the wrapper extractors — matched B1's existing approach. A long-destination test locks in this contract.