### PR TITLE
feat(popup): Strip locally button + userCustomRules pref (#536)

### DIFF
--- a/docs/data_architect.md
+++ b/docs/data_architect.md
@@ -37,6 +37,7 @@ Source of truth: `PREF_DEFAULTS` in `src/lib/storage.js`.
 | `canonicalExtractorEnabled` | boolean | `true` | (#442, B7) When the wrapper engine detects an opaque wrapper (host matched but no destination in URL), consult content-script-supplied `<link rel=canonical>` / JSON-LD `@id` before giving up. Default ON. |
 | `crossSiteFrequencyEnabled` | boolean | `true` | (#446, B16) Local-only Cross-Site Frequency Tracker: maintains a `(paramName, sha256(value))` map keyed per first-party domain so the popup can flag params that appear on 3+ domains AND have 3+ distinct values. LRU-capped at 1000 unique params. NEVER transmitted. Toggle off to make observations a no-op and hide the freq subgroup. |
 | `attributionLedgerEnabled` | boolean | `true` | (#460, A2) Persist the Attribution Ledger ring buffer to `chrome.storage.local["attributionLedger"]` so the popup's "Recent activity" section survives service-worker restarts. Toggle off to gate the SW writer (no local-storage writes; popup section stays empty). |
+| `userCustomRules` | string[] | `[]` | (#536) Per-user custom strip rules promoted from the popup's "Strip locally" button on flagged Suspicious-params rows. Each entry is a bare param name (matched case-insensitively by the cleaner) stripped on EVERY host. Lives in sync so promotions follow the user across devices. Affiliate-preservation always wins (the affiliateParamSet skip in `stripTrackingParams` runs first), so a user can never accidentally strip their own creator referral tag. |
 
 ### List entry format
 

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -32,11 +32,17 @@ const TRACKING_PREFIXES = [
 ];
 
 /** Returns true if the param is a known tracking param (exact match or prefix). */
-function isTrackingParam(lower, customParams, domainStrip, remoteParams) {
+function isTrackingParam(lower, customParams, domainStrip, remoteParams, userCustomRules) {
   if (TRACKING_PARAMS_SET.has(lower)) return true;
   if (customParams.has(lower)) return true;
   if (domainStrip.has(lower)) return true;
   if (remoteParams.has(lower)) return true;  // T1.5: additive remote params (ADR-D10)
+  // #536: user-promoted custom strip rules. Global across hosts because
+  // the user explicitly clicked "Strip locally" on a flagged param. The
+  // affiliateParamSet skip in stripTrackingParams() runs BEFORE this
+  // function is consulted, so a user-listed "tag" cannot wipe an
+  // Amazon creator's affiliate referral.
+  if (userCustomRules && userCustomRules.has(lower)) return true;
   for (const prefix of TRACKING_PREFIXES) {
     if (lower.startsWith(prefix)) return true;
   }
@@ -168,6 +174,9 @@ function stripTrackingParams(url, prefs, domainRules, disabledCategories, classi
   const affiliateParamSet = new Set(patterns.map(p => p.param.toLowerCase()));
   const customParams = new Set((prefs.customParams || []).map(p => p.toLowerCase()));
   const remoteParams = new Set((prefs.remoteParams || []).map(p => p.toLowerCase()));  // T1.5: ADR-D10
+  // #536: user-promoted strip rules. Lowercased once for case-insensitive
+  // membership; consulted last so built-in/affiliate paths still win.
+  const userCustomRules = new Set((prefs.userCustomRules || []).map(p => p.toLowerCase()));
   const { preserved, domainStrip } = getDomainParamSets(hostname, domainRules);
 
   const disabledParams = new Set();
@@ -194,7 +203,7 @@ function stripTrackingParams(url, prefs, domainRules, disabledCategories, classi
     if (preserved.has(lower)) continue;
     if (disabledParams.has(lower)) continue;
     const isClassified = classifierLower && classifierLower.has(lower);
-    if (isClassified || isTrackingParam(lower, customParams, domainStrip, remoteParams)) {
+    if (isClassified || isTrackingParam(lower, customParams, domainStrip, remoteParams, userCustomRules)) {
       // Capture the value BEFORE delete so we can feed it to the
       // frequency tracker without re-parsing the URL. searchParams.get()
       // returns "" for empty values; that's fine — the tracker hashes

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -135,6 +135,31 @@ export const TRANSLATIONS = {
   suspicious_params_entropy_group:   { en: "On this page (entropy)",                              es: "En esta página (entropía)",                               pt: "Nesta página (entropia)",                               de: "Auf dieser Seite (Entropie)" },
   suspicious_params_frequency_group: { en: "Across sites you've visited",                         es: "En varios sitios que has visitado",                       pt: "Em vários sites que você visitou",                      de: "Über besuchte Sites hinweg" },
   suspicious_params_freq_detail:     { en: "{domains} domains • {values} distinct values",        es: "{domains} dominios • {values} valores distintos",         pt: "{domains} domínios • {values} valores distintos",       de: "{domains} Domains • {values} verschiedene Werte" },
+
+  // ── Popup: Strip locally per-row button (#536) ──────────────────────────
+  // Promotes a flagged Suspicious-params row into prefs.userCustomRules so
+  // the cleaner strips the param on every subsequent navigation. The "_done"
+  // variant replaces the button text after a successful click; the active
+  // count surfaces total active custom rules so the user has a reference
+  // for what they have promoted.
+  strip_locally_btn: {
+    en: "Strip locally",
+    es: "Eliminar localmente",
+    pt: "Remover localmente" /* FIXME: needs native speaker review */,
+    de: "Lokal entfernen" /* FIXME: needs native speaker review */,
+  },
+  strip_locally_btn_done: {
+    en: "Stripped locally ✓",
+    es: "Eliminado localmente ✓",
+    pt: "Removido localmente ✓" /* FIXME: needs native speaker review */,
+    de: "Lokal entfernt ✓" /* FIXME: needs native speaker review */,
+  },
+  strip_locally_active_count: {
+    en: "{n} custom rules active",
+    es: "{n} reglas personalizadas activas",
+    pt: "{n} regras personalizadas ativas" /* FIXME: needs native speaker review */,
+    de: "{n} benutzerdefinierte Regeln aktiv" /* FIXME: needs native speaker review */,
+  },
   domain_stats_empty:    { en: "No domain stats yet. Keep browsing!", es: "Aún no hay estadísticas. ¡Sigue navegando!", pt: "Sem estatísticas ainda. Continue navegando!", de: "Noch keine Domain-Statistiken. Weiter surfen!" },
   domain_stats_params:   { en: "params stripped", es: "parámetros eliminados", pt: "parâmetros removidos", de: "Parameter entfernt" },
   domain_stats_urls:     { en: "URLs cleaned", es: "URLs limpiadas", pt: "URLs limpas", de: "URLs bereinigt" },

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -140,6 +140,16 @@ export const PREF_DEFAULTS = {
   // Privacy-sensitive (it carries URLs), so we expose it as its own
   // toggle even though the data is local-only.
   attributionLedgerEnabled: true,
+  // User-promoted custom strip rules (#536). Populated by the popup's
+  // "Strip locally" button on flagged Suspicious-params rows. Each entry
+  // is a bare param name (lowercased on read by the cleaner) that
+  // processUrl strips on EVERY host — the user has explicitly trusted
+  // the rule. Affiliate-preservation still wins (the affiliateParamSet
+  // skip in stripTrackingParams runs before custom-rule matching), so a
+  // user can never accidentally strip their own creator's referral tag.
+  // Lives in sync so the rule list follows the user across devices.
+  // Default empty — opt-in by user click only.
+  userCustomRules: [],
 };
 
 /**

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -784,11 +784,42 @@ footer .footer-link-btn:hover { color: var(--accent-strong); }
 
 .suspicious-row {
   display: grid;
-  grid-template-columns: 1fr auto;
+  /* #536: name | detail | strip-locally button */
+  grid-template-columns: 1fr auto auto;
   gap: 8px;
   align-items: center;
   padding: 4px 14px;
   font-size: 11px;
+}
+
+/* #536: per-row "Strip locally" button. Keeps the row visible after
+ * promotion (collapses into a disabled "done" pill) so the user sees
+ * the receipt of what they have promoted. */
+.strip-locally-btn {
+  background: transparent;
+  border: 1px solid var(--border-1, #ccc);
+  color: var(--text-1, inherit);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.strip-locally-btn:hover:not(:disabled) {
+  background: var(--bg-2, rgba(0, 0, 0, 0.04));
+}
+.strip-locally-btn.is-done,
+.strip-locally-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+  border-color: transparent;
+}
+
+.strip-locally-count {
+  font-size: 10px;
+  color: var(--text-3);
+  padding: 6px 14px 4px;
+  font-style: italic;
 }
 
 .suspicious-name {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -69,6 +69,9 @@
   <details class="suspicious-params" id="suspicious-params" hidden>
     <summary data-i18n="suspicious_params_label">Suspicious params</summary>
     <div id="suspicious-params-list"></div>
+    <!-- #536: counter rendered when prefs.userCustomRules.length > 0.
+         Hidden on a fresh install so a chrome-less header never appears. -->
+    <div id="strip-locally-count" class="strip-locally-count" hidden aria-live="polite"></div>
   </details>
 
   <details class="history" id="history" hidden>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -324,7 +324,7 @@ async function init() {
   // customParams. We refetch full prefs instead of diffing to stay simple.
   chrome.storage.onChanged.addListener(async (changes, area) => {
     if (area !== "sync") return;
-    if (!changes.enabled && !changes.blacklist && !changes.whitelist && !changes.customParams) return;
+    if (!changes.enabled && !changes.blacklist && !changes.whitelist && !changes.customParams && !changes.userCustomRules) return;
     try {
       const fresh = await getPrefs();
       // Keep the popup's own toggle in sync with any external change
@@ -332,6 +332,11 @@ async function init() {
         enabledToggle.checked = fresh.enabled;
       }
       await showUrlPreview(fresh, lang);
+      // #536: re-render the Suspicious-params section too so the per-row
+      // button reflects the new userCustomRules state without a popup reopen.
+      if (changes.userCustomRules) {
+        await showSuspiciousParams(fresh, lang);
+      }
     } catch (err) {
       console.error("[MUGA] reactive re-render:", err);
     }
@@ -787,6 +792,12 @@ async function showSuspiciousParams(prefs, lang) {
   // Reset so repeated calls (storage.onChanged) stay idempotent.
   list.replaceChildren();
 
+  // #536: snapshot of current user-promoted rules. The lower-cased view
+  // backs idempotency for the per-row button — we never add a duplicate
+  // and we hide the button when the param is already promoted.
+  const userCustomRules = Array.isArray(prefs.userCustomRules) ? prefs.userCustomRules : [];
+  const userCustomRulesLower = new Set(userCustomRules.map(p => p.toLowerCase()));
+
   // ── Entropy subgroup: synchronous, scans current tab URL only ──
   let entropyFlags = [];
   try {
@@ -849,6 +860,12 @@ async function showSuspiciousParams(prefs, lang) {
       detailEl.textContent = `score ${flag.score}`;
       row.appendChild(detailEl);
 
+      // #536: per-row Strip locally button. Promotes the flagged param
+      // into prefs.userCustomRules so future navigations strip it. Row
+      // stays visible after promotion (collapses button into a "done"
+      // disabled state) so the user keeps the visual receipt.
+      _appendStripLocallyButton(row, flag.param, userCustomRulesLower, prefs, lang);
+
       list.appendChild(row);
     }
   }
@@ -878,9 +895,101 @@ async function showSuspiciousParams(prefs, lang) {
         .replace("{values}", String(flag.values));
       row.appendChild(detailEl);
 
+      _appendStripLocallyButton(row, flag.param, userCustomRulesLower, prefs, lang);
+
       list.appendChild(row);
     }
   }
+
+  // #536: counter widget — surfaces the total number of user-promoted
+  // strip rules so the user has a reference for what they own. Hidden
+  // when zero so a fresh install never sees a 0-count widget.
+  _renderStripLocallyCount(userCustomRules.length, lang);
+}
+
+/**
+ * Appends the per-row "Strip locally" button to a Suspicious-params row.
+ * If the param is already in userCustomRulesLower, renders a disabled
+ * "Stripped locally ✓" pill instead — the row stays visible so the user
+ * keeps the visual receipt of what they promoted (design choice for #536:
+ * keep-row-with-done-state, NOT remove-row, so re-promoting after a
+ * popup close stays one click away).
+ *
+ * @param {HTMLElement} row              The .suspicious-row element being built.
+ * @param {string}      paramName        Original-case param name (preserved).
+ * @param {Set<string>} alreadyPromoted  Lowercased snapshot of current rules.
+ * @param {object}      prefs            Reactive prefs object (mutated locally on click).
+ * @param {string}      lang             Active UI language code.
+ */
+function _appendStripLocallyButton(row, paramName, alreadyPromoted, prefs, lang) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "strip-locally-btn";
+  btn.dataset.param = paramName;
+
+  const isPromoted = alreadyPromoted.has(paramName.toLowerCase());
+  if (isPromoted) {
+    btn.textContent = t("strip_locally_btn_done", lang);
+    btn.classList.add("is-done");
+    btn.disabled = true;
+    btn.setAttribute("aria-label", t("strip_locally_btn_done", lang));
+  } else {
+    btn.textContent = t("strip_locally_btn", lang);
+    btn.setAttribute("aria-label", t("strip_locally_btn", lang));
+    btn.addEventListener("click", async () => {
+      // Read-modify-write against chrome.storage.sync. We re-read inside
+      // the handler so concurrent popup actions (or another device's
+      // sync) don't blow away each other's rules.
+      try {
+        const current = await new Promise((resolve, reject) => {
+          chrome.storage.sync.get({ userCustomRules: [] }, (r) => {
+            if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+            else resolve(r);
+          });
+        });
+        const list = Array.isArray(current.userCustomRules) ? current.userCustomRules : [];
+        const lowerSet = new Set(list.map(p => p.toLowerCase()));
+        if (!lowerSet.has(paramName.toLowerCase())) {
+          list.push(paramName);
+        }
+        await new Promise((resolve, reject) => {
+          chrome.storage.sync.set({ userCustomRules: list }, () => {
+            if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+            else resolve();
+          });
+        });
+        // Mutate the in-flight prefs object so a follow-up re-render
+        // (from the storage.onChanged listener or otherwise) sees the
+        // new state without an extra round-trip.
+        prefs.userCustomRules = list;
+        // Optimistic re-render: collapse the button to the "done" state
+        // and refresh the counter inline so the user gets immediate
+        // feedback even before chrome.storage.onChanged fires.
+        btn.textContent = t("strip_locally_btn_done", lang);
+        btn.classList.add("is-done");
+        btn.disabled = true;
+        btn.setAttribute("aria-label", t("strip_locally_btn_done", lang));
+        _renderStripLocallyCount(list.length, lang);
+      } catch (err) {
+        console.error("[MUGA] strip-locally save:", err);
+      }
+    });
+  }
+  row.appendChild(btn);
+}
+
+/** Renders the active-rules counter inside the suspicious-params section. */
+function _renderStripLocallyCount(count, lang) {
+  const el = document.getElementById("strip-locally-count");
+  if (!el) return;
+  if (count <= 0) {
+    el.hidden = true;
+    el.textContent = "";
+    return;
+  }
+  // textContent + manual {n} replace — never innerHTML.
+  el.textContent = t("strip_locally_active_count", lang).replace("{n}", String(count));
+  el.hidden = false;
 }
 
 /**

--- a/tests/unit/cleaner-user-custom-rules.test.mjs
+++ b/tests/unit/cleaner-user-custom-rules.test.mjs
@@ -1,0 +1,93 @@
+/**
+ * MUGA — Cleaner consults prefs.userCustomRules (#536, slice 1).
+ *
+ * The popup's "Strip locally" button promotes a flagged suspicious param
+ * into prefs.userCustomRules (a chrome.storage.sync array). On every
+ * subsequent navigation, processUrl must strip those params globally —
+ * that is what gives the user the "no waiting for a release" promise.
+ *
+ * Precedence rule: affiliate-preservation ALWAYS wins over user custom
+ * rules. A user shouldn't be able to accidentally strip their own
+ * creator's affiliate tag (e.g. Amazon "tag"). The cleaner already
+ * enforces this via the affiliateParamSet skip-list inside
+ * stripTrackingParams() — these tests pin that contract.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { processUrl } from "../../src/lib/cleaner.js";
+
+const BASE_PREFS = {
+  enabled: true,
+  injectOwnAffiliate: false,
+  notifyForeignAffiliate: false,
+  blacklist: [],
+  whitelist: [],
+  customParams: [],
+  userCustomRules: [],
+};
+
+test("userCustomRules: empty list does NOT strip a param the cleaner doesn't know", () => {
+  const url = "https://example.com/?foo=bar&keep=me";
+  const { cleanUrl, removedTracking } = processUrl(url, { ...BASE_PREFS });
+  // Neither "foo" nor "keep" is a known tracker; both must survive.
+  assert.equal(cleanUrl, url);
+  assert.deepEqual(removedTracking, []);
+});
+
+test("userCustomRules: param listed in userCustomRules IS stripped on any host", () => {
+  const url = "https://example.com/?mytrackingparam=abc&keep=me";
+  const { cleanUrl, removedTracking } = processUrl(url, {
+    ...BASE_PREFS,
+    userCustomRules: ["mytrackingparam"],
+  });
+  assert.equal(cleanUrl, "https://example.com/?keep=me");
+  assert.deepEqual(removedTracking, ["mytrackingparam"]);
+});
+
+test("userCustomRules: case-insensitive match — uppercase URL key, lowercase rule", () => {
+  const url = "https://example.com/?MyTrackingParam=abc&keep=me";
+  const { cleanUrl, removedTracking } = processUrl(url, {
+    ...BASE_PREFS,
+    userCustomRules: ["mytrackingparam"],
+  });
+  // The original-case key is reported in removedTracking, value stripped.
+  assert.ok(!cleanUrl.includes("MyTrackingParam"));
+  assert.ok(cleanUrl.includes("keep=me"));
+  assert.deepEqual(removedTracking, ["MyTrackingParam"]);
+});
+
+test("userCustomRules: applies on a different host too (rules are GLOBAL)", () => {
+  const url = "https://other.example.org/path?mytrackingparam=zzz";
+  const { cleanUrl, removedTracking } = processUrl(url, {
+    ...BASE_PREFS,
+    userCustomRules: ["mytrackingparam"],
+  });
+  assert.equal(cleanUrl, "https://other.example.org/path");
+  assert.deepEqual(removedTracking, ["mytrackingparam"]);
+});
+
+test("affiliate precedence: Amazon ?tag= is NOT stripped even when 'tag' is in userCustomRules", () => {
+  // Amazon ES has an active ourTag. The user adding "tag" to their custom
+  // rules MUST NOT strip the affiliate param — otherwise users would
+  // accidentally tear down creator referrals (the whole point of MUGA).
+  const url = "https://www.amazon.es/dp/B000000000?tag=youtuber-21";
+  const { cleanUrl } = processUrl(url, {
+    ...BASE_PREFS,
+    userCustomRules: ["tag"],
+  });
+  // The "tag" param must survive on amazon.es because it is registered
+  // as an affiliate param for that host. The path may be cleaned by the
+  // Amazon-specific path normaliser; we only assert the affiliate tag
+  // is retained.
+  assert.match(cleanUrl, /[?&]tag=youtuber-21/, "Amazon affiliate tag must NOT be stripped by userCustomRules");
+});
+
+test("userCustomRules: ignored when prefs.enabled is false (cleaner short-circuits upstream — sanity)", () => {
+  // Note: processUrl itself doesn't check prefs.enabled (callers do).
+  // This test just makes sure adding userCustomRules doesn't break the
+  // pipeline for an empty-array variant — defensive against typos.
+  const url = "https://example.com/?clean=true";
+  const { cleanUrl } = processUrl(url, { ...BASE_PREFS, userCustomRules: undefined });
+  assert.equal(cleanUrl, url);
+});

--- a/tests/unit/popup-strip-locally-button.test.mjs
+++ b/tests/unit/popup-strip-locally-button.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * MUGA — Popup "Strip locally" button per Suspicious-params row (#536).
+ *
+ * The button promotes a flagged param into prefs.userCustomRules
+ * (chrome.storage.sync). The cleaner consults that array on every
+ * subsequent navigation, so the user gets immediate, persistent strip
+ * behaviour without waiting for a release.
+ *
+ * These structural tests pin:
+ *   - the i18n keys exist (en + es non-empty)
+ *   - the popup JS contains the marker class for the button so future
+ *     refactors keep it discoverable
+ *   - the popup JS references chrome.storage.sync.{get,set} for
+ *     userCustomRules in the click-handler path
+ *   - the renderer references the userCustomRules pref by name
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+
+import { makeChromeMock } from "./helpers/chrome-stub.mjs";
+globalThis.chrome = makeChromeMock({ hasSession: false, promiseShape: true });
+
+const { TRANSLATIONS } = await import("../../src/lib/i18n.js");
+
+// ── i18n keys ────────────────────────────────────────────────────────────────
+
+test("strip_locally_btn: i18n key exists with en + es non-empty", () => {
+  const k = TRANSLATIONS.strip_locally_btn;
+  assert.ok(k, "strip_locally_btn must exist");
+  assert.ok(typeof k.en === "string" && k.en.length > 0, "en non-empty");
+  assert.ok(typeof k.es === "string" && k.es.length > 0, "es non-empty");
+});
+
+test("strip_locally_btn_done: i18n key exists with en + es non-empty", () => {
+  const k = TRANSLATIONS.strip_locally_btn_done;
+  assert.ok(k, "strip_locally_btn_done must exist");
+  assert.ok(typeof k.en === "string" && k.en.length > 0, "en non-empty");
+  assert.ok(typeof k.es === "string" && k.es.length > 0, "es non-empty");
+});
+
+test("strip_locally_active_count: i18n key exists with en + es and {n} placeholder", () => {
+  const k = TRANSLATIONS.strip_locally_active_count;
+  assert.ok(k, "strip_locally_active_count must exist");
+  assert.ok(typeof k.en === "string" && k.en.includes("{n}"), "en must carry {n}");
+  assert.ok(typeof k.es === "string" && k.es.includes("{n}"), "es must carry {n}");
+});
+
+// ── JS surface ───────────────────────────────────────────────────────────────
+
+test("popup.js declares a 'strip-locally-btn' class for the per-row button", () => {
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+  assert.ok(
+    /strip-locally-btn/.test(popupSrc),
+    "popup.js must reference the strip-locally-btn class so the button is discoverable",
+  );
+});
+
+test("popup.js click-handler reads + writes userCustomRules via chrome.storage.sync", () => {
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+  // Both a read and a write of userCustomRules must appear; the read
+  // can be via getPrefs() / chrome.storage.sync.get, the write must be
+  // chrome.storage.sync.set (or setPrefs) so the rule survives reloads.
+  assert.ok(
+    /userCustomRules/.test(popupSrc),
+    "popup.js must reference the userCustomRules pref by name",
+  );
+  assert.ok(
+    /chrome\.storage\.sync\.set\(\s*\{\s*userCustomRules/.test(popupSrc) ||
+      /setPrefs\(\s*\{\s*userCustomRules/.test(popupSrc),
+    "popup.js must persist userCustomRules to chrome.storage.sync (set or setPrefs)",
+  );
+});
+
+test("popup.js renders the active custom-rules counter via the i18n template", () => {
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+  assert.ok(
+    /strip_locally_active_count/.test(popupSrc),
+    "popup.js must reference the strip_locally_active_count i18n key for the counter",
+  );
+});
+
+// ── HTML surface ─────────────────────────────────────────────────────────────
+
+test("popup.html still exposes the suspicious-params section host (regression guard)", () => {
+  // The Strip locally button lives INSIDE rows that the JS injects, so
+  // there is no direct HTML token to assert beyond the existing host
+  // section. This test exists so a future refactor that drops the
+  // section also fails this slice's surface check, not just B16's.
+  const html = readFileSync(resolve(root, "src/popup/popup.html"), "utf8");
+  assert.match(html, /id="suspicious-params-list"/);
+});

--- a/tests/unit/storage-user-custom-rules-pref.test.mjs
+++ b/tests/unit/storage-user-custom-rules-pref.test.mjs
@@ -1,0 +1,53 @@
+/**
+ * MUGA — PREF_DEFAULTS + docs surface for userCustomRules (#536).
+ *
+ * The "Strip locally" button in the popup's Suspicious Params section
+ * promotes a flagged param into a per-user array of param names that the
+ * cleaner consults globally. The list lives in chrome.storage.sync so it
+ * follows the user across devices (it is small — empty by default and
+ * generally a handful of entries even for power users).
+ *
+ * These tests pin both the code surface (PREF_DEFAULTS in storage.js)
+ * AND the documentation surface (docs/data_architect.md) so the schema
+ * stays a single source of truth (parity test docs-prefs-table also
+ * enforces 1:1 key coverage).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+
+import { makeChromeMock } from "./helpers/chrome-stub.mjs";
+globalThis.chrome = makeChromeMock({ hasSession: false, promiseShape: true });
+
+const { PREF_DEFAULTS } = await import("../../src/lib/storage.js");
+
+test("PREF_DEFAULTS includes userCustomRules: []", () => {
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(PREF_DEFAULTS, "userCustomRules"),
+    "PREF_DEFAULTS must include userCustomRules",
+  );
+  assert.ok(
+    Array.isArray(PREF_DEFAULTS.userCustomRules),
+    "userCustomRules default must be an array",
+  );
+  assert.equal(
+    PREF_DEFAULTS.userCustomRules.length,
+    0,
+    "userCustomRules default must be empty — users opt in by clicking 'Strip locally'",
+  );
+});
+
+test("docs/data_architect.md documents userCustomRules (sync prefs row)", () => {
+  const md = readFileSync(resolve(root, "docs/data_architect.md"), "utf8");
+  assert.match(
+    md,
+    /\|\s*`userCustomRules`\s*\|/,
+    "docs/data_architect.md must contain a sync-prefs row for userCustomRules",
+  );
+});


### PR DESCRIPTION
Closes #536. Fourth slice of PRD #529.

Per-row "Strip locally" button in the popup's existing Suspicious params section (B16). Click promotes the flagged param into `userCustomRules`. Subsequent navigations strip the param immediately.

## Re-render design

Keep the row, collapse the button to a disabled "Stripped locally ✓" pill. Preserves the visual receipt + idempotent on re-open + avoids disorienting row-disappears UX.

## Affiliate precedence preserved

A user-promoted "tag" cannot wipe a creator referral on Amazon. The existing `affiliateParamSet` check runs BEFORE `isTrackingParam` is consulted. Regression test included.

## Storage

`userCustomRules: []` in `PREF_DEFAULTS` (chrome.storage.sync — follows user across devices). docs/data_architect.md row added.

## Test plan

- [x] `npm test` → **3404/3404** passing (+27 from baseline 3377)
- [x] `npm run benchmark` → 117/117 (no behavior change without user prefs)
- [x] `npm run lint` → 0 errors
- [x] processUrl with userCustomRules=['mytrackingparam'] strips it
- [x] Without prefs → preserved
- [x] Affiliate-precedence regression: Amazon ?tag= preserved even with userCustomRules=['tag']
- [x] Popup structural test confirms button exists
- [x] Click handler does read-modify-write of chrome.storage.sync
- [x] storage.onChanged re-renders the section