### PR TITLE
chore(release): bump version to 1.13.1 (AMO publish recovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-05-04
+
+Recovery release. No functional or user-visible changes vs v1.13.0 — same code, same rules, same behavior. The v1.13.0 release reached Chrome Web Store but never reached Firefox AMO: the upload was rejected with HTTP 400 because the auto-generated `release_notes` (full CHANGELOG slice) was 4938 characters, over Mozilla's 3000-character cap. The release workflow had `continue-on-error: true` on the AMO step plus a lenient AND-gate on the summary, so the failure shipped green while AMO got nothing.
+
+### Fixed
+- **Release pipeline**: AMO `release_notes` are now truncated to 2900 characters (100-char headroom under Mozilla's 3000 cap) with a link back to the GitHub Release for the full notes. Truncation logic lives in `tools/amo-build-metadata.mjs` (testable) and is pinned by `tests/unit/amo-release-notes-truncation.test.mjs`. (#556)
+- **Release pipeline**: `release.yml` `Check store submissions` step now fails the workflow if **any** store step fails (AMO, CWS upload, CWS publish), with per-store error annotations. The previous gate only failed if both stores failed, which masked the v1.13.0 AMO regression. (#556)
+
 ## [1.13.0] - 2026-05-04
 
 PRD #529 first wave — adaptive URL coverage expansion. Six user-visible features land together. The wave shifts MUGA from purely curated rules toward a mix of curated + bounded-scope contextual + user-mediated discovery, while keeping the false-positive principle intact and the zero-telemetry promise unchanged.
@@ -599,6 +607,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - MIT License, README
 
 [Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.0...HEAD
+[1.13.1]: https://github.com/yocreoquesi/muga/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/yocreoquesi/muga/compare/v1.11.0...v1.13.0
 [1.12.0]: https://github.com/yocreoquesi/muga/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/yocreoquesi/muga/compare/v1.10.2...v1.11.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.13.0-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.13.1-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-2531_pass-brightgreen)](#development)
 # MUGA: Privacy Without Breaking Creator Links
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://yocreoquesi.github.io/muga/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.13.0"
+    "softwareVersion": "1.13.1"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 1.13.0
+> Version: 1.13.1
 > Last updated: 2026-05-04
 > Status: Final listing for Chrome Web Store and Firefox AMO. Lead headline rewritten to surface the "fair to creators" wedge per the 2026-04-26 strategic review (consensus across three independent analyses). Aligned with the post-grill privacy-policy and ToS rollout (#399, #400) — per-device consent, local cleaning architecture, and #353 conditional preservation of MUGA's own tag.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.0 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.1 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.13.0</span>
+      <span class="at-a-glance-value">1.13.1</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -206,7 +206,7 @@
   <hr>
 
   <div class="footer">
-    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.0 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
+    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.1 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
   </div>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Privacy without breaking creator links. Strips 450+ tracking params, preserves creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.


### PR DESCRIPTION
## Why

v1.13.0 reached Chrome Web Store but **never reached Firefox AMO** — the upload was rejected with HTTP 400 because the auto-generated `release_notes` (full CHANGELOG slice) was 4938 chars, over Mozilla's 3000-char cap. The release workflow shipped green because the AMO step had `continue-on-error: true` and the summary gate only failed if both stores failed.

PR #556 fixed the truncation logic and hardened the gate. **This PR cuts v1.13.1 to actually deliver that fix to AMO**, since the `v1.13.0` git tag points at the broken-script commit (9ad4bb5) and re-running `workflow_dispatch` on it would just reproduce the failure.

## What

Mechanical version bump only. **No functional or user-visible changes vs v1.13.0** — same code, same rules, same behavior.

- `package.json`, `src/manifest.json`, `src/manifest.v2.json` → 1.13.1
- `README.md` version badge
- `docs/index.html` softwareVersion
- `docs/store-listing.md` Version line
- `docs/privacy-page.html` Version line
- `src/privacy/privacy.html` Version line
- `docs/transparency.html` (3 occurrences: meta line, at-a-glance value, footer)
- `CHANGELOG.md` new `[1.13.1]` section + link reference

## Verified

- `node --test tests/unit/version-consistency.test.mjs tests/unit/legal-sync.test.mjs tests/unit/amo-release-notes-truncation.test.mjs` → 30 passing
- Dry-run `bash scripts/prepare-amo-metadata.sh 1.13.1` → `release_notes` lands at **1127/3000** chars (safely under the AMO cap)

## Test plan

- [ ] CI passes
- [ ] After merge, tag `v1.13.1` and push → `release.yml` builds, AMO step succeeds, GitHub Release created
- [ ] Verify v1.13.1 appears on AMO listing within 24h (review queue)
- [ ] Chrome Web Store gets a fresh 1.13.1 upload (no "version already exists" since it's a new version number)

## Related

- PR #556 — the actual bug fix (release_notes truncation + strict gate)
- Issue #557 — follow-up to distinguish "version already exists" from real store errors in the gate
- Run [`25292615064`](https://github.com/yocreoquesi/muga/actions/runs/25292615064) — the v1.13.0 silent AMO failure