### PR TITLE
chore(release): bump version to 1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,26 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.4] - 2026-05-05
+
+Coverage + standards-compliance + CI hygiene release. Headline: MUGA now consumes `caps-spec/manifest.json` as the source of truth for affiliate program identity, and the preserve set is decoupled from MUGA's own affiliate accounts — creator referrals are honored on Booking, Vercel, DigitalOcean, Humble Bundle, and Lemon Squeezy even though MUGA has no direct account on those programs.
+
 ### Added
 
+- **`caps-spec/manifest.json` consumed as source of truth for the affiliate preserve set** (#523, landed via #576/#577/#578). The 12-entry hand-maintained `AFFILIATE_PATTERNS` array is replaced by 7 consolidated entries generated at module load by joining the vendored `caps-spec` direct-injection programs with MUGA's hand-maintained `OUR_TAGS` map. New `scripts/sync-affiliate-manifest.mjs` mirrors the existing `sync-wrappers.mjs` pattern (Ed25519 signature verification when available, `--allow-unsigned` for the interim). Files: [`scripts/sync-affiliate-manifest.mjs`](scripts/sync-affiliate-manifest.mjs), [`src/vendor/caps-spec/manifest.data.js`](src/vendor/caps-spec/manifest.data.js), [`src/lib/affiliates.js`](src/lib/affiliates.js).
 - **Sprinklr campaign-manager params (`spr`, `sprtype`) added to universal `TRACKING_PARAMS`** ([`src/lib/affiliates.js`](src/lib/affiliates.js), [`src/rules/tracking-params.json`](src/rules/tracking-params.json)). Stripped on every domain. False-positive risk is low — these identify the campaign and asset that referred a click inside Sprinklr's backend and have no functional payload from the user's perspective. Closes the last "low-risk universal" gap from the #508 acceptance list (the merchant-specific gaps remain). (#508)
 - **`tracker-flag.yml` issue template** ([`.github/ISSUE_TEMPLATE/tracker-flag.yml`](.github/ISSUE_TEMPLATE/tracker-flag.yml)). Wires Channel 1 of CAPS decision 6 — receives structured tracker reports prefilled by MUGA's local heuristics (entropy + cross-site frequency). Schema mirrors the privacy contract already enforced by `csft-upstream.js`: only the SHAPE of the observation, never raw URLs or raw values. The existing `tracking-param.md` template is preserved (different intent — hand-written carrier-aware param requests). (#522)
 - **`tracker-candidate` repo label** to receive auto-labelled issues from the new form.
 
 ### Changed
 
+- **Preserve set is now declarative, not gated on MUGA's own affiliate account.** The `if (!pattern.ourTag) continue` short-circuit in `detectPreservedAffiliate` (cleaner.js line 124 pre-#523) is removed. Result: when a user clicks a Booking, Vercel, DigitalOcean, Humble Bundle, or Lemon Squeezy link that carries someone's affiliate tag, MUGA preserves it and shows the "Creator referral preserved" badge in the popup — even though MUGA has no account on those programs. Aligns with the wedge ("MUGA preserves any creator's tag") and with caps-spec's declarative semantics. (#523 phase 3)
+- **`pattern.ourTag` shape**: was a flat string per legacy per-marketplace entry. Now a `{ host -> tag }` map per consolidated program. Cleaner-side comparisons read `pattern.ourTag[hostname]`. Service-worker, options page, and the legacy unit-test patterns updated to match. (#523 phase 3)
 - **Release pipeline submission gate now distinguishes "version already submitted" from real store errors** ([`.github/workflows/release.yml`](.github/workflows/release.yml)). Each store step (AMO, CWS upload, CWS publish) emits a `result` output of `success | noop | failure`. The summary gate fails the workflow only on `failure`; `noop` is treated as success-or-no-op. This unblocks the partial-recovery scenario from v1.13.1 — a maintainer can re-tag a patch release without the gate spuriously failing on the store that already published the previous tag. Detection patterns are conservative; real failures still surface. (#557)
 
 ### Fixed (CI / hygiene)
 
+- **Branch protection on `main`** now requires both `test` and `e2e` jobs to pass before merge. Fixes the gap that allowed PRs #487-#490 to land with `cleaner-bundle.js` drift even though CI flagged it. `enforce_admins: false` preserves the admin-merge escape hatch for legitimate flakes. (#513)
 - **`actions/upload-artifact@v4` SHA-pinned in `benchmark.yml`** to commit `ea165f8` (v4.6.2). Brings the workflow in line with the existing pin convention used for `actions/checkout` and `actions/setup-node` in the same file and across `ci.yml`. The previous tag-only reference shipped with a `FIXME` comment from the original workflow author. (#528)
 
 ### Internal
@@ -659,7 +667,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.3...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.4...HEAD
+[1.13.4]: https://github.com/yocreoquesi/muga/compare/v1.13.3...v1.13.4
 [1.13.3]: https://github.com/yocreoquesi/muga/compare/v1.13.2...v1.13.3
 [1.13.2]: https://github.com/yocreoquesi/muga/compare/v1.13.1...v1.13.2
 [1.13.1]: https://github.com/yocreoquesi/muga/compare/v1.13.0...v1.13.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.13.3-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.13.4-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-2531_pass-brightgreen)](#development)
 [![CAPS](https://img.shields.io/badge/CAPS-Basic%20%2B%20Contextual-2ea44f)](CONFORMANCE.md)
 # MUGA: Privacy Without Breaking Creator Links

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://yocreoquesi.github.io/muga/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.13.3"
+    "softwareVersion": "1.13.4"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.3 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.4 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 1.13.3
+> Version: 1.13.4
 > Last updated: 2026-05-04
 > Status: Final listing for Chrome Web Store and Firefox AMO. Lead headline rewritten to surface the "fair to creators" wedge per the 2026-04-26 strategic review (consensus across three independent analyses). Aligned with the post-grill privacy-policy and ToS rollout (#399, #400) — per-device consent, local cleaning architecture, and #353 conditional preservation of MUGA's own tag.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.3 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.4 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.13.3</span>
+      <span class="at-a-glance-value">1.13.4</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -206,7 +206,7 @@
   <hr>
 
   <div class="footer">
-    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.3 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
+    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.4 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
   </div>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Privacy without breaking creator links. Strips 450+ tracking params, preserves creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.3 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.4 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.


### PR DESCRIPTION
## Summary

Cuts **v1.13.4** — coverage + standards-compliance + CI hygiene release.

### Headline

MUGA now consumes `caps-spec/manifest.json` as the source of truth for affiliate program identity (#523). The preserve set is decoupled from MUGA's own affiliate accounts — creator referrals on **Booking, Vercel, DigitalOcean, Humble Bundle, and Lemon Squeezy** are now honored even though MUGA has no direct account on those programs.

### User-visible behavior changes vs v1.13.3

- "Creator referral preserved" badge fires on 5 additional programs that previously needed an active MUGA account to trigger.
- Popup "store" name no longer differs across Amazon marketplaces (one program identity, one display label).
- Sprinklr `spr`/`sprtype` params now stripped universally.

### Bundles

| Issue | PR | Headline |
|---|---|---|
| #523 | #579/#580/#581 | caps-spec manifest sync + decouple preserve |
| #508 (partial) | #572 | Sprinklr spr/sprtype universal strip |
| #522 | #571 | tracker-flag.yml issue template |
| #557 | #570 | release pipeline noop detection |
| #528 | #569 | SHA-pin upload-artifact in benchmark.yml |
| #513 | — | branch protection on main (admin action) |
| #510 | #573 | Playwright DNR spec + empirical finding |

## Test plan

- [x] `npm test` → 3419/3419 unit tests pass locally
- [ ] CI passes both `test` and `e2e` jobs (now required by branch protection)
- [ ] Release CI publishes to AMO and Chrome Web Store on tag push
- [ ] Smoke after publish:
  - [ ] Visit a Booking link with someone's `aid` parameter → "Creator referral preserved" badge fires
  - [ ] Visit an Amazon link → popup shows program "Amazon" (not "Amazon España" / "Amazon Deutschland")
  - [ ] Visit a URL with `?spr=foo&sprtype=bar` → both params stripped

## Refs

Closes the v1.13.3 follow-up loop. The caps-spec manifest sync (#523) is the load-bearing change — review the consolidated `AFFILIATE_PATTERNS` shape if you want to verify the join logic.