### PR TITLE
feat(benchmark): A6 phase 2a — synthetic baseline adapter (#506)

### DIFF
--- a/tests/benchmark/competitors/baseline.mjs
+++ b/tests/benchmark/competitors/baseline.mjs
@@ -1,0 +1,81 @@
+/**
+ * MUGA: Synthetic baseline adapter — A6 phase 2a (#506).
+ *
+ * NOT a real competitor. Represents the FLOOR of URL-cleaning coverage:
+ * the 9 UTM params plus the most common cross-network click IDs. Any
+ * dedicated URL cleaner — ClearURLs, AdGuard URL Tracking Protection,
+ * Brave Shields, Firefox built-in — covers at least these. So the
+ * baseline is a useful "if you do nothing else" reference line in
+ * comparison reports.
+ *
+ * Why ship a synthetic baseline before the real adapters: it exercises
+ * the #519 adapter contract end-to-end with actual report data, and it
+ * gives the report a stable lower-bound that doesn't depend on external
+ * snapshots being current. Real competitor adapters land in phases 2b
+ * (ClearURLs), 2c (AdGuard), 2d (Brave), 2e (Firefox) — each will be
+ * scored against this baseline AND MUGA.
+ *
+ * Coverage list is INTENTIONALLY conservative. Adding anything beyond
+ * the canonical UTM + click IDs would muddle "this is what every
+ * cleaner does" — that distinction is what makes the baseline useful.
+ */
+
+const STRIP = new Set([
+  // UTM family (Google Analytics standard, 9 params)
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "utm_id",
+  "utm_source_platform",
+  "utm_creative_format",
+  "utm_marketing_tactic",
+  // Cross-network click IDs every dedicated cleaner strips
+  "fbclid",         // Facebook
+  "gclid",          // Google Ads
+  "gclsrc",         // Google Ads source attribution
+  "dclid",          // DoubleClick
+  "msclkid",        // Microsoft Bing
+  "twclid",         // Twitter / X
+  "yclid",          // Yandex
+  "gbraid",         // Google iOS attribution (web→app)
+  "wbraid",         // Google iOS attribution (app→web)
+  "_gl",            // Google Analytics cross-domain linker
+]);
+
+/**
+ * @param {string} rawUrl
+ * @returns {string} the cleaned URL or rawUrl unchanged if no changes were made
+ */
+function cleanBaseline(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return rawUrl;
+
+  let changed = false;
+  // Snapshot keys before iterating — searchParams.delete() during
+  // forEach would skip the next entry.
+  for (const key of [...url.searchParams.keys()]) {
+    if (STRIP.has(key.toLowerCase())) {
+      url.searchParams.delete(key);
+      changed = true;
+    }
+  }
+  return changed ? url.toString() : rawUrl;
+}
+
+export const baselineAdapter = {
+  name: "baseline",
+  label: "Synthetic baseline (UTM + common click IDs)",
+  source: "synthetic — represents the floor coverage of any URL cleaner",
+  version: "1",
+  clean: cleanBaseline,
+};
+
+// Exposed for tests. Not part of the public adapter contract.
+export const _STRIP = STRIP;

--- a/tests/benchmark/runner.mjs
+++ b/tests/benchmark/runner.mjs
@@ -20,14 +20,17 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { processUrl } from "../../src/lib/cleaner.js";
 import { loadCorpus } from "./lib/corpus-loader.mjs";
 import { compareEntry, buildReport, exitCodeFromReport, runCompetitors } from "./lib/runner-core.mjs";
+import { baselineAdapter } from "./competitors/baseline.mjs";
 
-// Phase 2 of A6 (#506) ships the competitor adapter contract but no
-// real adapter yet. ClearURLs / AdGuard / Brave / Firefox each get
-// their own slice (phase 2a / 2b / 2c / 2d). Each will append to this
-// list. See tests/benchmark/competitors/README-CONTRACT.txt for the
-// adapter contract. Today this stays empty — runCompetitors handles
-// the no-adapters case gracefully.
-const COMPETITOR_ADAPTERS = [];
+// A6 phase 2 (#506) competitor adapter list.
+//
+// Phase 2a ships the synthetic baseline (UTM + common click IDs) — a
+// floor reference line. Phases 2b/2c/2d/2e will add the real
+// competitors (ClearURLs / AdGuard / Brave / Firefox) — each is a
+// separate slice that vendors a rule snapshot under
+// tests/benchmark/competitors/data/ and appends an adapter here.
+// See tests/benchmark/competitors/README-CONTRACT.txt for the contract.
+const COMPETITOR_ADAPTERS = [baselineAdapter];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CORPUS_DIR = join(__dirname, "corpus");

--- a/tests/unit/benchmark-baseline-adapter.test.mjs
+++ b/tests/unit/benchmark-baseline-adapter.test.mjs
@@ -1,0 +1,98 @@
+/** MUGA: Tests for the benchmark synthetic baseline adapter (#506 phase 2a). */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { baselineAdapter, _STRIP } from "../benchmark/competitors/baseline.mjs";
+
+test("baseline — adapter shape matches the contract", () => {
+  assert.equal(typeof baselineAdapter.name, "string");
+  assert.equal(typeof baselineAdapter.label, "string");
+  assert.equal(typeof baselineAdapter.source, "string");
+  assert.equal(typeof baselineAdapter.version, "string");
+  assert.equal(typeof baselineAdapter.clean, "function");
+});
+
+test("baseline — strips utm_source", () => {
+  assert.equal(
+    baselineAdapter.clean("https://example.com/?utm_source=newsletter"),
+    "https://example.com/",
+  );
+});
+
+test("baseline — strips all 9 UTM params", () => {
+  const url = "https://example.com/?utm_source=a&utm_medium=b&utm_campaign=c&utm_content=d&utm_term=e&utm_id=f&utm_source_platform=g&utm_creative_format=h&utm_marketing_tactic=i";
+  assert.equal(baselineAdapter.clean(url), "https://example.com/");
+});
+
+test("baseline — strips fbclid, gclid, msclkid, dclid, twclid", () => {
+  for (const param of ["fbclid", "gclid", "msclkid", "dclid", "twclid"]) {
+    const url = `https://example.com/?${param}=ABC123`;
+    assert.equal(
+      baselineAdapter.clean(url),
+      "https://example.com/",
+      `failed to strip ${param}`,
+    );
+  }
+});
+
+test("baseline — preserves non-tracking params", () => {
+  assert.equal(
+    baselineAdapter.clean("https://example.com/?id=42&utm_source=x"),
+    "https://example.com/?id=42",
+  );
+});
+
+test("baseline — preserves fragment", () => {
+  assert.equal(
+    baselineAdapter.clean("https://example.com/article?utm_source=x#section"),
+    "https://example.com/article#section",
+  );
+});
+
+test("baseline — returns rawUrl unchanged when no tracking present", () => {
+  const url = "https://example.com/article?id=42&page=3";
+  assert.equal(baselineAdapter.clean(url), url);
+});
+
+test("baseline — returns rawUrl unchanged for malformed URL (no throw)", () => {
+  const malformed = "not a url";
+  assert.equal(baselineAdapter.clean(malformed), malformed);
+});
+
+test("baseline — returns rawUrl unchanged for non-http(s) protocol", () => {
+  for (const url of ["javascript:alert(1)", "data:text/plain,hi", "mailto:foo@bar.com", "file:///etc/passwd"]) {
+    assert.equal(baselineAdapter.clean(url), url, `should not touch ${url}`);
+  }
+});
+
+test("baseline — case-insensitive on param keys", () => {
+  // Param names in URLs are case-sensitive per spec, but tracker params
+  // are lowercase by convention. Adapters typically normalize.
+  assert.equal(
+    baselineAdapter.clean("https://example.com/?UTM_SOURCE=newsletter"),
+    "https://example.com/",
+  );
+});
+
+test("baseline — does NOT strip params outside the floor list (no scope creep)", () => {
+  // The whole point of baseline is to be the FLOOR. If it accidentally
+  // strips things ClearURLs-and-friends do but the bare minimum doesn't,
+  // the comparison loses meaning.
+  const beyondFloor = ["mc_eid", "_hsenc", "mkt_tok", "ref", "campid", "tag"];
+  for (const param of beyondFloor) {
+    const url = `https://example.com/?${param}=value`;
+    assert.equal(
+      baselineAdapter.clean(url),
+      url,
+      `baseline must NOT strip ${param} — only UTM + common click IDs`,
+    );
+  }
+});
+
+test("baseline — STRIP set has expected size (sanity check on coverage list)", () => {
+  // 9 UTM + 10 click IDs (fbclid, gclid, gclsrc, dclid, msclkid, twclid,
+  // yclid, gbraid, wbraid, _gl) = 19. If this assertion changes, update
+  // the docblock + this comment so future readers know what shifted.
+  assert.equal(_STRIP.size, 19);
+});


### PR DESCRIPTION
## Summary

**Phase 2a of A6 (#506).** First adapter exercising the #519 contract end-to-end with real report data. NOT a real competitor — represents the **FLOOR** of URL-cleaning coverage: the 9 UTM params plus the 10 most common cross-network click IDs. Any dedicated URL cleaner covers at least these, so the baseline gives the report a stable reference line that doesn't depend on external snapshots.

## Adapter

`tests/benchmark/competitors/baseline.mjs`:

- `name`: `"baseline"`
- `label`: `"Synthetic baseline (UTM + common click IDs)"`
- `source`: `"synthetic — represents the floor coverage of any URL cleaner"`
- `clean(rawUrl)`: strips 19 params if present; returns `rawUrl` unchanged otherwise. http(s) only. Case-insensitive on param keys.

## Coverage list (intentionally conservative)

**UTM family (9)**: `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `utm_id`, `utm_source_platform`, `utm_creative_format`, `utm_marketing_tactic`

**Click IDs (10)**: `fbclid`, `gclid`, `gclsrc`, `dclid`, `msclkid`, `twclid`, `yclid`, `gbraid`, `wbraid`, `_gl`

Adding anything beyond this would muddle "this is what every cleaner does" — that distinction is what makes the baseline useful as a reference line.

## Comparison shape working

Current corpus run:

```
baseline: 34/77 scoreable matched → matchRate 44.2%
MUGA:     110/110                  → matchRate 100%
```

Baseline correctly fails on entries that need:
- wrapper unwrapping (it doesn't)
- affiliate-foreign preservation (it doesn't)
- non-utm/click-id tracking strip (xtor, mc_eid, mkt_tok, etc.)

MUGA's broader coverage is now visible in numbers — exactly what a benchmark should show.

## Test plan

- [x] `npm test` → **3268/3268** passing (+12 from baseline 3256)
- [x] `npm run benchmark` → MUGA 110/110, baseline 44.2% on scoreable
- [x] `npm run lint` → 0 errors
- [x] All 9 UTM params + all common click IDs strip correctly
- [x] Non-tracking params preserved (`?id=42`)
- [x] Fragment preserved
- [x] Clean URL → unchanged
- [x] Malformed URL → no throw
- [x] Non-http(s) protocols (javascript:, data:, mailto:, file:) → untouched
- [x] Case-insensitive on param keys (`?UTM_SOURCE=` strips)
- [x] **Scope-creep guard**: does NOT strip mc_eid, _hsenc, mkt_tok, ref, campid, tag — those are beyond the floor

## What ships next

Phase 2b/2c/2d/2e: real competitor adapters (ClearURLs, AdGuard, Brave, Firefox). Each vendors a rule snapshot under `tests/benchmark/competitors/data/<vendor>.json`, implements an adapter, and appends to `COMPETITOR_ADAPTERS`. Phase 3 (#507) layers Markdown + HTML reports and CI on release tags on top.