### PR TITLE
feat(lib): Attribution Ledger Presenter — pure module (#454)

### DIFF
--- a/src/lib/attribution-ledger.js
+++ b/src/lib/attribution-ledger.js
@@ -1,0 +1,182 @@
+/**
+ * MUGA — Attribution Ledger presenter (#454, A1).
+ *
+ * Pure module — no DOM, no storage, no fetches, no clock. Transforms a
+ * caller-managed array of cleaner pipeline events into popup view-state.
+ *
+ * The cleaner pipeline does NOT emit events today: `processUrl` returns a
+ * result object and exits. So this module is a PRESENTER, not a subscriber.
+ * The "stream" is whatever array the caller (popup, tests, future telemetry)
+ * decides to keep around. We hand back a new ledger on every push so that
+ * popup state can be threaded through plain reducers without surprise
+ * mutation, and we cap the buffer at N (default 10) so the popup never has
+ * to render an unbounded list.
+ *
+ * `fromCleanerResult` is a small adaptor that maps a `processUrl()` return
+ * value into one of our event shapes. It's a convenience for the popup —
+ * push-side callers can also build events by hand (e.g. from webNavigation
+ * for the bare `navigate` event, which the cleaner never emits).
+ *
+ * Badge identifiers are i18n KEYS, not translated text. Translation happens
+ * at the popup boundary so the same ledger can be re-rendered when the
+ * user switches language without rebuilding event history.
+ */
+
+/** Default size of the ledger ring buffer. Caps how many events the popup ever renders. */
+export const DEFAULT_LEDGER_CAPACITY = 10;
+
+/**
+ * Frozen list of event types the presenter recognizes. Anything else is
+ * dropped by `pushEvent` so a buggy caller can't poison the buffer.
+ */
+export const EVENT_TYPES = Object.freeze([
+  "navigate",
+  "clean",
+  "preserve-affiliate",
+  "inject-affiliate",
+  "honor-creator",
+  "blocked-opaque",
+]);
+
+const EVENT_TYPE_SET = new Set(EVENT_TYPES);
+
+/**
+ * i18n key for the "this URL was cleaned" badge. The popup translates this
+ * into a localized string. We do NOT reuse the impact-dashboard's
+ * "params removed" copy because the ledger is per-URL, not aggregate.
+ */
+const BADGE_CLEANED = "ledger_badge_cleaned";
+
+/**
+ * Creates an empty ledger with the given capacity. Capacity is captured on
+ * the ledger so individual instances can disagree (e.g. tests use 3).
+ *
+ * @param {number} [capacity=DEFAULT_LEDGER_CAPACITY]
+ * @returns {{ events: Array<object>, capacity: number }}
+ */
+export function createLedger(capacity = DEFAULT_LEDGER_CAPACITY) {
+  return { events: [], capacity };
+}
+
+/**
+ * Returns a new ledger with `event` appended, evicting the oldest event
+ * when the resulting length would exceed `ledger.capacity`. Invalid events
+ * (non-object, missing/unknown `type`) are dropped — the same ledger
+ * reference is returned so callers can rely on `===` to skip re-renders.
+ *
+ * @param {{ events: Array<object>, capacity: number }} ledger
+ * @param {object} event
+ * @returns {{ events: Array<object>, capacity: number }}
+ */
+export function pushEvent(ledger, event) {
+  if (!event || typeof event !== "object") return ledger;
+  if (!EVENT_TYPE_SET.has(event.type)) return ledger;
+
+  const next = ledger.events.concat(event);
+  // Drop oldest entries when we overflow capacity. This keeps the popup
+  // render bounded and the eviction order deterministic (FIFO).
+  while (next.length > ledger.capacity) next.shift();
+
+  return { events: next, capacity: ledger.capacity };
+}
+
+/**
+ * Maps a single ledger event to its view-friendly entry shape. Decision
+ * is the event type (intentional — popup keys behaviour off it). Optional
+ * fields are only set when semantically present.
+ *
+ * @param {object} ev
+ * @returns {{url:string, decision:string, creatorCredit?:string, network?:string, badge?:string}}
+ */
+function entryFor(ev) {
+  const entry = { url: ev.url, decision: ev.type };
+  switch (ev.type) {
+    case "clean":
+      entry.badge = BADGE_CLEANED;
+      break;
+    case "preserve-affiliate":
+    case "inject-affiliate":
+      if (ev.network) entry.network = ev.network;
+      break;
+    case "honor-creator":
+      if (ev.network) entry.network = ev.network;
+      if (ev.creator) entry.creatorCredit = ev.creator;
+      break;
+    // navigate / blocked-opaque carry no extras.
+    default:
+      break;
+  }
+  return entry;
+}
+
+/**
+ * Projects a ledger into popup view-state. Pure: same input → same output,
+ * no aliasing of the ledger's internal events array (callers can mutate
+ * the returned `entries` without affecting future pushes).
+ *
+ * @param {{ events: Array<object>, capacity: number }} ledger
+ * @returns {{ entries: Array<object> }}
+ */
+export function presentLedger(ledger) {
+  return { entries: ledger.events.map(entryFor) };
+}
+
+/**
+ * Adapts a `processUrl()` result object into a presenter event. Returns
+ * null when the action is unrecognized so callers can skip without
+ * polluting the ledger with garbage entries.
+ *
+ * Action mapping:
+ *   `untouched`        → navigate         (URL passed through unchanged)
+ *   `cleaned`          → clean            (tracking params stripped)
+ *   `blacklisted`      → clean            (params stripped via blacklist)
+ *   `injected`         → inject-affiliate (our tag added; network from preservedAffiliate.group)
+ *   `detected_foreign` → preserve-affiliate (third-party tag preserved; network from detectedAffiliate.pattern.group)
+ *   `honored-creator`  → honor-creator    (wrapper passed through; network + creator)
+ *
+ * `blocked-opaque` has no cleaner action today — it's a future event the
+ * popup may emit when an opaque wrapper (t.co etc.) couldn't be resolved.
+ * Callers build that event by hand for now.
+ *
+ * @param {string} rawUrl
+ * @param {object|null|undefined} result - return value from processUrl
+ * @returns {object|null}
+ */
+export function fromCleanerResult(rawUrl, result) {
+  if (!result || typeof result !== "object") return null;
+
+  switch (result.action) {
+    case "untouched":
+      return { type: "navigate", url: rawUrl };
+    case "cleaned":
+    case "blacklisted":
+      return { type: "clean", url: rawUrl };
+    case "injected": {
+      // Network sourced from the preservedAffiliate descriptor when the
+      // cleaner attached one (group is the program family, e.g. "amazon").
+      const network = result.preservedAffiliate?.group || result.preservedAffiliate?.store;
+      const ev = { type: "inject-affiliate", url: rawUrl };
+      if (network) ev.network = network;
+      return ev;
+    }
+    case "detected_foreign": {
+      // detectedAffiliate carries the matched pattern; group identifies
+      // the program family the foreign tag belongs to.
+      const network =
+        result.detectedAffiliate?.pattern?.group ||
+        result.detectedAffiliate?.pattern?.name;
+      const ev = { type: "preserve-affiliate", url: rawUrl };
+      if (network) ev.network = network;
+      return ev;
+    }
+    case "honored-creator":
+      return {
+        type: "honor-creator",
+        url: rawUrl,
+        network: result.network,
+        creator: result.creator,
+      };
+    default:
+      return null;
+  }
+}

--- a/tests/unit/attribution-ledger.test.mjs
+++ b/tests/unit/attribution-ledger.test.mjs
@@ -1,0 +1,299 @@
+/**
+ * MUGA — Unit tests for attribution-ledger presenter (#454, A1).
+ *
+ * The presenter is a pure module: caller passes pipeline events in via an
+ * immutable ledger, popup view-state comes back. No DOM, no storage, no
+ * subscriptions. The "stream of pipeline events" is just an array — the
+ * caller (popup, etc.) decides how/when to push.
+ *
+ * Coverage:
+ *   - createLedger: defaults + custom capacity
+ *   - pushEvent: append, ring-buffer eviction, immutability, validation
+ *   - presentLedger: per-event-type mapping, optional fields, empty case
+ *   - fromCleanerResult: maps each processUrl action → event shape
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_LEDGER_CAPACITY,
+  EVENT_TYPES,
+  createLedger,
+  pushEvent,
+  presentLedger,
+  fromCleanerResult,
+} from "../../src/lib/attribution-ledger.js";
+
+const URL_A = "https://example.com/article";
+const URL_B = "https://shop.example/product?utm_source=x";
+
+describe("createLedger", () => {
+  test("default capacity is 10", () => {
+    assert.equal(DEFAULT_LEDGER_CAPACITY, 10);
+    const ledger = createLedger();
+    assert.equal(ledger.capacity, 10);
+    assert.deepEqual(ledger.events, []);
+  });
+
+  test("custom capacity is respected", () => {
+    const ledger = createLedger(3);
+    assert.equal(ledger.capacity, 3);
+    assert.deepEqual(ledger.events, []);
+  });
+
+  test("EVENT_TYPES is the full set the popup may receive", () => {
+    assert.deepEqual(
+      [...EVENT_TYPES].sort(),
+      [
+        "blocked-opaque",
+        "clean",
+        "honor-creator",
+        "inject-affiliate",
+        "navigate",
+        "preserve-affiliate",
+      ],
+    );
+  });
+});
+
+describe("pushEvent", () => {
+  test("appends a valid event and returns a new ledger (immutability)", () => {
+    const a = createLedger();
+    const b = pushEvent(a, { type: "navigate", url: URL_A });
+    assert.notEqual(a, b);
+    assert.deepEqual(a.events, []);
+    assert.equal(b.events.length, 1);
+    assert.equal(b.events[0].type, "navigate");
+    assert.equal(b.events[0].url, URL_A);
+  });
+
+  test("ignores events with unknown type (returns ledger unchanged)", () => {
+    const a = createLedger();
+    const b = pushEvent(a, { type: "garbage", url: URL_A });
+    assert.equal(a, b);
+    assert.deepEqual(b.events, []);
+  });
+
+  test("ignores non-object / null events", () => {
+    const a = createLedger();
+    assert.equal(pushEvent(a, null), a);
+    assert.equal(pushEvent(a, undefined), a);
+    assert.equal(pushEvent(a, "navigate"), a);
+    assert.equal(pushEvent(a, 42), a);
+  });
+
+  test("ignores events without a type field", () => {
+    const a = createLedger();
+    const b = pushEvent(a, { url: URL_A });
+    assert.equal(a, b);
+  });
+
+  test("evicts oldest when over capacity (ring buffer)", () => {
+    let ledger = createLedger(3);
+    for (let i = 0; i < 5; i++) {
+      ledger = pushEvent(ledger, { type: "navigate", url: `${URL_A}?n=${i}` });
+    }
+    assert.equal(ledger.events.length, 3);
+    // Most recent three retained, in chronological order (oldest → newest).
+    assert.deepEqual(
+      ledger.events.map(e => e.url),
+      [`${URL_A}?n=2`, `${URL_A}?n=3`, `${URL_A}?n=4`],
+    );
+  });
+
+  test("11th event evicts the first (default capacity = 10)", () => {
+    let ledger = createLedger();
+    for (let i = 0; i < 11; i++) {
+      ledger = pushEvent(ledger, { type: "navigate", url: `${URL_A}?n=${i}` });
+    }
+    assert.equal(ledger.events.length, 10);
+    assert.equal(ledger.events[0].url, `${URL_A}?n=1`);
+    assert.equal(ledger.events[9].url, `${URL_A}?n=10`);
+  });
+
+  test("preserves auxiliary fields (network, creator) on the event", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, {
+      type: "honor-creator",
+      url: URL_A,
+      network: "skimlinks",
+      creator: "youtube.com/@foo",
+    });
+    assert.equal(ledger.events[0].network, "skimlinks");
+    assert.equal(ledger.events[0].creator, "youtube.com/@foo");
+  });
+});
+
+describe("presentLedger", () => {
+  test("empty ledger maps to empty entries", () => {
+    const view = presentLedger(createLedger());
+    assert.deepEqual(view, { entries: [] });
+  });
+
+  test("navigate event → { url, decision: 'navigate' }", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, { type: "navigate", url: URL_A });
+    const view = presentLedger(ledger);
+    assert.equal(view.entries.length, 1);
+    assert.deepEqual(view.entries[0], { url: URL_A, decision: "navigate" });
+  });
+
+  test("clean event → carries a badge i18n key", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, { type: "clean", url: URL_B });
+    const [entry] = presentLedger(ledger).entries;
+    assert.equal(entry.url, URL_B);
+    assert.equal(entry.decision, "clean");
+    // Badge is an i18n KEY, not translated text — popup translates.
+    assert.equal(typeof entry.badge, "string");
+    assert.ok(entry.badge.length > 0);
+    assert.ok(!entry.badge.includes(" "), "badge must be an i18n key, not a sentence");
+  });
+
+  test("preserve-affiliate event → carries network", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, {
+      type: "preserve-affiliate",
+      url: URL_A,
+      network: "amazon",
+    });
+    const [entry] = presentLedger(ledger).entries;
+    assert.equal(entry.decision, "preserve-affiliate");
+    assert.equal(entry.network, "amazon");
+    assert.equal(entry.creatorCredit, undefined);
+  });
+
+  test("inject-affiliate event → carries network", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, {
+      type: "inject-affiliate",
+      url: URL_A,
+      network: "amazon",
+    });
+    const [entry] = presentLedger(ledger).entries;
+    assert.equal(entry.decision, "inject-affiliate");
+    assert.equal(entry.network, "amazon");
+  });
+
+  test("honor-creator event → carries network + creatorCredit", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, {
+      type: "honor-creator",
+      url: URL_A,
+      network: "skimlinks",
+      creator: "youtube.com/@foo",
+    });
+    const [entry] = presentLedger(ledger).entries;
+    assert.equal(entry.decision, "honor-creator");
+    assert.equal(entry.network, "skimlinks");
+    assert.equal(entry.creatorCredit, "youtube.com/@foo");
+  });
+
+  test("blocked-opaque event → just url + decision, no extras", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, { type: "blocked-opaque", url: URL_A });
+    const [entry] = presentLedger(ledger).entries;
+    assert.equal(entry.decision, "blocked-opaque");
+    assert.equal(entry.url, URL_A);
+    assert.equal(entry.network, undefined);
+    assert.equal(entry.creatorCredit, undefined);
+    assert.equal(entry.badge, undefined);
+  });
+
+  test("entries appear in chronological order (oldest first)", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, { type: "navigate", url: "https://a.test/" });
+    ledger = pushEvent(ledger, { type: "clean", url: "https://b.test/" });
+    ledger = pushEvent(ledger, { type: "navigate", url: "https://c.test/" });
+    const urls = presentLedger(ledger).entries.map(e => e.url);
+    assert.deepEqual(urls, [
+      "https://a.test/",
+      "https://b.test/",
+      "https://c.test/",
+    ]);
+  });
+
+  test("returned view state does not alias internal arrays (defensive copy)", () => {
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, { type: "navigate", url: URL_A });
+    const view = presentLedger(ledger);
+    view.entries.push({ url: "mutation", decision: "navigate" });
+    // Pushing again from the original ledger should NOT see the mutation —
+    // ledger.events must remain length 1.
+    assert.equal(ledger.events.length, 1);
+  });
+});
+
+describe("fromCleanerResult", () => {
+  test("action='honored-creator' → honor-creator event with network + creator", () => {
+    const ev = fromCleanerResult("https://wrap.example/", {
+      action: "honored-creator",
+      network: "skimlinks",
+      creator: "youtube.com/@foo",
+    });
+    assert.deepEqual(ev, {
+      type: "honor-creator",
+      url: "https://wrap.example/",
+      network: "skimlinks",
+      creator: "youtube.com/@foo",
+    });
+  });
+
+  test("action='cleaned' → clean event", () => {
+    const ev = fromCleanerResult(URL_B, { action: "cleaned" });
+    assert.equal(ev.type, "clean");
+    assert.equal(ev.url, URL_B);
+  });
+
+  test("action='injected' → inject-affiliate event with network when present", () => {
+    const ev = fromCleanerResult(URL_A, {
+      action: "injected",
+      preservedAffiliate: { group: "amazon" },
+    });
+    assert.equal(ev.type, "inject-affiliate");
+    assert.equal(ev.url, URL_A);
+    assert.equal(ev.network, "amazon");
+  });
+
+  test("action='detected_foreign' → preserve-affiliate event", () => {
+    const ev = fromCleanerResult(URL_A, {
+      action: "detected_foreign",
+      detectedAffiliate: { pattern: { group: "aliexpress" } },
+    });
+    assert.equal(ev.type, "preserve-affiliate");
+    assert.equal(ev.url, URL_A);
+    assert.equal(ev.network, "aliexpress");
+  });
+
+  test("action='untouched' → navigate event", () => {
+    const ev = fromCleanerResult(URL_A, { action: "untouched" });
+    assert.equal(ev.type, "navigate");
+    assert.equal(ev.url, URL_A);
+  });
+
+  test("action='blacklisted' → clean event (params stripped)", () => {
+    const ev = fromCleanerResult(URL_A, { action: "blacklisted" });
+    assert.equal(ev.type, "clean");
+  });
+
+  test("returns null for unrecognized actions (defensive)", () => {
+    assert.equal(fromCleanerResult(URL_A, { action: "what" }), null);
+    assert.equal(fromCleanerResult(URL_A, null), null);
+    assert.equal(fromCleanerResult(URL_A, {}), null);
+  });
+
+  test("end-to-end: cleaner result → pushEvent → presentLedger entry", () => {
+    const result = {
+      action: "honored-creator",
+      network: "skimlinks",
+      creator: "youtube.com/@foo",
+    };
+    const ev = fromCleanerResult("https://wrap.example/", result);
+    let ledger = createLedger();
+    ledger = pushEvent(ledger, ev);
+    const [entry] = presentLedger(ledger).entries;
+    assert.equal(entry.decision, "honor-creator");
+    assert.equal(entry.network, "skimlinks");
+    assert.equal(entry.creatorCredit, "youtube.com/@foo");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #454 (A1). Pure presenter module that maps a stream of cleaner-pipeline events into popup view state with a ring-buffer history. **No DOM, no storage, no fetches, no clock.**

This is the **pure module** slice only — A2 (#460) will integrate it into the popup and ship the i18n translations for the badge keys.

## Public API (`src/lib/attribution-ledger.js`)

```js
DEFAULT_LEDGER_CAPACITY = 10
EVENT_TYPES = ["navigate", "clean", "preserve-affiliate", "inject-affiliate", "honor-creator", "blocked-opaque"] // frozen

createLedger(capacity?) → ledger
pushEvent(ledger, event)   → NEW ledger (FIFO ring-buffer; invalid events return SAME ref so reducers can `===`-skip)
presentLedger(ledger)      → { entries: [{ url, decision, creatorCredit?, network?, badge? }] }
fromCleanerResult(rawUrl, processUrlResult) → event (or null)
```

## Adaptor mapping

| `result.action` | event type | extras |
|---|---|---|
| `untouched` | `navigate` | — |
| `cleaned` / `blacklisted` | `clean` | — |
| `injected` | `inject-affiliate` | `network` from `preservedAffiliate.group` |
| `detected_foreign` | `preserve-affiliate` | `network` from `detectedAffiliate.pattern.group` |
| `honored-creator` (B14) | `honor-creator` | `network` + `creator` |

## Design notes

- **Badge field uses i18n KEY** (e.g. `"ledger_badge_cleaned"`), NOT translated text. Translation lives at the popup boundary so language switches don't rebuild history.
- **`presentLedger` defensive copy**: builds fresh entry objects via `.map()` so callers mutating `entries` can't poison the ledger.
- **`blocked-opaque` has no cleaner action today** — listed in `EVENT_TYPES` for popup-side hand-built events (future opaque-wrapper failures). `fromCleanerResult` never produces it.
- **Invalid events return SAME ledger ref** — tested explicitly so popup state reducers can short-circuit cleanly.

## Test plan

- [x] `npm test` → **3091/3091** passing (+27 from baseline 3064)
- [x] `npm run lint` → 0 errors
- [x] All 6 event types have at least one fixture
- [x] Ring buffer: 11th event evicts oldest, 12th evicts second-oldest
- [x] Custom capacity respected
- [x] Invalid event type → same ledger ref
- [x] Empty ledger → empty entries
- [x] `fromCleanerResult` for each `result.action` → expected event
- [x] honor-creator carries `network` + `creator` end-to-end
- [x] `presentLedger` is a pure projection (mutating output doesn't affect ledger)

## Note for A2

A2 (#460) will need to add real translations to `i18n.js` for the badge keys (`ledger_badge_cleaned`, etc.). A1 deliberately does NOT touch `i18n.js` — keeps the pure-module slice clean and lets A2 own the surface text.