### PR TITLE
fix(release): cap AMO release_notes at 3000 chars and fail fast on store errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,21 +157,35 @@ jobs:
           fi
 
       # ── Submission summary ──────────────────────────────────────────
+      # Fail if EITHER store fails. The previous "fail only if both failed" gate
+      # masked a real AMO failure on v1.13.0 (release_notes >3000 chars) — the
+      # workflow shipped green while Firefox got nothing. If a re-run trips on
+      # "version already exists" because one store published the first time, the
+      # operator should re-tag with a bumped patch or skip the offending step.
       - name: Check store submissions
         if: always()
         run: |
           AMO="${{ steps.amo.outcome }}"
           CWS_UP="${{ steps.cws-upload.outcome }}"
           CWS_PUB="${{ steps.cws-publish.outcome }}"
-          echo "## Store submission results" >> "$GITHUB_STEP_SUMMARY"
-          echo "- AMO: ${AMO}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- CWS upload: ${CWS_UP}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- CWS publish: ${CWS_PUB}" >> "$GITHUB_STEP_SUMMARY"
-          # Fail only if BOTH stores failed
-          if [ "$AMO" = "failure" ] && [ "$CWS_UP" = "failure" -o "$CWS_PUB" = "failure" ]; then
-            echo "::error::Both AMO and CWS submissions failed"
-            exit 1
+          {
+            echo "## Store submission results"
+            echo "- AMO: ${AMO}"
+            echo "- CWS upload: ${CWS_UP}"
+            echo "- CWS publish: ${CWS_PUB}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          FAILED=0
+          if [ "$AMO" = "failure" ]; then
+            echo "::error::AMO submission failed — see 'Submit to Firefox AMO' step"
+            FAILED=1
           fi
-          [ "$AMO" = "failure" ] && echo "::warning::AMO submission failed (version may already exist)"
-          [ "$CWS_UP" = "failure" -o "$CWS_PUB" = "failure" ] && echo "::warning::CWS submission failed"
-          exit 0
+          if [ "$CWS_UP" = "failure" ]; then
+            echo "::error::CWS upload failed — see 'Upload to Chrome Web Store' step"
+            FAILED=1
+          fi
+          if [ "$CWS_PUB" = "failure" ]; then
+            echo "::error::CWS publish failed — see 'Publish on Chrome Web Store' step"
+            FAILED=1
+          fi
+          [ "$FAILED" -eq 1 ] && exit 1
+          echo "All store submissions succeeded"

--- a/scripts/prepare-amo-metadata.sh
+++ b/scripts/prepare-amo-metadata.sh
@@ -2,6 +2,10 @@
 # Reads the latest CHANGELOG.md entry and injects release_notes into amo-metadata.json.
 # Usage: bash scripts/prepare-amo-metadata.sh [version]
 #   version: optional, defaults to package.json version
+#
+# Truncation to AMO's 3000-char release_notes cap lives in tools/amo-build-metadata.mjs
+# (testable). v1.13.0's release notes were 4938 chars and silently broke the AMO upload —
+# do not reintroduce inline truncation logic here.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -15,12 +19,4 @@ if [ -z "$NOTES" ]; then
   NOTES="Bug fixes and improvements. See https://github.com/yocreoquesi/muga/releases"
 fi
 
-# Build the release_notes JSON with node (handles escaping properly)
-node -e "
-const fs = require('fs');
-const meta = JSON.parse(fs.readFileSync('$ROOT/amo-metadata.json', 'utf8'));
-const notes = $(node -e "console.log(JSON.stringify(process.argv[1]))" -- "$NOTES");
-meta.version.release_notes = { 'en-US': notes };
-fs.writeFileSync('$ROOT/amo-metadata.json', JSON.stringify(meta, null, 2) + '\n');
-console.log('amo-metadata.json updated with release notes for v' + '$VERSION');
-"
+printf '%s' "$NOTES" | node "$ROOT/tools/amo-build-metadata.mjs" "$VERSION"

--- a/tests/unit/amo-release-notes-truncation.test.mjs
+++ b/tests/unit/amo-release-notes-truncation.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * MUGA: AMO release_notes truncation invariant
+ *
+ * Mozilla's Add-ons API rejects version submissions whose release_notes
+ * exceed 3000 characters with `WebExtError: Submission failed (2): Bad
+ * Request`. v1.13.0 hit exactly this — the CHANGELOG slice was 4938 chars
+ * and the AMO upload silently failed under `continue-on-error: true`.
+ *
+ * truncateForAmo() is the single chokepoint that enforces the cap before
+ * the bytes ever leave CI. These tests pin its contract so a future
+ * "improvement" to release notes formatting can't reintroduce the bug.
+ *
+ * Run with: npm test
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  truncateForAmo,
+  AMO_RELEASE_NOTES_HARD_LIMIT,
+} from "../../tools/amo-build-metadata.mjs";
+
+describe("AMO release_notes — truncation contract", () => {
+  test("short input is returned unchanged (modulo trailing whitespace)", () => {
+    const input = "Bug fixes and improvements.";
+    assert.equal(truncateForAmo(input, "1.0.0"), input);
+  });
+
+  test("input at the budget boundary is returned unchanged", () => {
+    const input = "x".repeat(2900);
+    assert.equal(truncateForAmo(input, "1.0.0"), input);
+  });
+
+  test("oversized input is truncated below the AMO 3000-char hard limit", () => {
+    const input = "x".repeat(10000);
+    const out = truncateForAmo(input, "1.13.0");
+    assert.ok(
+      out.length < AMO_RELEASE_NOTES_HARD_LIMIT,
+      `expected < ${AMO_RELEASE_NOTES_HARD_LIMIT}, got ${out.length}`,
+    );
+  });
+
+  test("truncated output ends with a link to the GitHub Release tag for the version", () => {
+    const input = "line\n".repeat(2000);
+    const out = truncateForAmo(input, "1.13.0");
+    assert.match(
+      out,
+      /https:\/\/github\.com\/yocreoquesi\/muga\/releases\/tag\/v1\.13\.0$/,
+    );
+  });
+
+  test("realistic v1.13.0-shaped CHANGELOG (4938 chars) stays under the AMO cap", () => {
+    // Realistic shape: many short bulleted lines, like the actual v1.13.0
+    // entry that broke the upload. The exact text doesn't matter — what
+    // matters is the size and the line-break density.
+    const input =
+      "PRD #529 first wave — adaptive URL coverage expansion.\n" +
+      "- bullet line about a feature with file paths and issue refs (#530)\n".repeat(80);
+    assert.ok(input.length > 3000, "test fixture must exceed the AMO cap to be meaningful");
+    const out = truncateForAmo(input, "1.13.0");
+    assert.ok(out.length < AMO_RELEASE_NOTES_HARD_LIMIT);
+    assert.match(out, /releases\/tag\/v1\.13\.0$/);
+  });
+
+  test("truncates at a newline boundary when one is available within budget", () => {
+    const input = "first paragraph.\n" + "x".repeat(5000);
+    const out = truncateForAmo(input, "9.9.9");
+    // Should preserve "first paragraph." intact, not slice mid-word.
+    assert.ok(out.startsWith("first paragraph."));
+  });
+});

--- a/tools/amo-build-metadata.mjs
+++ b/tools/amo-build-metadata.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Builds amo-metadata.json release_notes from CHANGELOG content piped on stdin.
+// Truncates to stay under AMO's 3000-char hard cap with a link back to the
+// GitHub Release for the full notes.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+export const AMO_RELEASE_NOTES_HARD_LIMIT = 3000;
+const SAFE_BUDGET = 2900;
+
+export function truncateForAmo(rawNotes, version, max = SAFE_BUDGET) {
+  const suffix = `\n\n…full release notes: https://github.com/yocreoquesi/muga/releases/tag/v${version}`;
+  const trimmed = rawNotes.replace(/\s+$/, "");
+  if (trimmed.length <= max) return trimmed;
+
+  const budget = max - suffix.length;
+  let cut = trimmed.lastIndexOf("\n", budget);
+  if (cut < budget * 0.5) cut = budget;
+  return trimmed.slice(0, cut).replace(/\s+$/, "") + suffix;
+}
+
+function isMain() {
+  const entry = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  return entry === fileURLToPath(import.meta.url);
+}
+
+if (isMain()) {
+  const version = process.argv[2];
+  if (!version) {
+    console.error("Usage: node tools/amo-build-metadata.mjs <version>  (CHANGELOG slice on stdin)");
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(0, "utf8");
+  const notes = truncateForAmo(raw, version);
+  if (notes.length > AMO_RELEASE_NOTES_HARD_LIMIT) {
+    console.error(
+      `FATAL: release_notes still exceeds ${AMO_RELEASE_NOTES_HARD_LIMIT} chars after truncation: ${notes.length}`,
+    );
+    process.exit(1);
+  }
+  const metaPath = path.join(ROOT, "amo-metadata.json");
+  const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+  meta.version.release_notes = { "en-US": notes };
+  fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2) + "\n");
+  console.log(
+    `amo-metadata.json updated with release notes for v${version} (${notes.length}/${AMO_RELEASE_NOTES_HARD_LIMIT} chars)`,
+  );
+}


### PR DESCRIPTION
## Why

`v1.13.0` was tagged on 2026-05-03 and **never reached Firefox AMO** despite the release workflow finishing green.

Root cause from run [`25292615064`](https://github.com/yocreoquesi/muga/actions/runs/25292615064):

```
WebExtError: Submission failed (2): Bad Request
{
  "version": {
    "release_notes": [
      "Ensure this field has no more than 3000 characters."
    ]
  }
}
```

The CHANGELOG slice for v1.13.0 was **4938 chars**. `release.yml` masked the failure two ways:

1. `Submit to Firefox AMO` had `continue-on-error: true` so the failed step did not stop the job.
2. `Check store submissions` only failed if **both** AMO and CWS failed. CWS published fine, so the workflow shipped green while Mozilla got nothing.

## Changes

- **`tools/amo-build-metadata.mjs`** (new) — exports `truncateForAmo(notes, version, max=2900)`. Cuts at the nearest newline within budget and appends a link to the GitHub Release tag for the full notes.
- **`scripts/prepare-amo-metadata.sh`** — pipes the CHANGELOG slice into the new module via stdin (eliminates shell-arg length risk and the inline `node -e "..."` heredoc).
- **`.github/workflows/release.yml`** — `Check store submissions` now fails if **any** store step (`amo`, `cws-upload`, `cws-publish`) fails, with per-store `::error::` annotations.
- **`tests/unit/amo-release-notes-truncation.test.mjs`** (new) — pins the truncation contract: short input passes through, oversized input always lands <3000 chars, the link suffix is preserved, cuts respect newline boundaries. Includes a v1.13.0-shaped fixture (>4900 chars) that would have caught this.

## Verified

- `node --test tests/unit/amo-release-notes-truncation.test.mjs tests/unit/legal-sync.test.mjs` → 9 passing.
- Dry-run `bash scripts/prepare-amo-metadata.sh 1.13.0` → `release_notes` lands at **2633/3000** chars, cuts at a paragraph boundary, suffix link present.

## Test plan

- [ ] CI passes on this branch.
- [ ] After merge, re-trigger `release.yml` via `workflow_dispatch` with `tag: v1.13.0` to actually publish to AMO. CWS will return "version already exists" and the new strict gate will (correctly) fail the run — that's expected and acceptable for this one-time recovery; AMO submission outcome is what matters.

## Follow-ups (out of scope)

- Consider distinguishing "version already exists" responses from real errors so workflow_dispatch re-runs against an already-published store don't fail noisily.