### PR TITLE
feat(content): window.name URL-shaped payload defuser (#451)

### DIFF
--- a/src/content/window-name-defuser-mainworld.js
+++ b/src/content/window-name-defuser-mainworld.js
@@ -1,0 +1,164 @@
+/**
+ * MUGA: Window-Name Defuser — main-world content script (#451 / B11)
+ *
+ * Runs IN THE PAGE WORLD (`world: "MAIN"`) at `document_start` so it
+ * can install a property accessor on the page's `window.name` BEFORE
+ * any page script reads it. The isolated-world content script cannot
+ * shadow `window.name` for the page — same MV3 isolated-world boundary
+ * documented in `history-defuser-mainworld.js` (B10).
+ *
+ * Why on-read instead of on-write: many legitimate scripts WRITE a
+ * value and then READ IT BACK expecting their exact value to round-
+ * trip (cross-frame handshakes, popup result transports, OAuth flows).
+ * Cleaning on write would corrupt those flows. Cleaning on read
+ * mutates only what the tracking-recovery scripts see when they fish
+ * the URL back out post-navigation; non-URL payloads pass through
+ * verbatim because the URL-shape gate skips them.
+ *
+ * Firefox MV2 does not support `world: "MAIN"`; MV2 ships this file as
+ * an ordinary content script in the manifest and the lack of a true
+ * page-world inject is a known compromise (the gate still works
+ * because the property accessor lives on the same `window` reference
+ * the page sees in MV2's content-script world).
+ *
+ * Important constraints for this file:
+ *
+ *   - No chrome.* APIs. Main-world scripts have NO access to
+ *     extension messaging — they share the page's privileges only.
+ *   - No ES module imports. Runs as a classic script in the page
+ *     world.
+ *   - Tracking-param list is a HARD-CODED SUBSET. Same subset as
+ *     `history-defuser-mainworld.js` — see comment on the STRIP table.
+ *     Round-tripping to the SW per read would be async; the page may
+ *     read `window.name` synchronously and feed it straight into a
+ *     beacon. The subset covers the highest-volume params (UTM, click
+ *     IDs, social).
+ *   - Disabled-state guard: cannot read prefs from main world. Reuses
+ *     the existing B10 `muga:history-gate` event so a single isolated-
+ *     world dispatcher (`history-defuser.js`) governs both defusers.
+ *     Same active-defense pref domain → same gate.
+ */
+
+(function () {
+  "use strict";
+
+  // Skip iframes — same guard as cleaner.js. Wrapping `window.name`
+  // inside cross-origin iframes risks corrupting cross-frame messaging
+  // patterns that legitimately use the property as a transport.
+  if (window.self !== window.top) return;
+  if (window.__mugaWindowNameDefused) return;
+  window.__mugaWindowNameDefused = true;
+
+  // Subset of TRACKING_PARAMS from src/lib/affiliates.js. Kept in sync
+  // with the same table in `history-defuser-mainworld.js` (B10) — the
+  // two defusers share the same active-defense param coverage.
+  // Object lookup is faster than a Set for this hot path; values are
+  // unused (truthiness only).
+  const STRIP = Object.freeze({
+    utm_source: 1, utm_medium: 1, utm_campaign: 1, utm_content: 1, utm_term: 1, utm_id: 1,
+    utm_source_platform: 1, utm_creative_format: 1, utm_marketing_tactic: 1,
+    fbclid: 1, gclid: 1, gclsrc: 1, dclid: 1, gbraid: 1, wbraid: 1, msclkid: 1, tclid: 1, twclid: 1,
+    mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
+    _hsenc: 1, _hsmi: 1, mkt_tok: 1,
+    yclid: 1, ysclid: 1, _openstat: 1,
+    irclickid: 1, cjevent: 1, awc: 1,
+    ttclid: 1, sccid: 1, rdt_cid: 1,
+    _branch_match_id: 1, _branch_referrer: 1,
+    pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,
+    mtm_campaign: 1, mtm_source: 1, mtm_medium: 1, mtm_content: 1,
+    hsctatracking: 1,
+    __s: 1, _ga: 1, _gl: 1, _gac: 1,
+    ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
+    mibextid: 1, share_id: 1,
+  });
+
+  /**
+   * Heuristic: only http/https URLs are treated as cleanable. Anything
+   * else (opaque tokens, JSON, javascript:/data: URIs, plain words) is
+   * returned verbatim by the caller without consulting the cleaner.
+   */
+  function looksLikeHttpUrl(s) {
+    if (typeof s !== "string" || s.length === 0) return false;
+    if (!/^https?:\/\//i.test(s)) return false;
+    try {
+      const u = new URL(s);
+      return u.protocol === "http:" || u.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Strips the static tracking-param subset from `rawUrl`. Returns the
+   * original string when nothing changed or when parsing fails — never
+   * throws (a property-getter throw would be catastrophic for the
+   * page).
+   */
+  function cleanUrl(rawUrl) {
+    if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+    if (rawUrl.indexOf("?") < 0) return rawUrl;
+    let u;
+    try {
+      u = new URL(rawUrl);
+    } catch {
+      return rawUrl;
+    }
+    let changed = false;
+    const keys = [];
+    u.searchParams.forEach((_v, k) => keys.push(k));
+    for (let i = 0; i < keys.length; i++) {
+      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
+        u.searchParams.delete(keys[i]);
+        changed = true;
+      }
+    }
+    if (!changed) return rawUrl;
+    return u.toString();
+  }
+
+  // Disabled-state gate. We REUSE the B10 event (`muga:history-gate`)
+  // because both defusers fall under the same general "active-defense"
+  // pref (gated on `enabled && onboardingDone`). One isolated-world
+  // dispatcher → both main-world wraps. Until the first event arrives
+  // the gate stays CLOSED (fail-closed): the wrap is installed but
+  // pass-through, matching the disabled-state guard contract.
+  let _gateOpen = false;
+  document.addEventListener("muga:history-gate", (e) => {
+    _gateOpen = !!(e && e.detail && e.detail.enabled);
+  });
+
+  // Capture whatever value `window.name` held before we replaced the
+  // property. The page may have set it before our document_start wrap
+  // landed (rare in MV3 — we run before any page script — but possible
+  // when another extension beat us to the property).
+  let stored;
+  try {
+    stored = window.name;
+  } catch {
+    stored = "";
+  }
+  if (typeof stored !== "string") stored = "";
+
+  Object.defineProperty(window, "name", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      const raw = stored;
+      if (typeof raw !== "string" || raw.length === 0) return raw;
+      if (!_gateOpen) return raw;
+      if (!looksLikeHttpUrl(raw)) return raw;
+      try {
+        const cleaned = cleanUrl(raw);
+        if (typeof cleaned !== "string" || cleaned.length === 0) return raw;
+        return cleaned;
+      } catch {
+        // Property getters MUST NOT throw — return the raw value.
+        return raw;
+      }
+    },
+    set(v) {
+      // Mirror the browser's own coercion: `window.name` stores strings.
+      stored = typeof v === "string" ? v : String(v);
+    },
+  });
+})();

--- a/src/content/window-name-defuser.js
+++ b/src/content/window-name-defuser.js
@@ -1,0 +1,39 @@
+/**
+ * MUGA: Window-Name Defuser — isolated-world gatekeeper (#451 / B11)
+ *
+ * The actual `window.name` property accessor lives in a sibling main-
+ * world content script (`window-name-defuser-mainworld.js`) — see that
+ * file for the WHY of dual-world wiring.
+ *
+ * Gate sharing with B10: this file deliberately does NOT dispatch its
+ * own gate event. The isolated-world gatekeeper for the History
+ * Defuser (`history-defuser.js`) already reads prefs and dispatches
+ * `muga:history-gate`; the window-name main-world wrap listens on the
+ * same event. One isolated-world dispatcher governs both main-world
+ * defusers because both are gated on the same "active-defense"
+ * domain (`enabled && onboardingDone`). Splitting the gate would mean
+ * two independent prefs round-trips on every page load and two
+ * separate `chrome.storage.onChanged` re-evaluations — a cost without
+ * a corresponding feature win.
+ *
+ * The companion isolated-world gate (`history-defuser.js`) is
+ * registered alongside this file in both manifests; this script's
+ * existence is therefore primarily structural — it keeps the B11
+ * file set parallel to B10 (so future divergence, e.g. a dedicated
+ * `windowNameDefuserEnabled` pref, has a place to land) and gives the
+ * manifest wiring tests a script to assert.
+ */
+
+(function () {
+  "use strict";
+
+  // Skip iframes — same guard as cleaner.js.
+  if (window.self !== window.top) return;
+  if (window.__mugaWindowNameDefuserGate) return;
+  window.__mugaWindowNameDefuserGate = true;
+
+  // Intentionally empty body. Gate dispatch is handled by
+  // `history-defuser.js` via the `muga:history-gate` event, which the
+  // window-name main-world wrap also listens to. See the docblock for
+  // the rationale.
+})();

--- a/src/lib/window-name-defuser.js
+++ b/src/lib/window-name-defuser.js
@@ -1,0 +1,157 @@
+/**
+ * MUGA: Window-Name Defuser (#451 / B11)
+ *
+ * `window.name` persists across same-origin navigations within a tab and
+ * across page reloads — it's the only top-frame slot that survives
+ * `location.assign()` without a referrer leak. Tracking SDKs abuse this
+ * by stashing a URL with tracking params into `window.name` BEFORE
+ * navigating, then reading it back after the navigation to "recover"
+ * params MUGA stripped at the navigation edge. This is the
+ * window.name-as-side-channel pattern documented in the privacy
+ * literature (e.g. Google Analytics' linker plugin and a long tail of
+ * affiliate scripts).
+ *
+ * Strategy: install a property accessor on `window.name` at
+ * `document_start` so all subsequent READS go through us. Cleaning at
+ * read-time (not write-time) is the safer contract:
+ *
+ *   - Many legitimate scripts WRITE a value and immediately READ IT
+ *     BACK expecting their exact value to round-trip (cross-frame
+ *     handshakes, popup result transports). Cleaning on write would
+ *     corrupt those flows. Cleaning on read mutates the OUTPUT only —
+ *     legitimate non-URL payloads return verbatim because the URL-shape
+ *     heuristic skips them.
+ *   - The tracking-recovery scripts read after navigation; we win that
+ *     read.
+ *
+ * Pure module — no DOM, no globals, no chrome.* — so unit tests can
+ * exercise the wrapping logic with plain stubs (no jsdom).
+ *
+ * Two correctness invariants:
+ *
+ *   1. STORED VALUE IS NEVER REWRITTEN. Writes pass through into a
+ *      private slot exactly as the page sent them; the cleaner runs on
+ *      read only. Sites that round-trip a token through window.name
+ *      see their token unchanged.
+ *   2. NON-URL READS ARE PASS-THROUGH. The URL-shape gate (must parse
+ *      with `new URL()` AND have an http/https scheme) keeps cross-
+ *      frame tokens, JSON blobs, opaque session strings, etc. out of
+ *      the cleaner entirely.
+ *
+ * Cleaner errors (e.g. cleaner blowing up deep inside `processUrl`)
+ * MUST NOT crash the read. We swallow the throw and return the raw
+ * stored value: a dirty value re-emerging is strictly better than the
+ * page crashing on a property read.
+ */
+
+/**
+ * Heuristic: is this string URL-shaped enough to worth cleaning?
+ *
+ * We only treat http(s) URLs as cleanable. Anything else — opaque
+ * tokens, JSON, javascript: URIs, data: URIs — is returned verbatim.
+ * The conservative scheme allowlist matches what the cleaner pipeline
+ * itself accepts and prevents collateral damage on the long tail of
+ * legitimate window.name payloads.
+ *
+ * @param {string} s
+ * @returns {boolean}
+ */
+function looksLikeHttpUrl(s) {
+  if (typeof s !== "string" || s.length === 0) return false;
+  // Cheap prefix check before paying for `new URL()`.
+  if (!/^https?:\/\//i.test(s)) return false;
+  try {
+    const u = new URL(s);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Installs the window-name defuser on the given window-like host.
+ *
+ * The host's `name` property is replaced with a configurable accessor.
+ * Reads pass the stored value through `urlCleaner` only when it looks
+ * URL-shaped; non-URL values fall through untouched. Writes update the
+ * private storage slot only — they do NOT mutate the value the cleaner
+ * sees on subsequent reads (cleaning is read-time).
+ *
+ * @param {object} target
+ *   The host object whose `name` property will be redefined IN PLACE.
+ *   Typically `window` from a content script. Plain objects with a
+ *   `name` data property also work — useful for tests.
+ * @param {(url: string) => string|null|undefined} urlCleaner
+ *   Synchronous cleaner. Receives the URL the page tried to read.
+ *   Should return the cleaned URL string. If it returns null,
+ *   undefined, or a non-string, the wrapper falls back to the original
+ *   stored value.
+ * @param {object} [options]
+ * @param {() => boolean} [options.isEnabled]
+ *   Optional disabled-state guard. When provided and returns false at
+ *   read time, the wrapper bypasses the cleaner entirely and returns
+ *   the raw stored value. Default: always enabled.
+ * @returns {() => void}
+ *   Uninstall callback. Restores a plain data property on the host
+ *   with the latest stored value, so reads and writes flow normally
+ *   afterwards.
+ */
+export function installWindowNameDefuser(target, urlCleaner, options = {}) {
+  const isEnabled = typeof options.isEnabled === "function"
+    ? options.isEnabled
+    : () => true;
+
+  // Capture whatever the property held BEFORE we replaced it. This is
+  // the value the page may have set before our document_start wrap
+  // landed (rare, but possible if some earlier extension or manifest
+  // entry beat us to it — fail-safe).
+  let stored;
+  try {
+    stored = target.name;
+  } catch {
+    stored = "";
+  }
+  if (typeof stored !== "string") stored = "";
+
+  Object.defineProperty(target, "name", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      const raw = stored;
+      if (typeof raw !== "string" || raw.length === 0) return raw;
+      let enabled;
+      try { enabled = !!isEnabled(); } catch { enabled = false; }
+      if (!enabled) return raw;
+      if (!looksLikeHttpUrl(raw)) return raw;
+      let cleaned;
+      try {
+        cleaned = urlCleaner(raw);
+      } catch {
+        // Cleaner blew up — return raw rather than crashing the read.
+        return raw;
+      }
+      if (typeof cleaned !== "string" || cleaned.length === 0) return raw;
+      return cleaned;
+    },
+    set(v) {
+      // Coerce to string the way `window.name` itself does. The browser
+      // converts non-strings to their string form before storage; we
+      // mirror that so the round-trip semantics match what the page
+      // would have observed without our wrap.
+      stored = typeof v === "string" ? v : String(v);
+    },
+  });
+
+  return function uninstall() {
+    // Restore a plain data property holding the LATEST stored value.
+    // This is the closest we can get to "remove our wrap" without
+    // capturing the original property descriptor (which we deliberately
+    // don't, because we want a clean slate after uninstall).
+    Object.defineProperty(target, "name", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: stored,
+    });
+  };
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,14 +29,14 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content/history-defuser-mainworld.js"],
+      "js": ["content/history-defuser-mainworld.js", "content/window-name-defuser-mainworld.js"],
       "run_at": "document_start",
       "world": "MAIN",
       "all_frames": false
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/cleaner.js"],
       "run_at": "document_start"
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -25,12 +25,12 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/cleaner.js"],
       "run_at": "document_start"
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["content/history-defuser-mainworld.js"],
+      "js": ["content/history-defuser-mainworld.js", "content/window-name-defuser-mainworld.js"],
       "run_at": "document_start"
     },
     {

--- a/tests/unit/window-name-defuser.test.mjs
+++ b/tests/unit/window-name-defuser.test.mjs
@@ -1,0 +1,346 @@
+/**
+ * MUGA — Tests for the Window-Name Defuser (#451 / B11).
+ *
+ * The defuser intercepts reads of `window.name` via a property accessor
+ * installed at `document_start`. When the stored value is a URL with
+ * known tracking params, reads return the cleaned URL. Non-URL payloads
+ * (the common case: cross-frame tokens like "frame-foo") fall through
+ * untouched, so legitimate uses of `window.name` are never disturbed.
+ *
+ * The module under test is a PURE factory — `installWindowNameDefuser`
+ * — which takes an injectable host object (any object with a `name`
+ * property accessor or data property) and an injectable URL cleaner.
+ * No DOM, no jsdom (project rule: no third-party test libs). The
+ * content-script entry that wires the real `window` and the bundled
+ * `processUrl` is structural; the contract is enforced here.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { installWindowNameDefuser } from "../../src/lib/window-name-defuser.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a stub host object with a backing `name` data property,
+ * mimicking the `window` surface area the defuser touches. The defuser
+ * should redefine the `name` property as an accessor on this object.
+ */
+function makeWindowStub(initial = "") {
+  const host = {};
+  let backing = initial;
+  Object.defineProperty(host, "name", {
+    get() { return backing; },
+    set(v) { backing = v; },
+    configurable: true,
+    enumerable: true,
+  });
+  return host;
+}
+
+/**
+ * Tracking-stripping cleaner — strips `utm_source`, `utm_medium`, and
+ * `fbclid`. Returns the original string when the input is not a
+ * URL-shaped payload (no scheme + host) — that's the contract the
+ * defuser's heuristic relies on.
+ */
+function trackingCleaner(rawUrl) {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+  const STRIP = new Set(["utm_source", "utm_medium", "fbclid"]);
+  let u;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+  let changed = false;
+  for (const k of [...u.searchParams.keys()]) {
+    if (STRIP.has(k)) {
+      u.searchParams.delete(k);
+      changed = true;
+    }
+  }
+  return changed ? u.toString() : rawUrl;
+}
+
+const identityCleaner = (s) => s;
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("installWindowNameDefuser — basic install / uninstall", () => {
+  test("install returns an uninstall function", () => {
+    const host = makeWindowStub("");
+    const uninstall = installWindowNameDefuser(host, identityCleaner);
+    assert.equal(typeof uninstall, "function");
+    uninstall();
+  });
+
+  test("after install, name is a configurable accessor", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, identityCleaner);
+    const desc = Object.getOwnPropertyDescriptor(host, "name");
+    assert.ok(desc, "name descriptor must exist");
+    assert.equal(typeof desc.get, "function");
+    assert.equal(typeof desc.set, "function");
+    assert.equal(desc.configurable, true);
+  });
+
+  test("uninstall restores readable / writable behaviour", () => {
+    const host = makeWindowStub("initial");
+    const uninstall = installWindowNameDefuser(host, identityCleaner);
+    host.name = "after";
+    uninstall();
+    // Post-uninstall, reads and writes still flow.
+    assert.equal(host.name, "after");
+    host.name = "again";
+    assert.equal(host.name, "again");
+  });
+});
+
+describe("installWindowNameDefuser — read-time cleaning", () => {
+  test("URL with tracking params → cleaned on read", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = "https://example.com/path?utm_source=x&id=42";
+    assert.equal(host.name, "https://example.com/path?id=42");
+  });
+
+  test("URL without tracking params → unchanged on read", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = "https://example.com/path?id=42";
+    assert.equal(host.name, "https://example.com/path?id=42");
+  });
+
+  test("non-URL token → returned verbatim (no interference)", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = "frame-foo";
+    assert.equal(host.name, "frame-foo");
+  });
+
+  test("empty string → empty string (cleaner not consulted)", () => {
+    let called = 0;
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, (u) => { called++; return u; });
+    assert.equal(host.name, "");
+    assert.equal(called, 0);
+  });
+
+  test("JSON-shaped cross-frame payload → unchanged", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = '{"channel":"oauth","nonce":"abc123"}';
+    assert.equal(host.name, '{"channel":"oauth","nonce":"abc123"}');
+  });
+
+  test("URL with no query → unchanged", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = "https://example.com/no-query";
+    assert.equal(host.name, "https://example.com/no-query");
+  });
+
+  test("initial value present at install time is cleaned on first read", () => {
+    const host = makeWindowStub("https://example.com/?utm_source=x");
+    installWindowNameDefuser(host, trackingCleaner);
+    assert.equal(host.name, "https://example.com/");
+  });
+});
+
+describe("installWindowNameDefuser — error paths", () => {
+  test("cleaner throw → original value forwarded (never crash on read)", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, () => { throw new Error("boom"); });
+    host.name = "https://example.com/?utm_source=x";
+    assert.equal(host.name, "https://example.com/?utm_source=x");
+  });
+
+  test("cleaner returning non-string → original value forwarded", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, () => null);
+    host.name = "https://example.com/?utm_source=x";
+    assert.equal(host.name, "https://example.com/?utm_source=x");
+  });
+
+  test("malformed URL-ish string → returned as-is, never throws", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    // Looks vaguely URL-shaped but is not parseable — must not crash.
+    host.name = "http://[::not-a-url";
+    assert.equal(host.name, "http://[::not-a-url");
+  });
+});
+
+describe("installWindowNameDefuser — write-through semantics", () => {
+  test("writing a non-URL value and reading it returns the same value", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = "session-token-xyz";
+    assert.equal(host.name, "session-token-xyz");
+    host.name = "another-token";
+    assert.equal(host.name, "another-token");
+  });
+
+  test("subsequent writes update the stored value (read returns latest)", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = "https://a.test/?utm_source=x";
+    assert.equal(host.name, "https://a.test/");
+    host.name = "https://b.test/?utm_medium=y";
+    assert.equal(host.name, "https://b.test/");
+  });
+
+  test("writes do NOT mutate the stored value (cleaning is on-read only)", () => {
+    // The contract is: storage stays raw, cleaning happens at read time.
+    // This matters because some scripts write window.name and re-read it
+    // expecting their exact value back. Cleaning on write would corrupt
+    // legitimate uses; cleaning on read only mutates output.
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    const dirty = "https://example.com/?utm_source=x&id=1";
+    host.name = dirty;
+    // First read sees cleaned output (the defuser job).
+    assert.equal(host.name, "https://example.com/?id=1");
+    // Stored value (re-readable after uninstall) was never rewritten:
+    // we can verify by swapping cleaner for identity and checking again.
+    // Easier: install with identity and confirm round-trip equals dirty.
+    const host2 = makeWindowStub("");
+    installWindowNameDefuser(host2, identityCleaner);
+    host2.name = dirty;
+    assert.equal(host2.name, dirty);
+  });
+});
+
+describe("installWindowNameDefuser — disabled-state guard", () => {
+  test("when isEnabled returns false, cleaner is not consulted", () => {
+    let called = 0;
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, (u) => { called++; return "MUTATED"; }, {
+      isEnabled: () => false,
+    });
+    host.name = "https://example.com/?utm_source=x";
+    assert.equal(host.name, "https://example.com/?utm_source=x");
+    assert.equal(called, 0);
+  });
+
+  test("when isEnabled returns true, cleaner runs", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner, { isEnabled: () => true });
+    host.name = "https://example.com/?utm_source=x";
+    assert.equal(host.name, "https://example.com/");
+  });
+
+  test("isEnabled is consulted on each read (live toggle)", () => {
+    let enabled = false;
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner, {
+      isEnabled: () => enabled,
+    });
+    host.name = "https://example.com/?utm_source=x";
+    assert.equal(host.name, "https://example.com/?utm_source=x");
+    enabled = true;
+    assert.equal(host.name, "https://example.com/");
+    enabled = false;
+    assert.equal(host.name, "https://example.com/?utm_source=x");
+  });
+});
+
+describe("installWindowNameDefuser — URL-shape heuristic", () => {
+  test("only http/https scheme strings are treated as URL-shaped", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    // Non-http schemes should not be treated as URLs to clean (e.g. a
+    // page-internal payload that happens to start with a colon).
+    host.name = "javascript:void(0)";
+    assert.equal(host.name, "javascript:void(0)");
+    host.name = "data:text/plain,hello?utm_source=x";
+    assert.equal(host.name, "data:text/plain,hello?utm_source=x");
+  });
+
+  test("strings that contain '?' but no scheme are NOT treated as URLs", () => {
+    const host = makeWindowStub("");
+    installWindowNameDefuser(host, trackingCleaner);
+    host.name = "foo?bar=baz";
+    assert.equal(host.name, "foo?bar=baz");
+  });
+});
+
+// ── Manifest + content-script wiring (structural) ──────────────────────────
+
+describe("window-name-defuser — content-script wiring", () => {
+  test("manifest.json registers the main-world wrap at document_start with world MAIN", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("window-name-defuser-mainworld.js"))
+    );
+    assert.ok(entry, "window-name-defuser-mainworld.js must be in a content_scripts entry");
+    assert.equal(entry.run_at, "document_start");
+    assert.equal(entry.world, "MAIN",
+      "main-world wrap must declare world MAIN so the page-world window.name is wrapped");
+  });
+
+  test("manifest.json registers the isolated-world gate at document_start", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("window-name-defuser.js"))
+    );
+    assert.ok(entry, "window-name-defuser.js must be in a content_scripts entry");
+    assert.equal(entry.run_at, "document_start");
+  });
+
+  test("manifest.v2.json registers both window-name defuser scripts at document_start", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.v2.json"), "utf8"
+    ));
+    const gateEntry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("window-name-defuser.js"))
+    );
+    const wrapEntry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("window-name-defuser-mainworld.js"))
+    );
+    assert.ok(gateEntry, "window-name-defuser.js (gate) must be registered for MV2");
+    assert.equal(gateEntry.run_at, "document_start");
+    assert.ok(wrapEntry, "window-name-defuser-mainworld.js (wrap) must be registered for MV2");
+    assert.equal(wrapEntry.run_at, "document_start");
+  });
+
+  test("content/window-name-defuser.js is an IIFE (no ES module imports)", () => {
+    const src = readFileSync(
+      join(__dirname, "../../src/content/window-name-defuser.js"), "utf8"
+    );
+    assert.ok(/^\(function/m.test(src), "content script must be an IIFE");
+    assert.equal(/^\s*import\s+/m.test(src), false,
+      "content script must not contain top-level ES module imports");
+  });
+
+  test("content/window-name-defuser-mainworld.js is an IIFE that defines a name accessor", () => {
+    const src = readFileSync(
+      join(__dirname, "../../src/content/window-name-defuser-mainworld.js"), "utf8"
+    );
+    assert.ok(/^\(function/m.test(src), "content script must be an IIFE");
+    assert.equal(/^\s*import\s+/m.test(src), false,
+      "content script must not contain top-level ES module imports");
+    assert.ok(/Object\.defineProperty\s*\(\s*window\s*,\s*['"]name['"]/.test(src),
+      "main-world script must redefine window.name as an accessor");
+    // No chrome.* CALLS (strip comments first to avoid prose tripping the guard).
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+    assert.equal(/\bchrome\.[a-zA-Z]/.test(stripped), false,
+      "main-world script must not call any chrome.* extension API");
+    // Reuses the existing B10 gate event so a single isolated-world
+    // dispatcher governs both defusers.
+    assert.ok(/muga:history-gate/.test(src),
+      "main-world wrap must listen for muga:history-gate to honor disabled state");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #451 (B11). Detects URL-shaped tracking payloads stored in `window.name` and cleans them **on read**. Reuses the dual-world architecture established by B10.

## Behavior

- Property accessor on `window.name` installed at `document_start` (main world).
- **Writes pass through** to a private slot verbatim — legitimate cross-frame round-trips (OAuth, popup transports) keep their exact value.
- **Reads** return cleaned URL when payload is URL-shaped with tracking params; otherwise return the raw stored value.
- URL-shape heuristic: `^https?://` AND successful `new URL()` parse. `javascript:`, `data:`, JSON blobs, opaque tokens all bypass the cleaner.
- Iframes skipped (`window.self !== window.top`) — same guard as B10 and `cleaner.js`.
- Getter is fully try/catch-wrapped — never crashes the page on read.
- Setter mirrors browser coercion (`String(v)`) so non-string writes round-trip identically to native `window.name`.

## Gate sharing with B10

This slice does **NOT** add a new pref or a new isolated-world dispatcher. The History Defuser's isolated-world script already reads prefs and dispatches `muga:history-gate`; the window-name main-world wrap listens on the same event.

Both defusers gate on the same active-defense domain (`enabled && onboardingDone`) — a single dispatcher governs both, saving a duplicate prefs round-trip per page load. The B11 isolated-world script exists structurally (empty body) to keep file symmetry and give a future dedicated pref a place to land.

## STRIP table duplication

The inline ~50-param subset is duplicated with `history-defuser-mainworld.js` (comment points to B10). Extraction into a shared content-safe global would have been more invasive than the duplication. C11 sync tests (where applicable) cover replicas.

## Test plan

- [x] `npm test` → **2882/2882** passing (+26 from baseline 2856)
- [x] `npm run lint` → 0 errors
- [x] URL-shaped + tracking → cleaned
- [x] URL-shaped + no tracking → unchanged
- [x] Empty string → empty
- [x] Non-URL token → unchanged (cross-frame messaging compat)
- [x] Malformed URL → unchanged (no throw)
- [x] Disabled-state (gate off) → no-op (raw value untouched)
- [x] Uninstall returns native behavior