### PR TITLE
feat(content): DOM Link Rewriter — mousedown/click capture interception (#450)

### DIFF
--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -1,0 +1,182 @@
+/**
+ * MUGA: DOM Link Rewriter — Click Interceptor content script (#450 / B9)
+ *
+ * Sister script to `content/dom-link-rewriter.js` (B8). B8's
+ * MutationObserver rewrites `<a href>` values as the DOM mutates —
+ * great for SPA re-renders and static anchors, but blind to the
+ * last-millisecond reinjection trick used by Twitter, Facebook, and
+ * LinkedIn: a `mousedown` listener that re-decorates `event.target.href`
+ * AFTER MUGA has already cleaned it via the observer. The user clicks
+ * and the navigation heads to the dirty URL.
+ *
+ * B9 closes that gap by attaching capture-phase listeners on `mousedown`
+ * and `click` at the document level. Capture phase runs BEFORE the
+ * page's own bubble-phase listeners and BEFORE the browser starts
+ * navigation — exactly the window we need to re-run the cleaner.
+ *
+ * Why isolated world (matches B8):
+ *   - DOM is shared. Reading and writing `a.getAttribute('href')` /
+ *     `a.setAttribute('href', ...)` works fine here.
+ *   - We can listen for the SAME `muga:history-gate` event the History
+ *     Defuser publishes — no extra prefs round-trip, no second gate.
+ *
+ * Why we re-implement the cleaner inline (matches B8):
+ *   - Content scripts can't use ES module imports cross-browser
+ *     (Firefox MV2). The pure factories live under `src/lib/` and are
+ *     unit-tested directly; this file is a thin shell that mirrors
+ *     them. The pure-factory test files cover the algorithmic
+ *     invariants — this content script is structurally tested via
+ *     the IIFE/manifest assertions in the unit suite.
+ *
+ * NEVER calls preventDefault / stopPropagation / stopImmediatePropagation.
+ * The whole point is to be a passive observer of the click — we tweak
+ * the href the navigation will follow, the navigation itself proceeds
+ * untouched.
+ */
+
+(function () {
+  "use strict";
+
+  // Skip iframes — same guard as the rest of the content scripts.
+  if (window.self !== window.top) return;
+  if (window.__mugaDomLinkRewriterClick) return;
+  window.__mugaDomLinkRewriterClick = true;
+
+  // ── Inline tracking-param subset ──────────────────────────────────────
+  // Mirrors content/dom-link-rewriter.js (B8). The `__mugaCleaner`
+  // bundle is preferred when available; this is the safety net for
+  // very-early clicks that race the bundle attach.
+  const STRIP = Object.freeze({
+    utm_source: 1, utm_medium: 1, utm_campaign: 1, utm_content: 1, utm_term: 1, utm_id: 1,
+    utm_source_platform: 1, utm_creative_format: 1, utm_marketing_tactic: 1,
+    fbclid: 1, gclid: 1, gclsrc: 1, dclid: 1, gbraid: 1, wbraid: 1, msclkid: 1, tclid: 1, twclid: 1,
+    mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
+    _hsenc: 1, _hsmi: 1, mkt_tok: 1,
+    yclid: 1, ysclid: 1, _openstat: 1,
+    irclickid: 1, cjevent: 1, awc: 1,
+    ttclid: 1, sccid: 1, rdt_cid: 1,
+    _branch_match_id: 1, _branch_referrer: 1,
+    pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,
+    mtm_campaign: 1, mtm_source: 1, mtm_medium: 1, mtm_content: 1,
+    hsctatracking: 1,
+    __s: 1, _ga: 1, _gl: 1, _gac: 1,
+    ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
+    mibextid: 1, share_id: 1,
+  });
+
+  function inlineCleanUrl(rawUrl) {
+    if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+    if (rawUrl.indexOf("?") < 0) return rawUrl;
+    let u;
+    try {
+      u = new URL(rawUrl, window.location.href);
+    } catch {
+      return rawUrl;
+    }
+    let changed = false;
+    const keys = [];
+    u.searchParams.forEach((_v, k) => keys.push(k));
+    for (let i = 0; i < keys.length; i++) {
+      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
+        u.searchParams.delete(keys[i]);
+        changed = true;
+      }
+    }
+    if (!changed) return rawUrl;
+    const isAbsolute = /^[a-z]+:\/\//i.test(rawUrl);
+    if (isAbsolute) return u.toString();
+    return u.pathname + u.search + u.hash;
+  }
+
+  function urlCleaner(raw) {
+    const bundled = window.__mugaCleaner;
+    if (bundled && typeof bundled.processUrl === "function") {
+      try {
+        const out = bundled.processUrl(raw);
+        if (typeof out === "string") return out;
+        if (out && typeof out.url === "string") return out.url;
+      } catch {
+        // fall through to inline subset
+      }
+    }
+    return inlineCleanUrl(raw);
+  }
+
+  function isCleanLink(href) {
+    if (typeof href !== "string" || href.length === 0) return false;
+    if (/^(mailto|tel|javascript|data|blob|about|chrome|chrome-extension):/i.test(href)) {
+      return false;
+    }
+    return true;
+  }
+
+  // ── Inline rewriter (mirrors src/lib/dom-link-rewriter.js) ────────────
+  function rewriteLink(anchor) {
+    if (!anchor || anchor.nodeType !== 1 || anchor.tagName !== "A") return;
+    let current;
+    try { current = anchor.getAttribute("href"); } catch { return; }
+    if (typeof current !== "string" || current.length === 0) return;
+    if (!isCleanLink(current)) return;
+    let cleaned;
+    try { cleaned = urlCleaner(current); } catch { return; }
+    if (typeof cleaned !== "string" || cleaned.length === 0) return;
+    if (cleaned === current) return; // idempotency — see B8 docblock
+    try { anchor.setAttribute("href", cleaned); } catch { /* detached */ }
+  }
+
+  // ── Capture-phase click handler (mirrors src/lib/dom-link-rewriter-click.js) ─
+  function getAnchorFromEvent(event) {
+    if (!event) return null;
+    const target = event.target;
+    if (!target || typeof target.closest !== "function") return null;
+    try {
+      return target.closest("a[href]") || null;
+    } catch {
+      return null;
+    }
+  }
+
+  function handle(event) {
+    let anchor;
+    try { anchor = getAnchorFromEvent(event); } catch { return; }
+    if (!anchor) return;
+    try { rewriteLink(anchor); } catch { /* never throw out of capture phase */ }
+    // NEVER preventDefault / stopPropagation / stopImmediatePropagation.
+  }
+
+  function onMousedown(event) { handle(event); }
+  function onClick(event) { handle(event); }
+
+  // ── Disabled-state gate ───────────────────────────────────────────────
+  // Reuse the same `muga:history-gate` event the History Defuser
+  // publishes — no extra prefs round-trip, no second gate.
+  let _installed = false;
+  const CAPTURE_OPTS = { capture: true };
+
+  function install() {
+    if (_installed) return;
+    if (!document) return;
+    try {
+      document.addEventListener("mousedown", onMousedown, CAPTURE_OPTS);
+      document.addEventListener("click", onClick, CAPTURE_OPTS);
+      _installed = true;
+    } catch {
+      _installed = false;
+    }
+  }
+
+  function uninstall() {
+    if (!_installed) return;
+    try {
+      document.removeEventListener("mousedown", onMousedown, CAPTURE_OPTS);
+      document.removeEventListener("click", onClick, CAPTURE_OPTS);
+    } catch { /* document detached */ }
+    _installed = false;
+  }
+
+  document.addEventListener("muga:history-gate", (e) => {
+    const enabled = !!(e && e.detail && e.detail.enabled);
+    if (enabled) install();
+    else uninstall();
+  });
+})();

--- a/src/lib/dom-link-rewriter-click.js
+++ b/src/lib/dom-link-rewriter-click.js
@@ -1,0 +1,160 @@
+/**
+ * MUGA: DOM Link Rewriter — Click Interceptor (#450 / B9)
+ *
+ * Sister module to `src/lib/dom-link-rewriter.js` (B8). B8's
+ * MutationObserver covers SPA re-renders and static anchors but does
+ * NOT cover the last-millisecond reinjection trick used by Twitter,
+ * Facebook, LinkedIn and similar sites: a `mousedown` listener in the
+ * page that re-decorates `event.target.href` AFTER MUGA has already
+ * cleaned it via the observer. By the time the click fires, navigation
+ * is already heading to the dirty URL.
+ *
+ * B9 closes that gap with capture-phase listeners on `mousedown` and
+ * `click` at the document level. Capture phase runs BEFORE the page's
+ * own bubble-phase listeners and BEFORE the browser starts navigation
+ * — exactly the window we need to re-run the cleaner in place.
+ *
+ * Two non-negotiable contracts drive this module:
+ *
+ *   1. PASSIVE — never call preventDefault, stopPropagation, or
+ *      stopImmediatePropagation. The user's click and the resulting
+ *      navigation MUST proceed; we only tweak the href the navigation
+ *      will follow.
+ *   2. NEVER THROW — a thrown error in a capture-phase listener won't
+ *      block navigation in modern browsers, but it WILL spam the
+ *      console on every click and may trip page-level error reporters.
+ *      Swallow and skip; the rewriter is best-effort defense, not a
+ *      correctness gate.
+ *
+ * Reuses the B8 rewriter wholesale via dependency injection. The B8
+ * `rewriteLink(anchor)` is exactly the operation needed at click time
+ * — it reads the current href, runs the cleaner, and writes back only
+ * when something changed (idempotency invariant carries over).
+ *
+ * Idempotency: capture-phase mousedown AND capture-phase click on the
+ * same anchor will BOTH fire and BOTH call rewriteLink. Each rewrite
+ * is a no-op on already-clean URLs (B8 guarantee), so no debouncing
+ * is needed and we keep the implementation trivially simple.
+ */
+
+/**
+ * @typedef {object} ClickRewriterDeps
+ * @property {{ rewriteLink: (anchor: object) => void }} rewriter
+ *   The B8 rewriter (or any object exposing `rewriteLink`). Receives
+ *   the resolved anchor element on each mousedown/click in capture
+ *   phase. Throws inside `rewriteLink` are swallowed.
+ * @property {(event: object) => (object|null)} [getAnchorFromEvent]
+ *   Optional override resolver. Default closes over
+ *   `event.target.closest('a[href]')` — handles clicks on text, spans,
+ *   or images nested inside an anchor. Override when stub-testing or
+ *   when shadow-DOM event retargeting needs custom logic.
+ */
+
+/**
+ * @typedef {object} ClickRewriter
+ * @property {(event: object) => void} onMousedown
+ *   Capture-phase mousedown handler. Resolves the anchor, calls
+ *   `rewriter.rewriteLink`. Never preventsDefault/stopsPropagation.
+ * @property {(event: object) => void} onClick
+ *   Capture-phase click handler. Same shape as `onMousedown`.
+ * @property {(target: EventTarget) => void} install
+ *   Attaches `onMousedown` + `onClick` to the given target with
+ *   `{capture: true}`. Idempotent — calling twice with the same
+ *   target does NOT double-attach.
+ * @property {(target: EventTarget) => void} uninstall
+ *   Detaches the listeners installed by `install`. No-op if `install`
+ *   was never called.
+ */
+
+/**
+ * Default anchor resolver — `event.target.closest('a[href]')`.
+ *
+ * Encapsulated so tests can replace it via `getAnchorFromEvent`. The
+ * real DOM Element prototype provides `closest`; defensive checks
+ * accommodate synthetic events / shadow-DOM hosts that don't.
+ *
+ * @param {object} event
+ * @returns {object|null}
+ */
+function defaultGetAnchorFromEvent(event) {
+  if (!event) return null;
+  const target = event.target;
+  if (!target || typeof target.closest !== "function") return null;
+  try {
+    return target.closest("a[href]") || null;
+  } catch {
+    // closest can throw on detached nodes or unsupported selectors in
+    // exotic environments. Skip silently — the click still navigates.
+    return null;
+  }
+}
+
+/**
+ * Builds a click-rewriter bound to the given B8 rewriter.
+ *
+ * @param {ClickRewriterDeps} [deps]
+ * @returns {ClickRewriter}
+ */
+export function createClickRewriter(deps) {
+  const rewriter = deps && deps.rewriter;
+  if (!rewriter || typeof rewriter.rewriteLink !== "function") {
+    throw new TypeError(
+      "createClickRewriter requires { rewriter: { rewriteLink } }"
+    );
+  }
+  const getAnchor = (deps && deps.getAnchorFromEvent) || defaultGetAnchorFromEvent;
+
+  // Tracks whether listeners are currently attached to a target. Stored
+  // by reference so install() called twice with the same target is a
+  // no-op AND so a different target can still be installed/uninstalled
+  // independently. Most callers only ever pass `document` — the Map
+  // shape just keeps the module composable for tests.
+  const installed = new WeakSet();
+
+  function handle(event) {
+    let anchor;
+    try {
+      anchor = getAnchor(event);
+    } catch {
+      return;
+    }
+    if (!anchor) return;
+    try {
+      rewriter.rewriteLink(anchor);
+    } catch {
+      // Cleaner / rewriter blew up. We deliberately do NOT propagate —
+      // see the NEVER THROW contract in the docblock. Navigation
+      // proceeds to whatever href is on the anchor right now, which is
+      // strictly no worse than not having the rewriter at all.
+    }
+    // CRITICAL: control flow ends here. We do NOT call preventDefault,
+    // stopPropagation, or stopImmediatePropagation under any circumstance.
+  }
+
+  function onMousedown(event) { handle(event); }
+  function onClick(event) { handle(event); }
+
+  // Capture-phase options object. Spec form `{capture: true}` is supported
+  // in every modern browser and (importantly) in Firefox MV2 — using the
+  // boolean `true` shorthand also works but the object form documents
+  // intent at the call site.
+  const CAPTURE_OPTS = { capture: true };
+
+  function install(target) {
+    if (!target || typeof target.addEventListener !== "function") return;
+    if (installed.has(target)) return; // idempotent — see docblock
+    target.addEventListener("mousedown", onMousedown, CAPTURE_OPTS);
+    target.addEventListener("click", onClick, CAPTURE_OPTS);
+    installed.add(target);
+  }
+
+  function uninstall(target) {
+    if (!target || typeof target.removeEventListener !== "function") return;
+    if (!installed.has(target)) return;
+    target.removeEventListener("mousedown", onMousedown, CAPTURE_OPTS);
+    target.removeEventListener("click", onClick, CAPTURE_OPTS);
+    installed.delete(target);
+  }
+
+  return { onMousedown, onClick, install, uninstall };
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,7 @@
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/cleaner.js"],
       "run_at": "document_start"
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -25,7 +25,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/cleaner.js"],
       "run_at": "document_start"
     },
     {

--- a/tests/e2e/dom-link-rewriter-click.spec.mjs
+++ b/tests/e2e/dom-link-rewriter-click.spec.mjs
@@ -1,0 +1,116 @@
+/**
+ * E2E: DOM Link Rewriter Click Interceptor (#450 / B9)
+ *
+ * Verifies the capture-phase mousedown/click rewrite against a real
+ * Chromium with the extension loaded. The fixture page mimics the
+ * Twitter / Facebook / LinkedIn pattern: an anchor whose `mousedown`
+ * listener re-decorates `event.target.href` AFTER the page has loaded.
+ * Without B9, MUGA's MutationObserver (B8) cleans the link on load,
+ * but the page's reinjection-on-mousedown beats the click and the user
+ * navigates to the dirty URL.
+ *
+ * Capture-phase listener installed by B9 runs BEFORE the page's bubble
+ * mousedown, so the order is:
+ *   1. user presses mouse on anchor
+ *   2. B9 capture-phase mousedown — re-runs the cleaner (a no-op
+ *      because nothing has been re-injected YET)
+ *   3. page's bubble-phase mousedown — re-decorates with utm_source
+ *   4. user releases mouse → click event
+ *   5. B9 capture-phase click — re-runs the cleaner, STRIPS the
+ *      reinjected utm_source
+ *   6. browser navigates to the cleaned URL
+ *
+ * Single spec on purpose — same rationale as the B8 E2E.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+
+const HOST = "muga-test-link-rewriter-click.invalid";
+const TARGET_HOST = "muga-test-link-rewriter-click-target.invalid";
+
+async function completeOnboarding(context, extensionId) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.storage.sync.set({ enabled: true }, () => {
+        chrome.storage.local.set({
+          mugaConsent: { onboardingDone: true, consentVersion: "1.0", consentDate: Date.now() },
+        }, () => {
+          chrome.storage.sync.set({ onboardingDone: true }, resolve);
+        });
+      });
+    })
+  );
+  await page.close();
+  await new Promise(r => setTimeout(r, 500));
+}
+
+async function stubPages(page) {
+  // Source page: anchor whose mousedown listener REINJECTS utm_source
+  // onto event.target.href. Mirrors the Twitter/Facebook/LinkedIn
+  // pattern that B9 exists to defeat.
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <a id="evil" href="https://${TARGET_HOST}/dest">evil link</a>
+        <script>
+          // The reinjection trick: bubble-phase mousedown rewrites the
+          // href just before the click navigates. B9's CAPTURE-phase
+          // click listener runs AFTER this bubble-mousedown but BEFORE
+          // the navigation kicks off — exactly the gap we close.
+          document.getElementById("evil").addEventListener("mousedown", (e) => {
+            e.target.href = "https://${TARGET_HOST}/dest?utm_source=evil&id=42";
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+  // Destination page: echoes location.search so the test can assert
+  // the user landed on the CLEANED URL.
+  await page.route(`**://${TARGET_HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <pre id="search"></pre>
+        <script>
+          document.getElementById("search").textContent = location.search;
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("DOM Link Rewriter Click (#450)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId);
+  });
+
+  test("capture-phase listener strips utm_source reinjected on mousedown", async ({ context }) => {
+    const page = await context.newPage();
+    await stubPages(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the gate to open. B9 reuses the History Defuser's gate
+    // event — once that flag is set in the page, B9's listeners are up.
+    await page.waitForFunction(() => window.__mugaHistoryDefused === true, { timeout: 10000 });
+
+    // Click the anchor — the page's mousedown will reinject utm_source,
+    // B9's capture-phase click should strip it before navigation fires.
+    await Promise.all([
+      page.waitForURL(`**://${TARGET_HOST}/**`, { timeout: 10000 }),
+      page.locator("#evil").click(),
+    ]);
+
+    // The user must land on the CLEANED URL — utm_source must NOT be in
+    // location.search. id=42 (a real param) survives.
+    const search = await page.evaluate(() => location.search);
+    expect(search).not.toContain("utm_source");
+    expect(search).not.toContain("evil");
+
+    await page.close();
+  });
+});

--- a/tests/unit/dom-link-rewriter-click.test.mjs
+++ b/tests/unit/dom-link-rewriter-click.test.mjs
@@ -1,0 +1,437 @@
+/**
+ * MUGA — Tests for the DOM Link Rewriter Click interceptor (#450 / B9).
+ *
+ * B8 (#443) installs a MutationObserver that rewrites tracking-decorated
+ * `<a href>` values as the DOM mutates. That covers SPA re-renders and
+ * static page anchors — but NOT the last-millisecond reinjection trick
+ * Twitter / Facebook / LinkedIn use: a `mousedown` listener that re-
+ * decorates `event.target.href` AFTER MUGA has already cleaned it. By
+ * the time the click fires, the user navigates to the dirty URL.
+ *
+ * B9 closes that gap with a CAPTURE-PHASE listener on `mousedown` AND
+ * `click` at the document level. Capture phase runs BEFORE the page's
+ * own bubble-phase listeners — but more importantly, BEFORE the browser
+ * starts the navigation. We re-run the cleaner on the anchor's href in
+ * place via the B8 rewriter (idempotent on already-clean URLs).
+ *
+ * CRITICAL CONTRACT — never call preventDefault, stopPropagation, or
+ * stopImmediatePropagation. The rewriter is a passive observer of the
+ * click; the user's navigation MUST proceed to the cleaned destination.
+ *
+ * Like the B8 unit tests, this file uses the PURE FACTORY shape with
+ * stubbed events + stubbed rewriter. The thin content-script bootstrap
+ * is exercised structurally (manifest + IIFE shape + gate listener).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { createClickRewriter } from "../../src/lib/dom-link-rewriter-click.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a stub rewriter that records each `rewriteLink` call. Mirrors
+ * the surface of `createLinkRewriter().rewriteLink` from B8 — the only
+ * method B9 consumes.
+ */
+function makeStubRewriter() {
+  const calls = [];
+  return {
+    rewriteLink(anchor) { calls.push(anchor); },
+    get __calls() { return calls; },
+  };
+}
+
+/**
+ * Builds a stub event with target + flags that record any improper
+ * preventDefault/stopPropagation invocation. The B9 contract is that
+ * NONE of these are ever called — clicks must navigate to the cleaned
+ * URL exactly as the user intended.
+ */
+function makeEvent(target, type = "click") {
+  const flags = { prevented: false, stopped: false, stoppedImmediate: false };
+  return {
+    type,
+    target,
+    preventDefault() { flags.prevented = true; },
+    stopPropagation() { flags.stopped = true; },
+    stopImmediatePropagation() { flags.stoppedImmediate = true; },
+    get __flags() { return flags; },
+  };
+}
+
+/**
+ * Builds a stub anchor that supports `closest('a[href]')` returning
+ * itself, mirroring how a real `<a href>` element behaves when an
+ * inner `<span>`/`<img>` was the actual click target.
+ */
+function makeAnchor(href = "https://example.com/?utm_source=x") {
+  const a = {
+    tagName: "A",
+    nodeType: 1,
+    __href: href,
+    closest(selector) {
+      if (selector === "a[href]") return a;
+      return null;
+    },
+  };
+  return a;
+}
+
+/**
+ * Builds a stub inner element (e.g. <span> inside <a>) that resolves
+ * `closest('a[href]')` to the supplied parent anchor.
+ */
+function makeInnerEl(parentAnchor) {
+  return {
+    tagName: "SPAN",
+    nodeType: 1,
+    closest(selector) {
+      if (selector === "a[href]" && parentAnchor) return parentAnchor;
+      return null;
+    },
+  };
+}
+
+/**
+ * Builds a stub DOM target that records addEventListener / removeEventListener
+ * calls so install/uninstall semantics can be asserted.
+ */
+function makeListenerTarget() {
+  const adds = [];
+  const removes = [];
+  return {
+    addEventListener(type, fn, opts) { adds.push({ type, fn, opts }); },
+    removeEventListener(type, fn, opts) { removes.push({ type, fn, opts }); },
+    get __adds() { return adds; },
+    get __removes() { return removes; },
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("createClickRewriter — onMousedown / onClick dispatch", () => {
+  test("mousedown on element inside anchor → rewriter.rewriteLink called with the anchor", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const anchor = makeAnchor();
+    const inner = makeInnerEl(anchor);
+    const evt = makeEvent(inner, "mousedown");
+
+    cr.onMousedown(evt);
+
+    assert.equal(rewriter.__calls.length, 1);
+    assert.strictEqual(rewriter.__calls[0], anchor,
+      "must pass the resolved anchor (closest('a[href]')), not the click target");
+  });
+
+  test("click on element inside anchor → rewriter.rewriteLink called with the anchor", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const anchor = makeAnchor();
+    const inner = makeInnerEl(anchor);
+    const evt = makeEvent(inner, "click");
+
+    cr.onClick(evt);
+
+    assert.equal(rewriter.__calls.length, 1);
+    assert.strictEqual(rewriter.__calls[0], anchor);
+  });
+
+  test("mousedown directly on anchor target → rewriter called with the anchor itself", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const anchor = makeAnchor();
+    const evt = makeEvent(anchor, "mousedown");
+
+    cr.onMousedown(evt);
+
+    assert.equal(rewriter.__calls.length, 1);
+    assert.strictEqual(rewriter.__calls[0], anchor);
+  });
+
+  test("mousedown on element NOT inside an anchor → rewriter NOT called", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    // closest returns null — click happened outside any <a href>.
+    const standalone = {
+      tagName: "DIV",
+      nodeType: 1,
+      closest() { return null; },
+    };
+    const evt = makeEvent(standalone, "mousedown");
+
+    cr.onMousedown(evt);
+
+    assert.equal(rewriter.__calls.length, 0);
+  });
+
+  test("click on element NOT inside an anchor → rewriter NOT called", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const standalone = {
+      tagName: "BUTTON",
+      nodeType: 1,
+      closest() { return null; },
+    };
+    const evt = makeEvent(standalone, "click");
+
+    cr.onClick(evt);
+
+    assert.equal(rewriter.__calls.length, 0);
+  });
+
+  test("event with null target → no-op, no throw", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const evt = { type: "click", target: null };
+
+    assert.doesNotThrow(() => cr.onClick(evt));
+    assert.equal(rewriter.__calls.length, 0);
+  });
+
+  test("event without target.closest → no-op, no throw (defensive)", () => {
+    // Some synthetic events / shadow DOM hosts won't expose `closest`.
+    // The rewriter must skip silently rather than blow up the page's
+    // click pipeline.
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const evt = { type: "click", target: { tagName: "DIV", nodeType: 1 } };
+
+    assert.doesNotThrow(() => cr.onClick(evt));
+    assert.equal(rewriter.__calls.length, 0);
+  });
+
+  test("listeners do NOT call preventDefault / stopPropagation / stopImmediatePropagation", () => {
+    // THE LOAD-BEARING CONTRACT. If the rewriter ever calls any of these
+    // it breaks the user's click → navigation flow. The whole point of
+    // capture-phase rewriting is to be PASSIVE: tweak the href, let the
+    // browser navigate.
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const anchor = makeAnchor();
+    const inner = makeInnerEl(anchor);
+
+    const md = makeEvent(inner, "mousedown");
+    cr.onMousedown(md);
+    assert.equal(md.__flags.prevented, false);
+    assert.equal(md.__flags.stopped, false);
+    assert.equal(md.__flags.stoppedImmediate, false);
+
+    const ck = makeEvent(inner, "click");
+    cr.onClick(ck);
+    assert.equal(ck.__flags.prevented, false);
+    assert.equal(ck.__flags.stopped, false);
+    assert.equal(ck.__flags.stoppedImmediate, false);
+  });
+
+  test("rewriter that throws → swallowed, no error escapes the click handler", () => {
+    // A throw bubbling out of a capture-phase listener would not be
+    // fatal to navigation, but it would spam the console on every click
+    // and could be picked up by page-level error reporters as if it
+    // were the page's own bug. Match B8: swallow.
+    const explodingRewriter = {
+      rewriteLink() { throw new Error("boom"); },
+    };
+    const cr = createClickRewriter({ rewriter: explodingRewriter });
+    const anchor = makeAnchor();
+    const inner = makeInnerEl(anchor);
+    const evt = makeEvent(inner, "click");
+
+    assert.doesNotThrow(() => cr.onClick(evt));
+    // Still must NOT have called preventDefault — exception or not.
+    assert.equal(evt.__flags.prevented, false);
+  });
+
+  test("rapid double dispatch — rewriteLink called twice (no debounce, idempotent)", () => {
+    // If a site re-decorates on mousedown each time, BOTH events fire
+    // and BOTH should rewrite. The B8 rewriter is idempotent on already-
+    // clean URLs, so calling rewriteLink twice is safe and correct.
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const anchor = makeAnchor();
+    const inner = makeInnerEl(anchor);
+
+    cr.onMousedown(makeEvent(inner, "mousedown"));
+    cr.onClick(makeEvent(inner, "click"));
+
+    assert.equal(rewriter.__calls.length, 2,
+      "no debouncing — each event runs the cleaner; idempotency keeps it safe");
+  });
+
+  test("custom getAnchorFromEvent override is honored (testability hook)", () => {
+    // The default closes over event.target.closest('a[href]'); for
+    // testing or for future shadow-DOM support, the resolver is
+    // injectable. Wiring this through the factory keeps the production
+    // code simple AND keeps the seam.
+    const rewriter = makeStubRewriter();
+    const sentinelAnchor = makeAnchor("https://example.com/sentinel");
+    const cr = createClickRewriter({
+      rewriter,
+      getAnchorFromEvent: () => sentinelAnchor,
+    });
+    const evt = makeEvent({ tagName: "X" }, "click");
+
+    cr.onClick(evt);
+
+    assert.equal(rewriter.__calls.length, 1);
+    assert.strictEqual(rewriter.__calls[0], sentinelAnchor);
+  });
+});
+
+describe("createClickRewriter — install / uninstall", () => {
+  test("install attaches mousedown + click listeners with capture: true", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const target = makeListenerTarget();
+
+    cr.install(target);
+
+    assert.equal(target.__adds.length, 2);
+    const types = target.__adds.map((a) => a.type).sort();
+    assert.deepEqual(types, ["click", "mousedown"]);
+    // CAPTURE PHASE is the load-bearing detail. Capture runs BEFORE the
+    // page's own bubble listeners and BEFORE navigation; bubble runs
+    // after the page's listener has already re-decorated and after the
+    // browser has started navigating.
+    for (const a of target.__adds) {
+      assert.ok(
+        a.opts === true || (a.opts && a.opts.capture === true),
+        `${a.type} listener must use capture phase`
+      );
+    }
+  });
+
+  test("uninstall removes the same listeners that install attached", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const target = makeListenerTarget();
+
+    cr.install(target);
+    cr.uninstall(target);
+
+    assert.equal(target.__removes.length, 2);
+    // Same fn refs as add (otherwise removeEventListener is a no-op).
+    const addedFns = new Set(target.__adds.map((a) => a.fn));
+    for (const r of target.__removes) {
+      assert.ok(addedFns.has(r.fn),
+        `removeEventListener fn ref must match the addEventListener ref for ${r.type}`);
+    }
+  });
+
+  test("install is idempotent — calling twice does not double-attach", () => {
+    // A second install with the same target would attach a duplicate
+    // listener and fire rewriteLink twice for every event. Either we
+    // dedupe internally or uninstall-before-install. Match B8's gate
+    // pattern: the inner observer is only created once.
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const target = makeListenerTarget();
+
+    cr.install(target);
+    cr.install(target);
+
+    assert.equal(target.__adds.length, 2,
+      "second install must NOT attach a second pair of listeners");
+  });
+
+  test("uninstall without prior install is a no-op (does not throw)", () => {
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const target = makeListenerTarget();
+
+    assert.doesNotThrow(() => cr.uninstall(target));
+    assert.equal(target.__removes.length, 0);
+  });
+
+  test("installed listeners route mousedown / click through the rewriter", () => {
+    // End-to-end seam: install attaches the listeners, dispatching
+    // through the captured fn refs reaches the rewriter.
+    const rewriter = makeStubRewriter();
+    const cr = createClickRewriter({ rewriter });
+    const target = makeListenerTarget();
+    cr.install(target);
+
+    const mdEntry = target.__adds.find((a) => a.type === "mousedown");
+    const ckEntry = target.__adds.find((a) => a.type === "click");
+
+    const anchor = makeAnchor();
+    const inner = makeInnerEl(anchor);
+    mdEntry.fn(makeEvent(inner, "mousedown"));
+    ckEntry.fn(makeEvent(inner, "click"));
+
+    assert.equal(rewriter.__calls.length, 2);
+  });
+});
+
+describe("createClickRewriter — input validation", () => {
+  test("missing rewriter throws TypeError", () => {
+    assert.throws(() => createClickRewriter({}), TypeError);
+    assert.throws(() => createClickRewriter(), TypeError);
+  });
+
+  test("rewriter without rewriteLink throws TypeError", () => {
+    assert.throws(
+      () => createClickRewriter({ rewriter: { foo: 1 } }),
+      TypeError
+    );
+  });
+});
+
+// ── Manifest + content-script wiring (structural) ──────────────────────────
+
+describe("dom-link-rewriter-click — content-script wiring", () => {
+  test("manifest.json registers content/dom-link-rewriter-click.js at document_start in isolated world", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("dom-link-rewriter-click.js"))
+    );
+    assert.ok(entry, "dom-link-rewriter-click.js must be in a content_scripts entry");
+    assert.equal(entry.run_at, "document_start");
+    assert.notEqual(entry.world, "MAIN",
+      "click rewriter must run in the isolated world (shares DOM, reads gate)");
+  });
+
+  test("manifest.v2.json registers dom-link-rewriter-click.js at document_start", () => {
+    const manifest = JSON.parse(readFileSync(
+      join(__dirname, "../../src/manifest.v2.json"), "utf8"
+    ));
+    const entry = manifest.content_scripts.find((e) =>
+      Array.isArray(e.js) && e.js.some((p) => p.endsWith("dom-link-rewriter-click.js"))
+    );
+    assert.ok(entry, "dom-link-rewriter-click.js must be registered for MV2");
+    assert.equal(entry.run_at, "document_start");
+  });
+
+  test("content/dom-link-rewriter-click.js is an IIFE listening for the gate event", () => {
+    const src = readFileSync(
+      join(__dirname, "../../src/content/dom-link-rewriter-click.js"), "utf8"
+    );
+    assert.ok(/^\(function/m.test(src), "content script must be an IIFE");
+    assert.equal(/^\s*import\s+/m.test(src), false,
+      "content script must not contain top-level ES module imports");
+    assert.ok(/muga:history-gate/.test(src),
+      "rewriter must listen for muga:history-gate to honor disabled state");
+    // Capture phase is non-negotiable — bubble phase is too late.
+    assert.ok(/capture\s*:\s*true|true\s*\)/.test(src),
+      "listeners must be installed with capture: true");
+    // Listens to BOTH mousedown and click — mousedown catches reinjection
+    // between hover and click; click catches reinjection at click time.
+    assert.ok(/mousedown/.test(src), "must listen for mousedown");
+    assert.ok(/['"]click['"]/.test(src), "must listen for click");
+    // MUST NOT call preventDefault/stopPropagation/stopImmediatePropagation.
+    assert.equal(/preventDefault\s*\(/.test(src), false,
+      "click rewriter must NEVER call preventDefault");
+    assert.equal(/stopPropagation\s*\(/.test(src), false,
+      "click rewriter must NEVER call stopPropagation");
+    assert.equal(/stopImmediatePropagation\s*\(/.test(src), false,
+      "click rewriter must NEVER call stopImmediatePropagation");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #450 (B9). Capture-phase listeners on `mousedown` and `click` for `<a>` elements. Re-runs B8's rewriter on the href at click time to defuse **last-millisecond reinjection** by site scripts (Twitter, Facebook, LinkedIn re-decorate the href on mousedown after the MutationObserver from B8 has already cleaned it).

**Does NOT call `preventDefault`, `stopPropagation`, or `stopImmediatePropagation`.** Just rewrites in place; the browser navigates to the cleaned URL.

## Architecture (extends B8)

- **Pure factory** at `src/lib/dom-link-rewriter-click.js` — `createClickRewriter({ rewriter, getAnchorFromEvent })` returns `{ onMousedown, onClick, install, uninstall }`. Tests inject stub events + stub rewriter.
- **Isolated-world content script** at `src/content/dom-link-rewriter-click.js`. Listens for `muga:history-gate` (shared with B10/B11/B8). On `gate=true`, attaches capture-phase `mousedown` + `click` listeners on `document`. **Reuses B8's rewriter** for the cleaning operation via DI.

## Capture-phase rationale

- Capture runs BEFORE the page's own bubble listeners and BEFORE navigation starts. Bubble would be too late.
- Capture-phase **mousedown** catches reinjection between hover and click.
- Capture-phase **click** catches reinjection that happens AT mousedown (by the page's own bubble-mousedown listener).
- Both fire, both rewrite — B8's idempotency makes the redundancy free.

## Other notes

- `install()` is idempotent via WeakSet — re-firing `muga:history-gate` with `enabled=true` won't double-attach.
- `closest('a[href]')` wrapped in `try/catch` for shadow-DOM / synthetic-event resilience.

## Test plan

- [x] `npm test` → **2940/2940** passing (+24 from baseline 2916)
- [x] `npm run lint` → 0 errors
- [x] mousedown on element inside anchor → rewriter called
- [x] click on element inside anchor → rewriter called
- [x] mousedown / click NOT inside anchor → rewriter NOT called
- [x] preventDefault / stopPropagation / stopImmediatePropagation NEVER called (asserted both via test and grep-rejected in source)
- [x] install attaches with `{capture: true}`
- [x] uninstall removes both listeners
- [x] Rapid double-click → rewriter called twice (idempotent)
- [x] Disabled gate → no-op
- [x] Playwright E2E: fixture mimics Twitter/Facebook/LinkedIn pattern (anchor with bubble-phase mousedown listener that reinjects `?utm_source=evil`); after click, `location.search` contains neither `utm_source` nor `evil`