### PR TITLE
feat(content): DOM Link Rewriter — MutationObserver on a[href] (#443)

### DIFF
--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -1,0 +1,261 @@
+/**
+ * MUGA: DOM Link Rewriter — isolated-world content script (#443 / B8)
+ *
+ * Watches `<a href>` mutations on the page and rewrites tracking-decorated
+ * URLs in place. SPA pages frequently re-render link lists with the same
+ * dirty URLs the navigation pipeline already strips at request time. A
+ * user who copies a link, hovers to read the bottom-of-window URL preview,
+ * or middle-clicks to open a new tab would otherwise see/use the dirty
+ * URL — this rewriter closes that visible-DOM leak.
+ *
+ * Why isolated world (not main world):
+ *   - The DOM is shared between isolated and main worlds. Reading
+ *     `a.href` and writing `a.setAttribute('href', ...)` works fine
+ *     here. Only JS object identity is split — and we don't share
+ *     objects with the page.
+ *   - Running here means we can listen for the SAME `muga:history-gate`
+ *     CustomEvent that the History Defuser (#444 / B10) already
+ *     publishes from the isolated-world gate script. No extra prefs
+ *     round-trip, no second gate event, no separate disable plumbing.
+ *
+ * Why a hard-coded tracking-param subset (vs. the full bundled cleaner):
+ *   The cleaner bundle (`window.__mugaCleaner.processUrl`) is content-
+ *   script visible, but a MutationObserver that fires on a SPA's link
+ *   list rebuild can spike to hundreds of calls in a microtask. The
+ *   inline subset matches the History Defuser main-world script and
+ *   covers the highest-volume params (UTM, click IDs, social) without
+ *   the full cleaner's per-call overhead. Full coverage continues to
+ *   live in the navigation pipeline (DNR + cleaner-bundle.js).
+ *
+ *   If `window.__mugaCleaner.processUrl` is available we PREFER it over
+ *   the inline subset — same isolated world, same sync surface. The
+ *   inline subset is the safety net for paint-time mutations that fire
+ *   before the cleaner bundle has attached.
+ *
+ * Idempotency: the pure factory in `src/lib/dom-link-rewriter.js`
+ * guarantees that an already-clean href produces ZERO setAttribute calls
+ * — the `attributes` mutation that would re-trigger the observer never
+ * happens. See that file's docblock for the invariant.
+ */
+
+(function () {
+  "use strict";
+
+  // Skip iframes — same guard as the rest of the content scripts.
+  // Wrapping inside an iframe risks corrupting cross-origin parent
+  // navigation handling for embedded routers (Stripe, OAuth).
+  if (window.self !== window.top) return;
+  if (window.__mugaDomLinkRewriter) return;
+  window.__mugaDomLinkRewriter = true;
+
+  // ── Inline tracking-param subset ──────────────────────────────────────
+  // Mirrors the subset in content/history-defuser-mainworld.js. Object
+  // lookup is faster than a Set on this hot path. Values are unused.
+  const STRIP = Object.freeze({
+    utm_source: 1, utm_medium: 1, utm_campaign: 1, utm_content: 1, utm_term: 1, utm_id: 1,
+    utm_source_platform: 1, utm_creative_format: 1, utm_marketing_tactic: 1,
+    fbclid: 1, gclid: 1, gclsrc: 1, dclid: 1, gbraid: 1, wbraid: 1, msclkid: 1, tclid: 1, twclid: 1,
+    mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
+    _hsenc: 1, _hsmi: 1, mkt_tok: 1,
+    yclid: 1, ysclid: 1, _openstat: 1,
+    irclickid: 1, cjevent: 1, awc: 1,
+    ttclid: 1, sccid: 1, rdt_cid: 1,
+    _branch_match_id: 1, _branch_referrer: 1,
+    pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,
+    mtm_campaign: 1, mtm_source: 1, mtm_medium: 1, mtm_content: 1,
+    hsctatracking: 1,
+    __s: 1, _ga: 1, _gl: 1, _gac: 1,
+    ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
+    mibextid: 1, share_id: 1,
+  });
+
+  /**
+   * Synchronous URL cleaner. Strips the static tracking-param subset
+   * and re-emits in the same shape (relative vs absolute) the caller
+   * passed in so attribute string-comparisons match. Returns the
+   * original string when nothing changed or parsing fails — never
+   * throws. The pure factory is built to swallow throws anyway, but
+   * keeping this defensive matches the History Defuser pattern.
+   */
+  function inlineCleanUrl(rawUrl) {
+    if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+    if (rawUrl.indexOf("?") < 0) return rawUrl;
+    let u;
+    try {
+      u = new URL(rawUrl, window.location.href);
+    } catch {
+      return rawUrl;
+    }
+    let changed = false;
+    const keys = [];
+    u.searchParams.forEach((_v, k) => keys.push(k));
+    for (let i = 0; i < keys.length; i++) {
+      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
+        u.searchParams.delete(keys[i]);
+        changed = true;
+      }
+    }
+    if (!changed) return rawUrl;
+    const isAbsolute = /^[a-z]+:\/\//i.test(rawUrl);
+    if (isAbsolute) return u.toString();
+    return u.pathname + u.search + u.hash;
+  }
+
+  /**
+   * Prefer the bundled `processUrl` if it's already attached. Both
+   * scripts run in the isolated world and the cleaner bundle loads
+   * earlier in the manifest content_scripts array, so by the time the
+   * gate opens the bundle is typically up. The inline subset is the
+   * fallback when an extremely-early mutation (rare — observer doesn't
+   * start until the gate event) outraces the bundle attach.
+   */
+  function urlCleaner(raw) {
+    const bundled = window.__mugaCleaner;
+    if (bundled && typeof bundled.processUrl === "function") {
+      try {
+        const out = bundled.processUrl(raw);
+        // processUrl returns an object on hit; the rewriter wants a
+        // string. Be defensive — if the bundled API ever changes shape,
+        // we silently fall through to the inline subset.
+        if (typeof out === "string") return out;
+        if (out && typeof out.url === "string") return out.url;
+      } catch {
+        // fall through to the inline subset
+      }
+    }
+    return inlineCleanUrl(raw);
+  }
+
+  /**
+   * Scope guard — mirrors AGENTS.md's URL scope rules. Keeps the cleaner
+   * (and `new URL()`) off non-http schemes that would either parse to
+   * something nonsensical or throw.
+   */
+  function isCleanLink(href) {
+    if (typeof href !== "string" || href.length === 0) return false;
+    // Skip schemes the cleaner has no business touching. Hash-only
+    // links and same-page anchors are kept out via the "must contain ?"
+    // shortcut in inlineCleanUrl, but rejecting non-http schemes here
+    // saves a `new URL()` per non-candidate.
+    if (/^(mailto|tel|javascript|data|blob|about|chrome|chrome-extension):/i.test(href)) {
+      return false;
+    }
+    return true;
+  }
+
+  // ── Pure factory inlined ──────────────────────────────────────────────
+  // Same logic as src/lib/dom-link-rewriter.js. Inlined because content
+  // scripts can't use ES module imports cross-browser (Firefox MV2). The
+  // unit tests cover the factory directly; this copy is a thin shell.
+  function createLinkRewriter() {
+    function isAnchor(node) {
+      return !!(node && node.nodeType === 1 && node.tagName === "A");
+    }
+
+    function rewriteLink(anchor) {
+      if (!isAnchor(anchor)) return;
+      let current;
+      try { current = anchor.getAttribute("href"); } catch { return; }
+      if (typeof current !== "string" || current.length === 0) return;
+      if (!isCleanLink(current)) return;
+      let cleaned;
+      try { cleaned = urlCleaner(current); } catch { return; }
+      if (typeof cleaned !== "string" || cleaned.length === 0) return;
+      // IDEMPOTENCY: a write of the same string would still observable
+      // as an `attributes` mutation and re-fire the observer. Skip.
+      if (cleaned === current) return;
+      try { anchor.setAttribute("href", cleaned); } catch { /* detached */ }
+    }
+
+    function rewriteAll(nodeIterable) {
+      if (!nodeIterable) return;
+      try {
+        for (const node of nodeIterable) rewriteLink(node);
+      } catch { /* iterator threw mid-walk */ }
+    }
+
+    function processAddedNode(node) {
+      if (!node || node.nodeType !== 1) return;
+      if (isAnchor(node)) rewriteLink(node);
+      if (typeof node.querySelectorAll === "function") {
+        let descendants;
+        try { descendants = node.querySelectorAll("a[href]"); } catch { return; }
+        if (descendants) rewriteAll(descendants);
+      }
+    }
+
+    function onMutation(records) {
+      if (!records) return;
+      const len = records.length;
+      if (typeof len !== "number") return;
+      for (let i = 0; i < len; i++) {
+        const r = records[i];
+        if (!r) continue;
+        if (r.type === "attributes") {
+          if (r.attributeName !== "href") continue;
+          rewriteLink(r.target);
+        } else if (r.type === "childList") {
+          const added = r.addedNodes;
+          if (!added) continue;
+          const n = added.length || 0;
+          for (let j = 0; j < n; j++) processAddedNode(added[j]);
+        }
+      }
+    }
+
+    return { rewriteLink, rewriteAll, onMutation };
+  }
+
+  const rewriter = createLinkRewriter();
+
+  // ── Disabled-state gate ───────────────────────────────────────────────
+  // Reuse the same `muga:history-gate` event the History Defuser already
+  // publishes from `content/history-defuser.js`. A separate gate event
+  // would mean two prefs round-trips on every page; sharing keeps
+  // disabled-state behavior coherent and cheap.
+  let _observer = null;
+
+  function observerCallback(records) {
+    // The MutationObserver callback IS already a microtask boundary —
+    // the browser batches DOM writes from a turn of the event loop and
+    // delivers them in one callback. Process synchronously: queueing
+    // another microtask just adds latency without adding batching.
+    rewriter.onMutation(records);
+  }
+
+  function startObserver() {
+    if (_observer) return;
+    if (!document || !document.documentElement) return;
+    try {
+      _observer = new MutationObserver(observerCallback);
+      _observer.observe(document.documentElement, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        // attributeFilter is the load-bearing perf optimization — without
+        // it every attribute change on every element pages through this
+        // callback. With it the browser short-circuits in C++.
+        attributeFilter: ["href"],
+      });
+    } catch {
+      _observer = null;
+      return;
+    }
+    // Initial pass — anchors that already exist when the gate opens.
+    try {
+      rewriter.rewriteAll(document.querySelectorAll("a[href]"));
+    } catch { /* document detached or selector unsupported */ }
+  }
+
+  function stopObserver() {
+    if (!_observer) return;
+    try { _observer.disconnect(); } catch { /* already disconnected */ }
+    _observer = null;
+  }
+
+  document.addEventListener("muga:history-gate", (e) => {
+    const enabled = !!(e && e.detail && e.detail.enabled);
+    if (enabled) startObserver();
+    else stopObserver();
+  });
+})();

--- a/src/lib/dom-link-rewriter.js
+++ b/src/lib/dom-link-rewriter.js
@@ -1,0 +1,183 @@
+/**
+ * MUGA: DOM Link Rewriter (#443 / B8)
+ *
+ * Watches `<a href>` attribute mutations in a page and runs URL cleaning
+ * on each. Pairs with a content-script bootstrap that installs a real
+ * `MutationObserver` and feeds its callback into `onMutation`. This pure
+ * module has NO DOM, NO chrome.*, NO globals — so unit tests can exercise
+ * it with stub anchors and stub mutation records.
+ *
+ * Two correctness invariants drive the design:
+ *
+ *   1. IDEMPOTENCY. If the cleaner returns the SAME string the anchor
+ *      already has, this module MUST NOT call `setAttribute`. Calling
+ *      `setAttribute('href', existingValue)` is observable as an
+ *      `attributes` mutation; the observer would re-fire, and we'd
+ *      either burn CPU forever or need an exclude-set workaround. The
+ *      "no write when cleaned === current" rule lets self-induced
+ *      mutations converge naturally on the second pass.
+ *   2. NEVER THROW. A bad URL or a cleaner that explodes must NOT bubble
+ *      out into the page's mutation flow. The browser will keep firing
+ *      mutations regardless; failing loud just spams the console and
+ *      leaves links unmodified anyway. Swallow and skip.
+ *
+ * Scope guard: only http(s)-shaped hrefs are candidates. mailto:, tel:,
+ * javascript:, data:, blob: — and anything `URL` parses but the cleaner
+ * doesn't know how to handle — pass through with no DOM write. Decision
+ * deferred to the injected `isCleanLink` predicate so the content-script
+ * wiring can match the rest of MUGA's scope rules without this module
+ * making its own policy.
+ */
+
+/**
+ * @typedef {object} LinkRewriterDeps
+ * @property {(rawUrl: string) => string|null|undefined} urlCleaner
+ *   Synchronous cleaner. Receives the anchor's current href string.
+ *   Should return the cleaned URL string, or null/undefined when it has
+ *   no opinion. Throws are swallowed.
+ * @property {(href: string) => boolean} isCleanLink
+ *   Returns true when the href is in scope for cleaning. Implementations
+ *   typically reject mailto:, tel:, javascript:, data:, blob:, and empty
+ *   strings. Called BEFORE the cleaner to avoid wasted parsing work on
+ *   non-http schemes the cleaner can't handle anyway.
+ */
+
+/**
+ * @typedef {object} LinkRewriter
+ * @property {(anchor: object) => void} rewriteLink
+ *   Reads `anchor.getAttribute('href')`, runs the cleaner, and only
+ *   calls `anchor.setAttribute('href', cleaned)` when `cleaned !==
+ *   current`. No-op when the anchor's tagName isn't "A".
+ * @property {(nodeIterable: Iterable|ArrayLike|null) => void} rewriteAll
+ *   Iterates and calls `rewriteLink` on each. Accepts arrays, NodeLists
+ *   (Symbol.iterator + length), and null/undefined (no-op).
+ * @property {(records: MutationRecord[]|null) => void} onMutation
+ *   Processes a `MutationObserver` callback's record list. For each
+ *   record:
+ *     - `attributes` with `attributeName === 'href'` → rewrite the
+ *       record's `target`.
+ *     - `childList` → rewrite each `addedNode` that's an anchor, plus
+ *       descend via `querySelectorAll('a[href]')` on element children.
+ *   Other records ignored.
+ */
+
+/**
+ * Builds a link-rewriter bound to the given cleaner + scope predicate.
+ *
+ * @param {LinkRewriterDeps} deps
+ * @returns {LinkRewriter}
+ */
+export function createLinkRewriter(deps) {
+  const urlCleaner = deps && deps.urlCleaner;
+  const isCleanLink = deps && deps.isCleanLink;
+
+  if (typeof urlCleaner !== "function" || typeof isCleanLink !== "function") {
+    throw new TypeError(
+      "createLinkRewriter requires { urlCleaner, isCleanLink } functions"
+    );
+  }
+
+  function isAnchor(node) {
+    // nodeType 1 is ELEMENT_NODE. tagName comparison is uppercase in
+    // HTML documents — XHTML is case-sensitive but the observer is
+    // installed on HTML pages exclusively.
+    return !!(node && node.nodeType === 1 && node.tagName === "A");
+  }
+
+  function rewriteLink(anchor) {
+    if (!isAnchor(anchor)) return;
+    let current;
+    try {
+      current = anchor.getAttribute("href");
+    } catch {
+      return;
+    }
+    if (typeof current !== "string" || current.length === 0) return;
+    if (!isCleanLink(current)) return;
+
+    let cleaned;
+    try {
+      cleaned = urlCleaner(current);
+    } catch {
+      // Cleaner blew up on a malformed URL or some unexpected input.
+      // Leaving the link untouched is strictly better than a runtime
+      // error on a SPA mutation hot path.
+      return;
+    }
+    // Reject anything that isn't a non-empty string — if the cleaner
+    // can't produce one, the DOM stays as-is.
+    if (typeof cleaned !== "string" || cleaned.length === 0) return;
+    // THE IDEMPOTENCY GUARD. Without this check, the observer's next
+    // callback would see our own setAttribute as a mutation, re-enter,
+    // and (worst case) loop forever.
+    if (cleaned === current) return;
+    try {
+      anchor.setAttribute("href", cleaned);
+    } catch {
+      // Detached node or readonly anchor — neither rare nor fatal.
+    }
+  }
+
+  function rewriteAll(nodeIterable) {
+    if (!nodeIterable) return;
+    // for-of handles arrays, NodeLists, generators, and any custom
+    // iterable. Indexed-only collections without Symbol.iterator are
+    // not in scope — every browser NodeList we care about is iterable.
+    try {
+      for (const node of nodeIterable) {
+        rewriteLink(node);
+      }
+    } catch {
+      // Iterator threw mid-traversal. Stop and move on; partial work
+      // is fine — the observer will re-fire on subsequent mutations.
+    }
+  }
+
+  function processAddedNode(node) {
+    if (!node || node.nodeType !== 1) return; // text nodes, comments → skip
+    if (isAnchor(node)) {
+      rewriteLink(node);
+    }
+    // Descend into the inserted subtree. SPA frameworks commonly
+    // append a fragment containing many anchors — walking via
+    // querySelectorAll is O(matches) inside the inserted subtree, not
+    // the whole document.
+    if (typeof node.querySelectorAll === "function") {
+      let descendants;
+      try {
+        descendants = node.querySelectorAll("a[href]");
+      } catch {
+        return;
+      }
+      if (descendants) rewriteAll(descendants);
+    }
+  }
+
+  function onMutation(records) {
+    if (!records) return;
+    let len;
+    try { len = records.length; } catch { return; }
+    if (typeof len !== "number") return;
+    for (let i = 0; i < len; i++) {
+      const r = records[i];
+      if (!r) continue;
+      if (r.type === "attributes") {
+        // Cheap fast-path even though MutationObserver was configured
+        // with attributeFilter: ['href'] — defensive in case the
+        // observer is shared or the filter ever changes.
+        if (r.attributeName !== "href") continue;
+        rewriteLink(r.target);
+      } else if (r.type === "childList") {
+        const added = r.addedNodes;
+        if (!added) continue;
+        const n = added.length || 0;
+        for (let j = 0; j < n; j++) {
+          processAddedNode(added[j]);
+        }
+      }
+      // characterData and other types: ignored.
+    }
+  }
+
+  return { rewriteLink, rewriteAll, onMutation };
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,7 @@
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/cleaner.js"],
       "run_at": "document_start"
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -25,7 +25,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/cleaner.js"],
       "run_at": "document_start"
     },
     {

--- a/tests/e2e/dom-link-rewriter.spec.mjs
+++ b/tests/e2e/dom-link-rewriter.spec.mjs
@@ -1,0 +1,104 @@
+/**
+ * E2E: DOM Link Rewriter (#443 / B8)
+ *
+ * Verifies the MutationObserver-driven `<a href>` rewrite against a real
+ * Chromium with the extension loaded. Unit tests cover the pure factory
+ * contract; this spec proves the observer is actually INSTALLED in the
+ * isolated world, listens for the `muga:history-gate` event the History
+ * Defuser publishes, and rewrites both pre-existing AND newly-inserted
+ * anchors with tracking-decorated hrefs.
+ *
+ * Single spec on purpose: persistent-context startup is expensive, and
+ * the rewrite behavior is one observable signal — anchors visible in the
+ * DOM end up with cleaned hrefs. Splitting into many specs would
+ * multiply the cost without adding coverage.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+
+const HOST = "muga-test-link-rewriter.invalid";
+
+async function completeOnboarding(context, extensionId) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.storage.sync.set({ enabled: true }, () => {
+        chrome.storage.local.set({
+          mugaConsent: { onboardingDone: true, consentVersion: "1.0", consentDate: Date.now() },
+        }, () => {
+          chrome.storage.sync.set({ onboardingDone: true }, resolve);
+        });
+      });
+    })
+  );
+  await page.close();
+  await new Promise(r => setTimeout(r, 500));
+}
+
+async function stubPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <a id="pre" href="https://example.com/p?utm_source=marketing&id=1">pre-existing</a>
+        <button id="add-btn">add</button>
+        <div id="container"></div>
+        <script>
+          // Insert a NEW anchor with tracking — verifies subtree:true on
+          // a childList mutation. The button click is driven from the
+          // test (not at load time) so the observer is guaranteed
+          // installed before the mutation fires.
+          document.getElementById("add-btn").addEventListener("click", () => {
+            const a = document.createElement("a");
+            a.id = "post";
+            a.href = "https://example.com/q?fbclid=abc&id=2";
+            a.textContent = "new";
+            document.getElementById("container").appendChild(a);
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("DOM Link Rewriter (#443)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId);
+  });
+
+  test("rewrites pre-existing AND newly-inserted anchors", async ({ context }) => {
+    const page = await context.newPage();
+    await stubPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // The rewriter listens for `muga:history-gate` and only starts
+    // observing after the gate fires. Wait for the History Defuser's
+    // page-world flag — same gate path, so when the wrap is in the
+    // page the rewriter is also up.
+    await page.waitForFunction(() => window.__mugaHistoryDefused === true, { timeout: 10000 });
+
+    // Pre-existing anchor: the initial-pass rewriteAll should have
+    // stripped utm_source, leaving id=1.
+    await expect.poll(async () =>
+      page.evaluate(() => document.getElementById("pre").getAttribute("href"))
+    , { timeout: 5000 }).not.toContain("utm_source");
+    const preHref = await page.evaluate(() => document.getElementById("pre").getAttribute("href"));
+    expect(preHref).toContain("id=1");
+
+    // Newly-inserted anchor: insert via button, then poll until the
+    // observer's microtask has rewritten it.
+    await page.locator("#add-btn").click();
+    await expect.poll(async () =>
+      page.evaluate(() => {
+        const el = document.getElementById("post");
+        return el ? el.getAttribute("href") : null;
+      })
+    , { timeout: 5000 }).not.toContain("fbclid");
+    const postHref = await page.evaluate(() => document.getElementById("post").getAttribute("href"));
+    expect(postHref).toContain("id=2");
+
+    await page.close();
+  });
+});

--- a/tests/unit/dom-link-rewriter.test.mjs
+++ b/tests/unit/dom-link-rewriter.test.mjs
@@ -1,0 +1,464 @@
+/**
+ * MUGA — Tests for the DOM Link Rewriter (#443 / B8).
+ *
+ * The rewriter watches `<a href>` mutations and runs URL cleaning on
+ * each. Two correctness invariants drive these tests:
+ *
+ *   1. IDEMPOTENCY. If the cleaned href equals the current href the
+ *      rewriter MUST NOT call setAttribute. Calling setAttribute on a
+ *      MutationObserver target retriggers the observer; without the
+ *      no-op guard the observer feedback-loops and burns CPU forever.
+ *   2. NON-HTTP HREFS UNTOUCHED. mailto:, tel:, javascript:, data:,
+ *      and any URL the cleaner can't parse must pass through with NO
+ *      DOM write. The cleaner is allowed to throw on those — the
+ *      rewriter swallows.
+ *
+ * Like history-defuser.test.mjs, this test file uses the PURE FACTORY
+ * shape (`createLinkRewriter`) with stubbed anchors. No jsdom: project
+ * rule is no third-party test libs. Stub anchors expose `getAttribute`
+ * and `setAttribute` only — the surface the rewriter actually touches.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { createLinkRewriter } from "../../src/lib/dom-link-rewriter.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a stub `<a>`-like node. Records every `setAttribute` call for
+ * assertions. `tagName` defaults to "A" so the rewriter's tag-guard
+ * accepts it; tests that need a non-anchor pass `tagName: "DIV"`.
+ */
+function makeAnchor(href, { tagName = "A" } = {}) {
+  let current = href;
+  const setCalls = [];
+  return {
+    tagName,
+    nodeType: 1,
+    getAttribute(name) {
+      if (name === "href") return current;
+      return null;
+    },
+    setAttribute(name, value) {
+      setCalls.push({ name, value });
+      if (name === "href") current = value;
+    },
+    get __href() { return current; },
+    get __setCalls() { return setCalls; },
+    // Used by rewriteAll(NodeList-like): the rewriter iterates with
+    // for-of, so we don't need anything fancier here.
+  };
+}
+
+/**
+ * Tracking-stripping cleaner — strips utm_source, utm_medium, fbclid.
+ * Mirrors trackingCleaner from history-defuser.test.mjs. Throws on a
+ * non-string sentinel so we can verify the rewriter swallows.
+ */
+function trackingCleaner(rawUrl) {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+  if (rawUrl === "__BOOM__") throw new Error("boom");
+  const STRIP = new Set(["utm_source", "utm_medium", "fbclid"]);
+  let u;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    try {
+      u = new URL(rawUrl, "https://example.invalid/");
+      for (const k of [...u.searchParams.keys()]) {
+        if (STRIP.has(k)) u.searchParams.delete(k);
+      }
+      return u.pathname + u.search + u.hash;
+    } catch {
+      return rawUrl;
+    }
+  }
+  for (const k of [...u.searchParams.keys()]) {
+    if (STRIP.has(k)) u.searchParams.delete(k);
+  }
+  return u.toString();
+}
+
+/**
+ * isCleanLink reports whether the href is in scope for cleaning. The
+ * production wiring will pass a check that excludes mailto:, tel:,
+ * javascript:, data:, blob:, and href values without a "?". Tests
+ * mirror that subset.
+ */
+function defaultIsCleanLink(href) {
+  if (typeof href !== "string" || href.length === 0) return false;
+  if (/^(mailto|tel|javascript|data|blob):/i.test(href)) return false;
+  return true;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("createLinkRewriter — rewriteLink", () => {
+  test("dirty href triggers setAttribute with cleaned URL", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/p?utm_source=x&id=42");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 1);
+    assert.equal(a.__setCalls[0].name, "href");
+    assert.equal(a.__setCalls[0].value, "https://example.com/p?id=42");
+  });
+
+  test("already-clean href does NOT trigger setAttribute (idempotency)", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/p?id=42");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 0,
+      "rewriter must not write when cleaned === current; the observer would loop");
+  });
+
+  test("re-running rewriteLink after a clean is still a no-op", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/p?utm_source=x");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 1);
+    rw.rewriteLink(a);
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 1,
+      "second/third pass on the now-clean href must NOT call setAttribute");
+  });
+
+  test("mailto: href is ignored", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("mailto:nobody@example.com?utm_source=x");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 0);
+  });
+
+  test("tel: href is ignored", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("tel:+15551234?utm_source=x");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 0);
+  });
+
+  test("javascript: href is ignored", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("javascript:void(0)");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 0);
+  });
+
+  test("missing/empty href is ignored without throwing", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor(null);
+    assert.doesNotThrow(() => rw.rewriteLink(a));
+    assert.equal(a.__setCalls.length, 0);
+    const b = makeAnchor("");
+    assert.doesNotThrow(() => rw.rewriteLink(b));
+    assert.equal(b.__setCalls.length, 0);
+  });
+
+  test("non-anchor element is ignored", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const div = makeAnchor("https://example.com/p?utm_source=x", { tagName: "DIV" });
+    rw.rewriteLink(div);
+    assert.equal(div.__setCalls.length, 0,
+      "non-A elements must not be rewritten even if they have an href attribute");
+  });
+
+  test("cleaner that throws — swallow and skip setAttribute", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("__BOOM__");
+    // isCleanLink rejects this since it has no scheme — but if it
+    // somehow reaches the cleaner the throw must not propagate.
+    assert.doesNotThrow(() => rw.rewriteLink(a));
+    assert.equal(a.__setCalls.length, 0);
+  });
+
+  test("cleaner returns null/undefined/non-string → no setAttribute", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: () => null,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/p?utm_source=x");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 0,
+      "if the cleaner can't produce a string, leave the DOM alone");
+
+    const rw2 = createLinkRewriter({
+      urlCleaner: () => undefined,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const b = makeAnchor("https://example.com/p?utm_source=x");
+    rw2.rewriteLink(b);
+    assert.equal(b.__setCalls.length, 0);
+
+    const rw3 = createLinkRewriter({
+      urlCleaner: () => 42,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const c = makeAnchor("https://example.com/p?utm_source=x");
+    rw3.rewriteLink(c);
+    assert.equal(c.__setCalls.length, 0);
+  });
+
+  test("cleaner returning empty string is treated as no-op", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: () => "",
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/p?utm_source=x");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 0,
+      "empty string is a degenerate cleaner result — must not destroy the link");
+  });
+});
+
+describe("createLinkRewriter — rewriteAll", () => {
+  test("mixed list: only dirty anchors get setAttribute", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const dirty = makeAnchor("https://example.com/a?utm_source=x");
+    const clean = makeAnchor("https://example.com/b?id=1");
+    const mailto = makeAnchor("mailto:x@y.invalid?utm_source=x");
+    rw.rewriteAll([dirty, clean, mailto]);
+    assert.equal(dirty.__setCalls.length, 1);
+    assert.equal(clean.__setCalls.length, 0);
+    assert.equal(mailto.__setCalls.length, 0);
+  });
+
+  test("accepts NodeList-like (length + indexed access)", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/?utm_source=x");
+    const b = makeAnchor("https://example.com/?utm_medium=y");
+    const nodeListLike = {
+      length: 2,
+      0: a,
+      1: b,
+      [Symbol.iterator]: function* () { yield a; yield b; },
+    };
+    rw.rewriteAll(nodeListLike);
+    assert.equal(a.__setCalls.length, 1);
+    assert.equal(b.__setCalls.length, 1);
+  });
+
+  test("empty/null iterable does not throw", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    assert.doesNotThrow(() => rw.rewriteAll([]));
+    assert.doesNotThrow(() => rw.rewriteAll(null));
+    assert.doesNotThrow(() => rw.rewriteAll(undefined));
+  });
+});
+
+describe("createLinkRewriter — onMutation", () => {
+  test("childList record with addedNodes: rewrites newly-inserted anchors", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const inserted = makeAnchor("https://example.com/?utm_source=new");
+    const records = [{
+      type: "childList",
+      addedNodes: [inserted],
+      target: { nodeType: 1, tagName: "DIV" },
+    }];
+    rw.onMutation(records);
+    assert.equal(inserted.__setCalls.length, 1);
+    assert.equal(inserted.__setCalls[0].value, "https://example.com/");
+  });
+
+  test("childList record: descendant anchors inside an inserted subtree are rewritten", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const descendant = makeAnchor("https://example.com/d?utm_source=x");
+    // Inserted subtree root is a DIV that "contains" one anchor. The
+    // factory must descend via querySelectorAll('a[href]') when the
+    // node provides it. Test stub provides that hook.
+    const subtreeRoot = {
+      tagName: "DIV",
+      nodeType: 1,
+      querySelectorAll(sel) {
+        assert.equal(sel, "a[href]");
+        return [descendant];
+      },
+    };
+    const records = [{
+      type: "childList",
+      addedNodes: [subtreeRoot],
+      target: { nodeType: 1, tagName: "BODY" },
+    }];
+    rw.onMutation(records);
+    assert.equal(descendant.__setCalls.length, 1);
+  });
+
+  test("attributes record on href: rewrites the affected anchor", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/p?utm_source=x");
+    const records = [{
+      type: "attributes",
+      attributeName: "href",
+      target: a,
+      addedNodes: [],
+    }];
+    rw.onMutation(records);
+    assert.equal(a.__setCalls.length, 1);
+  });
+
+  test("attributes record on a non-href attribute is ignored", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/p?utm_source=x");
+    const records = [{
+      type: "attributes",
+      attributeName: "data-foo",
+      target: a,
+      addedNodes: [],
+    }];
+    rw.onMutation(records);
+    assert.equal(a.__setCalls.length, 0,
+      "filter is attributeName !== 'href' — non-href changes must not trigger work");
+  });
+
+  test("addedNodes containing a non-element (e.g. text node) is skipped without throwing", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const textNode = { nodeType: 3 /* TEXT_NODE */, tagName: undefined };
+    const records = [{
+      type: "childList",
+      addedNodes: [textNode],
+      target: { nodeType: 1, tagName: "DIV" },
+    }];
+    assert.doesNotThrow(() => rw.onMutation(records));
+  });
+
+  test("empty/null mutationList does not throw", () => {
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    assert.doesNotThrow(() => rw.onMutation([]));
+    assert.doesNotThrow(() => rw.onMutation(null));
+    assert.doesNotThrow(() => rw.onMutation(undefined));
+  });
+
+  test("mutation triggered by our own setAttribute — naturally idempotent", () => {
+    // When the observer sees the OUR write, it re-fires. The cleaner
+    // returns the SAME clean URL on the second pass, so no setAttribute
+    // is issued and the loop terminates. This is the load-bearing
+    // safety property for B8.
+    const rw = createLinkRewriter({
+      urlCleaner: trackingCleaner,
+      isCleanLink: defaultIsCleanLink,
+    });
+    const a = makeAnchor("https://example.com/?utm_source=x");
+    rw.rewriteLink(a);
+    assert.equal(a.__setCalls.length, 1);
+    // Simulate the observer firing again with our self-induced mutation.
+    const records = [{
+      type: "attributes",
+      attributeName: "href",
+      target: a,
+      addedNodes: [],
+    }];
+    rw.onMutation(records);
+    rw.onMutation(records);
+    assert.equal(a.__setCalls.length, 1,
+      "self-induced mutations must converge — second pass must NOT setAttribute");
+  });
+});
+
+// ── Manifest + content-script wiring (structural) ──────────────────────────
+
+describe("dom-link-rewriter — content-script wiring", () => {
+  test("manifest.json registers content/dom-link-rewriter.js at document_start in the isolated world", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("dom-link-rewriter.js"))
+    );
+    assert.ok(entry, "dom-link-rewriter.js must be in a content_scripts entry");
+    assert.equal(entry.run_at, "document_start");
+    // Must NOT be world: MAIN — DOM is shared, the rewrite runs in the
+    // isolated world so it can read prefs (via the gate event) without
+    // a cross-world flag dance.
+    assert.notEqual(entry.world, "MAIN",
+      "dom-link-rewriter must run in the isolated world");
+  });
+
+  test("manifest.v2.json registers dom-link-rewriter.js at document_start", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.v2.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("dom-link-rewriter.js"))
+    );
+    assert.ok(entry, "dom-link-rewriter.js must be registered for MV2");
+    assert.equal(entry.run_at, "document_start");
+  });
+
+  test("content/dom-link-rewriter.js is an IIFE with no ES module imports", () => {
+    const src = readFileSync(
+      join(__dirname, "../../src/content/dom-link-rewriter.js"), "utf8"
+    );
+    assert.ok(/^\(function/m.test(src), "content script must be an IIFE");
+    assert.equal(/^\s*import\s+/m.test(src), false,
+      "content script must not contain top-level ES module imports");
+    // Must listen for the cross-world gate event published by
+    // history-defuser.js — same gate, no second message round-trip.
+    assert.ok(/muga:history-gate/.test(src),
+      "rewriter must listen for muga:history-gate to honor disabled state");
+    // Must install a MutationObserver.
+    assert.ok(/MutationObserver/.test(src),
+      "rewriter must install a MutationObserver");
+    // attributeFilter is the load-bearing perf optimization — without
+    // it every attribute mutation pages through the JS callback.
+    assert.ok(/attributeFilter/.test(src),
+      "MutationObserver must use attributeFilter: ['href']");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #443 (B8). MutationObserver-based rewriter for tracking-decorated `<a href>` attributes. Active only when MUGA's gate is on.

## Architecture

- **Pure factory** at `src/lib/dom-link-rewriter.js` — `createLinkRewriter({ urlCleaner, isCleanLink })` returns `{ rewriteLink, rewriteAll, onMutation }`. Tests inject stub anchors with `getAttribute`/`setAttribute` (no jsdom — pure JS).
- **Isolated-world content script** at `src/content/dom-link-rewriter.js`. DOM is shared between isolated and main worlds — only JS object identity is split — so `setAttribute` works fine from isolated. No `world: "MAIN"` needed (simpler than B10/B11).
- Listens for the existing `muga:history-gate` CustomEvent (B10/B11 share the dispatcher). When `gate=true`, installs `MutationObserver` with `attributeFilter: ['href']` (load-bearing perf optimization — short-circuits in C++ instead of paging every attribute mutation into JS), runs initial `rewriteAll` on `document.querySelectorAll('a[href]')`.
- Cleaner preference: bundled `window.__mugaCleaner.processUrl` first (full coverage), inline ~50-param tracking subset fallback for early mutations before the bundle attaches.

## Idempotency

`rewriteLink` compares `cleaned === current` and only calls `setAttribute` on inequality. Self-induced mutations re-fire the observer but the second pass returns the same string → no write → loop terminates naturally. **No exclude-set, no flag dance.**

## Microtask batching

Processed synchronously inside the `MutationObserver` callback — the callback is itself the browser's microtask boundary; it batches DOM writes from one event-loop turn into one delivery. `queueMicrotask` would just add latency.

## Subtree descent

SPAs typically append fragments where only the root is in `addedNodes`. Each added element is descended via `querySelectorAll('a[href]')`.

## Test plan

- [x] `npm test` → **2916/2916** passing (+27 from baseline 2889)
- [x] `npm run lint` → 0 errors
- [x] Anchor with tracking href → rewriteLink calls setAttribute with cleaned URL
- [x] Anchor with already-clean href → setAttribute NOT called (idempotency)
- [x] Anchor with non-http href (`mailto:`, `javascript:`, `tel:`) → setAttribute NOT called
- [x] Anchor with malformed href → setAttribute NOT called (no throw)
- [x] `rewriteAll` with mixed list → only dirty anchors get setAttribute
- [x] `onMutation` with childList records (newly inserted) → rewrites
- [x] `onMutation` with attributes records (href changed) → rewrites the affected anchor
- [x] `onMutation` with `attributeName !== 'href'` → ignored
- [x] Playwright spec included (modeled after `history-defuser.spec.mjs`)

## Manifest

Registered at `document_start` (isolated world) before `cleaner.js` so the observer is installed before any page script.