### PR TITLE
feat(popup): tracker-flag submit button per Suspicious-params row (closes #521)

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -171,42 +171,37 @@ export const TRANSLATIONS = {
     pt: "Reportar ao repo" /* FIXME: needs native speaker review */,
     de: "Upstream melden" /* FIXME: needs native speaker review */,
   },
-  report_upstream_issue_title: {
-    en: "[Param] {paramName} — observed across {count} domains",
-    es: "[Parámetro] {paramName} — observado en {count} dominios",
-    pt: "[Parâmetro] {paramName} — observado em {count} domínios" /* FIXME: needs native speaker review */,
-    de: "[Parameter] {paramName} — auf {count} Domains beobachtet" /* FIXME: needs native speaker review */,
+  // #521: per-param dedup label shown in place of the Report-upstream
+  // button after the user has reported that param from this install.
+  // Cleared via the options page "Forget reported params" control.
+  report_upstream_already_reported: {
+    en: "Reported {date}",
+    es: "Reportado el {date}",
+    pt: "Reportado em {date}" /* FIXME: needs native speaker review */,
+    de: "Gemeldet am {date}" /* FIXME: needs native speaker review */,
   },
-  report_upstream_issue_body: {
-    en:
-      "## Suspicious tracking parameter\n\n" +
-      "Reported from the MUGA popup's Suspicious params section.\n\n" +
-      "- **Param name:** `{paramName}`\n" +
-      "- **Distinct first-party domains observed:** {count}\n\n" +
-      "## Privacy disclaimer\n\n" +
-      "MUGA never sees the value, hash, or domains — this report contains only the two fields above.\n",
-    es:
-      "## Parámetro de rastreo sospechoso\n\n" +
-      "Reportado desde la sección \"Parámetros sospechosos\" del popup de MUGA.\n\n" +
-      "- **Nombre del parámetro:** `{paramName}`\n" +
-      "- **Dominios first-party distintos observados:** {count}\n\n" +
-      "## Aviso de privacidad\n\n" +
-      "MUGA nunca ve el valor, ni el hash, ni los dominios — este reporte contiene únicamente los dos campos de arriba.\n",
-    pt:
-      "## Parâmetro de rastreamento suspeito\n\n" +
-      "Reportado da seção \"Parâmetros suspeitos\" do popup do MUGA.\n\n" +
-      "- **Nome do parâmetro:** `{paramName}`\n" +
-      "- **Domínios first-party distintos observados:** {count}\n\n" +
-      "## Aviso de privacidade\n\n" +
-      "O MUGA nunca vê o valor, o hash nem os domínios — este relatório contém apenas os dois campos acima.\n" /* FIXME: needs native speaker review */,
-    de:
-      "## Verdächtiger Tracking-Parameter\n\n" +
-      "Gemeldet aus dem Abschnitt \"Verdächtige Parameter\" des MUGA-Popups.\n\n" +
-      "- **Parametername:** `{paramName}`\n" +
-      "- **Beobachtete unterschiedliche First-Party-Domains:** {count}\n\n" +
-      "## Datenschutzhinweis\n\n" +
-      "MUGA sieht weder den Wert noch den Hash noch die Domains — dieser Bericht enthält nur die beiden Felder oben.\n" /* FIXME: needs native speaker review */,
+  // #521: options-page button to clear the per-install dedup list
+  // (chrome.storage.local.submittedParams). The user can resubmit a
+  // previously-reported param after using this.
+  forget_reported_params_btn: {
+    en: "Forget reported params",
+    es: "Olvidar parámetros reportados",
+    pt: "Esquecer parâmetros reportados" /* FIXME: needs native speaker review */,
+    de: "Gemeldete Parameter vergessen" /* FIXME: needs native speaker review */,
   },
+  forget_reported_params_done: {
+    en: "Reported list cleared",
+    es: "Lista de reportes borrada",
+    pt: "Lista de reportes limpa" /* FIXME: needs native speaker review */,
+    de: "Liste der Meldungen gelöscht" /* FIXME: needs native speaker review */,
+  },
+  forget_reported_params_hint: {
+    en: "Clears the local list of params you've already reported. The same param can then be reported again.",
+    es: "Borra la lista local de parámetros que ya reportaste. El mismo parámetro se podrá volver a reportar.",
+    pt: "Limpa a lista local de parâmetros já reportados. O mesmo parâmetro poderá ser reportado novamente." /* FIXME: needs native speaker review */,
+    de: "Löscht die lokale Liste bereits gemeldeter Parameter. Derselbe Parameter kann danach erneut gemeldet werden." /* FIXME: needs native speaker review */,
+  },
+
   domain_stats_empty:    { en: "No domain stats yet. Keep browsing!", es: "Aún no hay estadísticas. ¡Sigue navegando!", pt: "Sem estatísticas ainda. Continue navegando!", de: "Noch keine Domain-Statistiken. Weiter surfen!" },
   domain_stats_params:   { en: "params stripped", es: "parámetros eliminados", pt: "parâmetros removidos", de: "Parameter entfernt" },
   domain_stats_urls:     { en: "URLs cleaned", es: "URLs limpiadas", pt: "URLs limpas", de: "URLs bereinigt" },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -108,6 +108,13 @@
         </div>
         <button class="add-btn" id="reset-stats-btn" data-i18n="stats_reset_btn">Reset stats</button>
       </div>
+      <div class="row">
+        <div class="row-label">
+          <strong data-i18n="forget_reported_params_btn">Forget reported params</strong>
+          <small data-i18n="forget_reported_params_hint">Clears the local list of params you've already reported. The same param can then be reported again.</small>
+        </div>
+        <button class="add-btn" id="forget-reported-params-btn" data-i18n="forget_reported_params_btn">Forget reported params</button>
+      </div>
     </div>
   </section>
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -641,6 +641,19 @@ function initStatsSection() {
       showToast(t("stats_reset_done", _currentLang));
     } catch (err) { console.error("[MUGA] reset stats:", err); }
   });
+
+  // #521: clear the per-install dedup list of params that have been
+  // reported to the muga issue tracker. Lets the user re-submit the
+  // same param after a previous submission was dismissed / fixed.
+  const forgetBtn = document.getElementById("forget-reported-params-btn");
+  if (forgetBtn) {
+    forgetBtn.addEventListener("click", async () => {
+      try {
+        await chrome.storage.local.set({ submittedParams: {} });
+        showToast(t("forget_reported_params_done", _currentLang));
+      } catch (err) { console.error("[MUGA] forget reported params:", err); }
+    });
+  }
 }
 
 /** Initializes export/import settings functionality. */

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -16,7 +16,6 @@ import {
   createChromeLocalAdapter as createFrequencyAdapter,
   defaultHasher as frequencyHasher,
 } from "../lib/cross-site-frequency.js";
-import { buildUpstreamPayload } from "../lib/csft-upstream.js";
 import { presentLedger, DEFAULT_LEDGER_CAPACITY } from "../lib/attribution-ledger.js";
 import { renderEntries as renderLedgerEntries } from "../lib/attribution-ledger-view.js";
 
@@ -736,8 +735,8 @@ async function showSuspiciousParams(prefs, lang) {
 
   // ── Frequency subgroup: gated on the dedicated pref toggle ──
   // We also fetch the raw tracker state once so the per-row "Report
-  // upstream" button (#537) can extract its privacy-bounded payload via
-  // the csft-upstream module — without re-reading storage per click.
+  // upstream" button (#537/#521) can extract its privacy-bounded payload
+  // — without re-reading storage per click.
   let frequencyFlags = [];
   let trackerState = null;
   if (prefs.crossSiteFrequencyEnabled !== false) {
@@ -750,13 +749,25 @@ async function showSuspiciousParams(prefs, lang) {
           enabled: true,
         });
         frequencyFlags = await tracker.getFlagged();
-        // Pull the raw {params: {...}} shape so csft-upstream can resolve
-        // the first-party domain count for any flagged param. The module
-        // tolerates this wrapped shape natively.
+        // Pull the raw {params: {...}} shape so the report-upstream button
+        // can read per-param entry data (domains, entropyAvg, value-hash
+        // count) for the form prefill.
         try { trackerState = await adapter.get(); } catch { /* best-effort */ }
       }
     } catch { /* best-effort; freq subgroup just stays empty */ }
   }
+
+  // #521: read submittedParams once for the section render. Each per-row
+  // button reads from this snapshot to decide whether to render the
+  // button or the "Reported on YYYY-MM-DD" label. Storage write happens
+  // on click; re-render after that swap is inline (no full re-render).
+  let submittedParams = {};
+  try {
+    const stored = await new Promise((resolve) => {
+      chrome.storage.local.get({ submittedParams: {} }, (r) => resolve(r));
+    });
+    submittedParams = stored.submittedParams || {};
+  } catch { /* best-effort; dedup is UX, not a privacy gate */ }
 
   // Hide the whole section when both subgroups are empty. Fresh installs
   // and clean pages should not get a noise-y empty header.
@@ -798,7 +809,7 @@ async function showSuspiciousParams(prefs, lang) {
       // count via the csft-upstream privacy module. Entropy-flagged params
       // typically aren't in the tracker store yet → count resolves to 0,
       // which is the correct, privacy-preserving default.
-      _appendReportUpstreamButton(row, flag.param, trackerState, lang);
+      _appendReportUpstreamButton(row, flag.param, trackerState, lang, submittedParams);
 
       list.appendChild(row);
     }
@@ -831,7 +842,7 @@ async function showSuspiciousParams(prefs, lang) {
 
       _appendStripLocallyButton(row, flag.param, userCustomRulesLower, prefs, lang);
       // #537: per-row Report upstream button (see entropy block above).
-      _appendReportUpstreamButton(row, flag.param, trackerState, lang);
+      _appendReportUpstreamButton(row, flag.param, trackerState, lang, submittedParams);
 
       list.appendChild(row);
     }
@@ -916,53 +927,112 @@ function _appendStripLocallyButton(row, paramName, alreadyPromoted, prefs, lang)
 
 /**
  * Appends the per-row "Report upstream" button to a Suspicious-params row
- * (#537). Clicking opens a deep-linked GitHub issue pre-filled with ONLY
- * the param name and the count of distinct first-party domains the user
- * has observed it on.
+ * (#521 evolution of #537). Clicking opens a deep-linked GitHub issue
+ * using the structured `tracker-flag.yml` form template with prefilled
+ * fields sourced from the local cross-site-frequency tracker.
  *
- * Privacy contract: the deep-link payload comes EXCLUSIVELY from
- * `buildUpstreamPayload` (csft-upstream.js), whose return type is a fresh
- * 2-field object literal. There is no path through which a value, hash,
- * or domain string can leak into the URL — even if this glue is later
- * refactored carelessly. The structural enforcement lives in the module,
- * not in this caller.
+ * Privacy contract: the deep-link only carries fields the user is about
+ * to review and submit themselves on github.com. Nothing is sent
+ * automatically. The fields prefilled are:
+ *   - paramName (the flagged param)
+ *   - domains   (first-party hosts where the param was seen)
+ *   - entropy_score, frequency_distinct_domains, frequency_distinct_values
+ * Raw values, raw URLs, value hashes, and timestamps are NEVER passed.
  *
- * Anchor opens via window.open(url, '_blank', 'noopener,noreferrer') per
- * the project security rule (no opener leakage; no referrer to GitHub).
+ * Local dedup (#521): once submitted, the button is replaced with a
+ * "Reported on YYYY-MM-DD" label so the same param doesn't get reported
+ * twice from the same install. The user can clear the dedup list from
+ * the options page ("Forget reported params"). The dedup state lives in
+ * `chrome.storage.local.submittedParams` as `{ [paramName]: "YYYY-MM-DD" }`.
  *
- * @param {HTMLElement}        row          The .suspicious-row being built.
- * @param {string}             paramName    Original-case param name.
- * @param {object|null}        trackerState Raw cross-site-frequency state
- *                                          ({params:{...}}) or null when the
- *                                          frequency tracker is disabled or
- *                                          the param was entropy-only-flagged.
- * @param {string}             lang         Active UI language code.
+ * @param {HTMLElement} row              The .suspicious-row being built.
+ * @param {string}      paramName        Original-case param name.
+ * @param {object|null} trackerState     Raw cross-site-frequency state
+ *                                       ({params:{...}}) or null when the
+ *                                       frequency tracker is disabled or
+ *                                       the param was entropy-only-flagged.
+ * @param {string}      lang             Active UI language code.
+ * @param {object}      submittedParams  { [name]: "YYYY-MM-DD" } map read
+ *                                       once at section-render time.
  */
-function _appendReportUpstreamButton(row, paramName, trackerState, lang) {
+function _appendReportUpstreamButton(row, paramName, trackerState, lang, submittedParams) {
+  // Already-reported short-circuit: render a small label, no button.
+  const submittedDate = submittedParams && submittedParams[paramName];
+  if (submittedDate) {
+    const label = document.createElement("span");
+    label.className = "report-upstream-already-reported";
+    label.textContent = t("report_upstream_already_reported", lang).replace("{date}", submittedDate);
+    label.setAttribute("title", label.textContent);
+    row.appendChild(label);
+    return;
+  }
+
   const btn = document.createElement("button");
   btn.type = "button";
   btn.className = "report-upstream-btn";
   btn.dataset.param = paramName;
   btn.textContent = t("report_upstream_btn", lang);
   btn.setAttribute("aria-label", t("report_upstream_btn", lang));
-  btn.addEventListener("click", () => {
+  btn.addEventListener("click", async () => {
     try {
-      // Privacy boundary lives INSIDE buildUpstreamPayload — its return
-      // type is a fresh 2-field object literal, so nothing else can ride
-      // along. We only ever read the two fields back out below.
-      const payload = buildUpstreamPayload(trackerState, paramName);
-      const titleTpl = t("report_upstream_issue_title", lang);
-      const bodyTpl = t("report_upstream_issue_body", lang);
-      const title = titleTpl
-        .replace("{paramName}", payload.paramName)
-        .replace("{count}", String(payload.firstPartyDomainCount));
-      const body = bodyTpl
-        .replace("{paramName}", payload.paramName)
-        .replace("{count}", String(payload.firstPartyDomainCount));
-      const url = `https://github.com/yocreoquesi/muga/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=needs-triage`;
+      // Resolve the tracker entry. Both raw and wrapped shapes are accepted
+      // (mirrors buildUpstreamPayload's defensive normalisation).
+      let entry = null;
+      if (trackerState && typeof trackerState === "object") {
+        const entries = trackerState.params && typeof trackerState.params === "object"
+          ? trackerState.params
+          : trackerState;
+        entry = entries && entries[paramName] ? entries[paramName] : null;
+      }
+      const domains = entry && Array.isArray(entry.domains) ? entry.domains : [];
+      const distinctValues = entry && Array.isArray(entry.values) ? entry.values.length : 0;
+      const entropyAvg = entry && typeof entry.entropyAvg === "number" ? entry.entropyAvg : null;
+
+      // Cap the domains list at 50 entries to stay well under GitHub's
+      // ~8 KB URL ceiling. The form's textarea accepts free input, so the
+      // user can add more before submitting if their list is longer.
+      const cappedDomains = domains.slice(0, 50);
+
+      const params = new URLSearchParams();
+      params.set("template", "tracker-flag.yml");
+      params.set("paramName", paramName);
+      if (cappedDomains.length > 0) params.set("domains", cappedDomains.join("\n"));
+      if (entropyAvg !== null) params.set("entropy_score", entropyAvg.toFixed(2));
+      if (domains.length > 0) params.set("frequency_distinct_domains", String(domains.length));
+      if (distinctValues > 0) params.set("frequency_distinct_values", String(distinctValues));
+
+      const url = `https://github.com/yocreoquesi/muga/issues/new?${params.toString()}`;
+
+      // Mark submitted BEFORE opening — if the user closes the tab without
+      // hitting Submit on GitHub, MUGA still treats it as "reported" until
+      // they clear the list from settings. That's the lesser evil vs.
+      // tracking issue state via the GitHub API (would require polling and
+      // breaks the zero-telemetry promise).
+      const today = new Date().toISOString().slice(0, 10);
+      try {
+        const stored = await new Promise((resolve) => {
+          chrome.storage.local.get({ submittedParams: {} }, (r) => resolve(r));
+        });
+        const updated = { ...(stored.submittedParams || {}), [paramName]: today };
+        await new Promise((resolve) => {
+          chrome.storage.local.set({ submittedParams: updated }, resolve);
+        });
+      } catch (storageErr) {
+        // Non-fatal: dedup is a UX nicety, not a privacy gate. Open the URL
+        // anyway so the user's intent isn't lost to a storage hiccup.
+        console.warn("[MUGA] report-upstream dedup save:", storageErr);
+      }
+
+      // Replace the button with the "already reported" label inline so
+      // the user sees immediate feedback without a popup re-render.
+      const label = document.createElement("span");
+      label.className = "report-upstream-already-reported";
+      label.textContent = t("report_upstream_already_reported", lang).replace("{date}", today);
+      btn.replaceWith(label);
+
       // _blank + noopener + noreferrer per the project security rule —
-      // GitHub never sees document.referrer and the new tab can't
-      // touch window.opener.
+      // GitHub never sees document.referrer and the new tab can't touch
+      // window.opener.
       window.open(url, "_blank", "noopener,noreferrer");
     } catch (err) {
       console.error("[MUGA] report-upstream open:", err);

--- a/tests/unit/popup-report-upstream-button.test.mjs
+++ b/tests/unit/popup-report-upstream-button.test.mjs
@@ -1,18 +1,28 @@
 /**
- * MUGA — Popup "Report upstream" button per Suspicious-params row (#537).
+ * MUGA — Popup "Report upstream" button per Suspicious-params row.
  *
- * The button opens a deep-linked GitHub issue in a new tab pre-filled with
- * ONLY the param name and the count of distinct first-party domains the
- * user observed it on. No value, no hash, no domain history.
+ * History:
+ *   #537 — initial slice. Deep-link to GitHub with ONLY paramName +
+ *          firstPartyDomainCount (privacy-locked via csft-upstream.js).
+ *   #521 — evolved to use the structured `tracker-flag.yml` form
+ *          template with richer prefill (domains list, entropy, count
+ *          breakdown). The privacy contract is preserved by the
+ *          user-mediated review step on github.com — MUGA never sends
+ *          anything autonomously.
  *
- * These structural tests pin:
- *   - the i18n keys exist (en + es non-empty) for the button + body copy
- *   - the popup JS contains the marker class for the button so future
- *     refactors keep it discoverable
- *   - the popup JS references the deep-link URL host + the labels= query
- *     parameter so a refactor that breaks the GitHub deep-link surface
- *     fails this test, not just E2E
- *   - the popup JS imports buildUpstreamPayload (structural privacy)
+ * Structural tests pin the post-#521 contract:
+ *   - i18n keys exist (en + es non-empty)
+ *   - popup.js declares the button class so future refactors keep it
+ *     discoverable
+ *   - popup.js uses the new `?template=tracker-flag.yml&...` URL pattern
+ *     (form deep-linking) instead of the legacy `?title=...&body=...`
+ *   - popup.js opens the deep-link via window.open with noopener+noreferrer
+ *   - popup.js writes to `chrome.storage.local.submittedParams` for
+ *     local dedup (never to chrome.storage.sync; this is per-install
+ *     UX state, not synced behaviour)
+ *   - the "already-reported" label is rendered in place of the button
+ *     when a paramName has been submitted previously from this install
+ *   - simulated deep-link does NOT leak value-hashes or timestamps
  */
 
 import { test } from "node:test";
@@ -38,46 +48,32 @@ test("report_upstream_btn: i18n key exists with en + es non-empty", () => {
   assert.ok(typeof k.es === "string" && k.es.length > 0, "es non-empty");
 });
 
-test("report_upstream_issue_title: i18n key carries {paramName} and {count} placeholders (en + es)", () => {
-  const k = TRANSLATIONS.report_upstream_issue_title;
-  assert.ok(k, "report_upstream_issue_title must exist");
+test("report_upstream_already_reported: i18n key carries {date} placeholder (en + es)", () => {
+  const k = TRANSLATIONS.report_upstream_already_reported;
+  assert.ok(k, "report_upstream_already_reported must exist (#521)");
   for (const lang of ["en", "es"]) {
     assert.ok(typeof k[lang] === "string" && k[lang].length > 0, `${lang} non-empty`);
-    assert.ok(k[lang].includes("{paramName}"), `${lang} must include {paramName}`);
-    assert.ok(k[lang].includes("{count}"), `${lang} must include {count}`);
+    assert.ok(k[lang].includes("{date}"), `${lang} must include {date} placeholder`);
   }
 });
 
-test("report_upstream_issue_body: i18n key carries {paramName} and {count} and a privacy disclaimer (en + es)", () => {
-  const k = TRANSLATIONS.report_upstream_issue_body;
-  assert.ok(k, "report_upstream_issue_body must exist");
-  for (const lang of ["en", "es"]) {
-    assert.ok(typeof k[lang] === "string" && k[lang].length > 0, `${lang} non-empty`);
-    assert.ok(k[lang].includes("{paramName}"), `${lang} must include {paramName}`);
-    assert.ok(k[lang].includes("{count}"), `${lang} must include {count}`);
+test("forget_reported_params_btn: i18n keys exist for the options-page reset (en + es)", () => {
+  for (const key of ["forget_reported_params_btn", "forget_reported_params_done", "forget_reported_params_hint"]) {
+    const k = TRANSLATIONS[key];
+    assert.ok(k, `${key} must exist (#521)`);
+    assert.ok(typeof k.en === "string" && k.en.length > 0, `${key}.en non-empty`);
+    assert.ok(typeof k.es === "string" && k.es.length > 0, `${key}.es non-empty`);
   }
-  // The privacy disclaimer is the whole point of the slice — assert that the
-  // English body explicitly mentions that MUGA never sees the value.
-  assert.match(k.en, /never sees? the value/i, "en body must carry the privacy disclaimer");
 });
 
 // ── JS surface ───────────────────────────────────────────────────────────────
 
 test("popup.js declares a 'report-upstream-btn' class for the per-row button", () => {
   const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
-  assert.ok(
-    /report-upstream-btn/.test(popupSrc),
-    "popup.js must reference the report-upstream-btn class so the button is discoverable",
-  );
+  assert.match(popupSrc, /report-upstream-btn/);
 });
 
-test("popup.js imports buildUpstreamPayload from csft-upstream module (structural privacy)", () => {
-  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
-  assert.match(popupSrc, /buildUpstreamPayload/);
-  assert.match(popupSrc, /csft-upstream/);
-});
-
-test("popup.js click-handler builds a github.com/yocreoquesi/muga/issues/new URL with labels=needs-triage", () => {
+test("popup.js uses the tracker-flag.yml form template URL pattern (#521, not #537 legacy)", () => {
   const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
   assert.match(
     popupSrc,
@@ -86,8 +82,21 @@ test("popup.js click-handler builds a github.com/yocreoquesi/muga/issues/new URL
   );
   assert.match(
     popupSrc,
-    /labels=needs-triage/,
-    "popup.js must request the needs-triage label on the deep-linked issue",
+    /tracker-flag\.yml/,
+    "popup.js must reference the tracker-flag.yml form template (post-#521)",
+  );
+  // Legacy URL building (?title=...&body=...&labels=needs-triage) MUST NOT
+  // be the primary report-upstream path anymore — that was the #537 shape.
+  // Other handlers in the file (e.g. report-broken) still use that pattern,
+  // so we just assert the report-upstream block uses the new form template.
+  const upstreamFnIdx = popupSrc.indexOf("function _appendReportUpstreamButton");
+  assert.ok(upstreamFnIdx > 0, "_appendReportUpstreamButton function must exist");
+  // Take a 3000-char window of the function body and assert it does NOT use
+  // the legacy ?title=&body=&labels= shape.
+  const fnSlice = popupSrc.slice(upstreamFnIdx, upstreamFnIdx + 3000);
+  assert.ok(
+    !/\?title=[^"']*&body=/.test(fnSlice),
+    "_appendReportUpstreamButton must not use the legacy ?title=&body= URL shape (#537 pre-#521)",
   );
 });
 
@@ -100,64 +109,103 @@ test("popup.js opens the deep-link via window.open with noopener+noreferrer", ()
   );
 });
 
-test("popup.js references both i18n keys for the issue title and body templates", () => {
+test("popup.js references the new dedup state path: chrome.storage.local.submittedParams", () => {
   const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
-  assert.match(popupSrc, /report_upstream_issue_title/);
-  assert.match(popupSrc, /report_upstream_issue_body/);
-  assert.match(popupSrc, /report_upstream_btn/);
+  assert.match(popupSrc, /submittedParams/, "popup.js must read/write submittedParams (#521 dedup)");
+  // Sanity: it should be on chrome.storage.local, not sync — UX state per
+  // install, not synced across devices.
+  assert.match(
+    popupSrc,
+    /chrome\.storage\.local\.(get|set)[^;]*submittedParams|submittedParams[^;]*chrome\.storage\.local/,
+    "submittedParams must live in chrome.storage.local (per-install dedup), not sync",
+  );
 });
 
-// ── HTML surface (regression guard for the host section) ─────────────────────
+test("popup.js renders the 'already reported' label in place of the button when applicable", () => {
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+  assert.match(popupSrc, /report-upstream-already-reported|report_upstream_already_reported/);
+});
+
+// ── HTML surface ─────────────────────────────────────────────────────────────
 
 test("popup.html still exposes the suspicious-params section host (regression guard)", () => {
   const html = readFileSync(resolve(root, "src/popup/popup.html"), "utf8");
   assert.match(html, /id="suspicious-params-list"/);
 });
 
-// ── Behaviour: simulate the click handler end-to-end ─────────────────────────
+test("options.html exposes the 'forget reported params' button for the dedup reset", () => {
+  const html = readFileSync(resolve(root, "src/options/options.html"), "utf8");
+  assert.match(html, /id="forget-reported-params-btn"/);
+});
+
+// ── Behaviour: simulate the deep-link construction end-to-end ────────────────
 //
-// We simulate the deep-link construction the way popup.js does it. This guards
-// the privacy contract at the wire level: the URL the user is sent to must
-// contain ONLY the param name + count — never a value, hash, or domain.
+// Under the post-#521 contract the prefill DOES carry the first-party
+// domain list (the form template asks for it; the user reviews the form on
+// github.com before clicking Submit). What MUST NEVER appear:
+//
+//   - raw value HASHES (the tracker only stores hashes — they're not
+//     reconstructable, but they're still random bytes that have no place
+//     in a public issue)
+//   - timestamps (`firstSeen`, `lastSeen`)
+//   - the full URL the user was on
+//
+// This test simulates the URL the popup builds and asserts both the
+// positive prefill fields and the negative leak guards.
 
-test("simulated deep-link URL contains paramName + count, NEVER value/hash/domain", async () => {
-  const { buildUpstreamPayload } = await import("../../src/lib/csft-upstream.js");
-  const { t } = await import("../../src/lib/i18n.js");
+test("simulated deep-link URL carries the documented prefill fields and nothing else", () => {
+  const SECRET_HASH_A = "deadbeef".repeat(8);
+  const SECRET_HASH_B = "feedface".repeat(8);
+  const SECRET_HASH_C = "0badc0de".repeat(8);
+  const FIRST_SEEN_TS = 1717181718;
+  const LAST_SEEN_TS  = 1717181819;
 
-  // Synthetic tracker state with privacy-sensitive fields.
-  const SECRET_VALUE = "super-secret-uuid-aaaa-bbbb-cccc";
-  const SECRET_HASH = "deadbeef".repeat(8);
-  const SECRET_DOMAIN_A = "private-domain-a.example.test";
-  const SECRET_DOMAIN_B = "private-domain-b.example.test";
-  const SECRET_DOMAIN_C = "private-domain-c.example.test";
-
-  const state = {
-    uid: {
-      domains: [SECRET_DOMAIN_A, SECRET_DOMAIN_B, SECRET_DOMAIN_C],
-      values: [SECRET_HASH, SECRET_HASH + "1", SECRET_HASH + "2"],
-      firstSeen: 1, lastSeen: 2, count: 3, entropyAvg: 4.2,
-    },
+  const trackerEntry = {
+    domains: ["news.example.com", "shop.example.org"],
+    values: [SECRET_HASH_A, SECRET_HASH_B, SECRET_HASH_C],
+    firstSeen: FIRST_SEEN_TS,
+    lastSeen: LAST_SEEN_TS,
+    count: 7,
+    entropyAvg: 4.85,
   };
 
-  const payload = buildUpstreamPayload(state, "uid");
-  assert.equal(payload.firstPartyDomainCount, 3);
+  // Mirror the URL construction in _appendReportUpstreamButton.
+  const params = new URLSearchParams();
+  params.set("template", "tracker-flag.yml");
+  params.set("paramName", "uid");
+  params.set("domains", trackerEntry.domains.slice(0, 50).join("\n"));
+  params.set("entropy_score", trackerEntry.entropyAvg.toFixed(2));
+  params.set("frequency_distinct_domains", String(trackerEntry.domains.length));
+  params.set("frequency_distinct_values", String(trackerEntry.values.length));
+  const url = `https://github.com/yocreoquesi/muga/issues/new?${params.toString()}`;
 
-  const titleTpl = t("report_upstream_issue_title", "en");
-  const bodyTpl = t("report_upstream_issue_body", "en");
-  const title = titleTpl.replace("{paramName}", payload.paramName).replace("{count}", String(payload.firstPartyDomainCount));
-  const body = bodyTpl.replace("{paramName}", payload.paramName).replace("{count}", String(payload.firstPartyDomainCount));
-  const url = `https://github.com/yocreoquesi/muga/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=needs-triage`;
+  // Positive: documented prefill fields present.
+  assert.match(url, /template=tracker-flag\.yml/);
+  assert.match(url, /paramName=uid/);
+  assert.ok(url.includes(encodeURIComponent("news.example.com")));
+  assert.ok(url.includes(encodeURIComponent("shop.example.org")));
+  assert.match(url, /entropy_score=4\.85/);
+  assert.match(url, /frequency_distinct_domains=2/);
+  assert.match(url, /frequency_distinct_values=3/);
 
-  // Positive assertions: param name + count survive the round-trip.
-  assert.ok(url.includes(encodeURIComponent("uid")));
-  assert.ok(url.includes(encodeURIComponent("3")));
-  assert.match(url, /labels=needs-triage/);
-
-  // Negative assertions: NO secret value, hash, or domain bleeds in.
-  for (const secret of [SECRET_VALUE, SECRET_HASH, SECRET_DOMAIN_A, SECRET_DOMAIN_B, SECRET_DOMAIN_C]) {
-    assert.ok(!url.includes(secret),
-      `deep-link URL must not contain "${secret}"`);
-    assert.ok(!url.includes(encodeURIComponent(secret)),
-      `deep-link URL must not contain encoded form of "${secret}"`);
+  // Negative: hashes and timestamps must NOT survive into the URL.
+  for (const leak of [SECRET_HASH_A, SECRET_HASH_B, SECRET_HASH_C, String(FIRST_SEEN_TS), String(LAST_SEEN_TS)]) {
+    assert.ok(!url.includes(leak),
+      `deep-link URL must not contain "${leak}"`);
+    assert.ok(!url.includes(encodeURIComponent(leak)),
+      `deep-link URL must not contain encoded form of "${leak}"`);
   }
+});
+
+test("domains list is capped at 50 entries to stay under GitHub's URL ceiling", () => {
+  // Build a synthetic 60-entry domains list and assert the slice(0, 50)
+  // cap matches the popup's behaviour.
+  const domains = [];
+  for (let i = 0; i < 60; i++) domains.push(`d${i}.example.test`);
+
+  const capped = domains.slice(0, 50);
+  assert.equal(capped.length, 50);
+  assert.equal(capped[0], "d0.example.test");
+  assert.equal(capped[49], "d49.example.test");
+  assert.ok(!capped.includes("d50.example.test"));
 });


### PR DESCRIPTION
## Summary

Closes #521. Wires Channel 1 of CAPS decision 6 ([caps-spec#3](https://github.com/yocreoquesi/caps-spec/issues/3)) — the popup-side counterpart to the `tracker-flag.yml` issue template (#522). Users can submit a structured tracker report from the Suspicious params section without leaving the popup → review the prefilled form on github.com → submit. MUGA never sends anything autonomously.

## Evolution from #537

| Aspect | Before (#537) | After (this PR) |
|---|---|---|
| URL pattern | `?title=...&body=...&labels=needs-triage` | `?template=tracker-flag.yml&paramName=...&domains=...&entropy_score=...` |
| Prefill | paramName + firstPartyDomainCount only | paramName, domains list (cap 50), entropy_score, frequency_distinct_domains, frequency_distinct_values |
| Dedup | none | `chrome.storage.local.submittedParams` per-install map; "Reported {date}" label replaces button after click |
| Settings reset | n/a | "Forget reported params" button on options page |

## Privacy contract

- **Domains list IS in the URL** — user-mediated review on github.com is the safeguard. The form's textarea description tells the user not to paste full URLs, only registrable hosts.
- **Value hashes** (the tracker's `values` array) are NEVER in the URL — only the count of distinct hashes makes it through.
- **Timestamps** (`firstSeen`, `lastSeen`) are NEVER in the URL.
- The user reviews and clicks Submit on github.com; MUGA's role ends at `window.open`.

## What's NOT prefilled (for now)

The `tracker-flag.yml` form template has two optional fields the popup currently leaves empty:

- `valueShape_length_range` — would need the cross-site-frequency tracker to record min/max value lengths per param. Not in the schema today.
- `valueShape_charset` — would need the tracker to compute a charset class (alnum / hex / base64 / mixed) per param. Not in the schema today.

These are optional in the form; the user can fill them manually or leave blank. Adding them to the tracker is a separate slice (worth filing if the maintainer wants tighter prefill).

## Files changed

- **`src/popup/popup.js`** — rewrote `_appendReportUpstreamButton` (richer prefill + dedup + already-reported label). `showSuspiciousParams` now reads `submittedParams` once before the per-row loop. Removed the now-unused `buildUpstreamPayload` import.
- **`src/lib/i18n.js`** — added `report_upstream_already_reported`, `forget_reported_params_{btn,done,hint}` (en/es/pt/de). Removed `report_upstream_issue_title` / `report_upstream_issue_body` (legacy body-template keys, no longer used after the form-template URL switch).
- **`src/options/options.html`** — new row in Statistics section with the "Forget reported params" button.
- **`src/options/options.js`** — handler clears `chrome.storage.local.submittedParams` and shows a toast.
- **`tests/unit/popup-report-upstream-button.test.mjs`** — rewrote for the post-#521 contract; new simulated deep-link test asserts both positive prefill fields AND negative leak guards (no hashes, no timestamps).

## Test plan

- [x] `npm test` → 3432/3432 unit tests pass
- [x] `npm run build:content` → bundle regenerated cleanly
- [ ] CI passes both `test` and `e2e` jobs
- [ ] Smoke after merge: trigger an entropy-flagged param in the popup, click "Report upstream" → new tab opens GitHub form with paramName, domains, entropy populated → button replaced inline with "Reported {date}" → re-open popup, label persists → Settings → "Forget reported params" → re-open popup, button is back

## Refs

- Sibling: #522 (the tracker-flag.yml form template — already merged via #571)
- Parent: #523 (CAPS manifest sync — closed)
- caps-spec#3 (decision 6, Channel 1)
