### PR TITLE
feat(benchmark): add matchRate percentages to report

### DIFF
--- a/tests/benchmark/lib/runner-core.mjs
+++ b/tests/benchmark/lib/runner-core.mjs
@@ -45,10 +45,23 @@ export function compareEntry(entry, result) {
 }
 
 /**
+ * Round a fraction to one decimal percentage point. Returns 0 when the
+ * denominator is 0 (an empty category should not be NaN in the report).
+ */
+function pct(numerator, denominator) {
+  if (denominator === 0) return 0;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+/**
  * Build the report object summarising a benchmark run.
  *
+ * The per-category bucket gains a `matchRate` field (0..100, one decimal)
+ * so report readers can scan for the worst-covered categories without
+ * recomputing percentages.
+ *
  * @param {{ corpus: Array<{url:string, category:string, expectedAction:string}>, results: Array<{ok:boolean, expected:object, actual:object, diff?:string}>, generatedAt?: string, runner?: string }} params
- * @returns {{ generatedAt:string, runner:string, totalEntries:number, matched:number, mismatched:number, byCategory: Record<string,{total:number,matched:number,mismatched:number}>, mismatches: Array<object> }}
+ * @returns {{ generatedAt:string, runner:string, totalEntries:number, matched:number, mismatched:number, matchRate:number, byCategory: Record<string,{total:number,matched:number,mismatched:number,matchRate:number}>, mismatches: Array<object> }}
  */
 export function buildReport({ corpus, results, generatedAt, runner = "muga" }) {
   if (corpus.length !== results.length) {
@@ -61,7 +74,7 @@ export function buildReport({ corpus, results, generatedAt, runner = "muga" }) {
     const entry = corpus[i];
     const result = results[i];
     const cat = entry.category;
-    if (!byCategory[cat]) byCategory[cat] = { total: 0, matched: 0, mismatched: 0 };
+    if (!byCategory[cat]) byCategory[cat] = { total: 0, matched: 0, mismatched: 0, matchRate: 0 };
     byCategory[cat].total += 1;
     if (result.ok) {
       matched += 1;
@@ -77,12 +90,16 @@ export function buildReport({ corpus, results, generatedAt, runner = "muga" }) {
       });
     }
   }
+  for (const cat of Object.keys(byCategory)) {
+    byCategory[cat].matchRate = pct(byCategory[cat].matched, byCategory[cat].total);
+  }
   return {
     generatedAt: generatedAt || new Date().toISOString(),
     runner,
     totalEntries: corpus.length,
     matched,
     mismatched: corpus.length - matched,
+    matchRate: pct(matched, corpus.length),
     byCategory,
     mismatches,
   };

--- a/tests/unit/benchmark-runner.test.mjs
+++ b/tests/unit/benchmark-runner.test.mjs
@@ -97,6 +97,54 @@ test("buildReport — corpus/results length mismatch throws", () => {
   assert.throws(() => buildReport({ corpus: [{ url: "a", category: "utm", expectedAction: "cleaned" }], results: [] }));
 });
 
+test("buildReport — matchRate is a percentage (0..100, one decimal)", () => {
+  const corpus = [
+    { url: "u1", category: "utm", expectedAction: "cleaned" },
+    { url: "u2", category: "utm", expectedAction: "cleaned" },
+    { url: "u3", category: "utm", expectedAction: "cleaned" },
+    { url: "u4", category: "utm", expectedAction: "cleaned" },
+  ];
+  const results = [
+    { ok: true, expected: {}, actual: {} },
+    { ok: true, expected: {}, actual: {} },
+    { ok: true, expected: {}, actual: {} },
+    { ok: false, expected: {}, actual: {}, diff: "x" },
+  ];
+  const report = buildReport({ corpus, results });
+  assert.equal(report.matchRate, 75);
+  assert.equal(report.byCategory.utm.matchRate, 75);
+});
+
+test("buildReport — matchRate rounds to one decimal place", () => {
+  const corpus = Array.from({ length: 7 }, (_, i) => ({
+    url: `u${i}`,
+    category: "utm",
+    expectedAction: "cleaned",
+  }));
+  const results = corpus.map((_, i) => ({ ok: i < 5, expected: {}, actual: {}, diff: i < 5 ? undefined : "x" }));
+  const report = buildReport({ corpus, results });
+  // 5/7 = 0.71428... → 71.4% (one decimal)
+  assert.equal(report.matchRate, 71.4);
+  assert.equal(report.byCategory.utm.matchRate, 71.4);
+});
+
+test("buildReport — empty corpus gives matchRate 0 (no NaN)", () => {
+  const report = buildReport({ corpus: [], results: [], generatedAt: "2026-05-02T00:00:00Z" });
+  assert.equal(report.matchRate, 0);
+});
+
+test("buildReport — perfect run gives matchRate 100", () => {
+  const corpus = [
+    { url: "u1", category: "utm", expectedAction: "cleaned" },
+    { url: "u2", category: "clean-urls", expectedAction: "untouched" },
+  ];
+  const results = corpus.map(() => ({ ok: true, expected: {}, actual: {} }));
+  const report = buildReport({ corpus, results });
+  assert.equal(report.matchRate, 100);
+  assert.equal(report.byCategory.utm.matchRate, 100);
+  assert.equal(report.byCategory["clean-urls"].matchRate, 100);
+});
+
 test("exitCodeFromReport — 0 when all matched", () => {
   assert.equal(exitCodeFromReport({ mismatched: 0 }), 0);
 });


### PR DESCRIPTION
## Summary

Each category bucket and the top-level report now carry a `matchRate` field (0..100, one decimal). Lets readers scan a report for the worst-covered categories without recomputing percentages from `matched/mismatched` counts.

## Behavior

- `report.matchRate` — overall (matched / totalEntries × 100, one decimal)
- `report.byCategory[name].matchRate` — per-category
- Empty categories or empty corpus → `0` (not `NaN`)
- Rounding: 1 decimal place. 5/7 → 71.4, not 71.43
- Existing fields (matched, mismatched, byCategory.total/matched/mismatched) unchanged — additive

## Test plan

- [x] `npm test` → **3238/3238** passing (+4 from baseline 3234)
- [x] `npm run benchmark` → 110/110, report contains the new fields
- [x] `npm run lint` → 0 errors

Tests cover: percentage correctness (3/4 → 75), one-decimal rounding (5/7 → 71.4), empty-corpus no-NaN guard, perfect-run = 100.