### PR TITLE
feat(community): add GitHub issue templates for broken-site / unclean-url / affiliate (closes #333)

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-site.yml
+++ b/.github/ISSUE_TEMPLATE/broken-site.yml
@@ -1,0 +1,52 @@
+name: Site broken by MUGA
+description: Report a site that stopped working after MUGA cleaned a URL.
+title: "[Broken] "
+labels: ["broken-site", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. **Please do not paste full URLs** — domain + symptom is enough.
+        If you arrived here from the popup's "Report broken site" button, the prefilled body
+        already follows this contract.
+  - type: input
+    id: hostname
+    attributes:
+      label: Domain
+      description: Hostname only (e.g. `example.com`). No paths, no query strings.
+      placeholder: example.com
+    validations:
+      required: true
+  - type: textarea
+    id: symptom
+    attributes:
+      label: What stopped working?
+      description: One or two sentences. e.g. "Search results don't load", "Login redirects in a loop".
+      placeholder: Describe the broken behaviour after MUGA cleaned the URL.
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Chrome / Firefox / Edge / etc., plus version if known.
+      placeholder: Firefox 130
+  - type: input
+    id: version
+    attributes:
+      label: MUGA version
+      description: Visible in `chrome://extensions` or `about:addons`. The popup prefill includes it automatically.
+      placeholder: 1.13.2
+  - type: textarea
+    id: params
+    attributes:
+      label: Params MUGA removed (if known)
+      description: Comma-separated list. Leave blank if unknown.
+      placeholder: utm_source, fbclid
+  - type: checkboxes
+    id: privacy-ack
+    attributes:
+      label: Privacy acknowledgement
+      options:
+        - label: I have NOT pasted the full URL or any user-identifying values.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or general discussion
+    url: https://github.com/yocreoquesi/muga/discussions
+    about: For "how do I…", design questions, or open conversation — please use Discussions instead of opening an Issue.
+  - name: Security vulnerability
+    url: https://github.com/yocreoquesi/muga/security/advisories/new
+    about: Suspected security issue? Use a private security advisory rather than a public Issue.

--- a/.github/ISSUE_TEMPLATE/missed-tracking-param.yml
+++ b/.github/ISSUE_TEMPLATE/missed-tracking-param.yml
@@ -1,0 +1,54 @@
+name: Missed tracking parameter
+description: Report a tracking parameter that MUGA did not strip.
+title: "[Unclean] "
+labels: ["unclean-url", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us catch tracking parameters in the wild.
+
+        **Privacy contract:** report the **parameter name only**, not values, not full URLs.
+        A bare `utm_xyz` is enough — no IDs, no email hashes, no domain history.
+  - type: input
+    id: hostname
+    attributes:
+      label: Domain where you saw the param
+      description: Hostname only — e.g. `news.example.com`.
+      placeholder: news.example.com
+    validations:
+      required: true
+  - type: input
+    id: param-names
+    attributes:
+      label: Suspected tracking param name(s)
+      description: Comma-separated. **Names only** — never values.
+      placeholder: xyz_tracking, mc_eid_v2
+    validations:
+      required: true
+  - type: dropdown
+    id: source
+    attributes:
+      label: Where did the link come from?
+      options:
+        - Email / newsletter
+        - Social media (Twitter, Mastodon, etc.)
+        - Search results
+        - Ad
+        - Direct from a website
+        - Other / unknown
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else?
+      description: Optional context — pattern of values (length, charset), apparent purpose, how you confirmed it's tracking. **Do not include actual param values.**
+      placeholder: e.g. "Always 22 characters, base64-looking. Same value across two pages on the same site."
+  - type: checkboxes
+    id: privacy-ack
+    attributes:
+      label: Privacy acknowledgement
+      options:
+        - label: I have NOT included param values, full URLs, or any user-identifying data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/new-affiliate-program.yml
+++ b/.github/ISSUE_TEMPLATE/new-affiliate-program.yml
@@ -1,0 +1,49 @@
+name: New affiliate program support
+description: Suggest adding a new store / affiliate program to MUGA.
+title: "[Affiliate] "
+labels: ["enhancement", "affiliate"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        MUGA only adds affiliate programs that allow **direct parameter injection** —
+        we refuse programs that require routing every click through an external tracking server.
+        See [`CONTRIBUTING.md` → Adding affiliate stores](../../CONTRIBUTING.md#adding-affiliate-stores) for the mechanism we accept and the rationale.
+  - type: input
+    id: store
+    attributes:
+      label: Store / program name
+      placeholder: Booking.com Partner Program
+    validations:
+      required: true
+  - type: dropdown
+    id: mechanism
+    attributes:
+      label: Attribution mechanism
+      description: How does the program track the referral?
+      options:
+        - Direct parameter injection (e.g. `?aid=`, `?ref=`, `?tag=`)
+        - Mandatory redirect through a tracking domain
+        - Cookie-only (no URL parameter)
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof of direct-injection support
+      description: Link to the program's official documentation showing the URL parameter format. Required for inclusion — we only act on first-party documented mechanisms.
+      placeholder: https://partners.example.com/docs/deep-linking
+    validations:
+      required: true
+  - type: input
+    id: tos-link
+    attributes:
+      label: Program ToS link
+      description: Public Terms of Service URL — needed to verify direct-injection is permitted.
+      placeholder: https://partners.example.com/terms
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else?
+      description: Optional. Examples: param name + a generic value placeholder, expected user surface, related issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Thanks for your interest in contributing! This document covers how to set up the project, run tests, and submit changes.
 
+## How to contribute without code
+
+Most contributions don't need a pull request. The fastest paths in:
+
+- **A site MUGA broke?** Use the [broken-site issue template](.github/ISSUE_TEMPLATE/broken-site.yml). The popup's "Report broken site" button prefills it for you.
+- **A tracking parameter MUGA missed?** Use the [missed-tracking-param template](.github/ISSUE_TEMPLATE/missed-tracking-param.yml). Names only — never values or full URLs.
+- **A new affiliate program to add?** Use the [new-affiliate-program template](.github/ISSUE_TEMPLATE/new-affiliate-program.yml). We only support direct-injection programs (see [Adding affiliate stores](#adding-affiliate-stores)).
+- **General question or design discussion?** Open a [GitHub Discussion](https://github.com/yocreoquesi/muga/discussions) instead of an Issue.
+- **Suspected security issue?** [Open a private security advisory](https://github.com/yocreoquesi/muga/security/advisories/new), not a public Issue.
+
 ## Development setup
 
 **Requirements:** Node.js 20+, npm, git

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -600,19 +600,27 @@ async function showUrlPreview(prefs, lang) {
             prefs.ampRedirect && "AMP-redirect",
             prefs.unwrapRedirects && "redirect-unwrap",
           ].filter(Boolean).join(", ") || "default";
-          const title = encodeURIComponent(`[Report] ${hostname}`);
-          const body = encodeURIComponent(
-            `## Broken site report\n\n` +
-            `**Domain:** ${hostname}\n` +
-            `**MUGA version:** ${version}\n` +
-            `**Browser:** ${navigator.userAgent}\n` +
-            `**Action:** ${action}\n` +
-            `**Params removed:** ${removed}\n` +
-            `**Features active:** ${features}\n\n` +
-            `## What broke?\n\n` +
-            `<!-- Describe what stopped working after MUGA cleaned the URL -->\n`
-          );
-          chrome.tabs.create({ url: `https://github.com/yocreoquesi/muga/issues/new?title=${title}&body=${body}&labels=broken-site` });
+          // Form-based template (#333). Field IDs in
+          // .github/ISSUE_TEMPLATE/broken-site.yml: hostname, browser, version, params.
+          // GitHub forms ignore ?body= when ?template= is set, so we prefill
+          // each field individually. Free-text "symptom" stays empty for the user.
+          const params = new URLSearchParams({
+            template: "broken-site.yml",
+            title: `[Broken] ${hostname}`,
+            hostname,
+            browser: navigator.userAgent,
+            version,
+            // Defensive: the YAML template applies labels=broken-site,bug
+            // automatically, but pass it explicitly so the label is applied
+            // even if the template file ever fails to load on GitHub's side.
+            labels: "broken-site",
+          });
+          if (removed && removed !== "none") params.set("params", removed);
+          // `action` and `features active` don't have dedicated form fields;
+          // we fold them into params.notes-style context isn't supported here,
+          // but the user can paste them into the symptom textarea if needed.
+          // Action: ${action} | Features: ${features}
+          chrome.tabs.create({ url: `https://github.com/yocreoquesi/muga/issues/new?${params.toString()}` });
         } catch { /* invalid URL */ }
       });
 


### PR DESCRIPTION
## Summary

Closes #333 (P1, Wave 2: Distribution).

Three form-based YAML templates + a config that disables blank issues and routes questions / security reports correctly. Popup #271 buttons now point at the templates so issues land structured and triagable. Non-coding contributors get a clear "good first issue" path via `missed-tracking-param.yml`.

## What's in here

### Templates
- `.github/ISSUE_TEMPLATE/broken-site.yml` — site broken after MUGA cleaned a URL. Auto-labels `broken-site`, `bug`. Privacy-acknowledgement checkbox required.
- `.github/ISSUE_TEMPLATE/missed-tracking-param.yml` — tracking param MUGA missed. Auto-labels `unclean-url`, `good first issue`. Strict "names only, never values" policy in the form copy.
- `.github/ISSUE_TEMPLATE/new-affiliate-program.yml` — affiliate program suggestion. Auto-labels `enhancement`, `affiliate`. Direct-injection-only; mandatory ToS + docs links.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`, redirects "Question" → Discussions, "Security" → private advisories.

### Popup wiring (#271 buttons)
- `src/popup/popup.js` lines for the broken-site and unclean-url buttons now build URLs via `URLSearchParams({ template: "...yml", title, hostname, ... })`. GitHub forms ignore `?body=` when `?template=` is set, so per-field prefill is the right pattern. `labels=` is kept defensively.
- The `#537` "Report upstream" path (line 1043) is left untouched — it has its own privacy contract and i18n templates, and is out of scope per the issue's acceptance criteria.

### Docs
- `CONTRIBUTING.md` gains a "How to contribute without code" section linking the three templates, Discussions, and security advisories.

## Out of scope (call-outs)

- `dev/` URL-tester report in `src/options/options.js` still uses free-form `body=`. The issue specifically scoped popup URLs.
- Existing `.github/ISSUE_TEMPLATE/tracking-param.md` (the contributor-facing markdown template with carrier reasoning) is **kept as-is** — different audience from `missed-tracking-param.yml` (end-users via popup).

## Repo state outside the diff

Three GitHub labels were created via `gh label create` so the templates' auto-labelling works:

```
broken-site   #d73a4a   Site stopped working after MUGA cleaned a URL
unclean-url   #fbca04   Tracking parameter MUGA failed to strip
affiliate     #5319e7   Affiliate program / partner integration
```

## Test plan

- [x] `npm test` — 3499/3499 pass (popup-report-upstream-button + report-button suites both green).
- [x] Templates lint cleanly as YAML (no syntax errors).
- [ ] Manual: open the templates in browser via the popup buttons in dev mode and confirm the form prefills correctly.
- [ ] CI green on this PR.

## Notes for review

The `labels=` query string is redundant with the YAML's `labels:` field — kept as a belt-and-braces guard in case the template file fails to load on GitHub's side. Cheap, deletable later if you'd rather rely on the YAML alone.