### PR TITLE
release: v1.13.0 — PRD #529 first wave (adaptive URL coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-05-04
+
+PRD #529 first wave — adaptive URL coverage expansion. Six user-visible features land together. The wave shifts MUGA from purely curated rules toward a mix of curated + bounded-scope contextual + user-mediated discovery, while keeping the false-positive principle intact and the zero-telemetry promise unchanged.
+
+### Added
+
+- **PARAM_PAIRS bounded-scoping classifier** ([`src/lib/param-classifier.js`](src/lib/param-classifier.js)). Generic ambiguous parameters (`pid`, `icid`, `icmp`, `CMP`, `NLID`, `soc_src`) are now stripped — but ONLY when a definitive **anchor tracker** (`gclid`, `fbclid`, `msclkid`, `dclid`, `twclid`, `gbraid`, `wbraid`, `utm_source`, `utm_medium`, `utm_campaign`, `mc_eid`, `mc_cid`) co-occurs in the same URL. Standalone `pid=42` on a clean GitHub URL is preserved (functional). The same `pid` next to `gclid=…` on a marketing URL is stripped. Affiliate-precedence still wins: a pair that is also a creator-referral param for the host stays preserved. Unlocks 6+ benchmark-corpus URLs that were previously left untouched. (#530)
+- **Generic wrapper templates** in [`src/lib/wrapper-engine.js`](src/lib/wrapper-engine.js). When no explicit per-host wrapper recipe matches, the engine falls through to a generic code path that probes 5 common destination-parameter keys (`url`, `u`, `redirect`, `dest`, `target`) with 4 safety guards (destination must be absolute http(s), destination host ≠ wrapper host, destination must not be an auth/checkout shape, length cap). Catches new redirect networks the spec doesn't yet enumerate, without wide false-positive risk. Explicit per-host wrappers still take precedence. (#531)
+- **CSFT graduation pipeline** ([`src/lib/cross-site-frequency.js`](src/lib/cross-site-frequency.js)). Each tracked param record now carries a `state` field with three values: `observed → suspicious → candidate`. Promotion happens locally based on first-party domain count + value entropy + recurrence thresholds. Surfaces in the popup's "Suspicious params" section as evidence-graded recommendations, not just raw counters. New exports: `getState(paramName)`, `valueEntropy(s)`. The 17 pre-existing B16 unit tests still pass alongside new state-machine tests. (#532)
+- **"Strip locally" button** per flagged param in the popup's Suspicious section. One click promotes the param into a new local `userCustomRules: []` array in `chrome.storage.sync`. The cleaner consults the array on every navigation; affiliate-preservation still beats it. Per-user expansion of coverage with zero latency to upstream. (#536)
+- **"Report upstream" button** per flagged param in the same Suspicious section. One click opens a deep-linked GitHub issue in the muga repo containing strictly the parameter name and the count of distinct first-party domains the user observed it on — no value, no hash, no domain history, no telemetry. Privacy contract enforced structurally by the new [`src/lib/csft-upstream.js`](src/lib/csft-upstream.js) deep pure module: the only fields the payload-builder can produce are `paramName` and `firstPartyDomainCount`. (#537)
+- **Experimental param-class shape heuristic** behind `experimentalParamClassesEnabled` flag (default OFF). When enabled, the cleaner additionally strips parameters whose VALUE SHAPE matches a tracker pattern: suspicious key prefix (`*_id`, `*clid`, `*_token`, `*_uid`, `*_session`) AND value length > 16 AND Shannon entropy > 4.0 AND base64/hex/uuid charset. All four signals must hit (multi-signal AND). A small allowlist (`state`, `code`, `nonce`, `csrf`, `csrf_token`, `_csrf`, `oauth_token`, `oauth_verifier`, `access_token`, `refresh_token`, `id_token`, `session_id`, `sessionid`, `jsessionid`, `phpsessid`, `sid`, `aspsessionid`) is ALWAYS exempt to protect login flows. With the flag OFF, cleaner behaviour is byte-identical to the #530 baseline. (#544)
+
+### Changed
+
+- **`PREF_DEFAULTS`** in [`src/lib/storage.js`](src/lib/storage.js) gains two new fields: `userCustomRules: []` (per-user locally-promoted params from #536) and `experimentalParamClassesEnabled: false` (the #544 flag, default OFF).
+- **i18n keys** added in en + es for the two new popup buttons + the experimental-flag label. pt + de FIXME-flagged per project convention.
+- **CHANGELOG.md** structure: this 1.13.0 release sits above the previously-documented 1.12.0 (post-grill rollout). v1.12.0 was bumped in code on 2026-04-26 but never tagged into the wild; users on Chrome Web Store / Firefox AMO updating from v1.11.0 receive both waves under the v1.13.0 tag.
+
+### Internal
+
+- **Benchmark phase 2 + 3** ([`tests/benchmark/`](tests/benchmark/)): synthetic-baseline competitor adapter (#506 phase 2a — 9 UTM + 10 click IDs floor); Markdown report writer (#507 phase 3a); HTML report writer (#507 phase 3b); CI workflow on release-tag push (#507 phase 3c — `.github/workflows/benchmark.yml` with 90-day artifact retention). A6 #458 fully closed across phases 1-3.
+
 ## [1.12.0] - 2026-05-01
 
 This is the post-grill rollout release. The architectural surface that v1.11.0 took for granted was retrospectively interrogated in late April 2026; this release ships the resulting changes. Most of the user-visible behavior is unchanged — the work was structural: where consent lives, how the URL pipeline runs, and what the toolbar tells you at a glance.
@@ -575,7 +598,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/yocreoquesi/muga/compare/v1.11.0...v1.13.0
 [1.12.0]: https://github.com/yocreoquesi/muga/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/yocreoquesi/muga/compare/v1.10.2...v1.11.0
 [1.10.2]: https://github.com/yocreoquesi/muga/compare/v1.10.1...v1.10.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.12.0-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.13.0-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-2531_pass-brightgreen)](#development)
 # MUGA: Privacy Without Breaking Creator Links
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://yocreoquesi.github.io/muga/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.12.0"
+    "softwareVersion": "1.13.0"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.12.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,7 +1,7 @@
 # MUGA: Store Listings
 
-> Version: 1.12.0
-> Last updated: 2026-05-01
+> Version: 1.13.0
+> Last updated: 2026-05-04
 > Status: Final listing for Chrome Web Store and Firefox AMO. Lead headline rewritten to surface the "fair to creators" wedge per the 2026-04-26 strategic review (consensus across three independent analyses). Aligned with the post-grill privacy-policy and ToS rollout (#399, #400) — per-device consent, local cleaning architecture, and #353 conditional preservation of MUGA's own tag.
 
 ---

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.12.0 &nbsp;&middot;&nbsp; 2026-05-01 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.0 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.12.0</span>
+      <span class="at-a-glance-value">1.13.0</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -206,7 +206,7 @@
   <hr>
 
   <div class="footer">
-    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.12.0 — 2026-05-01 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
+    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.0 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
   </div>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Privacy without breaking creator links. Strips 450+ tracking params, preserves creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.12.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.


### PR DESCRIPTION
## Summary

Bumps version 1.12.0 → 1.13.0 + CHANGELOG entry + version stamps across all the docs that carry them, ready for tag → CWS/AMO upload.

## Why v1.13.0 (not v1.12.0)

\`v1.12.0\` was bumped in code on 2026-04-26 (commit \`a54b2f2\`) for the post-grill rollout but **never tagged into the wild** — the bundle drift in \`src/content/cleaner-bundle.js\` blocked release CI for over a week. Between then and now, the six PRD #529 slices landed on top.

Cutting a \`v1.12.0\` tag now would conflate two distinct release waves under one number. Bumping to \`v1.13.0\` preserves the v1.12.0 CHANGELOG entry as historic record and ships the PRD #529 wave under its own coherent release. End users on CWS/AMO updating from v1.11.0 receive both waves in a single update.

## What ships in v1.13.0 (the PRD #529 first wave)

| Slice | Feature | User-visible? |
|---|---|---|
| #530 | PARAM_PAIRS bounded scoping | Yes — silently strips ambiguous params when anchor co-occurs |
| #531 | Generic wrapper templates | Yes — auto-unwrap of new redirect networks matching common shape |
| #532 | CSFT graduation pipeline | Yes — Suspicious popup section now evidence-graded |
| #536 | "Strip locally" button | Yes — popup |
| #537 | "Report upstream" button + csft-upstream privacy module | Yes — popup |
| #544 | Shape heuristic (flag-OFF default) | No (until enabled) |

Plus internal: benchmark phase 2 + 3 (synthetic baseline, MD/HTML reports, CI on tags).

## Files touched

\`package.json\`, \`src/manifest.json\`, \`src/manifest.v2.json\`, \`README.md\` badge, \`CHANGELOG.md\` (new section + link footer), \`docs/index.html\` JSON-LD softwareVersion, \`docs/store-listing.md\` version line + last-updated, \`docs/transparency.html\` (3 stamps), \`src/privacy/privacy.html\`, \`docs/privacy-page.html\`.

## Local verification

\`\`\`
$ npm test
ℹ tests 3477  pass 3477  fail 0

$ npm run build:content   # bundle re-build, no drift
\`\`\`

## After merge

1. Cut the tag: \`git tag -a v1.13.0 -m "v1.13.0 — PRD #529 first wave" && git push origin v1.13.0\`
2. Release workflow triggers on tag push → builds Chrome + Firefox + uploads to CWS + AMO + creates GitHub Release
3. Both stores enter their review queues (CWS ~1-3 days, AMO variable)
4. Existing v1.11.0 users receive auto-update once stores approve

Refs: muga#529 (PRD)