### PR TITLE
feat(wrapper-engine): t.co + Facebook + Instagram social wrappers (#440)

### DIFF
--- a/src/lib/wrapper-engine.js
+++ b/src/lib/wrapper-engine.js
@@ -76,6 +76,38 @@ function extractFromParam(paramName) {
   };
 }
 
+/**
+ * Tries each query-parameter name in order and returns the first that yields
+ * a well-formed http(s) URL. Returns null when none succeed. Used by short
+ * URLs whose canonical destination lives behind an HTTP redirect (which the
+ * engine cannot follow) but where the destination is sometimes attached as
+ * a query fallback by upstream tooling.
+ *
+ * WHY: t.co is path-based (`/abcdef`) and the real destination only resolves
+ * via a 301 the engine cannot perform. Per #440, we register the host so
+ * detectWrapper() flags it, and try a small allowlist of conventional query
+ * keys (`url`, `u`) before giving up. The host is still identified as a
+ * wrapper (useful for caps-validator and metrics) even when extraction fails.
+ * @param {string[]} paramNames
+ * @returns {(url: URL) => string|null}
+ */
+function extractFromAnyParam(paramNames) {
+  return (url) => {
+    for (const name of paramNames) {
+      const value = url.searchParams.get(name);
+      if (!value) continue;
+      try {
+        const dest = new URL(value);
+        if (dest.protocol !== "https:" && dest.protocol !== "http:") continue;
+        return value;
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  };
+}
+
 export const WRAPPERS = [
   {
     id: "awin",
@@ -109,6 +141,48 @@ export const WRAPPERS = [
     id: "tradetracker",
     name: "TradeTracker",
     hostPatterns: ["tc.tradetracker.net"],
+    pathPatterns: null,
+    extract: extractFromParam("u"),
+  },
+  {
+    id: "tco",
+    name: "Twitter t.co",
+    // WHY exact host: t.co is the only label; subdomains like api.t.co are
+    // unrelated services and must not be flagged as wrappers.
+    hostPatterns: ["t.co"],
+    pathPatterns: null,
+    // WHY query fallback: t.co's canonical form is path-based and resolves
+    // through an HTTP 301 the engine cannot follow. We try ?url= / ?u= which
+    // some upstream tools attach, and otherwise return null gracefully.
+    extract: extractFromAnyParam(["url", "u"]),
+  },
+  {
+    id: "facebook-l",
+    name: "Facebook Outbound (web)",
+    // WHY only l.facebook.com (not facebook.com / www.facebook.com): the
+    // outbound link wrapper lives exclusively on the l. subdomain. Matching
+    // the parent would catch unrelated profile/post URLs.
+    hostPatterns: ["l.facebook.com"],
+    pathPatterns: ["/l.php"],
+    extract: extractFromParam("u"),
+  },
+  {
+    id: "facebook-lm",
+    name: "Facebook Outbound (mobile)",
+    // WHY separate id: l. and lm. carry the same wrapper schema but represent
+    // different surfaces (web vs. mobile-web). Tracking them separately lets
+    // metrics distinguish where outbound clicks originate.
+    hostPatterns: ["lm.facebook.com"],
+    pathPatterns: ["/l.php"],
+    extract: extractFromParam("u"),
+  },
+  {
+    id: "instagram-l",
+    name: "Instagram Outbound",
+    // WHY only l.instagram.com: parent instagram.com is the social network
+    // itself and must never be flagged. The outbound wrapper has no fixed
+    // path prefix — the destination travels in ?u= directly off the root.
+    hostPatterns: ["l.instagram.com"],
     pathPatterns: null,
     extract: extractFromParam("u"),
   },

--- a/tests/unit/wrapper-engine-social.test.mjs
+++ b/tests/unit/wrapper-engine-social.test.mjs
@@ -1,0 +1,334 @@
+/**
+ * MUGA — Unit tests for B4 social/short-URL wrappers (issue #440).
+ *
+ * Run with: npm test
+ *
+ * Networks covered (extending the WRAPPERS table):
+ *   - t.co              (Twitter): path-based redirect; engine cannot do HTTP.
+ *                       The wrapper is REGISTERED so detectWrapper() flags the
+ *                       host, but extraction is best-effort: when a query
+ *                       fallback is present (?url=, ?u=) it is returned;
+ *                       otherwise null.
+ *   - l.facebook.com    /l.php → ?u=  (Facebook outbound link wrapper, web)
+ *   - lm.facebook.com   /l.php → ?u=  (Facebook mobile outbound link wrapper)
+ *   - l.instagram.com   → ?u=         (Instagram outbound link wrapper)
+ *
+ * Acceptance highlights (from #440):
+ *   - Each wrapper detects without false positives on the parent domain
+ *     (facebook.com / instagram.com / twitter.com must NOT match).
+ *   - Facebook `l` and `lm` subdomains are tested separately (different hosts).
+ *   - Recursion smoke test: l.facebook.com wrapping go.redirectingat.com
+ *     wrapping a merchant URL resolves end-to-end through processUrl.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { unwrap, detectWrapper, WRAPPERS } from "../../src/lib/wrapper-engine.js";
+
+// ---------------------------------------------------------------------------
+// t.co — Twitter short-URL host
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — t.co", () => {
+  test("detectWrapper recognizes t.co host (registered as wrapper)", () => {
+    const w = detectWrapper("https://t.co/abcdef");
+    assert.ok(w, "t.co must be a recognized wrapper host");
+    assert.equal(w.id, "tco");
+  });
+
+  test("returns null for path-based t.co (no query fallback) — best-effort", () => {
+    // The real t.co hides the destination behind an HTTP redirect we cannot
+    // follow. With no query fallback, extraction returns null gracefully and
+    // unwrap() therefore returns null (engine contract: null on first miss).
+    const input = "https://t.co/abcdef";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("extracts destination from ?url= query fallback when present", () => {
+    const dest = "https://merchant.example.com/p/123";
+    const input = "https://t.co/abcdef?url=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result, "expected an unwrap result for ?url= fallback");
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["tco"]);
+  });
+
+  test("extracts destination from ?u= query fallback when present", () => {
+    const dest = "https://merchant.example.com/landing";
+    const input = "https://t.co/xyz789?u=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+
+  test("returns null when t.co query fallback is malformed", () => {
+    const input = "https://t.co/abcdef?url=not-a-url";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when t.co query fallback is non-HTTP(S)", () => {
+    const input =
+      "https://t.co/abcdef?url=" + encodeURIComponent("javascript:alert(1)");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when t.co query fallback is empty", () => {
+    const input = "https://t.co/abcdef?url=";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("twitter.com (parent domain) does NOT match t.co wrapper", () => {
+    // The shortener is t.co, not twitter.com. Avoid false-positive on the
+    // social network's main domain.
+    assert.equal(detectWrapper("https://twitter.com/user/status/123"), null);
+    assert.equal(detectWrapper("https://www.twitter.com/user"), null);
+    assert.equal(detectWrapper("https://x.com/user/status/123"), null);
+  });
+
+  test("subdomains of t.co do NOT match (exact host only)", () => {
+    assert.equal(detectWrapper("https://api.t.co/abcdef"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Facebook l.php — web (l.facebook.com) and mobile (lm.facebook.com)
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — l.facebook.com", () => {
+  test("unwraps l.facebook.com/l.php with u= parameter", () => {
+    const dest = "https://merchant.example.com/p/42";
+    const input =
+      "https://l.facebook.com/l.php?u=" +
+      encodeURIComponent(dest) +
+      "&h=AT0abc&__tn__=R";
+    const result = unwrap(input);
+    assert.ok(result, "expected an unwrap result");
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["facebook-l"]);
+  });
+
+  test("returns null when l.facebook.com URL has no u parameter", () => {
+    const input = "https://l.facebook.com/l.php?h=AT0abc";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when l.facebook.com u= is empty", () => {
+    const input = "https://l.facebook.com/l.php?u=";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when l.facebook.com u= is malformed", () => {
+    const input = "https://l.facebook.com/l.php?u=not-a-url";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when l.facebook.com u= is non-HTTP(S)", () => {
+    const input =
+      "https://l.facebook.com/l.php?u=" + encodeURIComponent("ftp://example.com/x");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("does not match l.facebook.com paths other than /l.php", () => {
+    const input =
+      "https://l.facebook.com/other?u=" + encodeURIComponent("https://merchant.com");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("preserves query string on the unwrapped Facebook destination", () => {
+    const dest = "https://merchant.example.com/p?utm_source=fb&id=42";
+    const input =
+      "https://l.facebook.com/l.php?u=" + encodeURIComponent(dest) + "&h=AT0";
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+});
+
+describe("Wrapper Engine — lm.facebook.com (mobile)", () => {
+  test("unwraps lm.facebook.com/l.php with u= parameter", () => {
+    const dest = "https://merchant.example.com/m/42";
+    const input =
+      "https://lm.facebook.com/l.php?u=" +
+      encodeURIComponent(dest) +
+      "&h=AT0abc";
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["facebook-lm"]);
+  });
+
+  test("returns null when lm.facebook.com URL has no u parameter", () => {
+    const input = "https://lm.facebook.com/l.php?h=AT0abc";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("does not match lm.facebook.com paths other than /l.php", () => {
+    const input =
+      "https://lm.facebook.com/other?u=" + encodeURIComponent("https://merchant.com");
+    assert.equal(unwrap(input), null);
+  });
+});
+
+describe("Wrapper Engine — Facebook parent-domain false-positive guard", () => {
+  test("facebook.com (apex) does NOT match either Facebook wrapper", () => {
+    // Only the l. and lm. subdomains carry outbound link wrappers; the apex
+    // is the social network itself and must never be flagged.
+    assert.equal(detectWrapper("https://facebook.com/user/posts/1"), null);
+    assert.equal(
+      detectWrapper("https://facebook.com/l.php?u=https%3A%2F%2Fx.com"),
+      null
+    );
+  });
+
+  test("www.facebook.com does NOT match either Facebook wrapper", () => {
+    assert.equal(detectWrapper("https://www.facebook.com/user/posts/1"), null);
+    assert.equal(
+      detectWrapper("https://www.facebook.com/l.php?u=https%3A%2F%2Fx.com"),
+      null
+    );
+  });
+
+  test("m.facebook.com (mobile main) does NOT match (only lm. does)", () => {
+    assert.equal(
+      detectWrapper("https://m.facebook.com/l.php?u=https%3A%2F%2Fx.com"),
+      null
+    );
+  });
+
+  test("l and lm hosts produce DIFFERENT wrapper ids", () => {
+    const wL = detectWrapper("https://l.facebook.com/l.php?u=https%3A%2F%2Fx.com");
+    const wLm = detectWrapper("https://lm.facebook.com/l.php?u=https%3A%2F%2Fx.com");
+    assert.ok(wL);
+    assert.ok(wLm);
+    assert.notEqual(wL.id, wLm.id, "l. and lm. must be tracked separately");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// l.instagram.com
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — l.instagram.com", () => {
+  test("unwraps l.instagram.com with u= parameter", () => {
+    const dest = "https://merchant.example.com/ig/42";
+    const input =
+      "https://l.instagram.com/?u=" +
+      encodeURIComponent(dest) +
+      "&e=AT0abc";
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+    assert.equal(result.hops, 1);
+    assert.deepEqual(result.networks, ["instagram-l"]);
+  });
+
+  test("returns null when l.instagram.com URL has no u parameter", () => {
+    const input = "https://l.instagram.com/?e=AT0abc";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when l.instagram.com u= is empty", () => {
+    const input = "https://l.instagram.com/?u=";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when l.instagram.com u= is malformed", () => {
+    const input = "https://l.instagram.com/?u=not-a-url";
+    assert.equal(unwrap(input), null);
+  });
+
+  test("returns null when l.instagram.com u= is non-HTTP(S)", () => {
+    const input =
+      "https://l.instagram.com/?u=" + encodeURIComponent("file:///etc/passwd");
+    assert.equal(unwrap(input), null);
+  });
+
+  test("instagram.com (parent) does NOT match the Instagram wrapper", () => {
+    assert.equal(detectWrapper("https://instagram.com/user/p/abc"), null);
+    assert.equal(detectWrapper("https://www.instagram.com/user/p/abc"), null);
+  });
+
+  test("preserves query string on the unwrapped Instagram destination", () => {
+    const dest = "https://merchant.example.com/p?utm_source=ig&id=42";
+    const input = "https://l.instagram.com/?u=" + encodeURIComponent(dest);
+    const result = unwrap(input);
+    assert.ok(result);
+    assert.equal(result.unwrapped, dest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recursion smoke: Facebook wrapping Skimlinks wrapping a merchant.
+// End-to-end through processUrl (the production entry point).
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — B4 recursion through processUrl", () => {
+  test("l.facebook.com wrapping go.redirectingat.com wrapping merchant resolves end-to-end", async () => {
+    const { processUrl } = await import("../../src/lib/cleaner.js");
+    const PREFS = {
+      enabled: true,
+      injectOwnAffiliate: false,
+      notifyForeignAffiliate: false,
+      blacklist: [],
+      whitelist: [],
+    };
+    // Merchant carries a tracker that must be stripped AFTER both unwraps,
+    // proving the full pipeline (FB → Skim → merchant → cleaner) executed.
+    const merchantWithTracker =
+      "https://merchant.example.com/p/123?utm_source=fb";
+    const merchantClean = "https://merchant.example.com/p/123";
+    const skim =
+      "https://go.redirectingat.com/?id=12345X&url=" +
+      encodeURIComponent(merchantWithTracker);
+    const fb = "https://l.facebook.com/l.php?u=" + encodeURIComponent(skim);
+    const result = processUrl(fb, PREFS);
+    assert.equal(result.cleanUrl, merchantClean);
+    assert.equal(result.action, "cleaned");
+    assert.ok(result.removedTracking.includes("utm_source"));
+  });
+
+  test("unwrap() reports both networks for FB → Skimlinks → merchant chain", () => {
+    const merchant = "https://merchant.example.com/final";
+    const skim =
+      "https://go.redirectingat.com/?id=1&url=" + encodeURIComponent(merchant);
+    const outer = "https://l.facebook.com/l.php?u=" + encodeURIComponent(skim);
+    const result = unwrap(outer);
+    assert.ok(result);
+    assert.equal(result.unwrapped, merchant);
+    assert.equal(result.hops, 2);
+    assert.deepEqual(result.networks, ["facebook-l", "skimlinks"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema introspection — every new B4 entry is well-formed
+// ---------------------------------------------------------------------------
+describe("Wrapper Engine — B4 schema", () => {
+  for (const id of ["tco", "facebook-l", "facebook-lm", "instagram-l"]) {
+    test(`WRAPPERS contains ${id} with required schema fields`, () => {
+      const w = WRAPPERS.find((entry) => entry.id === id);
+      assert.ok(w, `${id} entry must exist in WRAPPERS`);
+      assert.ok(typeof w.name === "string" && w.name.length > 0);
+      assert.ok(Array.isArray(w.hostPatterns) && w.hostPatterns.length > 0);
+      assert.ok(typeof w.extract === "function");
+    });
+  }
+
+  test("detectWrapper resolves each new B4 network correctly", () => {
+    assert.equal(
+      detectWrapper("https://t.co/abc?url=https%3A%2F%2Fx.com").id,
+      "tco"
+    );
+    assert.equal(
+      detectWrapper("https://l.facebook.com/l.php?u=https%3A%2F%2Fx.com").id,
+      "facebook-l"
+    );
+    assert.equal(
+      detectWrapper("https://lm.facebook.com/l.php?u=https%3A%2F%2Fx.com").id,
+      "facebook-lm"
+    );
+    assert.equal(
+      detectWrapper("https://l.instagram.com/?u=https%3A%2F%2Fx.com").id,
+      "instagram-l"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #440 (B4). First batch of social/short-URL wrappers in the Wrapper Engine, plus an end-to-end recursion smoke test.

## New wrappers

- **t.co** (Twitter): registered for metrics; extraction is best-effort via query fallback (engine can't follow HTTP redirects, so path-based shortlinks return null gracefully)
- **l.facebook.com/l.php** → `?u=` (web)
- **lm.facebook.com/l.php** → `?u=` (mobile-web — tracked as `facebook-lm`, separate from `facebook-l`, so metrics distinguish surfaces)
- **l.instagram.com** → `?u=`

## Helper added

`extractFromAnyParam(paramNames)` for wrappers that may use any of several keys (used by t.co). Short-circuits on first valid http(s) URL, ignores empty/malformed/non-HTTPS values.

## Recursion smoke test

Verifies the full pipeline end-to-end through `processUrl`:

```
l.facebook.com/l.php?u=<encoded go.redirectingat.com/?url=<encoded merchant?utm_source=fb>>
  → merchant.example.com/p/123
```

Result: `action: cleaned`, `removedTracking: [utm_source]`, `networks: [facebook-l, skimlinks]`, hops: 2.

## Test plan

- [x] `npm test` → **2726/2726** passing (+37 from baseline 2689)
- [x] `npm run lint` → 0 errors
- [x] False-positive guards verified: `facebook.com`, `www.facebook.com`, `m.facebook.com`, `instagram.com`, `www.instagram.com`, `twitter.com`, `x.com`, `api.t.co` → all `null`
- [x] Recursion smoke test passes (cross-network FB → Skimlinks → cleaner)