### PR TITLE
feat(benchmark): A6 phase 2 scaffold — competitor adapter contract (#506)

### DIFF
--- a/tests/benchmark/competitors/README-CONTRACT.txt
+++ b/tests/benchmark/competitors/README-CONTRACT.txt
@@ -1,0 +1,48 @@
+Competitor adapter contract — A6 phase 2 (#506)
+=================================================
+
+This directory hosts adapters that mimic external URL-cleaning tools so
+the benchmark can compare MUGA against ClearURLs, AdGuard URL Tracking
+Protection, Brave Shields, and Firefox built-in cleaner.
+
+Each adapter MUST conform to:
+
+  {
+    name:    string,    // short stable id (used in report keys)
+    label:   string,    // human-readable name
+    source:  string,    // URL of the rule set's official source (for
+                        // audit; adapters MUST NOT fetch at runtime)
+    version: string?,   // version of the rule snapshot
+    clean(rawUrl: string): string  // returns cleaned URL or rawUrl
+                                   // unchanged when the adapter has
+                                   // no opinion. Errors must NOT throw
+                                   // — return rawUrl on parse failure.
+  }
+
+The adapter runs PURELY ON THE CORPUS URL. It does not see MUGA's prefs,
+domain rules, or wrapper engine. That isolation is what makes the
+comparison meaningful: each adapter shows what its own rule set would
+have done on the URL the user landed on.
+
+Real adapters (ClearURLs / AdGuard / Brave / Firefox) ship as separate
+slices (phase 2a / 2b / 2c / 2d). Each will:
+  1. Vendor a rule snapshot under tests/benchmark/competitors/data/
+     so the benchmark stays reproducible offline.
+  2. Implement a thin adapter that consumes the snapshot.
+  3. Document the snapshot's source URL + capture date in this file.
+
+This phase (2 scaffold) ships only:
+  - The contract above (this file)
+  - Runner support for an array of adapters
+  - Report extension with a `competitorResults` field per entry plus
+    a `byCompetitor` summary in the top-level report
+  - A trivial "identity" adapter used by the test suite to prove the
+    integration shape end-to-end. The identity adapter is NOT a real
+    competitor — it returns rawUrl unchanged. The benchmark runner
+    does NOT load it; it lives only in the test suite.
+
+When phase 2a/2b/etc. ship, append their adapters' source snapshot
+metadata to a "Snapshots" section appended below this contract.
+
+----- Snapshots ------------------------------------------------------
+(none yet — phase 2a will add the first)

--- a/tests/benchmark/competitors/identity.mjs
+++ b/tests/benchmark/competitors/identity.mjs
@@ -1,0 +1,22 @@
+/**
+ * MUGA: Identity competitor adapter — TEST FIXTURE ONLY.
+ *
+ * Returns the input URL unchanged. Used by the benchmark unit tests to
+ * exercise the adapter integration shape end-to-end without pretending
+ * to represent any real cleaning tool. The benchmark runner does NOT
+ * load this adapter; it lives only here for tests.
+ *
+ * If you want to add a REAL competitor, ship a separate adapter under
+ * this directory and wire it into runner.mjs's competitor list. See
+ * README-CONTRACT.txt.
+ */
+
+export const identityAdapter = {
+  name: "identity",
+  label: "Identity (no-op test fixture)",
+  source: "n/a — internal test fixture",
+  version: "0",
+  clean(rawUrl) {
+    return rawUrl;
+  },
+};

--- a/tests/benchmark/lib/runner-core.mjs
+++ b/tests/benchmark/lib/runner-core.mjs
@@ -54,16 +54,51 @@ function pct(numerator, denominator) {
 }
 
 /**
+ * Run every competitor adapter against an entry, returning a record of
+ * { [adapter.name]: { cleanUrl } } per the contract in
+ * tests/benchmark/competitors/README-CONTRACT.txt.
+ *
+ * Adapter `clean()` errors are caught and the input URL is returned
+ * unchanged for that adapter — no single competitor's bug should crash
+ * the whole run.
+ *
+ * @param {{url:string}} entry
+ * @param {Array<{name:string, clean:(url:string)=>string}>} adapters
+ * @returns {Record<string, {cleanUrl:string}>}
+ */
+export function runCompetitors(entry, adapters) {
+  const out = {};
+  if (!Array.isArray(adapters)) return out;
+  for (const adapter of adapters) {
+    if (!adapter || typeof adapter.name !== "string" || typeof adapter.clean !== "function") continue;
+    let cleanUrl = entry.url;
+    try {
+      const result = adapter.clean(entry.url);
+      if (typeof result === "string") cleanUrl = result;
+    } catch {
+      // Swallow per contract — adapter bugs must not crash the run.
+    }
+    out[adapter.name] = { cleanUrl };
+  }
+  return out;
+}
+
+/**
  * Build the report object summarising a benchmark run.
  *
  * The per-category bucket gains a `matchRate` field (0..100, one decimal)
  * so report readers can scan for the worst-covered categories without
  * recomputing percentages.
  *
- * @param {{ corpus: Array<{url:string, category:string, expectedAction:string}>, results: Array<{ok:boolean, expected:object, actual:object, diff?:string}>, generatedAt?: string, runner?: string }} params
- * @returns {{ generatedAt:string, runner:string, totalEntries:number, matched:number, mismatched:number, matchRate:number, byCategory: Record<string,{total:number,matched:number,mismatched:number,matchRate:number}>, mismatches: Array<object> }}
+ * Optional `competitorResults` (parallel to `results`) carries per-entry
+ * competitor adapter outputs — when present, the report gains a
+ * `byCompetitor` summary keyed by adapter name. This is phase 2 of A6
+ * (#506) — phase 1 (#505) shipped MUGA-only.
+ *
+ * @param {{ corpus: Array<{url:string, category:string, expectedAction:string}>, results: Array<{ok:boolean, expected:object, actual:object, diff?:string}>, competitorResults?: Array<Record<string, {cleanUrl:string}>>, generatedAt?: string, runner?: string }} params
+ * @returns {{ generatedAt:string, runner:string, totalEntries:number, matched:number, mismatched:number, matchRate:number, byCategory: Record<string,{total:number,matched:number,mismatched:number,matchRate:number}>, byCompetitor?: Record<string,{total:number,changedFromInput:number,matchedExpectedClean:number,matchRate:number}>, mismatches: Array<object> }}
  */
-export function buildReport({ corpus, results, generatedAt, runner = "muga" }) {
+export function buildReport({ corpus, results, competitorResults, generatedAt, runner = "muga" }) {
   if (corpus.length !== results.length) {
     throw new Error(`buildReport: corpus length ${corpus.length} != results length ${results.length}`);
   }
@@ -93,7 +128,42 @@ export function buildReport({ corpus, results, generatedAt, runner = "muga" }) {
   for (const cat of Object.keys(byCategory)) {
     byCategory[cat].matchRate = pct(byCategory[cat].matched, byCategory[cat].total);
   }
-  return {
+
+  // Optional competitor summary. We only assert on `expectedClean` when
+  // the corpus entry declared one — same precedence rule as compareEntry.
+  let byCompetitor;
+  if (Array.isArray(competitorResults) && competitorResults.length === corpus.length) {
+    byCompetitor = {};
+    for (let i = 0; i < corpus.length; i++) {
+      const entry = corpus[i];
+      const adapterMap = competitorResults[i] || {};
+      for (const [name, { cleanUrl }] of Object.entries(adapterMap)) {
+        if (!byCompetitor[name]) {
+          byCompetitor[name] = { total: 0, changedFromInput: 0, matchedExpectedClean: 0, matchRate: 0 };
+        }
+        const bucket = byCompetitor[name];
+        bucket.total += 1;
+        if (cleanUrl !== entry.url) bucket.changedFromInput += 1;
+        if (entry.expectedClean !== undefined && cleanUrl === entry.expectedClean) {
+          bucket.matchedExpectedClean += 1;
+        }
+      }
+    }
+    // matchRate here is "fraction of corpus entries that have an
+    // `expectedClean` AND the competitor produced exactly it". It's a
+    // strict measure — competitors that produce a different-but-also-
+    // clean URL won't score. Fine for ranking comparison, less fine
+    // for raw "did they remove tracking?" coverage. Phase 3 reports
+    // can layer richer metrics on top.
+    for (const name of Object.keys(byCompetitor)) {
+      byCompetitor[name].matchRate = pct(
+        byCompetitor[name].matchedExpectedClean,
+        byCompetitor[name].total,
+      );
+    }
+  }
+
+  const out = {
     generatedAt: generatedAt || new Date().toISOString(),
     runner,
     totalEntries: corpus.length,
@@ -103,6 +173,8 @@ export function buildReport({ corpus, results, generatedAt, runner = "muga" }) {
     byCategory,
     mismatches,
   };
+  if (byCompetitor) out.byCompetitor = byCompetitor;
+  return out;
 }
 
 /**

--- a/tests/benchmark/runner.mjs
+++ b/tests/benchmark/runner.mjs
@@ -19,7 +19,15 @@ import { writeFileSync, mkdirSync } from "node:fs";
 
 import { processUrl } from "../../src/lib/cleaner.js";
 import { loadCorpus } from "./lib/corpus-loader.mjs";
-import { compareEntry, buildReport, exitCodeFromReport } from "./lib/runner-core.mjs";
+import { compareEntry, buildReport, exitCodeFromReport, runCompetitors } from "./lib/runner-core.mjs";
+
+// Phase 2 of A6 (#506) ships the competitor adapter contract but no
+// real adapter yet. ClearURLs / AdGuard / Brave / Firefox each get
+// their own slice (phase 2a / 2b / 2c / 2d). Each will append to this
+// list. See tests/benchmark/competitors/README-CONTRACT.txt for the
+// adapter contract. Today this stays empty — runCompetitors handles
+// the no-adapters case gracefully.
+const COMPETITOR_ADAPTERS = [];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CORPUS_DIR = join(__dirname, "corpus");
@@ -47,7 +55,8 @@ function main() {
     const result = processUrl(entry.url, PREFS, []);
     return compareEntry(entry, result);
   });
-  const report = buildReport({ corpus: entries, results, runner: "muga" });
+  const competitorResults = entries.map((entry) => runCompetitors(entry, COMPETITOR_ADAPTERS));
+  const report = buildReport({ corpus: entries, results, competitorResults, runner: "muga" });
   mkdirSync(REPORTS_DIR, { recursive: true });
   const stamp = report.generatedAt.replace(/[:.]/g, "-");
   const out = join(REPORTS_DIR, `${stamp}-muga.json`);

--- a/tests/unit/benchmark-runner.test.mjs
+++ b/tests/unit/benchmark-runner.test.mjs
@@ -8,7 +8,9 @@ import {
   buildReport,
   exitCodeFromReport,
   validateCorpusFile,
+  runCompetitors,
 } from "../benchmark/lib/runner-core.mjs";
+import { identityAdapter } from "../benchmark/competitors/identity.mjs";
 
 test("compareEntry — action-only match returns ok", () => {
   const r = compareEntry(
@@ -187,4 +189,100 @@ test("validateCorpusFile — rejects non-string expectedClean", () => {
   });
   assert.equal(v.ok, false);
   assert.ok(v.errors.some((e) => e.includes("expectedClean")));
+});
+
+// ── A6 phase 2 (#506) — competitor adapter contract ──────────────────
+
+test("runCompetitors — empty adapters list returns empty record", () => {
+  const out = runCompetitors({ url: "https://example.com/" }, []);
+  assert.deepEqual(out, {});
+});
+
+test("runCompetitors — null/undefined adapters list returns empty record", () => {
+  assert.deepEqual(runCompetitors({ url: "https://example.com/" }, null), {});
+  assert.deepEqual(runCompetitors({ url: "https://example.com/" }, undefined), {});
+});
+
+test("runCompetitors — identity adapter returns rawUrl unchanged", () => {
+  const out = runCompetitors({ url: "https://example.com/?utm_source=x" }, [identityAdapter]);
+  assert.deepEqual(out, { identity: { cleanUrl: "https://example.com/?utm_source=x" } });
+});
+
+test("runCompetitors — adapter throw is caught; cleanUrl falls back to input", () => {
+  const buggyAdapter = {
+    name: "buggy",
+    label: "Buggy fixture",
+    source: "n/a",
+    clean() { throw new Error("oops"); },
+  };
+  const out = runCompetitors({ url: "https://example.com/" }, [buggyAdapter]);
+  assert.deepEqual(out, { buggy: { cleanUrl: "https://example.com/" } });
+});
+
+test("runCompetitors — non-string adapter return falls back to input", () => {
+  const badReturnAdapter = {
+    name: "bad-return",
+    label: "Returns null",
+    source: "n/a",
+    clean() { return null; },
+  };
+  const out = runCompetitors({ url: "https://example.com/" }, [badReturnAdapter]);
+  assert.deepEqual(out, { "bad-return": { cleanUrl: "https://example.com/" } });
+});
+
+test("runCompetitors — skips malformed adapter entries (no name, no clean)", () => {
+  const out = runCompetitors({ url: "https://example.com/" }, [
+    null,
+    {},
+    { name: "no-clean" },
+    { clean: () => "x" }, // no name
+    identityAdapter,
+  ]);
+  assert.deepEqual(out, { identity: { cleanUrl: "https://example.com/" } });
+});
+
+test("buildReport — competitorResults absent → no byCompetitor in report", () => {
+  const corpus = [{ url: "u", category: "utm", expectedAction: "cleaned" }];
+  const results = [{ ok: true, expected: {}, actual: {} }];
+  const report = buildReport({ corpus, results });
+  assert.equal(report.byCompetitor, undefined);
+});
+
+test("buildReport — competitorResults present → byCompetitor summary", () => {
+  const corpus = [
+    { url: "https://example.com/?utm_source=x", category: "utm", expectedAction: "cleaned", expectedClean: "https://example.com/" },
+    { url: "https://example.com/article", category: "clean-urls", expectedAction: "untouched" },
+  ];
+  const results = [
+    { ok: true, expected: {}, actual: {} },
+    { ok: true, expected: {}, actual: {} },
+  ];
+  const competitorResults = [
+    // First entry: identity returns input unchanged (didn't strip utm_source)
+    { identity: { cleanUrl: "https://example.com/?utm_source=x" } },
+    // Second entry: identity returns input unchanged (correct — already clean)
+    { identity: { cleanUrl: "https://example.com/article" } },
+  ];
+  const report = buildReport({ corpus, results, competitorResults });
+  assert.ok(report.byCompetitor);
+  assert.equal(report.byCompetitor.identity.total, 2);
+  assert.equal(report.byCompetitor.identity.changedFromInput, 0); // identity never changes
+  assert.equal(report.byCompetitor.identity.matchedExpectedClean, 0); // first entry has expectedClean but identity didn't match it
+  assert.equal(report.byCompetitor.identity.matchRate, 0);
+});
+
+test("buildReport — byCompetitor matchRate counts entries WITH expectedClean only", () => {
+  const corpus = [
+    { url: "https://a.com/?utm=x", category: "utm", expectedAction: "cleaned", expectedClean: "https://a.com/" },
+    { url: "https://b.com/?utm=y", category: "utm", expectedAction: "cleaned", expectedClean: "https://b.com/" },
+  ];
+  const results = corpus.map(() => ({ ok: true, expected: {}, actual: {} }));
+  const competitorResults = [
+    // Adapter "perfect" produces the expectedClean for both
+    { perfect: { cleanUrl: "https://a.com/" } },
+    { perfect: { cleanUrl: "https://b.com/" } },
+  ];
+  const report = buildReport({ corpus, results, competitorResults });
+  assert.equal(report.byCompetitor.perfect.matchedExpectedClean, 2);
+  assert.equal(report.byCompetitor.perfect.matchRate, 100);
 });


### PR DESCRIPTION
## Summary

**Phase 2 scaffold of A6 (#506)**. Lays the groundwork for benchmark comparisons against ClearURLs, AdGuard URL Tracking Protection, Brave Shields, and Firefox built-in cleaner. Ships **only** the contract + runner integration; real adapter snapshots ship as separate slices (phase 2a / 2b / 2c / 2d).

## Adapter contract

`tests/benchmark/competitors/README-CONTRACT.txt`:

```
{
  name:    string,    // stable id used in report keys
  label:   string,    // human-readable name
  source:  string,    // URL of the rule set's official source
  version: string?,   // version of the rule snapshot
  clean(rawUrl: string): string  // returns cleaned URL or rawUrl
                                 // unchanged when the adapter has
                                 // no opinion. Errors must NOT throw.
}
```

Adapters MUST NOT fetch at runtime — they consume vendored rule snapshots committed under `tests/benchmark/competitors/data/` (per-phase slices add their snapshot).

## Runner integration

`tests/benchmark/lib/runner-core.mjs`:

- **`runCompetitors(entry, adapters)`** returns `{ [adapter.name]: { cleanUrl } }`. Skips malformed adapter entries, catches `clean()` throws, falls back to input on non-string returns.
- **`buildReport()` accepts an optional `competitorResults` parallel array.** When present, the report gains a `byCompetitor` summary:
  ```
  { total, changedFromInput, matchedExpectedClean, matchRate }
  ```
  `matchRate = matchedExpectedClean / total × 100` (one decimal). Strict measure — competitors that produce a different-but-still-clean URL won't score. Phase 3 reports can layer richer metrics on top.

## Wire-up

`tests/benchmark/runner.mjs`:
- `COMPETITOR_ADAPTERS` constant — **empty today**; phase 2a/2b/etc. append their adapters here.
- `runCompetitors` called per corpus entry; result threaded into `buildReport`.

## Test fixture

`tests/benchmark/competitors/identity.mjs`:
- `identityAdapter` returns input unchanged. **NOT loaded by the runner** — used only by the unit tests to exercise the integration shape end-to-end.

## Test plan

- [x] `npm test` → **3254/3254** passing (+9 from baseline 3245)
- [x] `npm run benchmark` → 110/110 matched (no behavior change for MUGA's own results)
- [x] `npm run lint` → 0 errors
- [x] Empty/null adapter list → empty record
- [x] Identity adapter end-to-end via `runCompetitors`
- [x] `clean()` throw caught; falls back to input
- [x] Non-string return falls back to input
- [x] Malformed adapter entries (no name, no clean) skipped
- [x] `byCompetitor` absent when no `competitorResults` passed
- [x] `byCompetitor` summary populated when `competitorResults` passed
- [x] `matchRate` counts only entries with `expectedClean`

## What ships next (phase 2a/2b/2c/2d)

Each will:
1. Vendor a rule snapshot under `tests/benchmark/competitors/data/<vendor>.json`
2. Implement a thin adapter that consumes the snapshot
3. Append the adapter to `COMPETITOR_ADAPTERS`
4. Document the snapshot's source URL + capture date in `README-CONTRACT.txt`

Phase 3 (#507) layers Markdown + HTML report formats on top.