### PR TITLE
ci(benchmark): SHA-pin actions/upload-artifact to v4.6.2 (closes #528)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,12 +43,7 @@ jobs:
         run: npm run benchmark
 
       - name: Upload report artifacts
-        # FIXME: this repo's convention is to SHA-pin actions (see ci.yml).
-        # Using the version tag here as a placeholder — the orchestrator
-        # author could not verify a SHA for upload-artifact@v4 without
-        # external lookup. Replace with the canonical SHA before this
-        # workflow first fires on a release tag. Tracked separately.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: muga-benchmark-${{ github.ref_name }}
           path: tests/benchmark/reports/*


### PR DESCRIPTION
## Summary

Closes #528. Resolves the `FIXME` placeholder shipped with `benchmark.yml` (#507 phase 3c) and brings it in line with the SHA-pin convention already used for `actions/checkout` and `actions/setup-node` in the same file (and across `ci.yml`).

## Resolution

| Tag | Commit SHA | Source |
|---|---|---|
| `actions/upload-artifact@v4.6.2` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `gh api repos/actions/upload-artifact/git/ref/tags/v4.6.2` |

The moving `v4` tag also points at the same commit at the time of this PR (verified independently), so v4.6.2 is the current head of v4.

## Test plan

- [x] Diff is one-line replacement of `@v4` → `@<sha>  # v4.6.2`, plus removal of the FIXME comment block
- [x] No functional change to the workflow itself
- [ ] Workflow next fires on the `v1.13.4`+ release tag — first opportunity to confirm CI still passes (the previous run on `v1.13.3` used the unpinned tag and succeeded, so behaviour parity is expected)