### PR TITLE
feat(benchmark): A6 phase 3b — HTML report writer (#507)

### DIFF
--- a/tests/benchmark/lib/report-html.mjs
+++ b/tests/benchmark/lib/report-html.mjs
@@ -1,0 +1,201 @@
+/**
+ * MUGA: Benchmark HTML report writer — A6 phase 3b (#507).
+ *
+ * Pure function: takes the report object produced by buildReport()
+ * and returns a self-contained HTML string. No external CSS, no
+ * external JS, no external assets — the file works offline from any
+ * browser. CSS is inlined; dark-mode friendly via prefers-color-scheme.
+ *
+ * Layout mirrors the Markdown writer (phase 3a / PR #525):
+ *   <h1> + metadata
+ *   "Overall coverage" table
+ *   "By category" table (sorted alphabetically)
+ *   "By competitor" table (only when byCompetitor non-empty)
+ *   "Mismatches" details/summary (only when mismatches.length > 0)
+ *
+ * The runner script does the file write — this module is I/O-free.
+ */
+
+/**
+ * Escape a value for safe HTML text content. Handles all five
+ * canonical XML special characters. Returns "" for null/undefined.
+ */
+function esc(s) {
+  if (s === undefined || s === null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Render a `<table>` element from a header row + array of value rows.
+ * Empty rows array returns "" (no orphan empty tables).
+ */
+function table(headers, rows) {
+  if (rows.length === 0) return "";
+  const head = `<thead><tr>${headers.map((h) => `<th>${esc(h)}</th>`).join("")}</tr></thead>`;
+  const body = `<tbody>${rows
+    .map((r) => `<tr>${r.map((c) => `<td>${esc(c)}</td>`).join("")}</tr>`)
+    .join("")}</tbody>`;
+  return `<table>${head}${body}</table>`;
+}
+
+/**
+ * Inlined stylesheet. Minimal, readable, dark-mode friendly. Tables
+ * have alternating row backgrounds for skim-ability.
+ */
+const STYLE = `
+:root {
+  color-scheme: light dark;
+  --fg: #111;
+  --bg: #fff;
+  --muted: #555;
+  --border: #ddd;
+  --row-alt: #f6f8fa;
+  --accent: #0969da;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e6edf3;
+    --bg: #0d1117;
+    --muted: #8b949e;
+    --border: #30363d;
+    --row-alt: #161b22;
+    --accent: #58a6ff;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  line-height: 1.5;
+}
+h1 { margin-top: 0; }
+h2 { margin-top: 2rem; border-bottom: 1px solid var(--border); padding-bottom: .25rem; }
+.meta { color: var(--muted); font-size: .9em; }
+.meta span + span::before { content: " · "; }
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+  font-size: .95em;
+}
+th, td {
+  text-align: left;
+  padding: .4rem .6rem;
+  border-bottom: 1px solid var(--border);
+}
+th { font-weight: 600; }
+tbody tr:nth-child(even) { background: var(--row-alt); }
+.note { color: var(--muted); font-size: .9em; font-style: italic; }
+details { margin-top: 1rem; }
+summary { cursor: pointer; font-weight: 600; }
+.mismatch { border-left: 3px solid var(--accent); padding: .25rem .75rem; margin: .5rem 0; background: var(--row-alt); }
+.mismatch code { background: transparent; }
+code {
+  font-family: ui-monospace, "SF Mono", Consolas, monospace;
+  font-size: .9em;
+  background: var(--row-alt);
+  padding: .1em .35em;
+  border-radius: 3px;
+}
+`;
+
+/**
+ * Build the full HTML report. Output is deterministic given the same
+ * input — no Date.now() inside, no Math.random(). The report's
+ * generatedAt is used verbatim so a regression test can assert on
+ * the exact output.
+ *
+ * @param {{generatedAt:string, runner:string, totalEntries:number, matched:number, mismatched:number, matchRate:number, byCategory: Record<string,{total:number,matched:number,mismatched:number,matchRate:number}>, byCompetitor?: Record<string,{total:number,withExpectedClean:number,changedFromInput:number,matchedExpectedClean:number,matchRate:number}>, mismatches: Array<{url:string,category:string,expected:object,actual:object,diff:string}>}} report
+ * @returns {string}
+ */
+export function renderHtml(report) {
+  const sections = [];
+
+  sections.push(`<h1>MUGA Benchmark Report</h1>`);
+  sections.push(
+    `<p class="meta">` +
+      `<span>Generated: ${esc(report.generatedAt)}</span>` +
+      `<span>Runner: ${esc(report.runner)}</span>` +
+      `<span>Corpus: ${esc(report.totalEntries)} entries</span>` +
+      `</p>`,
+  );
+
+  sections.push(`<h2>Overall coverage</h2>`);
+  sections.push(
+    table(
+      ["Matched", "Mismatched", "Match rate"],
+      [[report.matched, report.mismatched, `${report.matchRate}%`]],
+    ),
+  );
+
+  sections.push(`<h2>By category</h2>`);
+  const catRows = Object.entries(report.byCategory)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, b]) => [name, b.total, b.matched, b.mismatched, `${b.matchRate}%`]);
+  sections.push(
+    table(["Category", "Total", "Matched", "Mismatched", "Match rate"], catRows),
+  );
+
+  if (report.byCompetitor && Object.keys(report.byCompetitor).length > 0) {
+    sections.push(`<h2>By competitor</h2>`);
+    sections.push(
+      `<p class="note">matchRate = matchedExpectedClean / withExpectedClean × 100. Entries without <code>expectedClean</code> are unscoreable and excluded from the denominator.</p>`,
+    );
+    const compRows = Object.entries(report.byCompetitor)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, b]) => [
+        name,
+        b.total,
+        b.withExpectedClean,
+        b.matchedExpectedClean,
+        b.changedFromInput,
+        `${b.matchRate}%`,
+      ]);
+    sections.push(
+      table(
+        ["Adapter", "Total", "Scoreable", "Matched", "Changed", "Match rate"],
+        compRows,
+      ),
+    );
+  }
+
+  if (report.mismatches.length > 0) {
+    sections.push(
+      `<details open><summary>Mismatches (${report.mismatches.length})</summary>`,
+    );
+    for (const m of report.mismatches) {
+      sections.push(
+        `<div class="mismatch">` +
+          `<div><strong>[${esc(m.category)}]</strong> <code>${esc(m.url)}</code></div>` +
+          `<div>${esc(m.diff)}</div>` +
+          `</div>`,
+      );
+    }
+    sections.push(`</details>`);
+  }
+
+  return [
+    `<!doctype html>`,
+    `<html lang="en">`,
+    `<head>`,
+    `<meta charset="utf-8">`,
+    `<meta name="viewport" content="width=device-width,initial-scale=1">`,
+    `<title>MUGA Benchmark Report — ${esc(report.generatedAt)}</title>`,
+    `<style>${STYLE}</style>`,
+    `</head>`,
+    `<body>`,
+    sections.join("\n"),
+    `</body>`,
+    `</html>`,
+    "",
+  ].join("\n");
+}

--- a/tests/benchmark/runner.mjs
+++ b/tests/benchmark/runner.mjs
@@ -21,6 +21,7 @@ import { processUrl } from "../../src/lib/cleaner.js";
 import { loadCorpus } from "./lib/corpus-loader.mjs";
 import { compareEntry, buildReport, exitCodeFromReport, runCompetitors } from "./lib/runner-core.mjs";
 import { renderMarkdown } from "./lib/report-md.mjs";
+import { renderHtml } from "./lib/report-html.mjs";
 import { baselineAdapter } from "./competitors/baseline.mjs";
 
 // A6 phase 2 (#506) competitor adapter list.
@@ -65,12 +66,15 @@ function main() {
   const stamp = report.generatedAt.replace(/[:.]/g, "-");
   const jsonOut = join(REPORTS_DIR, `${stamp}-muga.json`);
   const mdOut = join(REPORTS_DIR, `${stamp}-muga.md`);
+  const htmlOut = join(REPORTS_DIR, `${stamp}-muga.html`);
   writeFileSync(jsonOut, JSON.stringify(report, null, 2) + "\n");
   writeFileSync(mdOut, renderMarkdown(report));
+  writeFileSync(htmlOut, renderHtml(report));
   process.stdout.write(
     `[muga-benchmark] corpus files: ${files.length}, entries: ${report.totalEntries}, matched: ${report.matched}, mismatched: ${report.mismatched}\n` +
       `[muga-benchmark] reports: ${jsonOut}\n` +
-      `                         ${mdOut}\n`,
+      `                         ${mdOut}\n` +
+      `                         ${htmlOut}\n`,
   );
   if (report.mismatched > 0) {
     process.stdout.write(`[muga-benchmark] mismatches:\n`);

--- a/tests/unit/benchmark-report-html.test.mjs
+++ b/tests/unit/benchmark-report-html.test.mjs
@@ -1,0 +1,147 @@
+/** MUGA: Tests for the HTML report writer (#507 phase 3b). */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { renderHtml } from "../benchmark/lib/report-html.mjs";
+
+const SAMPLE_REPORT = {
+  generatedAt: "2026-05-02T22:00:00.000Z",
+  runner: "muga",
+  totalEntries: 4,
+  matched: 3,
+  mismatched: 1,
+  matchRate: 75,
+  byCategory: {
+    utm: { total: 2, matched: 2, mismatched: 0, matchRate: 100 },
+    "clean-urls": { total: 2, matched: 1, mismatched: 1, matchRate: 50 },
+  },
+  mismatches: [
+    {
+      url: "https://example.com/?weird=x",
+      category: "clean-urls",
+      expected: { action: "untouched" },
+      actual: { action: "cleaned" },
+      diff: 'action: expected "untouched", got "cleaned"',
+    },
+  ],
+};
+
+test("renderHtml — output is a string", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.equal(typeof html, "string");
+  assert.ok(html.length > 0);
+});
+
+test("renderHtml — well-formed doctype + html structure", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.match(html, /^<!doctype html>/);
+  assert.match(html, /<html lang="en">/);
+  assert.match(html, /<\/html>\s*$/);
+  assert.match(html, /<meta charset="utf-8">/);
+  assert.match(html, /<meta name="viewport"/);
+});
+
+test("renderHtml — title carries generatedAt for tab disambiguation", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.match(html, /<title>MUGA Benchmark Report — 2026-05-02T22:00:00\.000Z<\/title>/);
+});
+
+test("renderHtml — heading + meta paragraph rendered", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.match(html, /<h1>MUGA Benchmark Report<\/h1>/);
+  assert.match(html, /Generated: 2026-05-02T22:00:00\.000Z/);
+  assert.match(html, /Runner: muga/);
+  assert.match(html, /Corpus: 4 entries/);
+});
+
+test("renderHtml — overall coverage table rendered with matchRate %", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.match(html, /<h2>Overall coverage<\/h2>/);
+  assert.match(html, /<td>3<\/td><td>1<\/td><td>75%<\/td>/);
+});
+
+test("renderHtml — by-category table sorted alphabetically", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  const cleanIdx = html.indexOf("<td>clean-urls</td>");
+  const utmIdx = html.indexOf("<td>utm</td>");
+  assert.ok(cleanIdx > -1 && utmIdx > -1);
+  assert.ok(cleanIdx < utmIdx, "clean-urls should sort before utm");
+});
+
+test("renderHtml — mismatches details/summary rendered when non-empty", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.match(html, /<details open><summary>Mismatches \(1\)<\/summary>/);
+  assert.match(html, /<strong>\[clean-urls\]<\/strong>/);
+  assert.match(html, /<code>https:\/\/example\.com\/\?weird=x<\/code>/);
+  assert.match(html, /action: expected &quot;untouched&quot;, got &quot;cleaned&quot;/);
+});
+
+test("renderHtml — mismatches section absent when empty", () => {
+  const noMismatches = { ...SAMPLE_REPORT, matched: 4, mismatched: 0, matchRate: 100, mismatches: [] };
+  const html = renderHtml(noMismatches);
+  assert.doesNotMatch(html, /<details/);
+});
+
+test("renderHtml — byCompetitor section present when adapter results exist", () => {
+  const withCompetitors = {
+    ...SAMPLE_REPORT,
+    byCompetitor: {
+      baseline: {
+        total: 4,
+        withExpectedClean: 2,
+        changedFromInput: 1,
+        matchedExpectedClean: 1,
+        matchRate: 50,
+      },
+    },
+  };
+  const html = renderHtml(withCompetitors);
+  assert.match(html, /<h2>By competitor<\/h2>/);
+  assert.match(html, /<td>baseline<\/td>/);
+  assert.match(html, /<td>50%<\/td>/);
+});
+
+test("renderHtml — byCompetitor section absent when not provided", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.doesNotMatch(html, /<h2>By competitor<\/h2>/);
+});
+
+test("renderHtml — escapes HTML special chars in cell values (XSS guard)", () => {
+  const evil = {
+    ...SAMPLE_REPORT,
+    mismatches: [
+      {
+        url: "https://example.com/?x=<script>alert(1)</script>&y=\"a\"",
+        category: "utm",
+        expected: { action: "cleaned" },
+        actual: { action: "untouched" },
+        diff: "<img onerror=alert(1)>",
+      },
+    ],
+  };
+  const html = renderHtml(evil);
+  // Raw <script> must NOT appear unescaped in the body
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  // Should appear escaped instead
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /&quot;a&quot;/);
+  assert.match(html, /&lt;img onerror=alert\(1\)&gt;/);
+});
+
+test("renderHtml — output is deterministic for the same input", () => {
+  const a = renderHtml(SAMPLE_REPORT);
+  const b = renderHtml(SAMPLE_REPORT);
+  assert.equal(a, b);
+});
+
+test("renderHtml — inlines CSS (no external stylesheet links)", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.match(html, /<style>/);
+  assert.doesNotMatch(html, /<link[^>]+rel="stylesheet"/);
+});
+
+test("renderHtml — supports prefers-color-scheme dark mode in inlined CSS", () => {
+  const html = renderHtml(SAMPLE_REPORT);
+  assert.match(html, /@media \(prefers-color-scheme: dark\)/);
+});


### PR DESCRIPTION
## Summary

**Phase 3b of A6 (#507).** Pure function: takes the report object `buildReport()` produced and returns a **self-contained HTML string**. No external CSS/JS/assets — the file works offline from any browser. CSS is inlined; dark-mode aware via `prefers-color-scheme`.

Phase 3c (CI on release tags) ships next as a separate slice.

## Layout

Mirrors phase 3a (PR #525):

- `<h1>` + meta paragraph (generatedAt / runner / corpus size)
- "Overall coverage" table
- "By category" table (sorted alphabetically)
- "By competitor" table (only when `byCompetitor` non-empty)
- "Mismatches" `<details open>` with per-row cards (only when `mismatches.length > 0`)

## Design

- **Pure function** — no I/O, no `Date.now()`, output deterministic
- **XSS-safe**: all cell values escape five XML specials (`& < > " '`), so an evil URL in a corpus entry can't break out into raw HTML / inject script
- Tables use semantic `<thead>`/`<tbody>`/`<th>`/`<td>`. Alternating row backgrounds via `:nth-child(even)`
- **Dark-mode via `prefers-color-scheme`** — CSS variables in `:root`, overridden in `@media (prefers-color-scheme: dark)`. No JS needed.
- Mismatch entries rendered as `<div class="mismatch">` cards, NOT as table rows — the diff text is more readable as a card with the URL in `<code>`
- Title carries `generatedAt` so multiple report tabs are disambiguatable in the browser

## Runner

Now writes `.json` + `.md` + `.html` alongside each run.

## Test plan

- [x] `npm test` → **3294/3294** passing (+14 from baseline 3280)
- [x] `npm run benchmark` → emits all 3 formats, 110/110
- [x] `npm run lint` → 0 errors
- [x] Well-formed doctype + `<html lang>` + viewport + charset
- [x] Title with generatedAt
- [x] Heading + meta paragraph
- [x] Overall coverage table with matchRate %
- [x] By-category alphabetical
- [x] Mismatches `<details>` present/absent
- [x] byCompetitor section present/absent
- [x] **XSS guard**: `<script>`, `"a"`, `<img onerror=alert(1)>` all rendered as escaped entities, NOT as live markup
- [x] Deterministic output
- [x] Inlined CSS (no external `<link rel="stylesheet">`)
- [x] `@media (prefers-color-scheme: dark)` present