### PR TITLE
feat(content): History Defuser — wrap pushState/replaceState (#444)

### DIFF
--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -1,0 +1,136 @@
+/**
+ * MUGA: History Defuser — main-world content script (#444 / B10)
+ *
+ * Runs IN THE PAGE WORLD (`world: "MAIN"`) at `document_start` so it
+ * can wrap `history.pushState` / `history.replaceState` directly on
+ * the page's `window.history`. The isolated-world content script
+ * cannot wrap these methods — the same MV3 isolated-world constraint
+ * that forced the removal of the `navigator.sendBeacon` override
+ * (see content/cleaner.js comment near line 665).
+ *
+ * Firefox MV2 does not support `world: "MAIN"`; on that target the
+ * companion script `content/history-defuser.js` injects this body
+ * via a `<script>` tag (which Firefox MV2 does NOT block via page
+ * CSP for extension content scripts).
+ *
+ * Important constraints for this file:
+ *
+ *   - No chrome.* APIs. Main-world scripts have NO access to
+ *     extension messaging — they share the page's privileges only.
+ *   - No ES module imports. Runs as a classic script in the page
+ *     world.
+ *   - Tracking-param list is a HARD-CODED SUBSET. Round-tripping to
+ *     the SW per pushState would be async; the page may read
+ *     `window.location.search` synchronously after the call. The
+ *     subset covers the highest-volume params (UTM, click IDs,
+ *     social). Full coverage continues to live in the navigation
+ *     pipeline (DNR + cleaner-bundle.js).
+ *   - Disabled-state guard: cannot read prefs from main world. A
+ *     companion isolated-world content script writes a flag onto
+ *     `window.__mugaHistoryDefuserEnabled` that this wrapper polls
+ *     before doing any cleaning. Until that flag is true, the
+ *     wrappers fall through to the originals untouched.
+ */
+
+(function () {
+  "use strict";
+
+  // Skip iframes — same guard as cleaner.js. Wrapping inside an iframe
+  // risks corrupting cross-origin parent navigation handling.
+  if (window.self !== window.top) return;
+  if (window.__mugaHistoryDefused) return;
+  window.__mugaHistoryDefused = true;
+
+  // Subset of TRACKING_PARAMS from src/lib/affiliates.js. Keep in sync
+  // with the structural list in tests/unit/history-defuser.test.mjs.
+  // Object lookup is faster than a Set for this hot path; values are
+  // unused (truthiness only).
+  const STRIP = Object.freeze({
+    utm_source: 1, utm_medium: 1, utm_campaign: 1, utm_content: 1, utm_term: 1, utm_id: 1,
+    utm_source_platform: 1, utm_creative_format: 1, utm_marketing_tactic: 1,
+    fbclid: 1, gclid: 1, gclsrc: 1, dclid: 1, gbraid: 1, wbraid: 1, msclkid: 1, tclid: 1, twclid: 1,
+    mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
+    _hsenc: 1, _hsmi: 1, mkt_tok: 1,
+    yclid: 1, ysclid: 1, _openstat: 1,
+    irclickid: 1, cjevent: 1, awc: 1,
+    ttclid: 1, sccid: 1, rdt_cid: 1,
+    _branch_match_id: 1, _branch_referrer: 1,
+    pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,
+    mtm_campaign: 1, mtm_source: 1, mtm_medium: 1, mtm_content: 1,
+    hsctatracking: 1,
+    __s: 1, _ga: 1, _gl: 1, _gac: 1,
+    ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
+    mibextid: 1, share_id: 1,
+  });
+
+  /**
+   * Strips the static tracking-param subset from `rawUrl`. Re-emits in
+   * the same shape (relative vs absolute) the caller passed in so SPA
+   * routers that string-compare locations don't see a sudden absolute
+   * swap. Returns the original string when nothing changed or when
+   * parsing fails — never throws.
+   */
+  function cleanUrl(rawUrl) {
+    if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+    if (rawUrl.indexOf("?") < 0) return rawUrl;
+    let u;
+    try {
+      u = new URL(rawUrl, window.location.href);
+    } catch {
+      return rawUrl;
+    }
+    let changed = false;
+    const keys = [];
+    u.searchParams.forEach((_v, k) => keys.push(k));
+    for (let i = 0; i < keys.length; i++) {
+      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
+        u.searchParams.delete(keys[i]);
+        changed = true;
+      }
+    }
+    if (!changed) return rawUrl;
+    const isAbsolute = /^[a-z]+:\/\//i.test(rawUrl);
+    if (isAbsolute) return u.toString();
+    return u.pathname + u.search + u.hash;
+  }
+
+  // Disabled-state gate. Cross-world signaling happens via CustomEvents
+  // dispatched on `document`: events DO cross the isolated/main world
+  // boundary even though `window` properties don't. The companion
+  // isolated-world script (content/history-defuser.js) reads prefs and
+  // dispatches `muga:history-gate` with `detail: { enabled: bool }`.
+  // Until the first event arrives the gate stays CLOSED (fail-closed):
+  // the wrap is installed but pass-through, matching the
+  // disabled-state guard contract in AGENTS.md.
+  let _gateOpen = false;
+  document.addEventListener("muga:history-gate", (e) => {
+    _gateOpen = !!(e && e.detail && e.detail.enabled);
+  });
+
+  function gateOpen() {
+    return _gateOpen;
+  }
+
+  const origPush = history.pushState;
+  const origReplace = history.replaceState;
+
+  history.pushState = function pushState(state, title, url) {
+    let finalUrl = url;
+    if (arguments.length >= 3 && gateOpen()) {
+      try { finalUrl = cleanUrl(url); } catch { finalUrl = url; }
+    }
+    return arguments.length >= 3
+      ? origPush.call(this, state, title, finalUrl)
+      : origPush.call(this, state, title);
+  };
+
+  history.replaceState = function replaceState(state, title, url) {
+    let finalUrl = url;
+    if (arguments.length >= 3 && gateOpen()) {
+      try { finalUrl = cleanUrl(url); } catch { finalUrl = url; }
+    }
+    return arguments.length >= 3
+      ? origReplace.call(this, state, title, finalUrl)
+      : origReplace.call(this, state, title);
+  };
+})();

--- a/src/content/history-defuser.js
+++ b/src/content/history-defuser.js
@@ -1,0 +1,62 @@
+/**
+ * MUGA: History Defuser — isolated-world gatekeeper (#444 / B10)
+ *
+ * The actual `history.pushState` / `history.replaceState` wrap lives in
+ * a sibling main-world content script (`history-defuser-mainworld.js`)
+ * — see that file for the WHY of dual-world wiring. This isolated-world
+ * script is responsible for one job: reading the user's prefs and
+ * notifying the main-world wrap whether the disabled-state gate is
+ * open.
+ *
+ * Cross-world signaling: a `CustomEvent` dispatched on `document`
+ * crosses the isolated/main-world boundary in MV3 (and on Firefox MV2
+ * via the same DOM event bus). `window` property writes don't cross —
+ * that's why we don't just set `window.__mugaEnabled` from here.
+ *
+ * The gate fails CLOSED by default: until prefs land and we dispatch a
+ * `muga:history-gate { detail: { enabled: true } }` event, the
+ * main-world wrap forwards calls untouched. Cleaner safe than
+ * surprising a not-yet-onboarded user with a mutated URL.
+ */
+
+(function () {
+  "use strict";
+
+  // Skip iframes — same guard as cleaner.js.
+  if (window.self !== window.top) return;
+  if (window.__mugaHistoryDefuserGate) return;
+  window.__mugaHistoryDefuserGate = true;
+
+  function dispatchGate(enabled) {
+    try {
+      document.dispatchEvent(new CustomEvent("muga:history-gate", {
+        detail: { enabled: !!enabled },
+      }));
+    } catch { /* document detached or CustomEvent unavailable — silent */ }
+  }
+
+  function readPrefsAndGate() {
+    try {
+      chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
+        void chrome.runtime.lastError;
+        const ok = !!(prefs && prefs.enabled && prefs.onboardingDone);
+        dispatchGate(ok);
+      });
+    } catch {
+      // Extension context invalidated. Leave the gate closed.
+    }
+  }
+
+  // Eagerly populate the gate. The main-world wrap may have already
+  // intercepted the very first pushState before this resolves; that's
+  // an inherent race we accept (fail-closed).
+  readPrefsAndGate();
+
+  // Re-read on storage changes so toggling MUGA off in the popup closes
+  // the gate without a page reload.
+  if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.onChanged) {
+    chrome.storage.onChanged.addListener((_changes, area) => {
+      if (area === "sync" || area === "local") readPrefsAndGate();
+    });
+  }
+})();

--- a/src/lib/history-defuser.js
+++ b/src/lib/history-defuser.js
@@ -1,0 +1,100 @@
+/**
+ * MUGA: History Defuser (#444)
+ *
+ * Wraps `history.pushState` and `history.replaceState` so that the URL
+ * argument is passed through a cleaner before being committed to the
+ * session history. SPA routers (React Router, Next.js client router,
+ * Vue Router, etc.) call these methods with URLs that include the same
+ * tracking params MUGA stripped at navigation. Without this defuser,
+ * any page script that subsequently reads `window.location.search` —
+ * including in-page analytics — sees the dirty URL re-emerge.
+ *
+ * The cleaning happens SYNCHRONOUSLY: pushState is itself synchronous,
+ * and the page may read `window.location.search` on the next line. An
+ * async cleaner round-trip to the service worker would not be observed
+ * in time. The content-script entry that bootstraps this module uses
+ * the bundled `window.__mugaCleaner.processUrl()` for its sync-clean.
+ *
+ * Pure module — no DOM, no globals, no chrome.* — so unit tests can
+ * exercise the wrapping logic with plain stubs (no jsdom).
+ *
+ * Two correctness invariants:
+ *
+ *   1. State and title are FORWARDED VERBATIM. The browser stores
+ *      whatever object the page passed in; cloning, JSON-roundtripping,
+ *      or coercing here would silently corrupt SPA frameworks that
+ *      rely on object identity (React Router's location key, etc.).
+ *   2. URL absent (undefined or null) is the documented same-document
+ *      no-op signal — the cleaner is NOT invoked, and the original
+ *      argument is forwarded unchanged.
+ *
+ * Cleaner errors (e.g. malformed URL crashing `new URL()` deep inside
+ * processUrl) MUST NOT block the call. We swallow the throw and forward
+ * the original URL: a dirty URL in history is strictly better than a
+ * broken page.
+ */
+
+/**
+ * Installs the history defuser on the given history-like object.
+ *
+ * @param {{ pushState: Function, replaceState: Function }} historyLike
+ *   The host object whose methods will be wrapped IN PLACE. Typically
+ *   `window.history` from a content script. Plain objects with two
+ *   function properties also work — useful for tests.
+ * @param {(url: string) => string|null|undefined} urlCleaner
+ *   Synchronous cleaner. Receives the URL the page tried to push.
+ *   Should return the cleaned URL string. If it returns null, undefined,
+ *   or a non-string, the wrapper falls back to the original URL.
+ * @param {object} [options]
+ * @param {() => boolean} [options.isEnabled]
+ *   Optional disabled-state guard. When provided and returns false at
+ *   call time, the wrapper bypasses the cleaner entirely and forwards
+ *   the original arguments. Default: always enabled.
+ * @returns {{ pushState: Function, replaceState: Function }}
+ *   The original (pre-wrap) methods. Callers may stash these to
+ *   uninstall later by reassigning them onto the host object.
+ */
+export function installHistoryDefuser(historyLike, urlCleaner, options = {}) {
+  const originalPush = historyLike.pushState;
+  const originalReplace = historyLike.replaceState;
+  const isEnabled = typeof options.isEnabled === "function"
+    ? options.isEnabled
+    : () => true;
+
+  function cleanOrPassThrough(rawUrl) {
+    // Documented no-op: same-document push with no URL change.
+    if (rawUrl === undefined || rawUrl === null) return rawUrl;
+    if (typeof rawUrl !== "string") return rawUrl;
+    if (!isEnabled()) return rawUrl;
+    let cleaned;
+    try {
+      cleaned = urlCleaner(rawUrl);
+    } catch {
+      // Cleaner blew up — the page MUST still navigate. Forward the
+      // original URL so the SPA doesn't break.
+      return rawUrl;
+    }
+    if (typeof cleaned !== "string" || cleaned.length === 0) return rawUrl;
+    return cleaned;
+  }
+
+  historyLike.pushState = function pushState(state, title, url) {
+    const finalUrl = arguments.length >= 3
+      ? cleanOrPassThrough(url)
+      : url;
+    return arguments.length >= 3
+      ? originalPush.call(this, state, title, finalUrl)
+      : originalPush.call(this, state, title);
+  };
+
+  historyLike.replaceState = function replaceState(state, title, url) {
+    const finalUrl = arguments.length >= 3
+      ? cleanOrPassThrough(url)
+      : url;
+    return arguments.length >= 3
+      ? originalReplace.call(this, state, title, finalUrl)
+      : originalReplace.call(this, state, title);
+  };
+
+  return { pushState: originalPush, replaceState: originalReplace };
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,7 +29,14 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/cleaner.js"],
+      "js": ["content/history-defuser-mainworld.js"],
+      "run_at": "document_start",
+      "world": "MAIN",
+      "all_frames": false
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/cleaner.js"],
       "run_at": "document_start"
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -25,7 +25,12 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/cleaner.js"],
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/history-defuser-mainworld.js"],
       "run_at": "document_start"
     },
     {

--- a/tests/e2e/history-defuser.spec.mjs
+++ b/tests/e2e/history-defuser.spec.mjs
@@ -1,0 +1,102 @@
+/**
+ * E2E: History Defuser (#444 / B10)
+ *
+ * Verifies the document_start wrap of `history.pushState` /
+ * `history.replaceState` against a real Chromium with the extension
+ * loaded. The unit tests in tests/unit/history-defuser.test.mjs cover
+ * the pure factory contract; this spec proves the wrap is actually
+ * INSTALLED early enough that a page-script call to pushState lands a
+ * cleaned URL in `window.location`.
+ *
+ * Why this is structured as one spec, not many: the wrap behaviour is
+ * one observable signal (post-pushState `window.location.search` has
+ * no tracking params). Splitting it into many specs would multiply the
+ * persistent-context startup cost without adding coverage.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+
+const HOST = "muga-test-history.invalid";
+
+async function completeOnboarding(context, extensionId) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.storage.sync.set({ enabled: true }, () => {
+        chrome.storage.local.set({
+          mugaConsent: { onboardingDone: true, consentVersion: "1.0", consentDate: Date.now() },
+        }, () => {
+          // sync.set must include onboardingDone for the prefs cache the
+          // content script reads via getPrefs.
+          chrome.storage.sync.set({ onboardingDone: true }, resolve);
+        });
+      });
+    })
+  );
+  await page.close();
+  // Allow the prefs broadcast to propagate before the next page loads.
+  await new Promise(r => setTimeout(r, 500));
+}
+
+async function stubPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <button id="muga-push-btn">push</button>
+        <script>
+          // Drive the pushState from a button click triggered by the test.
+          // The content script's prefs cache is populated asynchronously
+          // (chrome.runtime.sendMessage round-trip to the SW), and the
+          // disabled-state guard fail-CLOSED until prefs land. Letting the
+          // test trigger the click only after the SW has answered the
+          // getPrefs message keeps this spec stable. A real SPA's first
+          // pushState typically happens inside a router init that runs
+          // hundreds of ms after document_start (well after prefs land).
+          document.getElementById("muga-push-btn").addEventListener("click", () => {
+            history.pushState({ tag: "muga-test" }, "TheTitle",
+              "/spa?utm_source=marketing&utm_medium=email&id=42");
+            window.__mugaTestState = history.state;
+            window.__mugaTestSearch = window.location.search;
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("History Defuser (#444)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId);
+  });
+
+  test("pushState with tracking params lands a cleaned URL in window.location", async ({ context }) => {
+    const page = await context.newPage();
+    await stubPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the page-world wrap flag set by the injected script.
+    // The content script reads prefs via SW round-trip and only injects
+    // the wrap when prefs.enabled && prefs.onboardingDone. Both are
+    // ensured by completeOnboarding above. The flag is set on the page
+    // window (not the isolated world) by the injected script body, so
+    // page.waitForFunction() can observe it directly.
+    await page.waitForFunction(() => window.__mugaHistoryDefused === true, { timeout: 10000 });
+
+    await page.locator("#muga-push-btn").click();
+    await page.waitForFunction(() => typeof window.__mugaTestSearch === "string");
+
+    const search = await page.evaluate(() => window.__mugaTestSearch);
+    const state = await page.evaluate(() => window.__mugaTestState);
+    // Tracking params stripped, business param preserved.
+    expect(search).not.toContain("utm_source");
+    expect(search).not.toContain("utm_medium");
+    expect(search).toContain("id=42");
+    // State forwarded verbatim.
+    expect(state).toEqual({ tag: "muga-test" });
+
+    await page.close();
+  });
+});

--- a/tests/unit/history-defuser.test.mjs
+++ b/tests/unit/history-defuser.test.mjs
@@ -1,0 +1,323 @@
+/**
+ * MUGA — Tests for the History Defuser (#444 / B10).
+ *
+ * The defuser wraps `history.pushState` and `history.replaceState` so that
+ * any URL the page tries to push into the session history is run through
+ * the cleaner pipeline first. This eliminates a major SPA leak: without
+ * the defuser, sites that read `window.location.search` AFTER a router
+ * push see the dirty URL and re-emit analytics with the tracking params
+ * MUGA had already stripped at navigation.
+ *
+ * The module under test is a PURE factory — `installHistoryDefuser` —
+ * which takes an injectable history-like object and an injectable URL
+ * cleaner. No DOM, no jsdom (project rule: no third-party test libs).
+ * The content-script entry that wires the real `window.history` and the
+ * content-bundled `processUrl` is structural; the contract is enforced
+ * here.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { installHistoryDefuser } from "../../src/lib/history-defuser.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a stub history-like object whose pushState/replaceState are spy
+ * functions that record their (state, title, url) arguments. Mirrors the
+ * shape of the real `window.history` for the two methods the defuser
+ * wraps. No prototype, no extra noise — just the surface area the
+ * defuser touches.
+ */
+function makeHistoryStub() {
+  const calls = { pushState: [], replaceState: [] };
+  const history = {
+    pushState(state, title, url) {
+      calls.pushState.push({ state, title, url, thisRef: this });
+    },
+    replaceState(state, title, url) {
+      calls.replaceState.push({ state, title, url, thisRef: this });
+    },
+  };
+  return { history, calls };
+}
+
+/**
+ * Identity cleaner — returns its argument unchanged. Used in tests where
+ * the defuser should be a transparent pass-through (e.g. URLs already
+ * clean, or the disabled-state guard).
+ */
+const identityCleaner = (url) => url;
+
+/**
+ * Tracking-stripping cleaner — strips `utm_source`, `utm_medium`, and
+ * `fbclid` query params from absolute or relative URLs. Mirrors the
+ * subset of behaviour the real cleaner exposes; tests don't need the
+ * full param list.
+ */
+function trackingCleaner(rawUrl) {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+  const STRIP = new Set(["utm_source", "utm_medium", "fbclid"]);
+  let u;
+  try {
+    // Absolute URL path.
+    u = new URL(rawUrl);
+  } catch {
+    // Relative URL path: anchor against an arbitrary base, then re-emit
+    // path+search+hash so callers see the same shape they passed in.
+    try {
+      u = new URL(rawUrl, "https://example.invalid/");
+      for (const k of [...u.searchParams.keys()]) {
+        if (STRIP.has(k)) u.searchParams.delete(k);
+      }
+      return u.pathname + u.search + u.hash;
+    } catch {
+      return rawUrl;
+    }
+  }
+  for (const k of [...u.searchParams.keys()]) {
+    if (STRIP.has(k)) u.searchParams.delete(k);
+  }
+  return u.toString();
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("installHistoryDefuser — basic wrapping", () => {
+  test("returns originals so callers can uninstall", () => {
+    const { history } = makeHistoryStub();
+    const originalPush = history.pushState;
+    const originalReplace = history.replaceState;
+    const originals = installHistoryDefuser(history, identityCleaner);
+    assert.equal(originals.pushState, originalPush);
+    assert.equal(originals.replaceState, originalReplace);
+  });
+
+  test("wrapping replaces both methods on the host object", () => {
+    const { history } = makeHistoryStub();
+    const before = history.pushState;
+    installHistoryDefuser(history, identityCleaner);
+    assert.notEqual(history.pushState, before);
+    assert.equal(typeof history.pushState, "function");
+    assert.equal(typeof history.replaceState, "function");
+  });
+
+  test("uninstall via returned originals restores host methods", () => {
+    const { history } = makeHistoryStub();
+    const originals = installHistoryDefuser(history, identityCleaner);
+    history.pushState = originals.pushState;
+    history.replaceState = originals.replaceState;
+    assert.equal(history.pushState, originals.pushState);
+    assert.equal(history.replaceState, originals.replaceState);
+  });
+});
+
+describe("installHistoryDefuser — pushState cleaning", () => {
+  test("pushState with a tracking-decorated URL produces a clean entry", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, trackingCleaner);
+    history.pushState(null, "", "/foo?utm_source=x&id=42");
+    assert.equal(calls.pushState.length, 1);
+    assert.equal(calls.pushState[0].url, "/foo?id=42");
+  });
+
+  test("pushState forwards state and title unchanged", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, trackingCleaner);
+    const stateObj = { page: 7, nested: { a: 1 } };
+    history.pushState(stateObj, "My Title", "/x?utm_medium=y");
+    assert.equal(calls.pushState.length, 1);
+    // Deep ref equality on state — must NOT be cloned or replaced.
+    assert.equal(calls.pushState[0].state, stateObj);
+    assert.equal(calls.pushState[0].title, "My Title");
+  });
+
+  test("pushState preserves an empty-string title verbatim", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, trackingCleaner);
+    history.pushState({}, "", "/y?fbclid=abc");
+    assert.equal(calls.pushState[0].title, "");
+  });
+
+  test("pushState forwards null url unchanged (cleaner not invoked)", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, () => {
+      throw new Error("cleaner should not run for null url");
+    });
+    history.pushState({ a: 1 }, "t", null);
+    assert.equal(calls.pushState[0].url, null);
+  });
+
+  test("pushState forwards undefined url unchanged (cleaner not invoked)", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, () => {
+      throw new Error("cleaner should not run for undefined url");
+    });
+    history.pushState({}, "t");
+    assert.equal(calls.pushState[0].url, undefined);
+  });
+
+  test("pushState swallows cleaner errors and forwards original url", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, () => {
+      throw new Error("boom");
+    });
+    history.pushState({}, "", "/foo?utm_source=x");
+    assert.equal(calls.pushState[0].url, "/foo?utm_source=x");
+  });
+});
+
+describe("installHistoryDefuser — replaceState parity", () => {
+  test("replaceState behaviour identical to pushState", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, trackingCleaner);
+    history.replaceState(null, "", "/foo?utm_source=x&id=42");
+    assert.equal(calls.replaceState.length, 1);
+    assert.equal(calls.replaceState[0].url, "/foo?id=42");
+  });
+
+  test("replaceState forwards state and title unchanged", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, trackingCleaner);
+    const stateObj = { route: "/dash" };
+    history.replaceState(stateObj, "T", "/z?fbclid=abc");
+    assert.equal(calls.replaceState[0].state, stateObj);
+    assert.equal(calls.replaceState[0].title, "T");
+    assert.equal(calls.replaceState[0].url, "/z");
+  });
+
+  test("does not invoke cleaner when url is missing", () => {
+    let called = 0;
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, (u) => {
+      called++;
+      return u;
+    });
+    history.replaceState({}, "");
+    assert.equal(called, 0);
+    assert.equal(calls.replaceState[0].url, undefined);
+  });
+});
+
+describe("installHistoryDefuser — disabled-state guard", () => {
+  test("when isEnabled returns false, cleaner is not called and original url forwards", () => {
+    let called = 0;
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, (u) => {
+      called++;
+      return "MUTATED";
+    }, { isEnabled: () => false });
+    history.pushState({}, "", "/foo?utm_source=x");
+    history.replaceState({}, "", "/bar?fbclid=z");
+    assert.equal(called, 0);
+    assert.equal(calls.pushState[0].url, "/foo?utm_source=x");
+    assert.equal(calls.replaceState[0].url, "/bar?fbclid=z");
+  });
+
+  test("when isEnabled returns true, cleaner runs", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, trackingCleaner, { isEnabled: () => true });
+    history.pushState({}, "", "/foo?utm_source=x");
+    assert.equal(calls.pushState[0].url, "/foo");
+  });
+});
+
+describe("installHistoryDefuser — passthrough on no-op clean", () => {
+  test("if cleaner returns the same string, the call still flows through", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, identityCleaner);
+    history.pushState({}, "", "/already-clean");
+    assert.equal(calls.pushState[0].url, "/already-clean");
+  });
+
+  test("if cleaner returns null, original url forwards", () => {
+    const { history, calls } = makeHistoryStub();
+    installHistoryDefuser(history, () => null);
+    history.pushState({}, "", "/x?utm_source=y");
+    assert.equal(calls.pushState[0].url, "/x?utm_source=y");
+  });
+});
+
+// ── Manifest + content-script wiring (structural) ──────────────────────────
+
+describe("history-defuser — content-script wiring", () => {
+  test("manifest.json registers the main-world wrap at document_start with world MAIN", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("history-defuser-mainworld.js"))
+    );
+    assert.ok(entry, "history-defuser-mainworld.js must be in a content_scripts entry");
+    assert.equal(entry.run_at, "document_start");
+    assert.equal(entry.world, "MAIN",
+      "main-world wrap must declare world MAIN so the page-world history is wrapped");
+  });
+
+  test("manifest.json registers the isolated-world gate at document_start", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("history-defuser.js"))
+    );
+    assert.ok(entry, "history-defuser.js must be in a content_scripts entry");
+    assert.equal(entry.run_at, "document_start");
+  });
+
+  test("manifest.v2.json registers both defuser scripts at document_start", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.v2.json"), "utf8"
+    ));
+    const gateEntry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("history-defuser.js"))
+    );
+    const wrapEntry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("history-defuser-mainworld.js"))
+    );
+    assert.ok(gateEntry, "history-defuser.js (gate) must be registered for MV2");
+    assert.equal(gateEntry.run_at, "document_start");
+    assert.ok(wrapEntry, "history-defuser-mainworld.js (wrap) must be registered for MV2");
+    assert.equal(wrapEntry.run_at, "document_start");
+  });
+
+  test("content/history-defuser.js is an IIFE (no ES module imports)", () => {
+    const src = readFileSync(
+      join(__dirname, "../../src/content/history-defuser.js"), "utf8"
+    );
+    assert.ok(/^\(function/m.test(src), "content script must be an IIFE");
+    assert.equal(/^\s*import\s+/m.test(src), false,
+      "content script must not contain top-level ES module imports");
+    // Gate dispatches the cross-world event.
+    assert.ok(/muga:history-gate/.test(src),
+      "gate script must dispatch muga:history-gate events");
+  });
+
+  test("content/history-defuser-mainworld.js is an IIFE that wraps both history methods", () => {
+    const src = readFileSync(
+      join(__dirname, "../../src/content/history-defuser-mainworld.js"), "utf8"
+    );
+    assert.ok(/^\(function/m.test(src), "content script must be an IIFE");
+    assert.equal(/^\s*import\s+/m.test(src), false,
+      "content script must not contain top-level ES module imports");
+    assert.ok(/history\.pushState\s*=/.test(src) && /history\.replaceState\s*=/.test(src),
+      "main-world script must reassign both history methods");
+    // No chrome.* CALLS — main-world scripts have no extension messaging.
+    // Strip line comments and block comments before scanning, so the
+    // file-level docblock that mentions "chrome.*" prose doesn't trip
+    // this guard.
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+    assert.equal(/\bchrome\.[a-zA-Z]/.test(stripped), false,
+      "main-world script must not call any chrome.* extension API");
+    // Gate listener present.
+    assert.ok(/muga:history-gate/.test(src),
+      "main-world wrap must listen for muga:history-gate to honor disabled state");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #444 (B10). Wraps `history.pushState` and `history.replaceState` at `document_start` so SPA navigations no longer leak tracking params into the URL bar or `window.location.search`.

## Architecture (dual-world)

MV3 isolated worlds **cannot wrap page-world `history.pushState`** (same constraint that gated the `sendBeacon` override). This slice ships the canonical workaround:

- **Pure factory** at `src/lib/history-defuser.js` — `installHistoryDefuser(historyLike, urlCleaner, options)`. Wraps in place, returns the originals so callers can uninstall. State/title forwarded **verbatim** (no clone, no JSON-roundtrip — preserves SPA framework object identity). Cleaner errors swallowed; original URL forwarded.

- **Main-world content script** (`world: "MAIN"`) performs the wrap. Hard-coded ~50-param tracking subset inline (UTM, click IDs, social trackers) because:
  - The main world has zero `chrome.*` access
  - It has zero access to the isolated world's `__mugaCleaner`
  - `pushState` is **synchronous** — an async SW round-trip would lose to the page reading `window.location.search` on the next line
  - Full param coverage continues to live in the navigation path (DNR + `cleaner-bundle.js`)

- **Isolated-world content script** reads prefs via `runtime.sendMessage` and dispatches `CustomEvent("muga:history-gate")` on `document`. The main-world script listens. Cross-world signaling via DOM events is the only reliable bridge in MV3. Re-fires on `chrome.storage.onChanged` so toggles propagate.

## Manifest

- **MV3**: two new `content_scripts` entries (MAIN + isolated), both `run_at: document_start`, `all_frames: false`.
- **MV2**: registered as regular content scripts. **Firefox MV2 does NOT support `world: "MAIN"`** — full Firefox parity is a documented follow-up (will need `exportFunction` / `wrappedJSObject`). The existing self-clean `replaceState` in `cleaner.js` still covers the initial-page case for Firefox.

## Tests

- **20 unit tests** with stubbed history — pure JS, no jsdom (project rule).
- **1 Playwright E2E** — stubbed page, gate-aware (waits for `__mugaHistoryDefused === true` before pushState), asserts cleaned search, preserved `id=42`, and `history.state` deep-equals original.

## Test plan

- [x] `npm test` → **2859/2859** passing (+27 from baseline 2832)
- [x] `npm run lint` → 0 errors
- [x] State/title forwarded verbatim (deep ref equality test)
- [x] Disabled-state guard (gate event suppresses wrap)
- [x] Uninstall returns original methods
- [x] Cleaner errors swallowed (forwarded original URL)
- [x] Relative URL stays relative (SPA router compat)
- [x] Playwright: pushState with `?utm_source=marketing&utm_medium=email&id=42` → search has `id=42` only

## Known gaps (follow-up)

- **Firefox MV2 `world: "MAIN"`** equivalent via `exportFunction` / `wrappedJSObject`. Tracking issue should be opened separately. The existing self-clean covers initial-page; B11 will likely depend on this gap closing.