### PR TITLE
fix(benchmark): byCompetitor matchRate denominator should be withExpectedClean (#506)

### DIFF
--- a/tests/benchmark/lib/runner-core.mjs
+++ b/tests/benchmark/lib/runner-core.mjs
@@ -96,7 +96,7 @@ export function runCompetitors(entry, adapters) {
  * (#506) — phase 1 (#505) shipped MUGA-only.
  *
  * @param {{ corpus: Array<{url:string, category:string, expectedAction:string}>, results: Array<{ok:boolean, expected:object, actual:object, diff?:string}>, competitorResults?: Array<Record<string, {cleanUrl:string}>>, generatedAt?: string, runner?: string }} params
- * @returns {{ generatedAt:string, runner:string, totalEntries:number, matched:number, mismatched:number, matchRate:number, byCategory: Record<string,{total:number,matched:number,mismatched:number,matchRate:number}>, byCompetitor?: Record<string,{total:number,changedFromInput:number,matchedExpectedClean:number,matchRate:number}>, mismatches: Array<object> }}
+ * @returns {{ generatedAt:string, runner:string, totalEntries:number, matched:number, mismatched:number, matchRate:number, byCategory: Record<string,{total:number,matched:number,mismatched:number,matchRate:number}>, byCompetitor?: Record<string,{total:number,withExpectedClean:number,changedFromInput:number,matchedExpectedClean:number,matchRate:number}>, mismatches: Array<object> }}
  */
 export function buildReport({ corpus, results, competitorResults, generatedAt, runner = "muga" }) {
   if (corpus.length !== results.length) {
@@ -136,29 +136,32 @@ export function buildReport({ corpus, results, competitorResults, generatedAt, r
     byCompetitor = {};
     for (let i = 0; i < corpus.length; i++) {
       const entry = corpus[i];
+      const hasExpectedClean = entry.expectedClean !== undefined;
       const adapterMap = competitorResults[i] || {};
       for (const [name, { cleanUrl }] of Object.entries(adapterMap)) {
         if (!byCompetitor[name]) {
-          byCompetitor[name] = { total: 0, changedFromInput: 0, matchedExpectedClean: 0, matchRate: 0 };
+          byCompetitor[name] = { total: 0, withExpectedClean: 0, changedFromInput: 0, matchedExpectedClean: 0, matchRate: 0 };
         }
         const bucket = byCompetitor[name];
         bucket.total += 1;
+        if (hasExpectedClean) bucket.withExpectedClean += 1;
         if (cleanUrl !== entry.url) bucket.changedFromInput += 1;
-        if (entry.expectedClean !== undefined && cleanUrl === entry.expectedClean) {
+        if (hasExpectedClean && cleanUrl === entry.expectedClean) {
           bucket.matchedExpectedClean += 1;
         }
       }
     }
-    // matchRate here is "fraction of corpus entries that have an
-    // `expectedClean` AND the competitor produced exactly it". It's a
-    // strict measure — competitors that produce a different-but-also-
-    // clean URL won't score. Fine for ranking comparison, less fine
-    // for raw "did they remove tracking?" coverage. Phase 3 reports
-    // can layer richer metrics on top.
+    // matchRate denominator is `withExpectedClean`, NOT `total` — entries
+    // without an `expectedClean` field cannot be scored fairly (the
+    // corpus author intentionally left the precise output unasserted).
+    // Including them in the denominator would unfairly punish adapters
+    // by counting unscoreable entries as fails. Phase 3 reports can
+    // layer richer metrics (e.g. "changedFromInput" for any-cleanup
+    // coverage) on top.
     for (const name of Object.keys(byCompetitor)) {
       byCompetitor[name].matchRate = pct(
         byCompetitor[name].matchedExpectedClean,
-        byCompetitor[name].total,
+        byCompetitor[name].withExpectedClean,
       );
     }
   }

--- a/tests/unit/benchmark-runner.test.mjs
+++ b/tests/unit/benchmark-runner.test.mjs
@@ -266,9 +266,10 @@ test("buildReport — competitorResults present → byCompetitor summary", () =>
   const report = buildReport({ corpus, results, competitorResults });
   assert.ok(report.byCompetitor);
   assert.equal(report.byCompetitor.identity.total, 2);
+  assert.equal(report.byCompetitor.identity.withExpectedClean, 1);
   assert.equal(report.byCompetitor.identity.changedFromInput, 0); // identity never changes
   assert.equal(report.byCompetitor.identity.matchedExpectedClean, 0); // first entry has expectedClean but identity didn't match it
-  assert.equal(report.byCompetitor.identity.matchRate, 0);
+  assert.equal(report.byCompetitor.identity.matchRate, 0); // 0 of 1 scoreable entry matched
 });
 
 test("buildReport — byCompetitor matchRate counts entries WITH expectedClean only", () => {
@@ -283,6 +284,53 @@ test("buildReport — byCompetitor matchRate counts entries WITH expectedClean o
     { perfect: { cleanUrl: "https://b.com/" } },
   ];
   const report = buildReport({ corpus, results, competitorResults });
+  assert.equal(report.byCompetitor.perfect.withExpectedClean, 2);
   assert.equal(report.byCompetitor.perfect.matchedExpectedClean, 2);
   assert.equal(report.byCompetitor.perfect.matchRate, 100);
+});
+
+test("buildReport — perfect adapter on scoreable subset isn't punished by unscoreable entries", () => {
+  // 4 entries: 2 with expectedClean, 2 without. Perfect adapter
+  // matches expectedClean on both that have it; the 2 without are
+  // unscoreable. matchRate must be 100, not 50 — the unscoreable
+  // entries cannot fairly count against the adapter.
+  const corpus = [
+    { url: "https://a.com/?utm=x", category: "utm", expectedAction: "cleaned", expectedClean: "https://a.com/" },
+    { url: "https://b.com/?utm=y", category: "utm", expectedAction: "cleaned", expectedClean: "https://b.com/" },
+    { url: "https://c.com/?id=42", category: "utm", expectedAction: "cleaned" }, // no expectedClean
+    { url: "https://d.com/?id=99", category: "utm", expectedAction: "cleaned" }, // no expectedClean
+  ];
+  const results = corpus.map(() => ({ ok: true, expected: {}, actual: {} }));
+  const competitorResults = [
+    { perfect: { cleanUrl: "https://a.com/" } },
+    { perfect: { cleanUrl: "https://b.com/" } },
+    { perfect: { cleanUrl: "https://c.com/?id=42" } }, // produced anything; can't score
+    { perfect: { cleanUrl: "https://d.com/?id=99" } },
+  ];
+  const report = buildReport({ corpus, results, competitorResults });
+  assert.equal(report.byCompetitor.perfect.total, 4);
+  assert.equal(report.byCompetitor.perfect.withExpectedClean, 2);
+  assert.equal(report.byCompetitor.perfect.matchedExpectedClean, 2);
+  assert.equal(
+    report.byCompetitor.perfect.matchRate,
+    100,
+    "matchRate must be 100 — 2 of 2 scoreable entries matched. Counting unscoreable entries in the denominator would punish a perfect adapter.",
+  );
+});
+
+test("buildReport — competitor with no expectedClean entries gives matchRate 0 (no NaN)", () => {
+  // Edge case: corpus has zero entries with expectedClean.
+  // matchRate denominator would be 0; pct() guards against NaN.
+  const corpus = [
+    { url: "https://a.com/", category: "clean-urls", expectedAction: "untouched" },
+    { url: "https://b.com/", category: "clean-urls", expectedAction: "untouched" },
+  ];
+  const results = corpus.map(() => ({ ok: true, expected: {}, actual: {} }));
+  const competitorResults = [
+    { identity: { cleanUrl: "https://a.com/" } },
+    { identity: { cleanUrl: "https://b.com/" } },
+  ];
+  const report = buildReport({ corpus, results, competitorResults });
+  assert.equal(report.byCompetitor.identity.withExpectedClean, 0);
+  assert.equal(report.byCompetitor.identity.matchRate, 0);
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #519 (A6 phase 2 scaffold). The scaffolded `matchRate` computation was unfair to adapters: it divided by `total` instead of by `withExpectedClean`. An adapter perfect on every scoreable entry would score ~73% if only 80 of 110 corpus entries declared `expectedClean` — even though it got 100% of what was scoreable.

## Fix

Introduce a `withExpectedClean` count in the bucket and use that as the denominator. Entries without `expectedClean` cannot be scored fairly (the corpus author intentionally left the precise output unasserted), so they don't punish the adapter. They DO still contribute to:
- `total` (so report readers see the unscored entries exist)
- `changedFromInput` (a permissive "any cleanup happened" metric)

## Bucket shape

```
{
  total,                      // every corpus entry
  withExpectedClean,          // subset with expectedClean defined
  changedFromInput,           // adapter produced ≠ input
  matchedExpectedClean,       // adapter produced exactly expectedClean
  matchRate,                  // matchedExpectedClean / withExpectedClean × 100
}
```

`matchRate` returns 0 when `withExpectedClean` is 0 (no NaN — same `pct()` helper).

## Test plan

- [x] `npm test` → **3256/3256** passing (+2 from baseline 3254)
- [x] `npm run benchmark` → 110/110 (no behavior change for MUGA)
- [x] `npm run lint` → 0 errors
- [x] **New test**: perfect adapter on 2-of-4 scoreable corpus → matchRate = 100, not 50
- [x] **New test**: adapter against corpus with zero `expectedClean` → matchRate = 0 (no NaN)
- [x] Existing "byCompetitor summary" test updated to assert `withExpectedClean: 1`
- [x] Existing "counts entries WITH expectedClean only" test updated to assert `withExpectedClean: 2`