### PR TITLE
feat(pipeline): Canonical Extractor tier — link rel + JSON-LD @id (#442)

### DIFF
--- a/docs/data_architect.md
+++ b/docs/data_architect.md
@@ -33,6 +33,7 @@ Source of truth: `PREF_DEFAULTS` in `src/lib/storage.js`.
 | `domainStats` | boolean | `true` | Track and display per-domain tracker counts in popup |
 | `remoteRulesEnabled` | boolean | `false` | Opt-in: fetch signed remote parameter updates weekly. Default off (zero network activity on fresh install) |
 | `honorCreatorMode` | boolean | `false` | Opt-in (#435, B12): preserve creator referral chains on trusted redirect networks. Plumbing only — no behaviour wired yet. |
+| `canonicalExtractorEnabled` | boolean | `true` | (#442, B7) When the wrapper engine detects an opaque wrapper (host matched but no destination in URL), consult content-script-supplied `<link rel=canonical>` / JSON-LD `@id` before giving up. Default ON. |
 
 ### List entry format
 

--- a/src/lib/canonical-extractor.js
+++ b/src/lib/canonical-extractor.js
@@ -1,0 +1,96 @@
+/**
+ * MUGA: Canonical URL Extractor (B7, #442)
+ *
+ * Second tier in the cleaner pipeline:
+ *   Wrapper Engine → Canonical Extractor → existing cleaner.
+ *
+ * Consulted only when the wrapper engine DETECTED a wrapper host but the
+ * destination URL could NOT be extracted from the URL itself ("opaque
+ * wrapper" — t.co, link.medium.com, …). Before falling back to a network
+ * resolution we do not perform, this module gives the page DOM a chance
+ * to volunteer the canonical URL via:
+ *   - <link rel="canonical">       (W3C standard; preferred)
+ *   - JSON-LD @id                  (schema.org metadata; secondary)
+ *
+ * ── Why a pure function over a "canonical bundle" object ──────────────────
+ * The MUGA test runner is plain `node:test` with no jsdom and no
+ * DOMParser. Accepting a Document/DocumentFragment directly would force
+ * tests to ship a DOM mock for every fixture. Instead, the caller (the
+ * content script — the only place with real DOM access) extracts the two
+ * raw values up-front:
+ *
+ *   const bundle = {
+ *     linkCanonical: document.querySelector('link[rel="canonical"]')?.href,
+ *     jsonLdId:      readJsonLdId(document), // see content script
+ *   };
+ *
+ * and passes the bundle to processUrl(). This module makes the W3C-vs-
+ * JSON-LD precedence decision and validates the resulting URL. Pure,
+ * deterministic, jsdom-free.
+ *
+ * ── Validation rules (consistent with the rest of the codebase) ──────────
+ *   - http:// or https:// only — never javascript:, data:, file:, etc.
+ *   - Length cap ≤ 2000 chars (matches wrapper-engine and cleaner caps).
+ *   - Malformed strings are silently rejected (try/catch around `new URL`).
+ *   - When linkCanonical fails validation, jsonLdId is given a chance.
+ */
+
+const URL_LENGTH_CAP = 2000;
+
+/**
+ * Returns the input string if it parses to a well-formed http(s) URL of
+ * acceptable length, otherwise null. Trims surrounding whitespace before
+ * parsing — common in DOM-extracted hrefs.
+ *
+ * @param {unknown} raw
+ * @returns {string|null}
+ */
+function validateHttpUrl(raw) {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > URL_LENGTH_CAP) return null;
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  // Only http(s) — match the rest of the cleaner / wrapper-engine policy.
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  return trimmed;
+}
+
+/**
+ * Pure canonical extractor.
+ *
+ * Decision rules (per acceptance criteria of #442):
+ *   1. If linkCanonical is a valid http(s) URL → return it.
+ *      (W3C `<link rel="canonical">` outranks JSON-LD `@id` even when both
+ *      are present and disagree.)
+ *   2. Otherwise, if jsonLdId is a valid http(s) URL → return it.
+ *   3. Otherwise → null (caller falls through to the rest of the pipeline).
+ *
+ * @param {{linkCanonical?: string|null, jsonLdId?: string|null}|null} bundle
+ *   A "canonical bundle" produced by the content script from the parsed
+ *   DOM. Either field may be absent, null, or empty string. Passing
+ *   undefined/null bundles is supported (returns null) so background
+ *   workers — which never have DOM access — can call freely.
+ * @returns {string|null} The canonical URL, or null if none usable.
+ */
+export function extractCanonical(bundle) {
+  if (!bundle || typeof bundle !== "object") return null;
+
+  // 1. linkCanonical wins on validity. We do NOT short-circuit on its
+  // mere presence — a malformed canonical href on the page must not poison
+  // the result; jsonLdId still gets a chance.
+  const link = validateHttpUrl(bundle.linkCanonical);
+  if (link) return link;
+
+  // 2. JSON-LD @id as fallback.
+  const id = validateHttpUrl(bundle.jsonLdId);
+  if (id) return id;
+
+  // 3. Neither slot yielded a usable URL.
+  return null;
+}

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -4,7 +4,8 @@
  */
 
 import { TRACKING_PARAMS, TRACKING_PARAM_CATEGORIES, getPatternsForHost } from "./affiliates.js";
-import { unwrap } from "./wrapper-engine.js";
+import { unwrap, detectWrapper } from "./wrapper-engine.js";
+import { extractCanonical } from "./canonical-extractor.js";
 
 // C5: O(1) lookup instead of O(n) array scan
 const TRACKING_PARAMS_SET = new Set(TRACKING_PARAMS.map(p => p.toLowerCase()));
@@ -200,9 +201,17 @@ function stripTrackingParams(url, prefs, domainRules, disabledCategories) {
  *
  * @param {string} rawUrl - The original URL to process.
  * @param {object} prefs  - User preferences from chrome.storage.sync.
+ * @param {Array}  [domainRules=[]] - Domain-rules array (preserveParams/stripParams).
+ * @param {{linkCanonical?: string|null, jsonLdId?: string|null}|undefined} [canonicalBundle]
+ *   Optional "canonical bundle" produced by the content script from the
+ *   page DOM (B7, #442). Used as a SECOND-TIER destination source only
+ *   when the wrapper engine detected a wrapper but extraction failed
+ *   (opaque wrapper case — t.co, link.medium.com, …). Background-worker
+ *   call sites that lack DOM access pass undefined and the canonical
+ *   tier no-ops.
  * @returns {{ cleanUrl: string, action: string, removedTracking: string[], junkRemoved: number, detectedAffiliate: object|null, preservedAffiliate: object|null }}
  */
-export function processUrl(rawUrl, prefs, domainRules = []) {
+export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle) {
   let url;
   try {
     url = new URL(rawUrl);
@@ -224,6 +233,26 @@ export function processUrl(rawUrl, prefs, domainRules = []) {
       url = new URL(rawUrl);
     } catch {
       return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null, preservedAffiliate: null };
+    }
+  } else if (
+    // Step 0b: Canonical Extractor tier (#442, B7). When the URL was
+    // identified as a wrapper but extraction failed (opaque wrapper —
+    // t.co, link.medium.com, …), give the page DOM a chance to volunteer
+    // the canonical destination via a bundle prepared by the content
+    // script. Default ON; bypass via prefs.canonicalExtractorEnabled=false.
+    // No-op when no bundle was supplied (background-worker case).
+    prefs.canonicalExtractorEnabled !== false &&
+    canonicalBundle &&
+    detectWrapper(rawUrl)
+  ) {
+    const canonical = extractCanonical(canonicalBundle);
+    if (canonical) {
+      rawUrl = canonical;
+      try {
+        url = new URL(rawUrl);
+      } catch {
+        return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null, preservedAffiliate: null };
+      }
     }
   }
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -112,6 +112,12 @@ export const PREF_DEFAULTS = {
   // chains may route through redirect networks the user did not consent to
   // contact otherwise.
   honorCreatorMode: false,
+  // Canonical Extractor toggle (#442, B7). Default ON: when the wrapper
+  // engine detects an opaque wrapper (host matched but no destination in
+  // the URL), the cleaner consults a content-script-supplied "canonical
+  // bundle" (<link rel=canonical> + JSON-LD @id) BEFORE giving up. Disable
+  // here to bypass that tier entirely without uninstalling content scripts.
+  canonicalExtractorEnabled: true,
 };
 
 /**

--- a/tests/unit/canonical-extractor.test.mjs
+++ b/tests/unit/canonical-extractor.test.mjs
@@ -1,0 +1,281 @@
+/**
+ * MUGA — Unit tests for B7 (#442): Canonical URL Extractor
+ *
+ * Pure module under test: src/lib/canonical-extractor.js
+ *
+ * The extractor sits as the SECOND tier in the cleaner pipeline:
+ *   Wrapper Engine → Canonical Extractor → existing cleaner.
+ *
+ * It is consulted only when the wrapper engine DETECTED an opaque wrapper
+ * (host matched a wrapper config) but EXTRACTION FAILED — i.e. the
+ * destination is not in the URL and must be read from the page DOM.
+ *
+ * Pure-function design (Approach A): the caller (content script with real
+ * DOM access) extracts `<link rel="canonical">` href and JSON-LD `@id`
+ * values up-front and passes them as a normalised "canonical bundle"
+ * object. The pure module decides what to return per the rules. Tests
+ * construct the bundle directly — no jsdom or DOMParser required.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractCanonical } from "../../src/lib/canonical-extractor.js";
+import { processUrl } from "../../src/lib/cleaner.js";
+
+// ── Pure module ─────────────────────────────────────────────────────────────
+
+describe("B7 canonical-extractor — bundle inputs", () => {
+  test("returns null when bundle is null/undefined", () => {
+    assert.strictEqual(extractCanonical(null), null);
+    assert.strictEqual(extractCanonical(undefined), null);
+  });
+
+  test("returns null when bundle is not an object", () => {
+    assert.strictEqual(extractCanonical("https://example.com"), null);
+    assert.strictEqual(extractCanonical(42), null);
+  });
+
+  test("returns null when neither linkCanonical nor jsonLdId present", () => {
+    assert.strictEqual(extractCanonical({}), null);
+    assert.strictEqual(extractCanonical({ linkCanonical: "", jsonLdId: "" }), null);
+    assert.strictEqual(extractCanonical({ linkCanonical: null, jsonLdId: null }), null);
+  });
+
+  test("returns linkCanonical when only it is present", () => {
+    const result = extractCanonical({
+      linkCanonical: "https://merchant.example.com/product/42",
+    });
+    assert.strictEqual(result, "https://merchant.example.com/product/42");
+  });
+
+  test("returns jsonLdId when only it is present", () => {
+    const result = extractCanonical({
+      jsonLdId: "https://merchant.example.com/product/42",
+    });
+    assert.strictEqual(result, "https://merchant.example.com/product/42");
+  });
+
+  test("prefers linkCanonical when BOTH agree", () => {
+    const url = "https://merchant.example.com/product/42";
+    const result = extractCanonical({ linkCanonical: url, jsonLdId: url });
+    assert.strictEqual(result, url);
+  });
+
+  test("prefers linkCanonical when both DISAGREE (W3C standard wins over JSON-LD metadata)", () => {
+    const result = extractCanonical({
+      linkCanonical: "https://merchant.example.com/canonical",
+      jsonLdId:      "https://merchant.example.com/jsonld",
+    });
+    assert.strictEqual(result, "https://merchant.example.com/canonical");
+  });
+
+  test("falls through to jsonLdId when linkCanonical is malformed", () => {
+    const result = extractCanonical({
+      linkCanonical: "not a url",
+      jsonLdId: "https://merchant.example.com/jsonld",
+    });
+    assert.strictEqual(result, "https://merchant.example.com/jsonld");
+  });
+
+  test("rejects non-http(s) schemes — javascript:", () => {
+    assert.strictEqual(
+      extractCanonical({ linkCanonical: "javascript:alert(1)" }),
+      null
+    );
+  });
+
+  test("rejects non-http(s) schemes — data:", () => {
+    assert.strictEqual(
+      extractCanonical({ linkCanonical: "data:text/html,<h1>x</h1>" }),
+      null
+    );
+  });
+
+  test("rejects file:// schemes", () => {
+    assert.strictEqual(
+      extractCanonical({ linkCanonical: "file:///etc/passwd" }),
+      null
+    );
+  });
+
+  test("rejects malformed URLs in BOTH slots → returns null", () => {
+    const result = extractCanonical({
+      linkCanonical: "not a url",
+      jsonLdId: "::also broken::",
+    });
+    assert.strictEqual(result, null);
+  });
+
+  test("rejects URLs over the 2000-character cap", () => {
+    const longUrl = "https://example.com/" + "a".repeat(2100);
+    assert.ok(longUrl.length > 2000);
+    assert.strictEqual(extractCanonical({ linkCanonical: longUrl }), null);
+  });
+
+  test("accepts URLs up to the 2000-character cap", () => {
+    // Build a URL that is exactly 2000 chars long.
+    const base = "https://example.com/";
+    const padding = "a".repeat(2000 - base.length);
+    const url = base + padding;
+    assert.strictEqual(url.length, 2000);
+    assert.strictEqual(extractCanonical({ linkCanonical: url }), url);
+  });
+
+  test("accepts http:// (not just https://)", () => {
+    const result = extractCanonical({ linkCanonical: "http://example.com/page" });
+    assert.strictEqual(result, "http://example.com/page");
+  });
+
+  test("trims surrounding whitespace before parsing", () => {
+    const result = extractCanonical({
+      linkCanonical: "   https://example.com/x   ",
+    });
+    assert.strictEqual(result, "https://example.com/x");
+  });
+});
+
+// ── Pipeline integration ────────────────────────────────────────────────────
+//
+// The canonical extractor is consulted from processUrl when:
+//   1. Feature flag `canonicalExtractorEnabled` is true (default ON)
+//   2. The URL host is a recognized wrapper (detectWrapper matches)
+//   3. Wrapper engine extraction failed (no destination in the URL)
+//   4. A canonical bundle was provided by the caller
+//
+// In every other case (flag off, no bundle, non-wrapper, wrapper that was
+// successfully unwrapped), the integration is a no-op.
+
+describe("B7 canonical-extractor — pipeline integration", () => {
+  // t.co is registered as a wrapper but its extract() returns null when no
+  // ?url=/?u= is present. That is the canonical "opaque wrapper" case.
+  const OPAQUE_WRAPPER_URL = "https://t.co/abcdef";
+  const CANONICAL_DEST = "https://merchant.example.com/article";
+
+  const PREFS_BASE = {
+    enabled: true,
+    injectOwnAffiliate: false,
+    notifyForeignAffiliate: false,
+    blacklist: [],
+    whitelist: [],
+  };
+
+  test("flag ON + opaque wrapper + bundle present → cleanUrl is the canonical destination", () => {
+    const { cleanUrl } = processUrl(
+      OPAQUE_WRAPPER_URL,
+      { ...PREFS_BASE, canonicalExtractorEnabled: true },
+      [],
+      { linkCanonical: CANONICAL_DEST }
+    );
+    assert.strictEqual(cleanUrl, CANONICAL_DEST);
+  });
+
+  test("flag ON + opaque wrapper + bundle prefers linkCanonical over jsonLdId", () => {
+    const { cleanUrl } = processUrl(
+      OPAQUE_WRAPPER_URL,
+      { ...PREFS_BASE, canonicalExtractorEnabled: true },
+      [],
+      {
+        linkCanonical: "https://merchant.example.com/canonical",
+        jsonLdId:      "https://merchant.example.com/jsonld",
+      }
+    );
+    assert.strictEqual(cleanUrl, "https://merchant.example.com/canonical");
+  });
+
+  test("flag OFF + opaque wrapper + bundle present → no canonical promotion", () => {
+    const { cleanUrl } = processUrl(
+      OPAQUE_WRAPPER_URL,
+      { ...PREFS_BASE, canonicalExtractorEnabled: false },
+      [],
+      { linkCanonical: CANONICAL_DEST }
+    );
+    assert.notStrictEqual(cleanUrl, CANONICAL_DEST);
+  });
+
+  test("flag ON + opaque wrapper + NO bundle → no canonical promotion (background worker case)", () => {
+    const { cleanUrl } = processUrl(
+      OPAQUE_WRAPPER_URL,
+      { ...PREFS_BASE, canonicalExtractorEnabled: true },
+      []
+      // bundle intentionally omitted
+    );
+    assert.notStrictEqual(cleanUrl, CANONICAL_DEST);
+  });
+
+  test("flag ON + non-wrapper URL + bundle present → bundle is ignored", () => {
+    // A plain URL is not a wrapper; the canonical tier must NOT fire.
+    const plain = "https://example.com/article?utm_source=foo";
+    const { cleanUrl } = processUrl(
+      plain,
+      { ...PREFS_BASE, canonicalExtractorEnabled: true },
+      [],
+      { linkCanonical: "https://attacker.example/take-over" }
+    );
+    // Tracking still strips, but the canonical takeover does NOT happen.
+    assert.notStrictEqual(cleanUrl, "https://attacker.example/take-over");
+    assert.ok(cleanUrl.startsWith("https://example.com/article"));
+  });
+
+  test("flag ON + wrapper that successfully extracted → bundle is ignored", () => {
+    // Awin successfully unwraps to the merchant; canonical tier must not run.
+    const merchant = "https://merchant.com/p";
+    const wrapper = `https://www.awin1.com/cread.php?awinmid=1&p=${encodeURIComponent(merchant)}`;
+    const { cleanUrl } = processUrl(
+      wrapper,
+      { ...PREFS_BASE, canonicalExtractorEnabled: true },
+      [],
+      { linkCanonical: "https://attacker.example/take-over" }
+    );
+    assert.notStrictEqual(cleanUrl, "https://attacker.example/take-over");
+    assert.ok(cleanUrl.startsWith("https://merchant.com/p"));
+  });
+
+  test("flag default (undefined in prefs) behaves as ON", () => {
+    // Acceptance: feature flag default is ON. When prefs lack the key,
+    // the pipeline must still consult the canonical extractor.
+    const { cleanUrl } = processUrl(
+      OPAQUE_WRAPPER_URL,
+      PREFS_BASE, // no canonicalExtractorEnabled
+      [],
+      { linkCanonical: CANONICAL_DEST }
+    );
+    assert.strictEqual(cleanUrl, CANONICAL_DEST);
+  });
+
+  test("canonical destination is run through the rest of the cleaner (tracking strip)", () => {
+    // When the canonical points to a URL with tracking params, those params
+    // must still be stripped by the existing cleaner stage.
+    const { cleanUrl, removedTracking } = processUrl(
+      OPAQUE_WRAPPER_URL,
+      { ...PREFS_BASE, canonicalExtractorEnabled: true },
+      [],
+      { linkCanonical: "https://merchant.example.com/article?utm_source=tw" }
+    );
+    assert.strictEqual(cleanUrl, "https://merchant.example.com/article");
+    assert.deepEqual(removedTracking, ["utm_source"]);
+  });
+
+  test("non-http(s) canonical is rejected — pipeline falls through unchanged", () => {
+    const { cleanUrl } = processUrl(
+      OPAQUE_WRAPPER_URL,
+      { ...PREFS_BASE, canonicalExtractorEnabled: true },
+      [],
+      { linkCanonical: "javascript:alert(1)" }
+    );
+    assert.notStrictEqual(cleanUrl, "javascript:alert(1)");
+  });
+});
+
+// ── Storage default ─────────────────────────────────────────────────────────
+
+describe("B7 canonical-extractor — storage defaults", () => {
+  test("PREF_DEFAULTS contains canonicalExtractorEnabled=true", async () => {
+    const { PREF_DEFAULTS } = await import("../../src/lib/storage.js");
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(PREF_DEFAULTS, "canonicalExtractorEnabled"),
+      "PREF_DEFAULTS must declare canonicalExtractorEnabled"
+    );
+    assert.strictEqual(PREF_DEFAULTS.canonicalExtractorEnabled, true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #442 (B7). Adds a second tier to the cleaner pipeline:

```
Wrapper Engine → Canonical Extractor → existing cleaner
```

When the wrapper engine identifies a host as a wrapper but extraction returns null (the "opaque wrapper" case), and the caller has provided a canonical bundle from the DOM, the extractor returns the canonical URL — which is then fed back through the rest of the pipeline so the merchant URL still gets tracking-stripped and affiliate-checked.

## Approach

**Pure function over a `{ linkCanonical, jsonLdId }` bundle**, not a Document/DocumentFragment. `node:test` has no jsdom; forcing tests to ship a DOM mock would have been worse than asking the content script (the only place with real DOM access) to extract the two fields up-front.

The pure module:
- Decides W3C-vs-JSON-LD precedence — `<link rel="canonical">` wins on disagreement
- Precedence on **validity**, not presence — a malformed `linkCanonical` still lets `jsonLdId` win (otherwise a corrupted href poisons the result)
- Validates: http/https only, length cap ≤ 2000 chars, try/catch around `new URL`, trim whitespace

## Pipeline integration

`processUrl()` in `src/lib/cleaner.js` gains an optional 4th param `canonicalBundle`. The new tier fires when:
1. Pref `canonicalExtractorEnabled !== false` (default ON; missing key still activates)
2. A bundle was provided (background-worker calls without bundle → no-op)
3. `detectWrapper(rawUrl)` matched (host is a wrapper)
4. The wrapper engine's `unwrap` returned null (opaque case)

Successful unwraps and non-wrapper URLs short-circuit before the canonical tier — no behavior change for either.

## Feature flag

- `canonicalExtractorEnabled: true` added to `PREF_DEFAULTS`
- Default ON per acceptance criteria
- `=== false` bypasses tier entirely
- `docs/data_architect.md` prefs table row added (parity test enforces this)

## Test plan

- [x] `npm test` → **2790/2790** passing (+26 from baseline 2764)
- [x] `npm run lint` → 0 errors
- [x] Pure-module cases: link only, JSON-LD only, both agree, both disagree (link wins), neither, malformed link → JSON-LD wins, malformed both, non-HTTPS scheme rejection, length cap rejection, whitespace trim
- [x] Pipeline cases: flag ON + bundle + opaque wrapper, flag OFF, no bundle, non-wrapper URL, successful unwrap (no-op)
- [x] Regression: existing wrapper engine + cleaner suites pass unchanged

## Notes

The canonical destination is fed back through the rest of the pipeline so tracking strip + affiliate logic still applies on the merchant URL. This is intentional — the canonical extractor finds the merchant; the cleaner cleans it.