### PR TITLE
feat(cleaner): Honor Creator Mode conditional behavior + popup badge (#452)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -605,7 +605,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // that onStartup can't reach. Runs in parallel with URL processing.
     maybeFetchRemoteRules(_remoteRulesDeps());
     const tabId = sender.tab?.id;
-    handleProcessUrl(message.url, { skipNotify: message.skipNotify, source: message.skipNotify ? "copy_selection" : "navigation", skipStats: !!message.skipStats })
+    handleProcessUrl(message.url, { skipNotify: message.skipNotify, source: message.skipNotify ? "copy_selection" : "navigation", skipStats: !!message.skipStats, referrer: typeof message.referrer === "string" ? message.referrer : "" })
       .then(result => {
         updateTabBadge(tabId, result.junkRemoved ?? 0);
         if (typeof tabId === "number" && result.preservedAffiliate) {
@@ -831,7 +831,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 });
 
-async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigation", skipStats = false } = {}) {
+async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigation", skipStats = false, referrer = "" } = {}) {
   if (!rawUrl?.startsWith("http")) return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
   // _domainRulesReady is nulled on fetch failure to allow retry on the next call
   if (!_domainRulesReady) _domainRulesReady = _loadDomainRules();
@@ -854,7 +854,11 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
     // (#446 / #495). Cleaner side fires-and-forgets one observe() per
     // stripped tracking param, gated on prefs.crossSiteFrequencyEnabled.
     // Null-safe: cleaner no-ops when the tracker is missing.
-    result = processUrl(rawUrl, effectivePrefs, domainRules, undefined, frequencyTracker);
+    // 6th arg `referrer` (#452 / B14) wires Honor Creator Mode — when the
+    // user enabled the toggle AND the navigation referrer matches an
+    // allowlisted creator, the cleaner short-circuits with action
+    // "honored-creator". Empty string for non-navigation contexts.
+    result = processUrl(rawUrl, effectivePrefs, domainRules, undefined, frequencyTracker, referrer);
   } catch (err) {
     console.error("[MUGA] processUrl failed:", err, rawUrl);
     return { cleanUrl: rawUrl, action: "error", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -225,6 +225,17 @@
       return true;
     }
 
+    // B14 (#452): popup asks the active tab for its document.referrer so
+    // the cleaner can decide whether to honor the creator's referral chain.
+    // No prefs gate — returning an empty string when nothing is known is
+    // safe (the cleaner treats no-referrer as "do not honor").
+    if (message.type === "GET_REFERRER") {
+      try {
+        sendResponse({ ok: true, referrer: document.referrer || "" });
+      } catch { /* channel closed */ }
+      return true;
+    }
+
     if (message.type === "SHOW_TEST_TOAST") {
       showAffiliateNotice(
         { param: "tag", value: "somestore-21" },

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -6,6 +6,7 @@
 import { TRACKING_PARAMS, TRACKING_PARAM_CATEGORIES, getPatternsForHost } from "./affiliates.js";
 import { unwrap, detectWrapper } from "./wrapper-engine.js";
 import { extractCanonical } from "./canonical-extractor.js";
+import { shouldHonor } from "./honor-creator.js";
 
 // C5: O(1) lookup instead of O(n) array scan
 const TRACKING_PARAMS_SET = new Set(TRACKING_PARAMS.map(p => p.toLowerCase()));
@@ -201,6 +202,8 @@ function stripTrackingParams(url, prefs, domainRules, disabledCategories) {
  * Processes a URL according to user preferences and blacklist/whitelist rules.
  *
  * Logic order:
+ *   0a. Honor Creator Mode (#452): pass redirect-network wrapper through
+ *       UNMODIFIED when user opted in AND referrer matches creatorAllowlist
  *   1. Blacklist check: domain-only entry → strip ALL params (Scenario D)
  *   2. Whitelist check: find protected affiliate values (never touch these)
  *   3. Foreign affiliate detection (Scenario C): skip whitelisted values
@@ -226,9 +229,27 @@ function stripTrackingParams(url, prefs, domainRules, disabledCategories) {
  *   hostname — i.e. the page being cleaned. Failures from the tracker are
  *   swallowed: the cleaner pipeline must never break on storage errors.
  *   Pass `undefined`/`null` (or omit) in contexts where no tracker exists.
- * @returns {{ cleanUrl: string, action: string, removedTracking: string[], junkRemoved: number, detectedAffiliate: object|null, preservedAffiliate: object|null }}
+ * @param {string|null|undefined} [referrer]
+ *   Optional navigation referrer (#452, B14). When provided AND
+ *   `prefs.honorCreatorMode === true` AND the URL is a recognized redirect
+ *   wrapper AND the referrer matches an entry in `prefs.creatorAllowlist`,
+ *   the pipeline short-circuits with `action: "honored-creator"` and
+ *   leaves the wrapper URL unmodified so the creator's referral chain is
+ *   preserved. Background-only contexts that lack a referrer (or that
+ *   omit this argument) never enter the honor path — defaulting to
+ *   pre-feature behaviour.
+ * @returns {{ cleanUrl: string, action: string, removedTracking: string[], junkRemoved: number, detectedAffiliate: object|null, preservedAffiliate: object|null, network?: string, creator?: string }}
+ *   `action` is one of:
+ *     `"untouched"`         — URL unchanged
+ *     `"cleaned"`           — tracking params and/or path tokens stripped
+ *     `"injected"`          — our affiliate tag was added
+ *     `"detected_foreign"`  — a third-party affiliate tag was detected
+ *     `"blacklisted"`       — domain-only blacklist stripped everything
+ *     `"honored-creator"`   — Honor Creator Mode passed the wrapper through
+ *                             unmodified; `network` (wrapper id) and
+ *                             `creator` (matching allowlist entry) are set.
  */
-export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle, frequencyTracker) {
+export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle, frequencyTracker, referrer) {
   let url;
   try {
     url = new URL(rawUrl);
@@ -238,6 +259,26 @@ export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle, fre
 
   if (url.protocol !== "https:" && url.protocol !== "http:") {
     return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null, preservedAffiliate: null };
+  }
+
+  // Step 0a: Honor Creator Mode (#452, B14). When the user opted in AND the
+  // navigation referrer matches an allowlisted creator AND the URL is a
+  // recognized redirect wrapper, pass it through UNMODIFIED so the creator's
+  // referral chain stays intact. Decision lives in src/lib/honor-creator.js
+  // (pure module, reuses Wrapper Engine for network classification).
+  // Background-only contexts (no referrer) never enter this branch.
+  const honor = shouldHonor({ url: rawUrl, referrer, prefs });
+  if (honor.honor) {
+    return {
+      cleanUrl: rawUrl,
+      action: "honored-creator",
+      removedTracking: [],
+      junkRemoved: 0,
+      detectedAffiliate: null,
+      preservedAffiliate: null,
+      network: honor.network,
+      creator: honor.creator,
+    };
   }
 
   // Step 0: unwrap recognized redirect wrappers (Awin etc.). The destination

--- a/src/lib/honor-creator.js
+++ b/src/lib/honor-creator.js
@@ -1,0 +1,131 @@
+/**
+ * MUGA — Honor Creator Mode decision module (#452, B14).
+ *
+ * Pure module — no DOM, no network, no clock. Given a URL, an optional
+ * navigation referrer, and the user's prefs, decides whether MUGA should
+ * "honor" the creator's referral chain (i.e. let the redirect-network
+ * wrapper URL pass through unmodified) or fall back to the default
+ * tracking-strip + unwrap pipeline.
+ *
+ * Three conditions must ALL hold for an honor decision:
+ *   1. `prefs.honorCreatorMode === true` (user opted in)
+ *   2. The URL is a recognized redirect-network wrapper, per
+ *      Wrapper Engine's `detectWrapper()`
+ *   3. The navigation referrer matches an entry in `prefs.creatorAllowlist`
+ *
+ * If any condition fails, the result is `{ honor: false }` and the caller
+ * (cleaner.js) proceeds with default behaviour. This module never mutates
+ * its inputs and never throws — defensive against malformed prefs and
+ * non-string URLs.
+ *
+ * ── Design notes ──────────────────────────────────────────────────────────
+ *
+ * Network classification reuses Wrapper Engine — single source of truth for
+ * "is this a redirect wrapper?". When `detectWrapper(url)` returns null,
+ * there's nothing to honor (we can't credit a creator on a URL the network
+ * hierarchy doesn't recognize).
+ *
+ * Referrer matching is intentionally `host + pathname` prefix-based:
+ *   - Strip `www.` from the referrer host (the most common alias) so users
+ *     don't have to add both `youtube.com/@foo` and `www.youtube.com/@foo`.
+ *   - Compare the lowercased `host + path` against the normalized entry.
+ *   - Match iff the referrer string starts with the entry AND the next
+ *     character is either end-of-string or a path/query/fragment boundary.
+ *     This blocks `example.com` from matching `evilexample.com` and prevents
+ *     `youtube.com/@foo` from matching `youtube.com/@foobar`.
+ *
+ * Entry normalization is delegated to `creator-allowlist.js#normalizeEntry`
+ * to guarantee identical semantics with the storage CRUD module — entries
+ * are written and read through the same normalizer.
+ */
+
+import { detectWrapper } from "./wrapper-engine.js";
+import { normalizeEntry } from "./creator-allowlist.js";
+
+/**
+ * Extracts a comparable `host + pathname` key from a referrer URL.
+ * Lowercases, strips a leading `www.` from the host, and concatenates the
+ * pathname (which always begins with `/` per the URL spec when present).
+ * Returns "" when the input is unusable.
+ *
+ * @param {string|null|undefined} referrer
+ * @returns {string} e.g. "youtube.com/@foo/community" or "" on failure.
+ */
+function refKey(referrer) {
+  if (typeof referrer !== "string" || !referrer) return "";
+  let parsed;
+  try {
+    parsed = new URL(referrer);
+  } catch {
+    return "";
+  }
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  // pathname is always at least "/"; concatenating gives "host" or "host/path".
+  // Lowercase the path too — allowlist entries are normalized lowercase by
+  // creator-allowlist.normalizeEntry, and URL paths can carry mixed case
+  // (e.g. `/@LinusTechTips`). Without this, `youtube.com/@LinusTechTips`
+  // would fail to match the stored entry `youtube.com/@linustechtips`.
+  // Strip a trailing slash so `host/` and `host` compare equal — entries are
+  // stored without trailing slashes (see creator-allowlist.normalizeEntry).
+  const path = parsed.pathname === "/" ? "" : parsed.pathname.toLowerCase();
+  return host + path;
+}
+
+/**
+ * Returns the matching allowlist entry for a navigation referrer, or null
+ * when nothing matches. The entry is returned in its normalized form (the
+ * same form that lives in `prefs.creatorAllowlist`), suitable for
+ * round-tripping into popup UI.
+ *
+ * Matching is prefix-based on `host + pathname` after `www.` stripping.
+ * The match boundary is enforced so partial host overlaps (e.g.
+ * `example.com` vs `evilexample.com`) and partial path segments (e.g.
+ * `@foo` vs `@foobar`) never produce false positives.
+ *
+ * @param {string|null|undefined} referrer
+ * @param {string[]|undefined}    allowlist
+ * @returns {string|null} the matching normalized entry, or null
+ */
+export function matchesAllowlist(referrer, allowlist) {
+  if (!Array.isArray(allowlist) || allowlist.length === 0) return null;
+  const key = refKey(referrer);
+  if (!key) return null;
+
+  for (const raw of allowlist) {
+    const entry = normalizeEntry(raw);
+    if (!entry) continue;
+    if (!key.startsWith(entry)) continue;
+    // Boundary check: the next char in `key` must be end-of-string or a
+    // path/query/fragment separator. Otherwise `example.com` would match
+    // `evilexample.com` (impossible because we anchored at start, but the
+    // path side still needs the boundary to block `@foo` matching `@foobar`).
+    const next = key.charAt(entry.length);
+    if (next === "" || next === "/" || next === "?" || next === "#") {
+      return entry;
+    }
+  }
+  return null;
+}
+
+/**
+ * Decides whether the cleaner pipeline should honor the creator's referral
+ * chain on this navigation. Pure inspection — never mutates inputs.
+ *
+ * @param {{ url: any, referrer: string|null|undefined, prefs: object }} args
+ * @returns {{ honor: boolean, network?: string, creator?: string }}
+ *   When `honor === true`, `network` is the wrapper id (e.g. `"skimlinks"`)
+ *   and `creator` is the matching normalized allowlist entry. Otherwise
+ *   only `honor: false` is returned.
+ */
+export function shouldHonor({ url, referrer, prefs }) {
+  if (!prefs || prefs.honorCreatorMode !== true) return { honor: false };
+  if (typeof url !== "string" || !url) return { honor: false };
+
+  const wrapper = detectWrapper(url);
+  if (!wrapper) return { honor: false };
+
+  const creator = matchesAllowlist(referrer, prefs.creatorAllowlist);
+  if (!creator) return { honor: false };
+
+  return { honor: true, network: wrapper.id, creator };
+}

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -44,6 +44,18 @@ export const TRANSLATIONS = {
   confirm_ok:            { en: "OK", es: "OK", pt: "OK", de: "OK" },
   domain_stats_label:    { en: "Your top trackers", es: "Tus principales rastreadores", pt: "Seus principais rastreadores", de: "Deine häufigsten Tracker" },
 
+  // ── Popup: Honor Creator Mode badge (#452, B14) ─────────────────────────
+  // Surfaced when MUGA passes a redirect-network wrapper through unmodified
+  // because the navigation referrer matched an allowlisted creator. {network}
+  // is the wrapper id (e.g. "skimlinks"); {creator} is the matching entry
+  // (e.g. "youtube.com/@LinusTechTips").
+  popup_badge_honored_creator: {
+    en: "Routed through {network} to honor {creator}",
+    es: "Pasamos por {network} para honrar a {creator}",
+    pt: "Passando por {network} para honrar {creator}" /* FIXME: needs native speaker review */,
+    de: "Über {network} weitergeleitet, um {creator} zu ehren" /* FIXME: needs native speaker review */,
+  },
+
   // ── Popup: suspicious-params section (B15 entropy + B16 cross-site freq) ──
   suspicious_params_label:           { en: "Suspicious params",                                   es: "Parámetros sospechosos",                                  pt: "Parâmetros suspeitos",                                  de: "Verdächtige Parameter" },
   suspicious_params_entropy_group:   { en: "On this page (entropy)",                              es: "En esta página (entropía)",                               pt: "Nesta página (entropia)",                               de: "Auf dieser Seite (Entropie)" },

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -89,6 +89,7 @@
       <span class="preview-preserved-label" data-i18n="preview_preserved_creator">Creator referral preserved</span>
       <span class="preview-preserved-tag" id="preview-preserved-tag"></span>
     </div>
+    <div class="preview-honored" id="preview-honored" hidden aria-live="polite"></div>
     <div class="preview-url clean" id="preview-clean" hidden></div>
     <a class="report-link" id="report-broken" href="#" hidden data-i18n="report_dirty_url">Report a problem with this URL</a>
     <a class="report-link" id="report-unclean" href="#" hidden data-i18n="report_unclean_url">Still see tracking? Help us improve</a>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -495,6 +495,13 @@ function _resetPreviewDom() {
     const tag = document.getElementById("preview-preserved-tag");
     if (tag) tag.textContent = "";
   }
+  // B14 (#452): honored-creator badge slot. Reset every render so a previous
+  // navigation's badge never bleeds into the next.
+  const previewHonored = el("preview-honored");
+  if (previewHonored) {
+    previewHonored.hidden = true;
+    previewHonored.textContent = "";
+  }
   const reportLink = el("report-broken");
   if (reportLink) reportLink.hidden = true;
   const reportUncleanLink = el("report-unclean");
@@ -553,7 +560,36 @@ async function showUrlPreview(prefs, lang) {
     if (resp.ok) domainRules = await resp.json();
   } catch (_) { /* non-critical: preview works without domain rules */ }
 
-  const result = processUrl(url, { ...prefs, notifyForeignAffiliate: false }, domainRules);
+  // B14 (#452): fetch the active tab's `document.referrer` from the content
+  // script so the cleaner can decide whether to honor the creator chain.
+  // Best-effort: missing/silent content scripts (chrome:// pages, popups,
+  // first-load before injection completes) collapse to no referrer, which
+  // disables honoring entirely — same as background-only contexts.
+  let referrer = "";
+  if (tab?.id) {
+    try {
+      const resp = await chrome.tabs.sendMessage(tab.id, { type: "GET_REFERRER" });
+      if (resp && typeof resp.referrer === "string") referrer = resp.referrer;
+    } catch { /* content script not loaded — ignore */ }
+  }
+
+  const result = processUrl(url, { ...prefs, notifyForeignAffiliate: false }, domainRules, undefined, undefined, referrer);
+
+  // B14 (#452): honored-creator badge. Surfaced when the wrapper URL was
+  // passed through unmodified to honor a creator referral chain. The
+  // template carries {network} and {creator} placeholders sourced from the
+  // cleaner result. textContent is used (no innerHTML) so user-controllable
+  // creator strings can never become an injection vector.
+  if (result.action === "honored-creator") {
+    const honoredEl = document.getElementById("preview-honored");
+    if (honoredEl) {
+      const template = t("popup_badge_honored_creator", lang);
+      honoredEl.textContent = template
+        .replace("{network}", String(result.network ?? ""))
+        .replace("{creator}", String(result.creator ?? ""));
+      honoredEl.hidden = false;
+    }
+  }
 
   // Wedge feedback: when MUGA preserved a third-party creator's affiliate tag,
   // surface it visibly. This is the core "fair to creators" promise made

--- a/tests/unit/cleaner-honor-creator.test.mjs
+++ b/tests/unit/cleaner-honor-creator.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * MUGA — processUrl × Honor Creator Mode integration (#452, B14)
+ *
+ * Asserts the cleaner pipeline short-circuits with `action: "honored-creator"`
+ * BEFORE the wrapper engine unwraps, and that the no-honor path remains
+ * byte-identical to pre-feature behaviour.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { processUrl } from "../../src/lib/cleaner.js";
+
+const SKIMLINKS = "https://go.redirectingat.com/?id=1&url=https%3A%2F%2Famazon.com%2Fdp%2FB000";
+const PLAIN_URL = "https://example.com/article?utm_source=foo";
+
+describe("processUrl × honor creator (B14)", () => {
+  test("honor path: matching referrer + wrapper URL → action=honored-creator, cleanUrl unchanged", () => {
+    const result = processUrl(
+      SKIMLINKS,
+      {
+        enabled: true,
+        honorCreatorMode: true,
+        creatorAllowlist: ["youtube.com/@linustechtips"],
+      },
+      [],
+      undefined,
+      undefined,
+      "https://www.youtube.com/@LinusTechTips/community",
+    );
+    assert.equal(result.action, "honored-creator");
+    assert.equal(result.cleanUrl, SKIMLINKS);
+    assert.equal(result.network, "skimlinks");
+    assert.equal(result.creator, "youtube.com/@linustechtips");
+    assert.equal(result.junkRemoved, 0);
+  });
+
+  test("mode OFF + matching referrer + wrapper URL → unwraps as before (no honor)", () => {
+    const honored = processUrl(
+      SKIMLINKS,
+      {
+        enabled: true,
+        honorCreatorMode: false,
+        creatorAllowlist: ["youtube.com/@linustechtips"],
+      },
+      [],
+      undefined,
+      undefined,
+      "https://www.youtube.com/@LinusTechTips/community",
+    );
+    // Pre-feature: cleaner unwraps the Skimlinks wrapper to the merchant URL.
+    assert.notEqual(honored.action, "honored-creator");
+    assert.ok(honored.cleanUrl.startsWith("https://amazon.com/dp/B000"));
+  });
+
+  test("mode ON + non-matching referrer → not honored, behaves as before", () => {
+    const before = processUrl(SKIMLINKS, { enabled: true });
+    const withMode = processUrl(
+      SKIMLINKS,
+      {
+        enabled: true,
+        honorCreatorMode: true,
+        creatorAllowlist: ["youtube.com/@linustechtips"],
+      },
+      [],
+      undefined,
+      undefined,
+      "https://news.ycombinator.com/",
+    );
+    assert.notEqual(withMode.action, "honored-creator");
+    assert.equal(withMode.cleanUrl, before.cleanUrl);
+    assert.equal(withMode.action, before.action);
+  });
+
+  test("no referrer (background context) → not honored", () => {
+    const withMode = processUrl(
+      SKIMLINKS,
+      {
+        enabled: true,
+        honorCreatorMode: true,
+        creatorAllowlist: ["youtube.com/@linustechtips"],
+      },
+      [],
+      undefined,
+      undefined,
+      // referrer omitted — background-only contexts
+    );
+    assert.notEqual(withMode.action, "honored-creator");
+  });
+
+  test("non-wrapper URL with mode ON + matching referrer → standard cleaning", () => {
+    const result = processUrl(
+      PLAIN_URL,
+      {
+        enabled: true,
+        honorCreatorMode: true,
+        creatorAllowlist: ["youtube.com/@linustechtips"],
+      },
+      [],
+      undefined,
+      undefined,
+      "https://www.youtube.com/@LinusTechTips/",
+    );
+    assert.notEqual(result.action, "honored-creator");
+    // Standard tracking-param cleaning still happens.
+    assert.equal(result.action, "cleaned");
+    assert.ok(result.removedTracking.includes("utm_source"));
+  });
+
+  test("regression: pre-feature default behaviour (no referrer arg) is identical", () => {
+    // Exact same call signature as before B14 — no 6th arg.
+    const result = processUrl(SKIMLINKS, { enabled: true });
+    assert.notEqual(result.action, "honored-creator");
+    assert.ok(result.cleanUrl.startsWith("https://amazon.com/dp/B000"));
+  });
+});

--- a/tests/unit/honor-creator.test.mjs
+++ b/tests/unit/honor-creator.test.mjs
@@ -1,0 +1,180 @@
+/**
+ * MUGA — Unit tests for honor-creator (#452, B14)
+ *
+ * The pure module that decides whether to "honor" a creator's referral chain:
+ * when the user enabled `honorCreatorMode`, AND the navigation referrer
+ * matches one of the user's `creatorAllowlist` entries, AND the URL is a
+ * recognized redirect-network wrapper, MUGA passes the wrapper URL through
+ * unmodified so the creator gets credit. Otherwise: default behaviour.
+ *
+ * Coverage:
+ *   - shouldHonor — full decision matrix (mode off / mode on + non-wrapper /
+ *     wrapper + empty allowlist / wrapper + matching referrer / wrapper +
+ *     non-matching referrer / null referrer)
+ *   - matchesAllowlist — normalization (case, scheme, trailing slash),
+ *     www. strip, prefix semantics, empty inputs
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { shouldHonor, matchesAllowlist } from "../../src/lib/honor-creator.js";
+
+// A real wrapper URL the engine recognizes (Skimlinks). Path is irrelevant —
+// detectWrapper matches on host alone for skimresources.
+const WRAPPER_URL =
+  "https://go.redirectingat.com/?id=1&url=https%3A%2F%2Famazon.com%2Fdp%2FB000";
+const NON_WRAPPER_URL = "https://example.com/article?utm_source=foo";
+
+describe("matchesAllowlist", () => {
+  test("empty allowlist never matches", () => {
+    const m = matchesAllowlist("https://www.youtube.com/@foo/community", []);
+    assert.equal(m, null);
+  });
+
+  test("missing/null/empty referrer never matches", () => {
+    const list = ["youtube.com/@foo"];
+    assert.equal(matchesAllowlist("", list), null);
+    assert.equal(matchesAllowlist(null, list), null);
+    assert.equal(matchesAllowlist(undefined, list), null);
+  });
+
+  test("invalid referrer string never matches", () => {
+    assert.equal(matchesAllowlist("not a url", ["example.com"]), null);
+  });
+
+  test("entry matches when host+path starts with normalized entry", () => {
+    const m = matchesAllowlist(
+      "https://www.youtube.com/@LinusTechTips/community",
+      ["youtube.com/@LinusTechTips"],
+    );
+    assert.equal(m, "youtube.com/@linustechtips");
+  });
+
+  test("strips leading www. from referrer host (common alias)", () => {
+    const m = matchesAllowlist(
+      "https://www.example.com/article",
+      ["example.com"],
+    );
+    assert.equal(m, "example.com");
+  });
+
+  test("normalizes the entry: scheme + uppercase + trailing slash", () => {
+    const m = matchesAllowlist(
+      "http://example.com/@foo/bar",
+      ["https://Example.com/@Foo/"],
+    );
+    assert.equal(m, "example.com/@foo");
+  });
+
+  test("does not match when the referrer is a different path", () => {
+    const m = matchesAllowlist(
+      "https://www.youtube.com/@OtherChannel/community",
+      ["youtube.com/@LinusTechTips"],
+    );
+    assert.equal(m, null);
+  });
+
+  test("returns the first matching entry when several entries are present", () => {
+    const list = ["dot-css-news.com", "youtube.com/@foo"];
+    const m = matchesAllowlist("https://www.dot-css-news.com/post/1", list);
+    assert.equal(m, "dot-css-news.com");
+  });
+
+  test("entry without path matches any path on that host", () => {
+    const list = ["dot-css-news.com"];
+    assert.equal(matchesAllowlist("https://dot-css-news.com/", list), "dot-css-news.com");
+    assert.equal(matchesAllowlist("https://dot-css-news.com/x/y", list), "dot-css-news.com");
+  });
+
+  test("entry must be a true prefix — partial host overlap does not match", () => {
+    // "example.com" must NOT match "evilexample.com" — host comparison must be
+    // anchored at the start AND followed by a path boundary or end-of-string.
+    const m = matchesAllowlist("https://evilexample.com/", ["example.com"]);
+    assert.equal(m, null);
+  });
+});
+
+describe("shouldHonor", () => {
+  const allowlist = ["youtube.com/@linustechtips"];
+  const referrer = "https://www.youtube.com/@LinusTechTips/community";
+
+  test("mode off → never honor (even with matching referrer + wrapper URL)", () => {
+    const r = shouldHonor({
+      url: WRAPPER_URL,
+      referrer,
+      prefs: { honorCreatorMode: false, creatorAllowlist: allowlist },
+    });
+    assert.equal(r.honor, false);
+  });
+
+  test("mode missing → never honor (defensive)", () => {
+    const r = shouldHonor({
+      url: WRAPPER_URL,
+      referrer,
+      prefs: { creatorAllowlist: allowlist },
+    });
+    assert.equal(r.honor, false);
+  });
+
+  test("mode on + non-wrapper URL → not honored", () => {
+    const r = shouldHonor({
+      url: NON_WRAPPER_URL,
+      referrer,
+      prefs: { honorCreatorMode: true, creatorAllowlist: allowlist },
+    });
+    assert.equal(r.honor, false);
+  });
+
+  test("mode on + wrapper URL + empty allowlist → not honored", () => {
+    const r = shouldHonor({
+      url: WRAPPER_URL,
+      referrer,
+      prefs: { honorCreatorMode: true, creatorAllowlist: [] },
+    });
+    assert.equal(r.honor, false);
+  });
+
+  test("mode on + wrapper URL + null/empty referrer → not honored", () => {
+    const r1 = shouldHonor({
+      url: WRAPPER_URL,
+      referrer: "",
+      prefs: { honorCreatorMode: true, creatorAllowlist: allowlist },
+    });
+    assert.equal(r1.honor, false);
+    const r2 = shouldHonor({
+      url: WRAPPER_URL,
+      referrer: null,
+      prefs: { honorCreatorMode: true, creatorAllowlist: allowlist },
+    });
+    assert.equal(r2.honor, false);
+  });
+
+  test("mode on + wrapper URL + non-matching referrer → not honored", () => {
+    const r = shouldHonor({
+      url: WRAPPER_URL,
+      referrer: "https://www.youtube.com/@OtherChannel/",
+      prefs: { honorCreatorMode: true, creatorAllowlist: allowlist },
+    });
+    assert.equal(r.honor, false);
+  });
+
+  test("mode on + wrapper URL + matching referrer → honored, network + creator returned", () => {
+    const r = shouldHonor({
+      url: WRAPPER_URL,
+      referrer,
+      prefs: { honorCreatorMode: true, creatorAllowlist: allowlist },
+    });
+    assert.equal(r.honor, true);
+    assert.equal(r.network, "skimlinks");
+    assert.equal(r.creator, "youtube.com/@linustechtips");
+  });
+
+  test("non-string url → not honored (safe default)", () => {
+    const r = shouldHonor({
+      url: null,
+      referrer,
+      prefs: { honorCreatorMode: true, creatorAllowlist: allowlist },
+    });
+    assert.equal(r.honor, false);
+  });
+});

--- a/tests/unit/popup-honored-creator-badge.test.mjs
+++ b/tests/unit/popup-honored-creator-badge.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * MUGA — Popup wiring for the "honored creator" badge (#452, B14).
+ *
+ * When the cleaner pipeline returns `action: "honored-creator"`, the popup
+ * surfaces a translatable badge:
+ *   "Routed through {network} to honor {creator}"
+ *
+ * These tests assert (1) the i18n key exists with en + es non-empty
+ * placeholders, (2) the popup HTML carries the badge slot inside #preview,
+ * (3) popup.js consumes `result.action === "honored-creator"` and renders
+ * the badge with both placeholders substituted, and (4) the reset helper
+ * clears the badge so stale state never leaks across re-renders.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+
+import { makeChromeMock } from "./helpers/chrome-stub.mjs";
+globalThis.chrome = makeChromeMock({ hasSession: false, promiseShape: true });
+
+const { TRANSLATIONS } = await import("../../src/lib/i18n.js");
+
+// ── i18n key ─────────────────────────────────────────────────────────────────
+
+test("popup_badge_honored_creator: key exists with en + es and uses {network}/{creator}", () => {
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(TRANSLATIONS, "popup_badge_honored_creator"),
+    "TRANSLATIONS must have popup_badge_honored_creator",
+  );
+  const k = TRANSLATIONS.popup_badge_honored_creator;
+  assert.ok(typeof k.en === "string" && k.en.length > 0, "en non-empty");
+  assert.ok(typeof k.es === "string" && k.es.length > 0, "es non-empty");
+  assert.ok(k.en.includes("{network}"), "en must reference {network}");
+  assert.ok(k.en.includes("{creator}"), "en must reference {creator}");
+  assert.ok(k.es.includes("{network}"), "es must reference {network}");
+  assert.ok(k.es.includes("{creator}"), "es must reference {creator}");
+});
+
+// ── HTML surface ─────────────────────────────────────────────────────────────
+
+test("popup.html exposes #preview-honored inside #preview", () => {
+  const html = readFileSync(resolve(root, "src/popup/popup.html"), "utf8");
+
+  assert.match(html, /id="preview-honored"/, "popup.html must contain #preview-honored");
+  const previewOpenIdx = html.indexOf('id="preview"');
+  const honoredIdx = html.indexOf('id="preview-honored"');
+  const previewCloseIdx = html.indexOf("</section>", previewOpenIdx);
+  assert.ok(
+    honoredIdx > previewOpenIdx && honoredIdx < previewCloseIdx,
+    "#preview-honored must live inside the #preview section",
+  );
+});
+
+// ── JS wiring ────────────────────────────────────────────────────────────────
+
+test('popup.js renders the badge when result.action === "honored-creator"', () => {
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+
+  assert.ok(
+    /honored-creator/.test(popupSrc),
+    "popup.js must consume the honored-creator action",
+  );
+  assert.ok(
+    /popup_badge_honored_creator/.test(popupSrc),
+    "popup.js must reference the i18n key",
+  );
+  // Both placeholders must be substituted (otherwise the user sees a literal "{network}").
+  assert.ok(
+    /\{network\}/.test(popupSrc) && /\{creator\}/.test(popupSrc),
+    "popup.js must substitute {network} and {creator} placeholders",
+  );
+});
+
+test("_resetPreviewDom clears the honored-creator badge", () => {
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+
+  const fnIdx = popupSrc.indexOf("function _resetPreviewDom");
+  assert.ok(fnIdx !== -1, "popup.js must define _resetPreviewDom");
+
+  const slice = popupSrc.slice(fnIdx, fnIdx + 3000);
+  assert.ok(
+    slice.includes("preview-honored"),
+    "_resetPreviewDom must reset the honored-creator badge slot",
+  );
+});


### PR DESCRIPTION
## Summary

Closes #452 (B14). Closes the Honor Creator Mode triad: **B12 (toggle) + B13 (allowlist) + B14 (this)**.

## Behavior

When `honorCreatorMode` is **true** AND the navigation referrer matches an entry in `creatorAllowlist` AND the URL is a redirect-network wrapper (`detectWrapper` non-null), MUGA passes the redirect through unmodified. Returns a new action value `"honored-creator"` with `network` (wrapper id) and `creator` (matching allowlist entry).

Otherwise default behavior is **byte-identical** to pre-feature.

## Pure module — `src/lib/honor-creator.js`

```js
shouldHonor({ url, referrer, prefs }) → { honor, network?, creator? }
matchesAllowlist(referrer, allowlist) → entry|null
```

- `matchesAllowlist` normalizes entries the same way `creator-allowlist.normalizeEntry` does (lowercase, trim, strip `http(s)://`)
- Compares against the referrer's `host + path` (lowercased; leading `www.` stripped on the **referrer** side — asymmetric so users entering `www.foo.com` aren't surprised by their entry collapsing)
- **Path-prefix boundary check**: the char immediately after the prefix must be `""`, `/`, `?`, or `#`. Blocks `youtube.com/@foo` from matching `youtube.com/@foobar`, and `example.com` from matching `evilexample.com`.

## Pipeline integration

`processUrl` signature: gained optional 6th param `referrer` (string | null | undefined). Omitted/empty referrer ⇒ byte-identical to pre-feature.

Step 0a in `src/lib/cleaner.js`, BEFORE unwrap. Returns short-circuit result with `action: "honored-creator"`. Wrapper unwrap and tracking strip are both skipped — full pass-through to honor the creator's referral chain.

## Popup badge

- `popup.js` fetches `document.referrer` from the active tab via `chrome.tabs.sendMessage(tabId, { type: "GET_REFERRER" })` — content-script handler added in `src/content/cleaner.js`
- Missing content script ⇒ no referrer ⇒ no honor (**safe default**)
- Badge slot at `<div id="preview-honored">` inside `#preview`, populated via `textContent` (no innerHTML)
- Template: "Routed through {network} to honor {creator}" / "Pasamos por {network} para honrar a {creator}"
- Cleared in `_resetPreviewDom` on tab change

## SW wiring

Referrer plumbed through `PROCESS_URL` message → `handleProcessUrl` → `processUrl`.

## i18n

`popup_badge_honored_creator` (en + es; pt/de FIXME-flagged per project convention).

## Test plan

- [x] `npm test` → **3064/3064** passing (+32 from baseline 3032)
- [x] `npm run lint` → 0 errors
- [x] **shouldHonor** unit tests: mode off / non-wrapper / empty allowlist / matching referrer / non-matching referrer
- [x] **matchesAllowlist** normalization: `https://Example.com/@Foo` matches `http://example.com/@foo/bar`
- [x] **www. strip** asymmetry verified
- [x] **Empty/null referrer** → no match
- [x] **processUrl** integration: honor path returns action="honored-creator", cleanUrl unchanged, network + creator populated
- [x] **No-honor path identical to pre-feature** (regression)
- [x] **Popup badge** structural test
- [x] Path-prefix boundary check (`@foobar` vs `@foo`) explicitly tested

## E2E skipped (rationale)

Three-state matrix (on+match, on+mismatch, off) is exhaustively covered at unit + integration level (32 tests). An E2E would need to fixture both a wrapper redirect AND a controlled navigation `Referer` header — significant fixture surface for a structural badge already proven at the JS layer. Document the gap; revisit if production logs show drift.