### PR TITLE
feat(launch): drafts for HN, ProductHunt, Reddit launch posts (closes #332)

### DIFF
--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -1,0 +1,41 @@
+# Launch drafts
+
+Platform-specific launch posts for MUGA's Wave 2 distribution push (closes #332).
+
+These are **drafts**, not yet posted. The launch sequence is:
+
+1. **HackerNews** — Tuesday or Wednesday morning ET (engineering angle, see [`hn-launch.md`](hn-launch.md)).
+2. **ProductHunt** — same week as HN (UX / "fair to creators" wedge, see [`producthunt-launch.md`](producthunt-launch.md)).
+3. **Reddit** — 24h after ProductHunt for echo (alternative-to-incumbent angle, see [`reddit-launch.md`](reddit-launch.md)).
+
+## Pre-launch checklist (must be true before posting any of the above)
+
+- [ ] **Domain live.** `muga.app` resolves and serves a landing page (#481).
+- [ ] **Comparison page live.** [`docs/comparison.html`](../comparison.html) is reachable from the landing page (#329).
+- [ ] **Store listings up to date.** Both Chrome Web Store and Firefox AMO show the latest version with the current screenshots and copy (#328).
+- [ ] **Wedge UI present.** The "Creator referral preserved" badge is visible in the popup on a real affiliate link (#327).
+- [ ] **Counter live.** The popup shows a non-zero "URLs cleaned" count after a brief test session (#326).
+- [ ] **Screenshots refreshed.** All four locales captured with `npm run screenshots`. Compressed and committed under `docs/screenshots/`.
+- [ ] **Press kit ready.** Brand assets (logo SVG/PNG, color tokens) reachable from the landing page or this directory.
+
+If any item is unchecked, **do not launch**. First impressions are the launch.
+
+## Post-launch metrics capture
+
+Track the following deltas at +24h, +7d, +30d after EACH platform post:
+
+- Chrome Web Store install count (visible on the developer dashboard).
+- Firefox AMO install count + ADU (active daily users) on `addons.mozilla.org/api/v5/addons/addon/muga/` weekly stats.
+- GitHub repo: stars, forks, issues opened, PRs opened.
+- `muga.app` traffic: unique visitors, top referrer, top landing path. (Plausible / GoatCounter — never GA.)
+- Issue-template intake: count of `unclean-url` and `broken-site` issues opened by users (signal that the popup buttons + #333 templates are working).
+
+Snapshot the numbers in a single follow-up issue (or in `docs/launch/postmortem-YYYY-MM-DD.md`) so the comparison is reviewable.
+
+## Launch principles (do not break)
+
+- **Honesty.** No "the most private", "the only", "the best" — the data does not support superlatives. Use "the first URL cleaner that respects creator affiliate links" because that one IS true and verifiable.
+- **No trash talk.** ClearURLs, AdGuard, Brave, and Firefox's built-in cleaner are valid tools with different trade-offs. Position MUGA against them by what MUGA does differently — not by what they do wrong.
+- **Show, don't tell.** Every claim ("zero telemetry", "Ed25519-signed pipeline", "MV3-native") must be a clickable link to either the source code or a public artifact.
+- **No metrics inflation.** Test count, params stripped, supported networks — quote the number that is true at launch time, with a link to the file. Do not round up. Do not use future numbers.
+- **Wave 1 first.** Domain, wedge UI, counter, comparison page, store listings. None of these drafts go live until those landed.

--- a/docs/launch/hn-launch.md
+++ b/docs/launch/hn-launch.md
@@ -1,0 +1,113 @@
+# HackerNews launch — engineering angle
+
+**Audience.** Engineers who appreciate architectural rigor, signed pipelines, and "no JS framework" projects. They will respect MV3-from-day-1, Ed25519-signing, and the deliberate "no build step" stance more than any UX claim.
+
+**Posting window.** Tuesday or Wednesday morning Eastern Time. Avoid Mondays (catch-up traffic), Fridays (low engagement), and weekends.
+
+**Account hygiene.** Use the project owner's HN account with at least 30 days of prior activity. Never seed votes — HN penalizes that severely.
+
+---
+
+## Title (≤80 chars)
+
+```
+Show HN: I built an MV3-native URL cleaner with a signed remote-rules pipeline
+```
+
+**Alternates:**
+- `Show HN: MUGA — URL cleaner that doesn't break creator affiliate links`
+- `Show HN: An MV3 URL cleaner with Ed25519-signed rules and zero telemetry`
+
+Pick the one that lands the wedge fastest. The first option leans into engineering credibility, which is the better fit for HN's audience.
+
+---
+
+## Body
+
+```
+MUGA strips tracking from URLs (utm_*, fbclid, gclid — 450+ params) and unwraps
+affiliate redirect networks like Awin and Skimlinks so your clicks never touch
+the tracker server. It's been on the Chrome Web Store and Firefox AMO since 2026.
+
+A few architectural notes that I think will land here:
+
+1. MV3 from day 1. No MV2-to-MV3 migration, no shim layer. The service worker
+   handles cross-cutting state (badge, stats, optional rules fetch) and the
+   content script does the URL work inline — service worker never sees URLs in
+   transit. There is no central pipeline that observes your browsing.
+
+2. Ed25519-signed remote rules pipeline. The 450+ param list is bundled with
+   the extension AND can optionally update once a week from a signed feed at
+   yocreoquesi.github.io. Off by default. Verified fail-closed in the service
+   worker before any rule lands. Code: src/lib/remote-rules.js, ~200 lines.
+
+3. Zero telemetry. No analytics. No crash reporting. No A/B framework. No user
+   accounts. The popup's "Creator referral preserved" claim is verifiable by
+   diffing the published .xpi against the GitHub source. The transparency
+   page (yocreoquesi.github.io/muga/transparency.html) lists every byte the
+   extension stores and what triggers each storage write.
+
+4. CAPS — Creator Affiliate Preservation Standard. I extracted the rule shapes
+   into a separate spec repo with Ed25519-signed normative artifacts. MUGA is
+   the first conforming implementation; the spec is shaped so muga-unwrap
+   (a Cloudflare Worker variant) and any future tool can claim conformance
+   against the same test vectors. SPEC.md and conformance levels are public.
+
+5. No build step beyond a 30-line esbuild bundler. No TypeScript. No Babel,
+   no JSX, no Webpack, no Rollup. The cleaning library is plain ES modules.
+   The single bundling step exists only because MV3 content scripts can't use
+   imports portably across Chrome and Firefox MV2. The bundled output is
+   committed and CI fails if it drifts from source.
+
+The wedge: MUGA is, as far as I know, the only URL cleaner that strips tracking
+WITHOUT silently stripping the creator's affiliate referral. ClearURLs, AdGuard,
+Brave, and Firefox's built-in cleaner all remove the creator's tag along with
+the trackers. MUGA preserves it and tells you it did, with a "Creator referral
+preserved" badge in the popup. The principle is in the README and the
+comparison page (docs/comparison.html in the repo).
+
+Not affiliated with anyone, no funding, no roadmap meeting at 9am. GPL v3.
+Code: <github URL>. Install: <CWS> / <AMO>. Comparison: <comparison URL>.
+
+Happy to discuss the MV3 architecture, the rule-signing pipeline, or the
+conformance spec design — that's the part I find most interesting. Feedback
+welcome.
+```
+
+---
+
+## Reply playbook
+
+Pre-draft answers to likely first comments:
+
+### "Why not just use ClearURLs?"
+
+> ClearURLs is a great tool and I run it myself for years. The reason I built MUGA is the affiliate question. ClearURLs strips `tag=`, `aff_id`, `ref_=` etc. across the board, which means when a YouTuber or newsletter writer sends you to Amazon with their referral, ClearURLs removes it before you click. The creator doesn't get paid for the recommendation. MUGA decided that was wrong — we strip the same trackers ClearURLs does, but we keep the creator's tag and tell you we did. The popup shows "Creator referral preserved" so it's never silent. That's the only thing MUGA does that ClearURLs doesn't, but it's the thing I built it for.
+
+### "MV3 cripples ad-blockers, why bother?"
+
+> MV3's `webRequest` blocking restriction is real and is what's hurting uBlock Origin. But MUGA is fundamentally not a request-blocker — it's a URL rewriter that runs at click time and unwraps redirect networks before they get to the tracker. The MV3 `declarativeNetRequest` API is more than enough for parameter stripping; the limitations bite only when you need to block by full request body. So MUGA on MV3 is not a feature compromise.
+
+### "Ed25519 signing for a 450-param list seems overkill"
+
+> Fair. The reason it's there: the optional remote rules feature lets the param list update without a release. If that path were unsigned, a compromised CDN could inject "preserve `gclid`" and break everything for all users at once. With Ed25519 + a pinned pubkey, even a compromised endpoint can only return rejected payloads. Off by default, signed when on, fails closed. Code is in `tools/sign-rules.mjs` and the verification at `src/lib/remote-rules.js` if you want to look.
+
+### "What about Manifest V2 — Firefox?"
+
+> Both targets ship from the same source. Firefox AMO ships MV2 (still supported there) with `webRequest`, Chrome ships MV3 with `declarativeNetRequest`. The `src/manifest.json` and `src/manifest.v2.json` split + `tools/with-firefox-manifest.sh` keep them in sync. The cleaning logic is identical; only the rule engine differs.
+
+### "Where do you make money?"
+
+> I don't. GPL v3, no donations, no Patreon. The affiliate-preservation thing isn't monetization for me — it's the principle. If the project ever needs sustainability funding, that conversation is public-first via Issues, not a quiet inflection.
+
+---
+
+## Self-check before posting
+
+- [ ] Title is under 80 characters and doesn't oversell.
+- [ ] Body has no superlatives ("the most", "the only" — except verifiable ones).
+- [ ] Every link is clickable and resolves to a public page.
+- [ ] Numbers (450 params, 3499 tests, etc.) match the version live in stores.
+- [ ] No emoji in title or body. HN convention.
+- [ ] No "please upvote" or "share if you like". Penalty risk.
+- [ ] Replies are drafted but not pasted yet — let them flow naturally.

--- a/docs/launch/producthunt-launch.md
+++ b/docs/launch/producthunt-launch.md
@@ -1,0 +1,120 @@
+# ProductHunt launch — UX / wedge angle
+
+**Audience.** Product people, makers, indie hackers, designers. They respond to *story* and *visible UX*, less to architectural detail. The wedge ("creator affiliate preserved") is the lede.
+
+**Posting window.** Same week as HackerNews launch, but on a different day. PH timezone is global; 12:01am PT is the standard "fresh launch" window. Aim for a Tuesday or Thursday post — Monday and Friday are crowded.
+
+**Maker hygiene.** Use the project owner's PH account. Hunter ≠ maker — submit yourself. Pre-launch teaser the day before is fine; "Coming soon" with the wedge tagline.
+
+---
+
+## Tagline (≤60 chars)
+
+```
+The first URL cleaner that respects creator affiliate links.
+```
+
+**Alternates:**
+- `URL cleaner that strips trackers — keeps creator referrals.`
+- `Cleans tracking. Keeps the creator paid. Open source.`
+
+Pick the first. It states the wedge, leaves no room for "the most private" / "the best" superlative bait.
+
+---
+
+## Description (≤260 chars per PH limit)
+
+```
+Strips utm_*, fbclid, gclid, and 450+ tracking params from every URL. But unlike
+every other URL cleaner, MUGA preserves the affiliate tag of the creator who
+recommended you — the YouTuber, newsletter, or reviewer who sent you the link.
+The popup tells you it did. Open source, zero telemetry.
+```
+
+---
+
+## Hero image
+
+The "Creator referral preserved" badge in the popup, captured against a real Amazon affiliate link. **Use a clean macOS-style frame around the popup** (the one in the existing `docs/screenshots/` set). Resolution at least 1270×760. Compressed, ≤500KB.
+
+If using a GIF: 5-second loop. Show the click → URL change → badge appearing → toast confirmation. Optimize with `gifsicle -O3`. Target ≤2MB.
+
+---
+
+## Body / first comment from maker
+
+```
+Hi PH — I'm the maker.
+
+Quick story: every URL cleaner I tried strips creator affiliate tags along with
+the trackers. ClearURLs, AdGuard, Brave's cleaner, Firefox's built-in cleaner —
+all of them remove `tag=`, `ref=`, `aff_id` whenever they remove `utm_source`.
+
+That's a privacy feature for the user, but it's also a quiet pay cut for every
+independent reviewer, YouTuber, and newsletter writer whose entire model is
+"I recommend something, you click, the merchant sends me a small cut." When
+your URL cleaner strips their tag, the merchant attributes the sale to "no
+referrer" and the creator who actually sent you there gets nothing.
+
+MUGA strips the SAME trackers as those tools — utm_*, fbclid, gclid, 450+ in
+total. But the creator's affiliate tag stays. And the popup tells you so:
+"Creator referral preserved". No magic, no judgment from MUGA, you can see
+exactly which tag survived and which trackers got stripped.
+
+A few details that might land here:
+- Zero telemetry. No analytics, no crash reporting, no user accounts. The
+  privacy claim is verifiable by diffing the published extension against the
+  GitHub source.
+- MV3 native (Chrome) and MV2 (Firefox), shipped from the same source.
+- Open source, GPL v3. No funding, no investors. I made the affiliate-respect
+  decision because I wanted to use my own URL cleaner without feeling guilty
+  about every newsletter creator I clicked through.
+- 450+ tracking params, 60+ stores supported, 10+ redirect networks unwrapped.
+
+It's not the most-private cleaner — that depends on what you mean by private.
+It's not the most popular — ClearURLs has years of head start. It's the only
+one I know of that respects creator referrals without anyone having to ask.
+That's the wedge.
+
+Comparison page: <comparison URL>
+Source: <github URL>
+Install: <CWS> / <AMO>
+
+Feedback welcome — especially from creators reading this. I'd love to hear
+whether this matches your model.
+```
+
+---
+
+## Hunter / discussion angles
+
+If a hunter (not the maker) lists MUGA, the maker still gets the "Maker" badge by claiming. Reply to early comments quickly — first 4 hours decide rank.
+
+Likely questions + drafted answers:
+
+### "How is this different from ClearURLs?"
+
+> ClearURLs and MUGA strip the same set of trackers — overlap is huge. The difference is one specific decision: when a URL has both a tracker AND a creator affiliate parameter, ClearURLs removes both. MUGA removes the tracker and keeps the affiliate tag. The popup tells you which one was preserved so you can verify. That's the wedge — everything else is overlap.
+
+### "Why should I trust the affiliate-preservation isn't just letting trackers through?"
+
+> Two answers. First: the affiliate-vs-tracker classification is in `src/lib/affiliates.js` — it's a static list, no AI, no inference. You can read it. Second: the popup shows you exactly which params were preserved with the "Creator referral" label. If MUGA ever preserves a tracker by mistake, you can report it via the "Missed tracking parameter" issue template (one click from the popup). It's structurally honest by design.
+
+### "What's the catch? Are you the affiliate?"
+
+> No. MUGA itself isn't an affiliate program — it doesn't inject any tag of its own anywhere. The affiliate tags MUGA preserves are whoever's tag was already on the URL when you clicked. If a YouTuber sent you, their tag survives. If you typed the URL yourself, no tag, nothing to preserve.
+
+### "Does this work for [my favorite store]?"
+
+> The 60+ stores currently supported are listed in the comparison page. If yours isn't on the list and you can paste a documented example of how their direct-injection affiliate system works, the "New affiliate program" issue template will take it from there. Direct-injection only — MUGA refuses programs that route every click through an external tracker (~10 of those exist; they're all rejected on principle).
+
+---
+
+## Self-check
+
+- [ ] Tagline is under 60 chars and states the wedge in active voice.
+- [ ] Description fits PH's 260-char limit.
+- [ ] Hero image is the popup with the badge, clean macOS frame, ≤500KB.
+- [ ] First comment leads with story, not specs.
+- [ ] No "please upvote" or asks. PH is allergic to that.
+- [ ] Replies are drafted but kept in this file — don't pre-paste.

--- a/docs/launch/reddit-launch.md
+++ b/docs/launch/reddit-launch.md
@@ -1,0 +1,157 @@
+# Reddit launch — alternative-to-incumbent angle
+
+**Audience.** Privacy enthusiasts in `/r/firefox`, `/r/chrome`, `/r/privacy`, `/r/privacytools`. They already use ClearURLs / AdGuard / Brave's cleaner. The pitch is **alternative**, not "everything else is broken".
+
+**Timing.** Post 24 hours after the ProductHunt launch so the PH ranking can echo into Reddit. Stagger the four subs by ~6 hours each — don't crosspost simultaneously, the spam filters dislike that.
+
+**Account hygiene.** The posting account needs prior activity in those subs (comments, not just submissions). Brand-new accounts get auto-removed by AutoModerator on most privacy subs. Use a real account.
+
+---
+
+## Suggested order + 24h offsets
+
+1. **`/r/firefox`** — first. Most active about extensions. Use the AMO link as primary.
+2. **`/r/chrome`** — +6h. Use the CWS link.
+3. **`/r/privacy`** — +12h. Use the GitHub link as primary; stores secondary. This sub respects open source.
+4. **`/r/privacytools`** — +24h. Smaller, more critical. Be ready for a deep architectural Q&A.
+
+Don't post in `/r/browsers` or `/r/internetisbeautiful` — wrong audience, will be downvoted as off-topic.
+
+---
+
+## Title — Reddit (≤300 chars per sub)
+
+**Single canonical title:**
+
+```
+MV3-ready ClearURLs alternative with signed remote rules and a "fair to creators" affiliate policy
+```
+
+This title earns its keep:
+- "MV3-ready" — engages the "is X dead under MV3?" anxiety.
+- "ClearURLs alternative" — sets expectations, anchors to the incumbent.
+- "signed remote rules" — earns engineering trust without going into Ed25519 detail.
+- "fair to creators affiliate policy" — the wedge, in scare quotes for honesty.
+
+**Per-sub variants** (only if the canonical doesn't fit the sub's tone):
+
+- `/r/firefox`: `MUGA — MV3/MV2-compatible URL cleaner with signed rules + creator-friendly affiliate handling`
+- `/r/chrome`: `Open-source MV3 URL cleaner that strips trackers but keeps creator affiliate tags`
+- `/r/privacy`: `MUGA — open-source URL cleaner with zero telemetry, signed remote rules, GPL v3`
+- `/r/privacytools`: same as canonical.
+
+---
+
+## Body — Reddit
+
+```
+TL;DR: I built an open-source URL cleaner that strips the same trackers
+ClearURLs / AdGuard / Brave do (utm_*, fbclid, gclid, 450+ params), but
+preserves the creator's affiliate tag instead of stripping it along with the
+trackers. Source, stores, comparison page below.
+
+Why this exists: every URL cleaner I tried treats `?tag=YouTuberX` the same
+way as `?utm_source=newsletter`. They both get stripped. That makes the user's
+URL cleaner-looking, but it also silently zeroes out the YouTuber, newsletter
+writer, or independent reviewer who recommended the link in the first place.
+Their affiliate tag is how they get paid for the recommendation.
+
+MUGA strips the trackers, keeps the creator tag, and tells you it did with a
+"Creator referral preserved" badge in the popup. You can verify which one was
+preserved on every click.
+
+How it compares (full table on the comparison page, this is the short
+version):
+
+| | MUGA | ClearURLs | AdGuard | Brave |
+|---|---|---|---|---|
+| Strips utm_*, fbclid, gclid, 450+ params | yes | yes | yes | yes |
+| Unwraps Awin / Skimlinks / etc. before tracker contact | yes | partial | partial | no |
+| Preserves creator affiliate tag | YES | no | no | no |
+| MV3 native | yes | partial | yes | yes |
+| Zero telemetry | yes | yes | partial | partial |
+| Open source | yes (GPL v3) | yes | partial | partial |
+| Signed remote rules pipeline | yes (Ed25519) | no | no | no |
+
+Not trying to dunk on the others — I run ClearURLs myself and have for years.
+This is one specific decision they all made the same way; MUGA made it
+differently. If you don't care about creator referrals, ClearURLs is great
+and you should keep using it. If you do, this is for you.
+
+Architecture notes for the curious:
+- MV3-native on Chrome (declarativeNetRequest), MV2 on Firefox AMO. Same
+  source, both ship from the repo.
+- Service worker handles badge + stats + optional weekly rules update. URL
+  cleaning runs in the content script — the SW never sees the URL.
+- Optional remote rules signed with Ed25519, verified fail-closed in the SW.
+  Off by default. The pinned public key is in the source.
+- Zero telemetry. No analytics, no crash reporting. The transparency page
+  enumerates every storage write the extension makes.
+
+Stores:
+- Firefox: addons.mozilla.org/firefox/addon/muga/
+- Chrome: chromewebstore.google.com/detail/muga/
+
+Source: github.com/yocreoquesi/muga (GPL v3)
+Comparison page: <comparison URL>
+
+Happy to answer anything — wedge, architecture, or "why didn't you just PR
+this into ClearURLs". Spoiler on the last: I tried, it's a different design
+philosophy and would have meant introducing the affiliate concept into a
+project that has explicitly chosen not to engage with it. Different goals,
+both valid.
+
+Open to feedback. If you spot a tracker MUGA missed, there's a one-click
+report button in the popup that opens a structured GitHub issue (no values,
+no full URLs — names only).
+```
+
+---
+
+## Reply playbook
+
+### "AdGuard is also open source, the table is wrong."
+
+> Fair point — AdGuard's core engine is open source (GPL); the desktop app is mixed. Updated the table to "partial" for that row. Will fix on the comparison page too. Thanks for the correction. *(Then actually open a PR fixing comparison.html.)*
+
+### "Why not contribute to ClearURLs instead of forking?"
+
+> Tried. The affiliate-preservation principle is a foundational design choice, not a feature flag — ClearURLs's stated philosophy is "all params equal, all suspicious". Adding a "preserve this category" code path would require the project to take a position on affiliate ethics, which they've explicitly chosen not to do. So a separate project made more sense than fighting that. Both can exist.
+
+### "Is this another Brave-style 'affiliate hijacking'?"
+
+> No, and the distinction matters. Brave's controversy was about INJECTING their own affiliate tag onto links that didn't have one. MUGA does NOT do that — there's a setting for "auto-injection of MUGA's own tag" but it's OFF by default and there's a per-device confirmation flow before any tag is ever injected. The default behaviour is: if a creator's tag is already on the URL, keep it. If no tag, no tag. MUGA never makes the URL more affiliated than the user found it.
+
+### "How do you classify what's an affiliate tag vs a tracker?"
+
+> Static lookup table in `src/lib/affiliates.js` plus per-domain rules in `src/rules/domain-rules.json`. No ML, no inference, no remote service. You can read every classification and PR a fix if any of them is wrong. The CAPS spec (separate repo) defines the test vectors so the classification is auditable against a written contract.
+
+### "What's stopping you from going closed-source after I install?"
+
+> GPL v3 license terms — every published version IS the open-source version. Each release `.zip` on AMO and CWS can be diffed against the corresponding tag in the GitHub repo (CWS doesn't make this trivial; on Firefox the .xpi is just an extracted-archive). There's a transparency page in the extension that explains how to verify this yourself. If a future version were closed-source, GPL would be violated and that would be public news fast.
+
+---
+
+## AutoModerator survival kit
+
+Some of these subs auto-remove "Show off" / promo posts unless they meet thresholds. Mitigations baked into the body above:
+
+- ✅ Concrete comparison table (not "we are the best").
+- ✅ Acknowledges the incumbent positively.
+- ✅ Open source + free + no upsell.
+- ✅ Architecture details, not just feature claims.
+- ✅ Account has prior comment history in the sub (PRECONDITION — verify before posting).
+
+If a post gets auto-removed, message the mods (NOT in the post — modmail). Do not repost — the duplicate-detection on most privacy subs is harsh.
+
+---
+
+## Self-check
+
+- [ ] Title fits each sub's character limit.
+- [ ] Comparison table is accurate as of the day of posting (re-verify each row).
+- [ ] No superlatives, no "the only", no "the best".
+- [ ] Account has prior comment activity in the sub (NOT just submissions).
+- [ ] Comparison-page URL is reachable (Wave 1 prerequisite).
+- [ ] Don't crosspost simultaneously to all four subs. 6h staggered.
+- [ ] Replies are drafted but live in this file — don't pre-paste.


### PR DESCRIPTION
## Summary

Closes #332 (P1, Wave 2: Distribution).

Three platform-specific launch drafts under `docs/launch/`, plus a coordinating README that hard-codes the pre-launch checklist + the launch principles ("no superlatives, no trash talk, show don't tell"). Drafts are NOT yet live — acceptance for this issue is "three drafts in repo, reviewed by maintainer".

## What's in here

- **`docs/launch/README.md`** — launch sequencing (HN Tue/Wed → PH same week → Reddit 24h after PH), pre-launch checklist, post-launch metrics capture (CWS / AMO / GitHub / muga.app deltas at +24h / +7d / +30d), and the launch principles.
- **`docs/launch/hn-launch.md`** — engineering-angle Show HN: title options, body, reply playbook for the predictable questions (ClearURLs comparison, MV3 cripple-bear, Ed25519 overkill, MV2 Firefox path, monetization).
- **`docs/launch/producthunt-launch.md`** — UX wedge angle: tagline, 260-char description, hero-image spec (popup with the "Creator referral preserved" badge), maker first-comment, hunter Q&A drafts.
- **`docs/launch/reddit-launch.md`** — alternative-to-incumbent angle for `/r/firefox` `/r/chrome` `/r/privacy` `/r/privacytools` with per-sub title variants, comparison table, AutoModerator survival kit, and reply playbook for "why not PR ClearURLs" / "is this Brave-style hijacking".

## What this PR is NOT

- Not a launch. Drafts only.
- Not a marketing claim audit — every claim in the drafts is a placeholder marker (`<comparison URL>`, etc.) that the launching person fills in at posting time. That keeps stale numbers out of git.
- Not a brand-asset PR — screenshots / GIFs are referenced but not included.

## Pre-launch dependencies (gate the actual posting, not this PR)

- [ ] #481 — `muga.app` domain wired
- [ ] #329 — `comparison.html` reachable from landing
- [ ] #328 — store listings up to date with current screenshots
- [ ] #327 — "Creator referral preserved" badge visible in the popup
- [ ] #326 — popup counter shows non-zero after a brief test session
- [ ] Screenshots refreshed via `npm run screenshots` and committed

The README pins all of these so a future me cannot accidentally launch before Wave 1 lands.

## Test plan

- [x] `npm test` — pure docs, no code touched, but suite re-run for safety: 3499/3499 pass on the parent main.
- [ ] Maintainer reads each draft and notes copy edits in PR comments.