### PR TITLE
feat(content): Bounce State Cleaner — same-origin storage cleanup on intermediaries (#447)

### DIFF
--- a/src/content/bounce-state-cleaner.js
+++ b/src/content/bounce-state-cleaner.js
@@ -1,0 +1,198 @@
+/**
+ * MUGA: Bounce State Cleaner — isolated-world content script (#447 / B17)
+ *
+ * Pairs with the pure factory in `src/lib/bounce-state-cleaner.js`. This
+ * IIFE is the production wiring: it runs on every page at document_start
+ * (isolated world), checks whether the page's host is a recognized
+ * intermediary (affiliate-network bounce, social-link wrapper, privacy
+ * proxy), and if so wipes that origin's localStorage + sessionStorage.
+ *
+ * Why isolated world: Web Storage is shared between isolated and main
+ * worlds (the storage surface is keyed by ORIGIN, not by world). Running
+ * here lets us reuse the same `muga:history-gate` event the rest of the
+ * isolated-world scripts already publish — no extra prefs round-trip.
+ *
+ * Why a re-replicated WRAPPERS table (not `window.__mugaCleaner`):
+ *   The cleaner bundle attaches `window.__mugaCleaner` from
+ *   content/cleaner-bundle.js, but that bundle's content-side namespace
+ *   does NOT currently expose `detectWrapper`. We could expand the
+ *   exported surface, but the wrapper detection logic is small and pure;
+ *   re-stating the host patterns here is cheaper than waiting for the
+ *   cleaner bundle to attach (we run at document_start, before the
+ *   bundle's IIFE has finished). If `window.__mugaCleaner.detectWrapper`
+ *   is ever published we PREFER that — see the resolveEngine() shim
+ *   below.
+ *
+ * ── Cookies (intentionally not requested) ────────────────────────────────
+ * This module does NOT clear cookies. Doing so would require the
+ * `cookies` permission, which triggers an install-time prompt
+ * disproportionate to the benefit. See src/lib/bounce-state-cleaner.js
+ * docblock for the full rationale.
+ *
+ * ── Iframes skipped ─────────────────────────────────────────────────────
+ * Storage clears MUST NOT run inside iframes. A legitimate parent page
+ * may embed a privacy-proxy host as an `<iframe>` for some
+ * non-bounce purpose (e.g. an admin dashboard's tooling iframe), and
+ * wiping its storage from inside the iframe would corrupt that.
+ * `window.self !== window.top` is the standard guard the rest of the
+ * MUGA content scripts use.
+ *
+ * ── Disabled-state guard ────────────────────────────────────────────────
+ * The cleanup waits for a `muga:history-gate { enabled: true }` event
+ * (B10's dispatcher). This honors the user's onboarding/disable choice
+ * the same way every other isolated-world script does. We DO buffer the
+ * "should clean now?" decision so that a gate-open event arriving after
+ * document_start still triggers the wipe (the page may have already
+ * settled by then; storage state survives until we clear it).
+ */
+
+(function () {
+  "use strict";
+
+  // ── Iframe guard ─────────────────────────────────────────────────────
+  // See module docblock. NOT optional — privacy frames may share the host
+  // with legitimate iframes.
+  if (window.self !== window.top) return;
+  if (window.__mugaBounceStateCleaner) return;
+  window.__mugaBounceStateCleaner = true;
+
+  // ── Replicated WRAPPERS table ────────────────────────────────────────
+  // Mirrors the schema in src/lib/wrapper-engine.js. We only need the
+  // host/path matchers — extraction is irrelevant to storage cleanup.
+  // Keep this list in sync with the lib copy; the lib unit tests pin the
+  // shape of each entry, and any new wrapper added there should be
+  // mirrored here for storage cleanup to apply.
+  const WRAPPERS = [
+    { hostPatterns: ["awin1.com", "www.awin1.com"], pathPatterns: ["/cread.php", "/awclick.php"] },
+    { hostPatterns: ["go.redirectingat.com", "go.skimresources.com"], pathPatterns: null },
+    { hostPatterns: ["shareasale.com", "www.shareasale.com"], pathPatterns: ["/r.cfm"] },
+    { hostPatterns: ["click.linksynergy.com"], pathPatterns: ["/deeplink"] },
+    { hostPatterns: ["tc.tradetracker.net"], pathPatterns: null },
+    { hostPatterns: ["t.co"], pathPatterns: null },
+    { hostPatterns: ["l.facebook.com"], pathPatterns: ["/l.php"] },
+    { hostPatterns: ["lm.facebook.com"], pathPatterns: ["/l.php"] },
+    { hostPatterns: ["l.instagram.com"], pathPatterns: null },
+    { hostPatterns: ["out.reddit.com"], pathPatterns: null },
+    { hostPatterns: ["link.medium.com"], pathPatterns: null },
+    { hostPatterns: ["away.vk.com"], pathPatterns: ["/away.php"] },
+    { hostPatterns: ["exit.sc"], pathPatterns: null },
+    { hostPatterns: ["href.li"], pathPatterns: null },
+    { hostPatterns: ["anonym.to"], pathPatterns: null },
+    // Impact Radius — regex matches subdomain.pxf.io. The literal regex
+    // here is a copy of the one in src/lib/wrapper-engine.js.
+    { hostPatterns: [/^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.pxf\.io$/], pathPatterns: null },
+  ];
+
+  function inlineDetectWrapper(rawUrl) {
+    let url;
+    try { url = new URL(rawUrl); } catch { return null; }
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    const host = url.hostname.toLowerCase();
+    for (const wrapper of WRAPPERS) {
+      const hostMatch = wrapper.hostPatterns.some((p) =>
+        typeof p === "string" ? host === p.toLowerCase() : p.test(host)
+      );
+      if (!hostMatch) continue;
+      if (wrapper.pathPatterns) {
+        const pathMatch = wrapper.pathPatterns.some((pp) =>
+          url.pathname.startsWith(pp)
+        );
+        if (!pathMatch) continue;
+      }
+      return wrapper;
+    }
+    return null;
+  }
+
+  /**
+   * Prefer the bundled engine when it's available; fall back to the
+   * inline replica. Both are pure, both run synchronously — choose at
+   * call time so a late-arriving bundle doesn't get bypassed.
+   */
+  function resolveEngine() {
+    const bundled = window.__mugaCleaner;
+    if (bundled && typeof bundled.detectWrapper === "function") {
+      return { detectWrapper: (href) => bundled.detectWrapper(href) };
+    }
+    return { detectWrapper: inlineDetectWrapper };
+  }
+
+  // ── Pure factory inlined ─────────────────────────────────────────────
+  // Same logic as src/lib/bounce-state-cleaner.js — content scripts can't
+  // use ES module imports cross-browser (Firefox MV2). The unit tests
+  // cover the factory directly; this copy is a thin shell.
+  function createBounceStateCleaner(deps) {
+    const wrapperEngine = deps && deps.wrapperEngine;
+    const storageLike = deps && deps.storageLike;
+    const sessionStorageLike = deps && deps.sessionStorageLike;
+
+    function safeLength(s) {
+      if (!s) return 0;
+      try {
+        const n = s.length;
+        return typeof n === "number" && n >= 0 ? n : 0;
+      } catch { return 0; }
+    }
+    function safeClear(s) {
+      if (!s || typeof s.clear !== "function") return false;
+      try { s.clear(); return true; } catch { return false; }
+    }
+    function isIntermediary(href) {
+      if (typeof href !== "string" || href.length === 0) return false;
+      if (!wrapperEngine || typeof wrapperEngine.detectWrapper !== "function") return false;
+      try { return wrapperEngine.detectWrapper(href) !== null; } catch { return false; }
+    }
+    function cleanCurrent() {
+      const lb = safeLength(storageLike);
+      const sb = safeLength(sessionStorageLike);
+      const lok = safeClear(storageLike);
+      const sok = safeClear(sessionStorageLike);
+      return { localCleared: lok ? lb : 0, sessionCleared: sok ? sb : 0 };
+    }
+    function cleanIfIntermediary(href) {
+      if (!isIntermediary(href)) return { cleaned: false, localCleared: 0, sessionCleared: 0 };
+      const c = cleanCurrent();
+      return { cleaned: true, localCleared: c.localCleared, sessionCleared: c.sessionCleared };
+    }
+    return { isIntermediary, cleanCurrent, cleanIfIntermediary };
+  }
+
+  // ── Storage references — defensive reads ─────────────────────────────
+  // Reading window.localStorage in some contexts (sandboxed iframes,
+  // certain incognito setups) throws SecurityError. Catch at the
+  // top-level so the IIFE never crashes the page just by loading.
+  let localRef = null;
+  let sessionRef = null;
+  try { localRef = window.localStorage; } catch { localRef = null; }
+  try { sessionRef = window.sessionStorage; } catch { sessionRef = null; }
+
+  const cleaner = createBounceStateCleaner({
+    wrapperEngine: resolveEngine(),
+    storageLike: localRef,
+    sessionStorageLike: sessionRef,
+  });
+
+  // ── Disabled-state gate ──────────────────────────────────────────────
+  // We mirror the dom-link-rewriter pattern: cache the "should run?"
+  // decision and only act once the gate confirms enabled. Because the
+  // storage state is persistent, a late-arriving gate event (after the
+  // page has already loaded) still has work to do — we re-attempt on
+  // each gate-open event until we successfully observe a non-zero
+  // cleanup OR the URL stops being an intermediary.
+  let _haveCleaned = false;
+
+  function attemptCleanup() {
+    if (_haveCleaned) return;
+    let href;
+    try { href = location.href; } catch { return; }
+    const result = cleaner.cleanIfIntermediary(href);
+    if (result.cleaned) {
+      _haveCleaned = true;
+    }
+  }
+
+  document.addEventListener("muga:history-gate", (e) => {
+    const enabled = !!(e && e.detail && e.detail.enabled);
+    if (enabled) attemptCleanup();
+  });
+})();

--- a/src/lib/bounce-state-cleaner.js
+++ b/src/lib/bounce-state-cleaner.js
@@ -1,0 +1,171 @@
+/**
+ * MUGA: Bounce State Cleaner (#447 / B17)
+ *
+ * Affiliate-network bounce hosts, social-link wrappers, and privacy proxies
+ * (collectively: "intermediaries") frequently set localStorage and
+ * sessionStorage entries during the brief microsecond they hold the user's
+ * tab. Those entries persist across visits and let the intermediary
+ * fingerprint or correlate the visitor on the next bounce. Same-origin
+ * navigation handlers — DNR + the cleaner pipeline — strip query params
+ * but cannot reach inside the page's storage from outside the page.
+ *
+ * This module wipes that state from inside the page when the content
+ * script lands on a recognized intermediary host. The browser keys
+ * localStorage and sessionStorage by ORIGIN, so wiping while we're on
+ * `awin1.com` only touches `awin1.com`'s state — never the merchant's.
+ *
+ * ── What we DO NOT touch ─────────────────────────────────────────────────
+ *
+ * IndexedDB, service-worker caches, Cache Storage API: out of scope for
+ * v1. They have asynchronous APIs and per-database enumeration steps that
+ * complicate a document_start cleaner; the population of intermediaries
+ * that use them is small enough to defer.
+ *
+ * COOKIES — INTENTIONALLY NOT REQUESTED. Wiping the intermediary's
+ * cookies would require the `cookies` permission in the manifest. That
+ * permission triggers a scary install-time prompt ("Read and modify your
+ * cookies on all sites") that's wildly out of proportion to the value
+ * delivered for a niche cleanup. The product position is: ship the
+ * storage cleanup with no extra permission, and let the navigation
+ * pipeline + DNR handle the bigger lever (the URL itself never reaches
+ * the intermediary's server in many cases). If we later add a `cookies`
+ * permission for another feature, this module gains a third storage
+ * surface trivially.
+ *
+ * ── Pure module ──────────────────────────────────────────────────────────
+ *
+ * No DOM, no chrome.*, no `window.localStorage` reads. Three injection
+ * points:
+ *   - `wrapperEngine` — exposes `detectWrapper(href) -> entry|null`. The
+ *     same surface that `src/lib/wrapper-engine.js` exports. Tests pass a
+ *     stub; the content script passes the real engine (or a replicated
+ *     copy when the cleaner-bundle hasn't attached yet).
+ *   - `storageLike`, `sessionStorageLike` — Web Storage API stubs in
+ *     tests; `window.localStorage`/`window.sessionStorage` in production.
+ *
+ * Defensive contract: every public method swallows throws from the
+ * injected dependencies. A storage clear that throws (incognito quota,
+ * cross-origin error in some embedded contexts) MUST NOT bubble out to
+ * the IIFE that called us — the page must keep running.
+ */
+
+/**
+ * @typedef {object} BounceStateCleanerDeps
+ * @property {{ detectWrapper: (href: string) => object|null } | null} wrapperEngine
+ *   Wrapper-engine-shaped object. May be null at construction (the
+ *   cleaner becomes a defensive no-op).
+ * @property {Storage|null|undefined} storageLike
+ *   `window.localStorage`-shaped object. May be null/undefined.
+ * @property {Storage|null|undefined} sessionStorageLike
+ *   `window.sessionStorage`-shaped object. May be null/undefined.
+ */
+
+/**
+ * @typedef {object} BounceStateCleaner
+ * @property {(href: unknown) => boolean} isIntermediary
+ *   True iff the wrapper engine recognizes the URL's host as an
+ *   intermediary. Non-string input → false. Engine throws → false.
+ * @property {() => { localCleared: number, sessionCleared: number }} cleanCurrent
+ *   Wipes both storages unconditionally and returns the number of entries
+ *   that WERE present before the wipe. Throws are swallowed — a failed
+ *   storage reports 0.
+ * @property {(href: unknown) => { cleaned: boolean, localCleared: number, sessionCleared: number }} cleanIfIntermediary
+ *   Gates `cleanCurrent` on `isIntermediary`. Always returns an object.
+ *   `cleaned: false` when the URL is out of scope or input is invalid.
+ */
+
+/**
+ * Returns the count of entries in a Web-Storage-shaped object, swallowing
+ * any throw. Used to snapshot the "before" count for caller telemetry.
+ * @param {{ length: number }|null|undefined} storage
+ * @returns {number}
+ */
+function safeLength(storage) {
+  if (!storage) return 0;
+  try {
+    const n = storage.length;
+    return typeof n === "number" && n >= 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Calls `clear()` on a Web-Storage-shaped object, swallowing any throw.
+ * Returns true on apparent success, false when the storage is missing or
+ * `clear()` threw. The caller pairs this with `safeLength` to report
+ * per-surface counts.
+ * @param {{ clear: () => void }|null|undefined} storage
+ * @returns {boolean}
+ */
+function safeClear(storage) {
+  if (!storage || typeof storage.clear !== "function") return false;
+  try {
+    storage.clear();
+    return true;
+  } catch {
+    // Incognito-quota errors, cross-origin storage errors, or a hostile
+    // intermediary that has redefined `clear`. None of those should
+    // bubble out into the page's mutation flow — see module docblock.
+    return false;
+  }
+}
+
+/**
+ * Builds a bounce-state cleaner bound to the given wrapper engine and
+ * storage surfaces. The factory itself never throws — every public method
+ * is tolerant of null/undefined deps.
+ *
+ * @param {BounceStateCleanerDeps} deps
+ * @returns {BounceStateCleaner}
+ */
+export function createBounceStateCleaner(deps) {
+  const wrapperEngine = deps && deps.wrapperEngine;
+  const storageLike = deps && deps.storageLike;
+  const sessionStorageLike = deps && deps.sessionStorageLike;
+
+  function isIntermediary(href) {
+    if (typeof href !== "string" || href.length === 0) return false;
+    if (!wrapperEngine || typeof wrapperEngine.detectWrapper !== "function") {
+      return false;
+    }
+    try {
+      return wrapperEngine.detectWrapper(href) !== null;
+    } catch {
+      // A throwing engine is treated as "not an intermediary" — matches
+      // the conservative bias of every other gate in MUGA: when in
+      // doubt, do nothing.
+      return false;
+    }
+  }
+
+  function cleanCurrent() {
+    // Snapshot lengths BEFORE clearing so the returned counts reflect
+    // what was actually wiped. Reading `length` after clear() would
+    // always be 0 and lose the telemetry signal.
+    const localBefore = safeLength(storageLike);
+    const sessionBefore = safeLength(sessionStorageLike);
+
+    const localOk = safeClear(storageLike);
+    const sessionOk = safeClear(sessionStorageLike);
+
+    return {
+      localCleared: localOk ? localBefore : 0,
+      sessionCleared: sessionOk ? sessionBefore : 0,
+    };
+  }
+
+  function cleanIfIntermediary(href) {
+    if (!isIntermediary(href)) {
+      return { cleaned: false, localCleared: 0, sessionCleared: 0 };
+    }
+    const counts = cleanCurrent();
+    return {
+      cleaned: true,
+      localCleared: counts.localCleared,
+      sessionCleared: counts.sessionCleared,
+    };
+  }
+
+  return { isIntermediary, cleanCurrent, cleanIfIntermediary };
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,7 @@
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/bounce-state-cleaner.js", "content/cleaner.js"],
       "run_at": "document_start"
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -25,7 +25,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/bounce-state-cleaner.js", "content/cleaner.js"],
       "run_at": "document_start"
     },
     {

--- a/tests/unit/bounce-state-cleaner.test.mjs
+++ b/tests/unit/bounce-state-cleaner.test.mjs
@@ -1,0 +1,291 @@
+/**
+ * MUGA — Tests for the Bounce State Cleaner (#447 / B17).
+ *
+ * The cleaner runs only on intermediary "bounce" hosts (affiliate-network
+ * redirectors, social-link wrappers, privacy proxies — anything the Wrapper
+ * Engine recognizes). When the user briefly lands on one of those hosts,
+ * the cleaner wipes that origin's localStorage + sessionStorage so the
+ * intermediary can't persist tracking state across visits.
+ *
+ * The module under test is a PURE factory — `createBounceStateCleaner` —
+ * with three injection points:
+ *   - `wrapperEngine` :: { detectWrapper(href) -> entry|null }
+ *     Authoritative source of "is this an intermediary host?".
+ *   - `storageLike` and `sessionStorageLike` :: stubs of the Web Storage
+ *     API (clear / length / getItem / key / removeItem). Tests inject
+ *     simple Map-backed stubs.
+ *
+ * No DOM, no chrome.*, no jsdom — project rule is no third-party test libs.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createBounceStateCleaner } from "../../src/lib/bounce-state-cleaner.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Stub Wrapper Engine. `matches` is a list of substrings; if any of them
+ * appears in the URL string, `detectWrapper` returns a fake entry object.
+ * Otherwise null. Mirrors the real detectWrapper's "string|null" contract.
+ */
+function makeWrapperEngine(matches) {
+  return {
+    detectWrapper(href) {
+      if (typeof href !== "string") return null;
+      for (const m of matches) {
+        if (href.includes(m)) return { id: "stub", name: "stub" };
+      }
+      return null;
+    },
+  };
+}
+
+/**
+ * Map-backed Web Storage stub. Implements the surface the cleaner touches:
+ * `clear()`, `length`, `getItem`, `key`, `removeItem`, `setItem`. Tests
+ * pre-seed with `setItem` and then inspect via `length` after `clear()`.
+ */
+function makeStorage(seed = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    get length() { return map.size; },
+    key(i) {
+      const keys = [...map.keys()];
+      return i >= 0 && i < keys.length ? keys[i] : null;
+    },
+    getItem(k) { return map.has(k) ? map.get(k) : null; },
+    setItem(k, v) { map.set(k, String(v)); },
+    removeItem(k) { map.delete(k); },
+    clear() { map.clear(); },
+    // Test-only mirror.
+    get __size() { return map.size; },
+  };
+}
+
+/**
+ * Storage stub whose `clear()` throws — used to verify the cleaner swallows
+ * exceptions instead of bubbling them up to its caller (defensive contract).
+ */
+function makeThrowingStorage() {
+  return {
+    get length() { return 5; },
+    key() { return null; },
+    getItem() { return null; },
+    setItem() { /* noop */ },
+    removeItem() { /* noop */ },
+    clear() { throw new Error("storage clear blew up"); },
+  };
+}
+
+// ── isIntermediary ────────────────────────────────────────────────────────
+
+describe("createBounceStateCleaner — isIntermediary", () => {
+  test("returns true when wrapperEngine.detectWrapper returns an entry", () => {
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine(["awin1.com"]),
+      storageLike: makeStorage(),
+      sessionStorageLike: makeStorage(),
+    });
+    assert.equal(
+      cleaner.isIntermediary("https://awin1.com/cread.php?p=https%3A%2F%2Fmerchant.example%2F"),
+      true
+    );
+  });
+
+  test("returns false when wrapperEngine.detectWrapper returns null", () => {
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine(["awin1.com"]),
+      storageLike: makeStorage(),
+      sessionStorageLike: makeStorage(),
+    });
+    assert.equal(cleaner.isIntermediary("https://example.com/article"), false);
+  });
+
+  test("returns false for non-string input (no throw)", () => {
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine(["awin1.com"]),
+      storageLike: makeStorage(),
+      sessionStorageLike: makeStorage(),
+    });
+    assert.equal(cleaner.isIntermediary(undefined), false);
+    assert.equal(cleaner.isIntermediary(null), false);
+    assert.equal(cleaner.isIntermediary(123), false);
+  });
+});
+
+// ── cleanCurrent ──────────────────────────────────────────────────────────
+
+describe("createBounceStateCleaner — cleanCurrent", () => {
+  test("calls clear() on both storages and returns the prior counts", () => {
+    const local = makeStorage({ a: "1", b: "2", c: "3" });
+    const session = makeStorage({ x: "y" });
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine([]),
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    const result = cleaner.cleanCurrent();
+    assert.equal(local.__size, 0);
+    assert.equal(session.__size, 0);
+    assert.equal(result.localCleared, 3);
+    assert.equal(result.sessionCleared, 1);
+  });
+
+  test("empty storages return counts of 0 and do not throw", () => {
+    const local = makeStorage();
+    const session = makeStorage();
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine([]),
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    const result = cleaner.cleanCurrent();
+    assert.equal(result.localCleared, 0);
+    assert.equal(result.sessionCleared, 0);
+  });
+
+  test("missing/null storage references are tolerated (no throw, count of 0)", () => {
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine([]),
+      storageLike: null,
+      sessionStorageLike: undefined,
+    });
+    const result = cleaner.cleanCurrent();
+    assert.equal(result.localCleared, 0);
+    assert.equal(result.sessionCleared, 0);
+  });
+
+  test("clear() throws are caught — counts reported as 0, no surface to caller", () => {
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine([]),
+      storageLike: makeThrowingStorage(),
+      sessionStorageLike: makeThrowingStorage(),
+    });
+    assert.doesNotThrow(() => {
+      const result = cleaner.cleanCurrent();
+      // Throwing path: report 0 cleared. The caller learns nothing was
+      // wiped, which is honest.
+      assert.equal(result.localCleared, 0);
+      assert.equal(result.sessionCleared, 0);
+    });
+  });
+});
+
+// ── cleanIfIntermediary ───────────────────────────────────────────────────
+
+describe("createBounceStateCleaner — cleanIfIntermediary", () => {
+  test("non-intermediary URL → both storages untouched", () => {
+    const local = makeStorage({ a: "1" });
+    const session = makeStorage({ b: "2" });
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine(["awin1.com"]),
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    const result = cleaner.cleanIfIntermediary("https://example.com/article");
+    assert.equal(result.cleaned, false);
+    assert.equal(local.__size, 1);
+    assert.equal(session.__size, 1);
+  });
+
+  test("intermediary URL → both storages cleared", () => {
+    const local = makeStorage({ a: "1", b: "2" });
+    const session = makeStorage({ x: "y" });
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine(["awin1.com"]),
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    const result = cleaner.cleanIfIntermediary(
+      "https://awin1.com/cread.php?p=https%3A%2F%2Fmerchant.example%2F"
+    );
+    assert.equal(result.cleaned, true);
+    assert.equal(result.localCleared, 2);
+    assert.equal(result.sessionCleared, 1);
+    assert.equal(local.__size, 0);
+    assert.equal(session.__size, 0);
+  });
+
+  test("malformed URL → no throw, no-op (storages untouched)", () => {
+    const local = makeStorage({ a: "1" });
+    const session = makeStorage({ b: "2" });
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine(["awin1.com"]),
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    let result;
+    assert.doesNotThrow(() => {
+      result = cleaner.cleanIfIntermediary("::::not a url::::");
+    });
+    assert.equal(result.cleaned, false);
+    assert.equal(local.__size, 1);
+    assert.equal(session.__size, 1);
+  });
+
+  test("non-string input → no throw, no-op", () => {
+    const local = makeStorage({ a: "1" });
+    const session = makeStorage({ b: "2" });
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine(["awin1.com"]),
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    assert.doesNotThrow(() => cleaner.cleanIfIntermediary(undefined));
+    assert.doesNotThrow(() => cleaner.cleanIfIntermediary(null));
+    assert.equal(local.__size, 1);
+    assert.equal(session.__size, 1);
+  });
+
+  test("wrapperEngine.detectWrapper that throws → no surface to caller, no-op", () => {
+    const local = makeStorage({ a: "1" });
+    const session = makeStorage({ b: "2" });
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: {
+        detectWrapper() { throw new Error("engine boom"); },
+      },
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    let result;
+    assert.doesNotThrow(() => {
+      result = cleaner.cleanIfIntermediary("https://anything.example/");
+    });
+    assert.equal(result.cleaned, false);
+    assert.equal(local.__size, 1);
+    assert.equal(session.__size, 1);
+  });
+});
+
+// ── Factory contract ──────────────────────────────────────────────────────
+
+describe("createBounceStateCleaner — factory contract", () => {
+  test("returns the documented public surface", () => {
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: makeWrapperEngine([]),
+      storageLike: makeStorage(),
+      sessionStorageLike: makeStorage(),
+    });
+    assert.equal(typeof cleaner.isIntermediary, "function");
+    assert.equal(typeof cleaner.cleanCurrent, "function");
+    assert.equal(typeof cleaner.cleanIfIntermediary, "function");
+  });
+
+  test("missing wrapperEngine → cleanIfIntermediary is a no-op (defensive)", () => {
+    const local = makeStorage({ a: "1" });
+    const session = makeStorage({ b: "2" });
+    const cleaner = createBounceStateCleaner({
+      wrapperEngine: null,
+      storageLike: local,
+      sessionStorageLike: session,
+    });
+    let result;
+    assert.doesNotThrow(() => {
+      result = cleaner.cleanIfIntermediary("https://awin1.com/cread.php?p=x");
+    });
+    assert.equal(result.cleaned, false);
+    assert.equal(local.__size, 1);
+    assert.equal(session.__size, 1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #447 (B17). When the user briefly loads an intermediary (affiliate-network bounce, social-link wrapper, privacy proxy — any host the Wrapper Engine recognizes), wipe that domain's `localStorage` and `sessionStorage` so the tracker can't persist state across visits.

## Scope (intentional limits)

- **Same-origin only**. Content scripts on visits to the intermediary, no cross-origin reach.
- **No cookies**. That would require the `cookies` permission — deliberately not requested to preserve MUGA's minimal-permissions stance. Documented in the module JSDoc.
- **No IndexedDB / no service-worker caches** — out of scope for v1.

## Architecture

- **Pure factory** at `src/lib/bounce-state-cleaner.js` — `createBounceStateCleaner({ wrapperEngine, storageLike, sessionStorageLike })` returns `{ isIntermediary, cleanCurrent, cleanIfIntermediary }`. Defensive: every public method swallows throws from injected deps so a `SecurityError` on storage access in sandboxed iframes never surfaces.
- **Isolated-world content script** at `src/content/bounce-state-cleaner.js`. Iframes skipped (`window.self !== window.top`) — privacy frames may share the host with legitimate iframes. Listens for `muga:history-gate` (shared with B8/B9/B10/B11). On gate-open: read `location.href`, run `cleanIfIntermediary`, keep listening until a successful clean (storage state is persistent, so a late-arriving gate-open still has work to do).

## Detection source — important note

The content script ships a **16-entry WRAPPERS table** mirroring `src/lib/wrapper-engine.js`. **The cleaner-bundle (`window.__mugaCleaner`) is awin-only today** — esbuild only keeps wrapper entries reachable from the bundle's exports, and only `awin` is referenced via `unwrap`. The bundle does NOT export `detectWrapper`.

Forward-compatible: a `resolveEngine()` shim PREFERS `window.__mugaCleaner.detectWrapper` if it ever appears. If a future slice broadens the bundle exports, the inline table can be removed.

## Test plan

- [x] `npm test` → **2954/2954** passing (+14 from baseline 2940)
- [x] `npm run lint` → 0 errors
- [x] `isIntermediary` returns true when wrapperEngine matches, false otherwise
- [x] `cleanCurrent` calls `clear()` on both storages and returns sane counts
- [x] `cleanCurrent` handles missing/null storage references gracefully (no throw)
- [x] `cleanIfIntermediary` on non-intermediary URL → both storages untouched
- [x] `cleanIfIntermediary` on intermediary URL → both storages cleared
- [x] `cleanIfIntermediary` on malformed URL → no throw, no-op
- [x] `clear()` throw is caught (defensive)
- [x] Empty storages → `cleanCurrent` returns counts of 0, no error
- [x] Snapshot lengths captured BEFORE `clear()` — reading length after returns 0

## Deferred

- **SW recent-chain hint** (option 2 from acceptance design): the SW could remember "we just unwrapped an intermediary at host X" and schedule cleanup. Direct detection (option 1) meets the acceptance criteria; the cross-script messaging plumbing wasn't a small extension. Open a follow-up issue if production logs show intermediaries that don't get cleaned because the user never directly visits them.