### PR TITLE
feat(privacy): CSFT graduation pipeline observed→suspicious→candidate (#532)

### DIFF
--- a/src/lib/cross-site-frequency.js
+++ b/src/lib/cross-site-frequency.js
@@ -1,11 +1,32 @@
 /**
- * MUGA: Cross-Site Frequency Tracker (#446, slice B16)
+ * MUGA: Cross-Site Frequency Tracker (#446 base, #532 graduation pipeline)
  *
  * Tracks URL parameters seen across visited first-party domains so the
  * popup can flag those that look like cross-site identifiers — params
  * that show up against MANY different domains AND with MANY different
  * values. That shape is the fingerprint of a tracking ID; a search
  * query, by contrast, has many values but few domains.
+ *
+ * ── Graduation pipeline (issue #532) ──────────────────────────────────
+ *
+ * Each tracked param carries an explicit lifecycle state:
+ *
+ *   observed  → seen on at least one first-party domain. Default state.
+ *   suspicious → meets the original B16 thresholds (≥3 domains AND
+ *                ≥3 distinct value-hashes). `getFlagged()` continues to
+ *                surface this set so consumers (popup) keep working.
+ *   candidate  → strong cross-site-tracker signal: ≥5 domains AND
+ *                ≥10 value-hashes AND running-mean entropy > 3.0 AND
+ *                param name length ≥ 4. The length guard exists because
+ *                PRD #529 explicitly rejects 3-letter generic params
+ *                (id, pid, ref) that are too noisy to graduate.
+ *
+ * State is computed LAZILY on read (inside `getState` and `getFlagged`).
+ * The hot `observe()` path stays cheap — it only updates the running-mean
+ * entropy (O(1)) and the LRU bookkeeping. Promotion is a function of the
+ * stored counts + entropyAvg, NEVER of the order in which observations
+ * arrived. That keeps the data future-proof: a stricter threshold can be
+ * applied retroactively without re-running the whole event log.
  *
  * ── Privacy contract ──────────────────────────────────────────────────
  *
@@ -59,12 +80,63 @@
  * is available in MV3 service workers AND in popup contexts.
  */
 
-/** Distinct first-party domains required before a param can be flagged. */
+/** Distinct first-party domains required before a param can be flagged (suspicious). */
 export const DOMAIN_THRESHOLD = 3;
-/** Distinct value-hashes required before a param can be flagged. */
+/** Distinct value-hashes required before a param can be flagged (suspicious). */
 export const VALUE_THRESHOLD = 3;
 /** Hard cap on tracked paramNames. LRU-evicts the least-recently-touched entry. */
 export const MAX_TRACKED_PARAMS = 1000;
+
+// ── Graduation thresholds (issue #532) ───────────────────────────────────────
+//
+// "candidate" is a STRONGER signal than "suspicious". A param earns it only
+// when ALL FOUR conditions hold simultaneously. Tunable; bumping any of
+// these tightens the funnel without breaking the lifecycle.
+
+/** Distinct first-party domains required to graduate from suspicious → candidate. */
+export const CANDIDATE_DOMAIN_THRESHOLD = 5;
+/** Distinct value-hashes required to graduate from suspicious → candidate. */
+export const CANDIDATE_VALUE_THRESHOLD = 10;
+/**
+ * Running-mean Shannon entropy required for graduation. UUIDs / base64 tokens
+ * routinely sit above 4. A value of 3.0 cleanly excludes sequential numeric
+ * IDs and short codes while keeping real cross-site identifiers in scope.
+ */
+export const CANDIDATE_ENTROPY_THRESHOLD = 3.0;
+/**
+ * Minimum param-name length for graduation. PRD #529 explicitly rejects
+ * 3-letter generic params (id, pid, ref) — they are too noisy across the
+ * web to deserve "candidate" status, even when they meet the other floors.
+ */
+export const CANDIDATE_NAME_LENGTH_MIN = 4;
+
+// ── Shannon entropy helper ───────────────────────────────────────────────────
+
+/**
+ * Shannon entropy of `s` in bits-per-symbol. Used by the graduation pipeline
+ * to distinguish high-entropy tracking IDs (UUIDs, base64 tokens — entropy
+ * routinely above 4) from low-entropy enumerated IDs (sequential integers,
+ * short codes — entropy near 0–2).
+ *
+ * Returns 0 for empty / nullish / single-symbol inputs (no information).
+ *
+ * @param {string|null|undefined} s
+ * @returns {number} entropy in bits per symbol; 0 ≤ result ≤ log2(|alphabet|)
+ */
+export function valueEntropy(s) {
+  if (s === null || s === undefined) return 0;
+  const str = String(s);
+  const n = str.length;
+  if (n <= 1) return 0;
+  const freq = new Map();
+  for (const ch of str) freq.set(ch, (freq.get(ch) || 0) + 1);
+  let h = 0;
+  for (const c of freq.values()) {
+    const p = c / n;
+    h -= p * Math.log2(p);
+  }
+  return h;
+}
 
 // ── Storage adapters ─────────────────────────────────────────────────────────
 
@@ -168,7 +240,8 @@ export async function defaultHasher(input) {
  * @param {boolean}  [options.enabled=true]
  * @returns {{
  *   observe: (domain: string, paramName: string, value: string) => Promise<void>,
- *   getFlagged: () => Promise<Array<{ param: string, domains: number, values: number }>>,
+ *   getFlagged: () => Promise<Array<{ param: string, domains: number, values: number, state: string }>>,
+ *   getState: (paramName: string) => Promise<"observed"|"suspicious"|"candidate">,
  *   setEnabled: (next: boolean) => void,
  * }}
  */
@@ -179,24 +252,47 @@ export function createTracker({ adapter, hasher, enabled = true }) {
    * Records that `paramName=value` was seen on `domain`. No-op when the
    * tracker is disabled. Touches `lastSeen` on every observation so the
    * LRU has fresh information to choose its eviction victim.
+   *
+   * Maintains a running-mean entropy for the param so graduation decisions
+   * can be made cheaply at read time (see graduate() / getState()). Running
+   * mean keeps observe() at O(1) — no per-observation array growth, no
+   * recomputation over historical values.
    */
   async function observe(domain, paramName, value) {
     if (!_enabled) return;
     if (!domain || !paramName) return;
 
-    const hash = await hasher(String(value ?? ""));
+    const rawValue = String(value ?? "");
+    const hash = await hasher(rawValue);
     const state = await adapter.get();
     state.params = state.params || {};
+    const now = Date.now();
     let entry = state.params[paramName];
     if (!entry) {
-      entry = { domains: [], values: [], lastSeen: 0 };
+      // firstSeen pinned at creation; never moves. lastSeen + count + entropyAvg
+      // evolve with every observation. count is a separate field because we need
+      // it to update the running mean, and `values.length` would only reflect
+      // DISTINCT values (re-observations would never adjust the mean).
+      entry = { domains: [], values: [], firstSeen: now, lastSeen: now, count: 0, entropyAvg: 0 };
       state.params[paramName] = entry;
     }
     if (!entry.domains.includes(domain)) entry.domains.push(domain);
     if (!entry.values.includes(hash)) entry.values.push(hash);
+    // Backfill defensive defaults for entries persisted by an older version of
+    // this module (pre-#532). Cheap and idempotent.
+    if (typeof entry.firstSeen !== "number") entry.firstSeen = now;
+    if (typeof entry.count !== "number") entry.count = 0;
+    if (typeof entry.entropyAvg !== "number") entry.entropyAvg = 0;
+    // Running-mean update: new_avg = old_avg + (sample - old_avg) / n.
+    // Done on EVERY observation (including re-observations of the same value)
+    // because a param dominated by repeated low-entropy values should see its
+    // running mean drift down, not stay frozen at the first sample.
+    const sample = valueEntropy(rawValue);
+    entry.count += 1;
+    entry.entropyAvg = entry.entropyAvg + (sample - entry.entropyAvg) / entry.count;
     // Touch on every observation, including no-op re-observations, so the
     // LRU correctly reflects "params I keep seeing", not just first-seen.
-    entry.lastSeen = Date.now();
+    entry.lastSeen = now;
 
     // LRU enforcement. Eviction triggers AFTER insertion so a write that
     // happens to be the cap+1 unique param doesn't get dropped before its
@@ -219,23 +315,70 @@ export function createTracker({ adapter, hasher, enabled = true }) {
   }
 
   /**
-   * Returns the list of params that meet BOTH thresholds. Each entry
-   * carries the param name and the (deduped) counts so the popup can
-   * tell the user "uid: 4 domains, 7 values" without re-reading the
-   * storage layer.
+   * Pure function: derive the lifecycle state of a single entry from its
+   * stored counts + entropyAvg + name. Lives outside observe() so promotion
+   * is purely a read-side concern — observe stays cheap and storage stays
+   * a pure event log we can re-evaluate against new thresholds at any time.
+   *
+   * @param {string} name — param name (used for the length guard)
+   * @param {object|undefined} entry — stored entry, or undefined
+   * @returns {"observed"|"suspicious"|"candidate"}
+   */
+  function graduate(name, entry) {
+    if (!entry) return "observed";
+    const dCount = entry.domains?.length ?? 0;
+    const vCount = entry.values?.length ?? 0;
+    if (dCount < DOMAIN_THRESHOLD || vCount < VALUE_THRESHOLD) return "observed";
+    // At least suspicious. Check whether it also crosses the candidate bar.
+    const eAvg = typeof entry.entropyAvg === "number" ? entry.entropyAvg : 0;
+    const nameLen = (name || "").length;
+    if (
+      dCount >= CANDIDATE_DOMAIN_THRESHOLD &&
+      vCount >= CANDIDATE_VALUE_THRESHOLD &&
+      eAvg > CANDIDATE_ENTROPY_THRESHOLD &&
+      nameLen >= CANDIDATE_NAME_LENGTH_MIN
+    ) {
+      return "candidate";
+    }
+    return "suspicious";
+  }
+
+  /**
+   * Returns the list of params that meet BOTH B16 thresholds — i.e. anything
+   * that has graduated to suspicious or higher. Each entry carries the param
+   * name, the (deduped) counts, and the current lifecycle state so the popup
+   * can tell the user "uid: 4 domains, 7 values" and (#532) optionally render
+   * a different badge for `candidate` entries without re-reading storage.
    */
   async function getFlagged() {
-    const state = await adapter.get();
-    const params = state.params || {};
+    const stateObj = await adapter.get();
+    const params = stateObj.params || {};
     const out = [];
     for (const [name, entry] of Object.entries(params)) {
-      const dCount = entry.domains?.length ?? 0;
-      const vCount = entry.values?.length ?? 0;
-      if (dCount >= DOMAIN_THRESHOLD && vCount >= VALUE_THRESHOLD) {
-        out.push({ param: name, domains: dCount, values: vCount });
+      const lifecycle = graduate(name, entry);
+      if (lifecycle === "suspicious" || lifecycle === "candidate") {
+        out.push({
+          param: name,
+          domains: entry.domains?.length ?? 0,
+          values: entry.values?.length ?? 0,
+          state: lifecycle,
+        });
       }
     }
     return out;
+  }
+
+  /**
+   * Returns the lifecycle state of `paramName`. Unknown params resolve to
+   * `"observed"` (defensive default — never throws, never returns undefined).
+   *
+   * @param {string} paramName
+   * @returns {Promise<"observed"|"suspicious"|"candidate">}
+   */
+  async function getState(paramName) {
+    const stateObj = await adapter.get();
+    const entry = stateObj.params?.[paramName];
+    return graduate(paramName, entry);
   }
 
   /**
@@ -247,5 +390,5 @@ export function createTracker({ adapter, hasher, enabled = true }) {
     _enabled = next !== false;
   }
 
-  return { observe, getFlagged, setEnabled };
+  return { observe, getFlagged, getState, setEnabled };
 }

--- a/tests/unit/cross-site-frequency.test.mjs
+++ b/tests/unit/cross-site-frequency.test.mjs
@@ -31,6 +31,11 @@ import {
   MAX_TRACKED_PARAMS,
   DOMAIN_THRESHOLD,
   VALUE_THRESHOLD,
+  CANDIDATE_DOMAIN_THRESHOLD,
+  CANDIDATE_VALUE_THRESHOLD,
+  CANDIDATE_ENTROPY_THRESHOLD,
+  CANDIDATE_NAME_LENGTH_MIN,
+  valueEntropy,
 } from "../../src/lib/cross-site-frequency.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -263,5 +268,226 @@ describe("createInMemoryAdapter — shape", () => {
     await a.set({ params: { z: { domains: ["a.com"], values: ["h:v1"], lastSeen: 1 } } });
     const dataB = await b.get();
     assert.deepEqual(dataB.params || {}, {});
+  });
+});
+
+// ── Graduation pipeline (issue #532, slice extension of B16) ─────────────────
+//
+// The tracker now carries an explicit per-param state machine:
+//   observed → suspicious → candidate
+//
+// `observed`   — first time we see the param on any domain.
+// `suspicious` — meets the existing B16 flagging threshold (≥3 domains AND
+//                ≥3 distinct value-hashes). `getFlagged()` continues to return
+//                this set, so consumers (popup) keep working unchanged.
+// `candidate`  — strong cross-site-tracker signal: ≥5 domains AND ≥10 values
+//                AND entropyAvg > 3.0 AND param name length ≥ 4. The length
+//                guard excludes generic 3-letter params (id/pid/ref) that the
+//                PRD (muga#529) explicitly rejects.
+//
+// State is computed LAZILY in getState() / getFlagged() — we do NOT pay the
+// cost on the hot observe() path. The only thing observe() updates is the
+// running mean entropy, which is O(1).
+
+describe("valueEntropy — Shannon entropy helper", () => {
+  test("returns 0 for an empty / null-ish input (no information)", () => {
+    assert.equal(valueEntropy(""), 0);
+    assert.equal(valueEntropy(null), 0);
+    assert.equal(valueEntropy(undefined), 0);
+  });
+
+  test("returns 0 for a single-character string (only one symbol)", () => {
+    assert.equal(valueEntropy("x"), 0);
+  });
+
+  test("returns 0 for a constant-character string (only one symbol)", () => {
+    assert.equal(valueEntropy("aaaa"), 0);
+  });
+
+  test("a uniform 2-symbol string has entropy 1.0 (one bit per symbol)", () => {
+    assert.equal(valueEntropy("ab"), 1);
+    assert.equal(valueEntropy("abab"), 1);
+  });
+
+  test("higher-variety strings produce strictly higher entropy than low-variety ones", () => {
+    const low = valueEntropy("aaab");
+    const high = valueEntropy("abcdefghij");
+    assert.ok(high > low, `expected ${high} > ${low}`);
+  });
+
+  test("a long random-ish hex-style id crosses the 3.0 candidate threshold", () => {
+    // Real-world cross-site IDs (UUIDs, base64 tokens) live well above 3.0.
+    const e = valueEntropy("9f3c1ea2b48d6701ffac5e2d");
+    assert.ok(e > 3.0, `expected entropy > 3, got ${e}`);
+  });
+});
+
+describe("createTracker — graduation thresholds export", () => {
+  test("exports CANDIDATE_DOMAIN_THRESHOLD = 5", () => {
+    assert.equal(CANDIDATE_DOMAIN_THRESHOLD, 5);
+  });
+  test("exports CANDIDATE_VALUE_THRESHOLD = 10", () => {
+    assert.equal(CANDIDATE_VALUE_THRESHOLD, 10);
+  });
+  test("exports CANDIDATE_ENTROPY_THRESHOLD = 3.0", () => {
+    assert.equal(CANDIDATE_ENTROPY_THRESHOLD, 3.0);
+  });
+  test("exports CANDIDATE_NAME_LENGTH_MIN = 4", () => {
+    assert.equal(CANDIDATE_NAME_LENGTH_MIN, 4);
+  });
+});
+
+describe("createTracker — getState() state machine", () => {
+  test("unknown param returns 'observed' (defensive default)", async () => {
+    const { tracker } = makeTracker();
+    assert.equal(await tracker.getState("nope"), "observed");
+  });
+
+  test("first observation on a single domain → 'observed'", async () => {
+    const { tracker } = makeTracker();
+    await tracker.observe("a.com", "uid", "v1");
+    assert.equal(await tracker.getState("uid"), "observed");
+  });
+
+  test("3 domains × 3 values → 'suspicious' (matches existing B16 flag)", async () => {
+    const { tracker } = makeTracker();
+    await tracker.observe("a.com", "uid", "v1");
+    await tracker.observe("b.com", "uid", "v2");
+    await tracker.observe("c.com", "uid", "v3");
+    assert.equal(await tracker.getState("uid"), "suspicious");
+    // And getFlagged still surfaces it, unchanged.
+    const flagged = await tracker.getFlagged();
+    assert.equal(flagged.length, 1);
+    assert.equal(flagged[0].param, "uid");
+  });
+
+  test("5 domains × 10 high-entropy values + name length ≥4 → 'candidate'", async () => {
+    // Use the real defaultHasher would slow tests; the stub hasher is fine
+    // because state evaluation looks at counts + entropyAvg, and entropyAvg
+    // is computed from the RAW value (pre-hash), so we can drive it directly.
+    const { tracker } = makeTracker();
+    const highEntropyValues = [
+      "9f3c1ea2b48d6701ffac5e2d",
+      "8a14bd0fe21c95773bbe44a1",
+      "7c0d59e6bb4827419fe10cda",
+      "6b21e8a44dc91075ffac88e3",
+      "5d39b07a6e15cc8842b990fe",
+      "4e54c01b8a76dd9711e205bb",
+      "3c61d52f9b8c11ea7700ff43",
+      "2a78e0419fcd203baa551c66",
+      "1b86f1538e0c34cd99cc7700",
+      "0a93021647db17ee4471ad58",
+    ];
+    const domains = ["a.com", "b.com", "c.com", "d.com", "e.com"];
+    // 5 domains × 10 values = 50 observations. Spread values across domains
+    // so we hit BOTH thresholds.
+    for (let i = 0; i < highEntropyValues.length; i++) {
+      const d = domains[i % domains.length];
+      await tracker.observe(d, "userid", highEntropyValues[i]);
+    }
+    // Make sure all 5 domains are touched at least once.
+    for (const d of domains) await tracker.observe(d, "userid", "9f3c1ea2b48d6701ffac5e2d");
+    assert.equal(await tracker.getState("userid"), "candidate");
+  });
+
+  test("5 domains × 10 high-entropy values BUT param length 3 → still 'suspicious' (length guard rejects)", async () => {
+    // PRD muga#529: 3-letter generic params (id, pid, ref) MUST NOT graduate.
+    const { tracker } = makeTracker();
+    const values = [
+      "9f3c1ea2b48d6701ffac5e2d", "8a14bd0fe21c95773bbe44a1",
+      "7c0d59e6bb4827419fe10cda", "6b21e8a44dc91075ffac88e3",
+      "5d39b07a6e15cc8842b990fe", "4e54c01b8a76dd9711e205bb",
+      "3c61d52f9b8c11ea7700ff43", "2a78e0419fcd203baa551c66",
+      "1b86f1538e0c34cd99cc7700", "0a93021647db17ee4471ad58",
+    ];
+    const domains = ["a.com", "b.com", "c.com", "d.com", "e.com"];
+    for (let i = 0; i < values.length; i++) {
+      await tracker.observe(domains[i % domains.length], "ref", values[i]);
+    }
+    for (const d of domains) await tracker.observe(d, "ref", "9f3c1ea2b48d6701ffac5e2d");
+    assert.equal(await tracker.getState("ref"), "suspicious");
+  });
+
+  test("5 domains × 10 LOW-entropy values → still 'suspicious' (entropy guard rejects)", async () => {
+    // Sequential numeric IDs have low Shannon entropy per character — they
+    // look like an enumerated user list, not a high-entropy tracking ID.
+    const { tracker } = makeTracker();
+    const values = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+    const domains = ["a.com", "b.com", "c.com", "d.com", "e.com"];
+    for (let i = 0; i < values.length; i++) {
+      await tracker.observe(domains[i % domains.length], "userid", values[i]);
+    }
+    for (const d of domains) await tracker.observe(d, "userid", "1");
+    const state = await tracker.getState("userid");
+    assert.equal(state, "suspicious", `got ${state} — entropy guard should have rejected this`);
+  });
+});
+
+describe("createTracker — entry metadata extensions", () => {
+  test("entry carries firstSeen, lastSeen, entropyAvg after observation", async () => {
+    const { tracker, adapter } = makeTracker();
+    await tracker.observe("a.com", "uid", "v1");
+    const stored = await adapter.get();
+    const e = stored.params.uid;
+    assert.equal(typeof e.firstSeen, "number");
+    assert.equal(typeof e.lastSeen, "number");
+    assert.equal(typeof e.entropyAvg, "number");
+    assert.ok(e.entropyAvg >= 0);
+  });
+
+  test("firstSeen ≤ lastSeen across many observations (monotonic)", async () => {
+    const { tracker, adapter } = makeTracker();
+    for (let i = 0; i < 5; i++) {
+      await tracker.observe("a.com", "uid", `v${i}`);
+    }
+    const e = (await adapter.get()).params.uid;
+    assert.ok(e.firstSeen <= e.lastSeen, `firstSeen ${e.firstSeen} > lastSeen ${e.lastSeen}`);
+  });
+
+  test("entropyAvg is a finite number ≥ 0 after many observations (running-mean property)", async () => {
+    const { tracker, adapter } = makeTracker();
+    const samples = ["abc", "aaaa", "9f3c1ea2", "xy", "qqqq", "abcdef"];
+    for (const v of samples) await tracker.observe("a.com", "uid", v);
+    const e = (await adapter.get()).params.uid;
+    assert.ok(Number.isFinite(e.entropyAvg), `entropyAvg not finite: ${e.entropyAvg}`);
+    assert.ok(e.entropyAvg >= 0, `entropyAvg negative: ${e.entropyAvg}`);
+  });
+
+  test("entropyAvg of constant-value observations stays 0", async () => {
+    const { tracker, adapter } = makeTracker();
+    for (let i = 0; i < 4; i++) await tracker.observe("a.com", "uid", "aaaa");
+    const e = (await adapter.get()).params.uid;
+    assert.equal(e.entropyAvg, 0);
+  });
+});
+
+describe("createTracker — LRU and graduation interact cleanly", () => {
+  test("a 'candidate' entry can be evicted by LRU just like any other entry", async () => {
+    // No special handling: the state machine is read-side only. If something
+    // graduates to candidate but then sits idle while 1000 newer params come
+    // in, it gets evicted along with everything else. That's intentional —
+    // the LRU is the storage budget; promotion doesn't pin entries.
+    const { tracker, adapter } = makeTracker();
+    // Promote "userid" to candidate first.
+    const values = [
+      "9f3c1ea2b48d6701ffac5e2d", "8a14bd0fe21c95773bbe44a1",
+      "7c0d59e6bb4827419fe10cda", "6b21e8a44dc91075ffac88e3",
+      "5d39b07a6e15cc8842b990fe", "4e54c01b8a76dd9711e205bb",
+      "3c61d52f9b8c11ea7700ff43", "2a78e0419fcd203baa551c66",
+      "1b86f1538e0c34cd99cc7700", "0a93021647db17ee4471ad58",
+    ];
+    const domains = ["a.com", "b.com", "c.com", "d.com", "e.com"];
+    for (let i = 0; i < values.length; i++) {
+      await tracker.observe(domains[i % domains.length], "userid", values[i]);
+    }
+    assert.equal(await tracker.getState("userid"), "candidate");
+    // Now flood with MAX unique params. "userid" is the OLDEST → evicted.
+    for (let i = 0; i < MAX_TRACKED_PARAMS; i++) {
+      await tracker.observe("z.com", `flood${i}`, "v");
+    }
+    const stored = await adapter.get();
+    assert.ok(!stored.params.userid, "candidate entry should have been evicted by LRU");
+    // After eviction, getState falls back to defensive default.
+    assert.equal(await tracker.getState("userid"), "observed");
   });
 });


### PR DESCRIPTION
Closes #532. Third slice of PRD #529.

Extends Cross-Site Frequency Tracker (B16, PR #492) with a formal graduation state machine. Each tracked param progresses through explicit lifecycle stages.

## State transitions (lazy on read, not on hot observe path)

- **observed** — first seen on any first-party domain
- **suspicious** — ≥3 distinct domains AND ≥3 distinct values (matches B16's existing flagging)
- **candidate** — ≥5 domains AND ≥10 values AND entropyAvg > 3.0 AND param name length ≥ 4

## Per-entry shape

`{ domains, values, lastSeen }` → `{ domains, values, firstSeen, lastSeen, count, entropyAvg }`. Backfill in observe() handles entries persisted by older module versions.

## Length-≥4 guard

Explicitly excludes 3-letter generic params (id, pid, ref) per PRD #529's rejection of aggressive global stripping. Locked in by a regression test.

## New exports

`valueEntropy(s)`, `getState(paramName)`, plus 4 candidate threshold constants.

## Non-breaking

`getFlagged()` entries now include a `state` field. Verified against 3 consumers (popup.js, cleaner.test.mjs, service-worker.js) — none destructure beyond param/domains/values.

## Test plan

- [x] `npm test` → **3377/3377** passing (+21 from baseline 3356)
- [x] `npm run benchmark` → 117/117 (no behavior change to processUrl)
- [x] `npm run lint` → 0 errors
- [x] All B16 module tests still pass (regression)
- [x] State transitions covered for all 3 stages
- [x] Length-≥4 guard regression test
- [x] Entropy threshold guard regression test
- [x] LRU eviction of candidate handled cleanly (getState defaults to observed)

Unblocks #536 (Strip locally) and #537 (Report upstream).