### PR TITLE
chore(ci): bump actions to Node 24 runtime (v4 → v6, action-gh-release v2 → v3)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/import-upstream.yml
+++ b/.github/workflows/import-upstream.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/publish-rules.yml
+++ b/.github/workflows/publish-rules.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # Use the default GITHUB_TOKEN — this is sufficient for push to main.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -64,7 +64,7 @@ jobs:
           mv dist/firefox/*.zip dist/firefox/muga-${{ steps.version.outputs.VERSION }}-firefox.zip
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           # Explicit tag_name lets the action work under workflow_dispatch,
           # where github.ref is the branch (e.g. refs/heads/main), not a tag.

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary

GitHub will force all Node 20 actions onto Node 24 by **2026-06-02** and remove Node 20 entirely on **2026-09-16**. The `Node.js 20 actions are deprecated` warning currently shows on every CI run. This PR opts in cleanly by bumping to v6 (Node 24 runtime) instead of relying on the forced-upgrade flag — which would run actions outside the runtime they were packaged for and risks silent incompatibilities.

## Changes

| Action | Before | After | Why bump |
|---|---|---|---|
| `actions/checkout` | `v4` (`34e11487…`) | `v6.0.2` (`de0fac2e…`) | Node 24 runtime |
| `actions/setup-node` | `v4` (`49933ea5…`) | `v6.4.0` (`48b55a01…`) | Node 24 runtime |
| `softprops/action-gh-release` | `v2` (`3bb12739…`) | `v3.0.0` (`b4309332…`) | v3 is a pure Node 24 migration, no other behavior changes |

SHA-pinning is preserved per repo convention. The `# v6.0.2` etc. comments are aligned with the actual SHA.

`import-upstream.yml` was already unpinned (`@v4`); kept that style and bumped to `@v6` to avoid mixing conventions in this PR.

## What is NOT changed

- `node-version: "20"` inside `setup-node` steps — that is the Node version the workflow installs to run our scripts. Our scripts still target Node 20.
- `actions/upload-artifact@v4` in `benchmark.yml` (still flagged as unpinned by issue #528) — out of scope; the FIXME comment already documents that follow-up.

## Test plan

- [ ] CI green on this PR (test + e2e jobs run on the new actions immediately).
- [ ] No new warnings about Node 20 deprecation in the run summary.

## References

- v6 release notes: <https://github.com/actions/checkout/releases/tag/v6.0.0>, <https://github.com/actions/setup-node/releases/tag/v6.0.0>
- v3 action-gh-release: <https://github.com/softprops/action-gh-release/releases/tag/v3.0.0> — explicitly states "moves the action runtime from Node 20 to Node 24".
- GitHub deprecation note: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>