### PR TITLE
feat(cleaner): wire cross-site-frequency observe() into pipeline (#495)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -22,6 +22,11 @@ import { TRUSTED_PUBLIC_KEYS } from "../lib/remote-rules-keys.js";
 import { createToolbarEventBus } from "../lib/toolbar-event-bus.js";
 import { createTabPresenterState } from "../lib/tab-presenter-state.js";
 import { createToolbarPresenter, iconForState } from "../lib/toolbar-presenter.js";
+import {
+  createTracker as createFrequencyTracker,
+  createChromeLocalAdapter as createFrequencyChromeAdapter,
+  defaultHasher as defaultFrequencyHasher,
+} from "../lib/cross-site-frequency.js";
 
 self.addEventListener("unhandledrejection", (e) => {
   console.warn("[MUGA] unhandled rejection:", e.reason);
@@ -140,6 +145,22 @@ const _origError = console.error.bind(console);
 console.error = (...args) => { _origError(...args); appendSessionLog("error", args); };
 const _origWarn = console.warn.bind(console);
 console.warn = (...args) => { _origWarn(...args); appendSessionLog("warn", args); };
+
+// --- Cross-site frequency tracker singleton (#446 / #495) ---
+//
+// The tracker is wired ONCE per service-worker lifetime. We pass it into
+// every processUrl() call from this SW so the cleaner can record the
+// (firstPartyDomain, paramName, value) tuple for each stripped tracking
+// param. Storage lives in chrome.storage.local — never sync.
+//
+// `createChromeLocalAdapter()` is feature-detected: in test contexts (and
+// in the rare runtime where chrome.storage.local is missing), it returns
+// null and we leave the tracker undefined. The cleaner already treats a
+// missing tracker as a no-op, so we don't need any extra guards.
+const _frequencyAdapter = createFrequencyChromeAdapter();
+const frequencyTracker = _frequencyAdapter
+  ? createFrequencyTracker({ adapter: _frequencyAdapter, hasher: defaultFrequencyHasher })
+  : null;
 
 // --- Prefs cache ---
 
@@ -829,7 +850,11 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
 
   let result;
   try {
-    result = processUrl(rawUrl, effectivePrefs, domainRules);
+    // 5th arg `frequencyTracker` is the cross-site-frequency singleton
+    // (#446 / #495). Cleaner side fires-and-forgets one observe() per
+    // stripped tracking param, gated on prefs.crossSiteFrequencyEnabled.
+    // Null-safe: cleaner no-ops when the tracker is missing.
+    result = processUrl(rawUrl, effectivePrefs, domainRules, undefined, frequencyTracker);
   } catch (err) {
     console.error("[MUGA] processUrl failed:", err, rawUrl);
     return { cleanUrl: rawUrl, action: "error", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -155,7 +155,10 @@ function isAliExpressItemPage(hostname, pathname) {
 
 /**
  * Strips tracking params from a URL object, respecting affiliate, preserved,
- * and disabled-category params.  Returns { removed, junkCount }.
+ * and disabled-category params.  Returns { removed, removedValues, junkCount }
+ * where `removedValues` is a parallel array carrying the original values of
+ * each stripped param (captured BEFORE deletion) so callers can feed the
+ * cross-site-frequency tracker the (paramName, value) tuple. (#495)
  */
 function stripTrackingParams(url, prefs, domainRules, disabledCategories) {
   const hostname = url.hostname;
@@ -175,17 +178,23 @@ function stripTrackingParams(url, prefs, domainRules, disabledCategories) {
   }
 
   const removed = [];
+  const removedValues = [];
   for (const param of [...url.searchParams.keys()]) {
     const lower = param.toLowerCase();
     if (affiliateParamSet.has(lower)) continue;
     if (preserved.has(lower)) continue;
     if (disabledParams.has(lower)) continue;
     if (isTrackingParam(lower, customParams, domainStrip, remoteParams)) {
+      // Capture the value BEFORE delete so we can feed it to the
+      // frequency tracker without re-parsing the URL. searchParams.get()
+      // returns "" for empty values; that's fine — the tracker hashes
+      // the empty string consistently.
+      removedValues.push(url.searchParams.get(param) ?? "");
       url.searchParams.delete(param);
       removed.push(param);
     }
   }
-  return { removed, junkCount: removed.length };
+  return { removed, removedValues, junkCount: removed.length };
 }
 
 /**
@@ -209,9 +218,17 @@ function stripTrackingParams(url, prefs, domainRules, disabledCategories) {
  *   (opaque wrapper case — t.co, link.medium.com, …). Background-worker
  *   call sites that lack DOM access pass undefined and the canonical
  *   tier no-ops.
+ * @param {{ observe: (domain: string, paramName: string, value: string) => Promise<void> } | null | undefined} [frequencyTracker]
+ *   Optional cross-site-frequency tracker (#446 / #495). When provided AND
+ *   `prefs.crossSiteFrequencyEnabled !== false`, every stripped tracking
+ *   param triggers a fire-and-forget `tracker.observe(firstPartyDomain,
+ *   name, value)` call. The tracker's first-party domain is the URL's
+ *   hostname — i.e. the page being cleaned. Failures from the tracker are
+ *   swallowed: the cleaner pipeline must never break on storage errors.
+ *   Pass `undefined`/`null` (or omit) in contexts where no tracker exists.
  * @returns {{ cleanUrl: string, action: string, removedTracking: string[], junkRemoved: number, detectedAffiliate: object|null, preservedAffiliate: object|null }}
  */
-export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle) {
+export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle, frequencyTracker) {
   let url;
   try {
     url = new URL(rawUrl);
@@ -298,6 +315,7 @@ export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle) {
 
   const patterns = getPatternsForHost(hostname);
   const removedTracking = [];
+  const removedTrackingValues = [];
   let detectedAffiliate = null;
   let action = "untouched";
 
@@ -308,8 +326,12 @@ export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle) {
   if (domainWhitelisted) {
     // Still strip tracking params, but leave all affiliate params untouched and skip injection
     const disabledCategoriesForSkip = new Set(prefs.disabledCategories || []);
-    const { removed: removedTrackingForSkip } = stripTrackingParams(url, prefs, domainRules, disabledCategoriesForSkip);
+    const {
+      removed: removedTrackingForSkip,
+      removedValues: removedValuesForSkip,
+    } = stripTrackingParams(url, prefs, domainRules, disabledCategoriesForSkip);
     const actionForSkip = (removedTrackingForSkip.length > 0 || pathCleaned) ? "cleaned" : "untouched";
+    recordFrequency(frequencyTracker, prefs, hostname, removedTrackingForSkip, removedValuesForSkip);
     return {
       cleanUrl: url.toString(),
       action: actionForSkip,
@@ -354,12 +376,16 @@ export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle) {
     const { preserved } = getDomainParamSets(hostname, domainRules);
     for (const param of [...url.searchParams.keys()]) {
       if (preserved.has(param.toLowerCase())) continue;
+      // Capture original value BEFORE delete so the frequency tracker can
+      // record the (paramName, value) tuple. (#495)
+      removedTrackingValues.push(url.searchParams.get(param) ?? "");
       url.searchParams.delete(param);
       removedTracking.push(param);
     }
   } else {
-    const { removed } = stripTrackingParams(url, prefs, domainRules, disabledCategories);
+    const { removed, removedValues } = stripTrackingParams(url, prefs, domainRules, disabledCategories);
     removedTracking.push(...removed);
+    removedTrackingValues.push(...removedValues);
   }
   if (pathCleaned && action === "untouched") action = "cleaned";
   if (removedTracking.length > 0 && action === "untouched") action = "cleaned";
@@ -427,6 +453,8 @@ export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle) {
     }
   }
 
+  recordFrequency(frequencyTracker, prefs, hostname, removedTracking, removedTrackingValues);
+
   return {
     cleanUrl: url.toString(),
     action,
@@ -435,4 +463,44 @@ export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle) {
     detectedAffiliate,
     preservedAffiliate: detectPreservedAffiliate(url, patterns),
   };
+}
+
+/**
+ * Fire-and-forget bridge from the cleaner to the cross-site-frequency
+ * tracker (#446 / #495). One observe() call per stripped tracking param,
+ * with the URL's hostname as the first-party domain and the param's
+ * ORIGINAL value (captured before deletion) as the value.
+ *
+ * No-op when:
+ *   - no tracker was injected (bookkeeping callers / background contexts
+ *     that don't have a tracker wired);
+ *   - the user opted out via `prefs.crossSiteFrequencyEnabled === false`
+ *     (default-on; only an explicit `false` disables);
+ *   - the firstPartyDomain can't be derived (defensive).
+ *
+ * Failures are swallowed via `.catch(() => {})` because storage errors
+ * MUST NOT break the cleaner pipeline. The cleaner's job is to clean URLs;
+ * frequency tracking is an opportunistic side-channel.
+ *
+ * @param {{ observe: Function } | null | undefined} tracker
+ * @param {object} prefs
+ * @param {string} firstPartyDomain
+ * @param {string[]} names
+ * @param {string[]} values - parallel array; values[i] corresponds to names[i]
+ */
+function recordFrequency(tracker, prefs, firstPartyDomain, names, values) {
+  if (!tracker || typeof tracker.observe !== "function") return;
+  if (prefs?.crossSiteFrequencyEnabled === false) return;
+  if (!firstPartyDomain) return;
+  if (!names || names.length === 0) return;
+  for (let i = 0; i < names.length; i++) {
+    try {
+      const ret = tracker.observe(firstPartyDomain, names[i], values[i] ?? "");
+      if (ret && typeof ret.catch === "function") {
+        ret.catch(() => {});
+      }
+    } catch {
+      // Synchronous throw from observe() — swallow. Cleaner must not break.
+    }
+  }
 }

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -24,6 +24,10 @@ import { join, dirname } from "node:path";
 import { createRequire } from "node:module";
 import { processUrl, parseListEntry } from "../../src/lib/cleaner.js";
 import { AFFILIATE_PATTERNS } from "../../src/lib/affiliates.js";
+import {
+  createInMemoryAdapter,
+  createTracker,
+} from "../../src/lib/cross-site-frequency.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -2656,6 +2660,182 @@ describe("T1.5 — remoteParams consumed by processUrl", () => {
     assert.strictEqual(action, "cleaned");
     assert.ok(cleanUrl.includes("legit=1"), "non-tracking params must be preserved");
     assert.ok(!cleanUrl.includes("utm_source"), "built-in params must still be stripped");
+  });
+
+});
+
+// ---------------------------------------------------------------------------
+// #495 — Cross-Site Frequency Tracker integration
+//
+// processUrl accepts an optional `frequencyTracker` (5th positional arg) that
+// implements `observe(domain, paramName, value)`. When supplied AND the user
+// has not opted out (`prefs.crossSiteFrequencyEnabled !== false`), the cleaner
+// records every stripped tracking param against the URL's first-party domain.
+//
+// Contract:
+//   - One observe() call per stripped tracking param (NOT per re-observation
+//     of the same URL by the caller).
+//   - Original VALUE — captured before deletion — is what we feed the tracker.
+//   - `id` (not a tracking param) must NOT be observed.
+//   - When the tracker is absent, behavior is identical to pre-#495 baseline.
+//   - When `crossSiteFrequencyEnabled === false`, the tracker is not invoked.
+//   - Promise rejections from observe() must NOT break the cleaner pipeline.
+// ---------------------------------------------------------------------------
+describe("#495 — frequency tracker integration with processUrl", () => {
+
+  /** Drains microtasks so fire-and-forget tracker calls settle before assertions. */
+  const flush = () => new Promise((r) => setImmediate(r));
+
+  // Hasher used by the in-memory tracker. Deterministic; no SubtleCrypto.
+  const stubHasher = async (s) => `h:${s}`;
+
+  test("invokes observe(domain, name, value) once per stripped tracking param, "
+    + "and skips non-tracking params like 'id'", async () => {
+    const calls = [];
+    const fakeTracker = {
+      observe: async (domain, name, value) => {
+        calls.push({ domain, name, value });
+      },
+    };
+    const { removedTracking } = processUrl(
+      "https://news.example/?utm_source=marketing&id=42",
+      PREFS,
+      [],
+      undefined,
+      fakeTracker,
+    );
+    await flush();
+    assert.deepEqual(removedTracking, ["utm_source"]);
+    assert.equal(calls.length, 1, "exactly one observe call");
+    assert.equal(calls[0].domain, "news.example");
+    assert.equal(calls[0].name, "utm_source");
+    assert.equal(calls[0].value, "marketing");
+  });
+
+  test("when no tracker is supplied, processUrl behaves identically to baseline", () => {
+    const { action, cleanUrl, removedTracking } = processUrl(
+      "https://news.example/?utm_source=marketing&id=42",
+      PREFS,
+    );
+    assert.equal(action, "cleaned");
+    assert.equal(cleanUrl, "https://news.example/?id=42");
+    assert.deepEqual(removedTracking, ["utm_source"]);
+  });
+
+  test("when prefs.crossSiteFrequencyEnabled === false, observe is NOT called", async () => {
+    const calls = [];
+    const fakeTracker = {
+      observe: async (domain, name, value) => {
+        calls.push({ domain, name, value });
+      },
+    };
+    const prefs = { ...PREFS, crossSiteFrequencyEnabled: false };
+    processUrl(
+      "https://news.example/?utm_source=marketing",
+      prefs,
+      [],
+      undefined,
+      fakeTracker,
+    );
+    await flush();
+    assert.equal(calls.length, 0);
+  });
+
+  test("when prefs.crossSiteFrequencyEnabled is omitted (default), observe IS called", async () => {
+    const calls = [];
+    const fakeTracker = {
+      observe: async (domain, name, value) => {
+        calls.push({ domain, name, value });
+      },
+    };
+    processUrl(
+      "https://news.example/?utm_source=marketing",
+      PREFS, // no crossSiteFrequencyEnabled key
+      [],
+      undefined,
+      fakeTracker,
+    );
+    await flush();
+    assert.equal(calls.length, 1);
+  });
+
+  test("a rejecting observe() does NOT throw out of processUrl and does not corrupt the result", async () => {
+    const fakeTracker = {
+      observe: () => Promise.reject(new Error("storage offline")),
+    };
+    let result;
+    assert.doesNotThrow(() => {
+      result = processUrl(
+        "https://news.example/?utm_source=marketing",
+        PREFS,
+        [],
+        undefined,
+        fakeTracker,
+      );
+    });
+    // Wait so the rejection settles inside the suppressed catch handler.
+    await flush();
+    await flush();
+    assert.equal(result.action, "cleaned");
+    assert.deepEqual(result.removedTracking, ["utm_source"]);
+  });
+
+  test("strips multiple tracking params and observes each one with its original value", async () => {
+    const calls = [];
+    const fakeTracker = {
+      observe: async (domain, name, value) => {
+        calls.push({ domain, name, value });
+      },
+    };
+    processUrl(
+      "https://news.example/?utm_source=marketing&utm_medium=email&fbclid=abc123",
+      PREFS,
+      [],
+      undefined,
+      fakeTracker,
+    );
+    await flush();
+    // Order is the order the cleaner stripped them in. Sort defensively for assertion.
+    const byName = Object.fromEntries(calls.map((c) => [c.name, c]));
+    assert.equal(calls.length, 3);
+    assert.equal(byName.utm_source.value, "marketing");
+    assert.equal(byName.utm_medium.value, "email");
+    assert.equal(byName.fbclid.value, "abc123");
+    for (const c of calls) {
+      assert.equal(c.domain, "news.example");
+    }
+  });
+
+  test("threshold-crossing integration: 3 unrelated domains × 3 distinct values → "
+    + "utm_source flagged via getFlagged()", async () => {
+    const adapter = createInMemoryAdapter();
+    const realTracker = createTracker({ adapter, hasher: stubHasher });
+
+    // Serialize observe() calls so the in-memory adapter's read-modify-write
+    // sequence doesn't race when processUrl fires-and-forgets multiple
+    // observations in quick succession. In production, navigation cadence is
+    // far slower than storage I/O so this isn't a real concern; the wrapper
+    // exists purely so the deterministic test doesn't depend on timing.
+    let chain = Promise.resolve();
+    const serializedTracker = {
+      observe: (domain, name, value) => {
+        const next = chain.then(() => realTracker.observe(domain, name, value));
+        chain = next.catch(() => {});
+        return next;
+      },
+    };
+
+    processUrl("https://a.example/?utm_source=marketing", PREFS, [], undefined, serializedTracker);
+    processUrl("https://b.example/?utm_source=email",     PREFS, [], undefined, serializedTracker);
+    processUrl("https://c.example/?utm_source=twitter",   PREFS, [], undefined, serializedTracker);
+    // Wait for the serialized chain to fully drain.
+    await chain;
+
+    const flagged = await realTracker.getFlagged();
+    assert.equal(flagged.length, 1);
+    assert.equal(flagged[0].param, "utm_source");
+    assert.ok(flagged[0].domains >= 3);
+    assert.ok(flagged[0].values >= 3);
   });
 
 });


### PR DESCRIPTION
## Summary

Closes #495. Wires the B16 frequency tracker into the cleaner pipeline so it actually populates as the user browses. B16 (#446) shipped the module + popup section but explicitly deferred this seam.

## Changes

### `processUrl` signature

Added optional 5th positional param `frequencyTracker` after `canonicalBundle`. **Backward compatible** — omitted/null tracker leaves cleaner behavior identical to baseline.

```
processUrl(rawUrl, prefs, domainRules, canonicalBundle, frequencyTracker)
```

### Tracker capture in `stripTrackingParams`

- Returns a new parallel `removedValues` array — captured BEFORE `searchParams.delete()` (otherwise the value is gone).
- `recordFrequency()` helper invokes `tracker.observe(domain, name, value)` for each removed param.
- Wrapped in `try/catch` (sync throws) AND `.catch(() => {})` on the returned promise (async rejection). **The cleaner pipeline NEVER breaks on tracker failure.**
- Gated on `prefs.crossSiteFrequencyEnabled !== false` (default ON — same default as the storage write and the popup gating).
- All three strip paths instrumented: main, AliExpress item-page, domain-whitelist branch.

### SW wiring

`src/background/service-worker.js` builds a singleton at module init:
- `createFrequencyTracker` with chrome.storage.local adapter + SubtleCrypto hasher
- Null-safe — when `chrome.storage.local` is unavailable (tests), adapter factory returns null and the cleaner treats missing tracker as no-op
- Passed into the only `processUrl` call site inside `handleProcessUrl`

## Test plan

- [x] `npm test` → **2889/2889** passing (+7 from baseline 2882)
- [x] `npm run lint` → 0 errors
- [x] processUrl + tracker + URL with `utm_source=marketing&id=42` → observe called for `utm_source` only (id is not a tracking param)
- [x] processUrl without tracker → no error, baseline behavior preserved
- [x] processUrl with tracker but `crossSiteFrequencyEnabled === false` → tracker NOT called
- [x] tracker.observe rejection swallowed → cleaner result unchanged
- [x] Threshold crossing integration: 3 unrelated domains × 3 distinct values for `utm_source` → flagged via `getFlagged()`

## Note for future test authors

`createInMemoryAdapter` does deep-copy read-modify-write, so concurrent fire-and-forget `observe()` calls race. The integration test uses a serializing observe-chain wrapper. Production navigation cadence dwarfs storage I/O so this isn't a real risk, but worth noting.