### PR TITLE
chore(release): bump version to 1.13.2 (CHANGELOG link recovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.2] - 2026-05-04
+
+Recovery release. No functional or user-visible changes vs v1.13.1 — same code, same rules, same behavior. The v1.13.1 release was tagged but its `Release` workflow failed at the unit-test step because the `[Unreleased]` reference link at the bottom of `CHANGELOG.md` still pointed at `v1.13.0...HEAD` after the bump. The `tests/unit/changelog-links.test.mjs` guard correctly flagged the drift, which blocked the AMO publish step from running. AMO therefore stayed on v1.11.0.
+
+### Fixed
+- **Release pipeline**: `[Unreleased]` link in `CHANGELOG.md` now tracks the latest released tag, satisfying the `changelog-links` test that gates the `Release` workflow. Without this, every bump that forgot to update the link would silently skip AMO publish.
+
 ## [1.13.1] - 2026-05-04
 
 Recovery release. No functional or user-visible changes vs v1.13.0 — same code, same rules, same behavior. The v1.13.0 release reached Chrome Web Store but never reached Firefox AMO: the upload was rejected with HTTP 400 because the auto-generated `release_notes` (full CHANGELOG slice) was 4938 characters, over Mozilla's 3000-character cap. The release workflow had `continue-on-error: true` on the AMO step plus a lenient AND-gate on the summary, so the failure shipped green while AMO got nothing.
@@ -606,7 +613,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.2...HEAD
+[1.13.2]: https://github.com/yocreoquesi/muga/compare/v1.13.1...v1.13.2
 [1.13.1]: https://github.com/yocreoquesi/muga/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/yocreoquesi/muga/compare/v1.11.0...v1.13.0
 [1.12.0]: https://github.com/yocreoquesi/muga/compare/v1.11.0...v1.12.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.13.1-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.13.2-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-2531_pass-brightgreen)](#development)
 # MUGA: Privacy Without Breaking Creator Links
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://yocreoquesi.github.io/muga/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.13.1"
+    "softwareVersion": "1.13.2"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.2 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 1.13.1
+> Version: 1.13.2
 > Last updated: 2026-05-04
 > Status: Final listing for Chrome Web Store and Firefox AMO. Lead headline rewritten to surface the "fair to creators" wedge per the 2026-04-26 strategic review (consensus across three independent analyses). Aligned with the post-grill privacy-policy and ToS rollout (#399, #400) — per-device consent, local cleaning architecture, and #353 conditional preservation of MUGA's own tag.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.1 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.2 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.13.1</span>
+      <span class="at-a-glance-value">1.13.2</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -206,7 +206,7 @@
   <hr>
 
   <div class="footer">
-    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.1 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
+    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.2 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
   </div>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Privacy without breaking creator links. Strips 450+ tracking params, preserves creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.2 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.


### PR DESCRIPTION
## Summary

- v1.13.1 tag exists but its `Release` workflow failed at the unit-test step: the `[Unreleased]` reference link at the bottom of `CHANGELOG.md` still pointed at `v1.13.0...HEAD` after the bump, and `tests/unit/changelog-links.test.mjs` correctly flagged the drift.
- Because the test failed inside the `Release` job, the AMO publish step never ran. **Firefox AMO is still serving v1.11.0** even though v1.13.1 already contained the AMO truncation fix from #556.
- This bump ships the CHANGELOG fix under v1.13.2 so the `Release` workflow can finally publish v1.13.1's pipeline fix to AMO.

No functional or user-visible changes vs v1.13.1 — recovery release only.

### What's in here
- `CHANGELOG.md`: new `## [1.13.2]` section + new `[1.13.2]: ...` reference link + **`[Unreleased]` link bumped to `v1.13.2...HEAD`** (the actual fix).
- Version bumped to `1.13.2` across `package.json`, `src/manifest.json`, `src/manifest.v2.json`, `README.md`, `docs/index.html`, `docs/transparency.html`, `docs/privacy-page.html`, `docs/store-listing.md`, `src/privacy/privacy.html`.

## Test plan

- [x] `node --test tests/unit/changelog-links.test.mjs` passes locally.
- [ ] CI green on this PR.
- [ ] After merge, tag `v1.13.2` triggers `Release` workflow successfully.
- [ ] AMO publish step runs (no longer blocked by the changelog-links guard).
- [ ] Firefox install at `addons.mozilla.org/firefox/addon/muga/` shows v1.13.2.