### PR TITLE
feat(firefox): inject mainworld defusers from MV2 isolated-world (closes #509)

### DIFF
--- a/src/content/history-defuser.js
+++ b/src/content/history-defuser.js
@@ -27,6 +27,38 @@
   if (window.__mugaHistoryDefuserGate) return;
   window.__mugaHistoryDefuserGate = true;
 
+  // ── Firefox MV2 page-world bootstrap (#509 / B12) ────────────────────
+  //
+  // Chrome MV3 registers `history-defuser-mainworld.js` as a `world: "MAIN"`
+  // content script (see src/manifest.json) — the browser handles loading
+  // it into the page world automatically. Firefox MV2 has no `world: "MAIN"`
+  // support, so the same script must be injected from this isolated-world
+  // script as a `<script src=...>` element pointing at the extension's
+  // web-accessible resource. The injected `<script>` runs in the page world
+  // because that's where `<script>` tags execute by default; the extension
+  // origin and `web_accessible_resources` declaration in manifest.v2.json
+  // make the resource URL loadable cross-origin from the page.
+  //
+  // MV3 detection is `manifest_version === 3`. We skip the inject in MV3 so
+  // we don't double-bootstrap.
+  try {
+    const mv = chrome.runtime.getManifest && chrome.runtime.getManifest().manifest_version;
+    if (mv === 2) {
+      const s = document.createElement("script");
+      s.src = chrome.runtime.getURL("content/history-defuser-mainworld.js");
+      // Synchronous so the wrap installs before the page's first script runs.
+      // Modern browsers honour async=false for in-document insertion.
+      s.async = false;
+      const target = document.head || document.documentElement;
+      if (target) {
+        target.appendChild(s);
+        // Detach from the DOM as soon as it's executed; the wrap lives on
+        // window.history regardless of whether the <script> node is present.
+        s.remove();
+      }
+    }
+  } catch { /* manifest unavailable / DOM not ready — leave the page-world wrap absent */ }
+
   function dispatchGate(enabled) {
     try {
       document.dispatchEvent(new CustomEvent("muga:history-gate", {

--- a/src/content/window-name-defuser.js
+++ b/src/content/window-name-defuser.js
@@ -32,6 +32,33 @@
   if (window.__mugaWindowNameDefuserGate) return;
   window.__mugaWindowNameDefuserGate = true;
 
+  // ── Firefox MV2 page-world bootstrap (#509 / B12) ────────────────────
+  //
+  // Same rationale as `history-defuser.js`: Chrome MV3 loads the page-
+  // world wrap automatically via `world: "MAIN"`; Firefox MV2 has no
+  // such directive, so this isolated-world script injects the
+  // `window-name-defuser-mainworld.js` resource as a page-world
+  // `<script>` element. The wrap installs the property accessor on
+  // `window.name` BEFORE the document parser starts running page
+  // scripts (synchronous insert at document_start).
+  //
+  // The `web_accessible_resources` entry in manifest.v2.json is what
+  // makes `chrome.runtime.getURL("content/window-name-defuser-mainworld.js")`
+  // loadable as a `<script src>` from the page origin.
+  try {
+    const mv = chrome.runtime.getManifest && chrome.runtime.getManifest().manifest_version;
+    if (mv === 2) {
+      const s = document.createElement("script");
+      s.src = chrome.runtime.getURL("content/window-name-defuser-mainworld.js");
+      s.async = false;
+      const target = document.head || document.documentElement;
+      if (target) {
+        target.appendChild(s);
+        s.remove();
+      }
+    }
+  } catch { /* manifest unavailable / DOM not ready — leave the page-world wrap absent */ }
+
   // Intentionally empty body. Gate dispatch is handled by
   // `history-defuser.js` via the `muga:history-gate` event, which the
   // window-name main-world wrap also listens to. See the docblock for

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -68,7 +68,9 @@
   "web_accessible_resources": [
     "onboarding/onboarding.html",
     "privacy/privacy.html",
-    "privacy/tos.html"
+    "privacy/tos.html",
+    "content/history-defuser-mainworld.js",
+    "content/window-name-defuser-mainworld.js"
   ],
 
   "declarative_net_request": {

--- a/tests/unit/firefox-mv2-mainworld-injection.test.mjs
+++ b/tests/unit/firefox-mv2-mainworld-injection.test.mjs
@@ -1,0 +1,132 @@
+/**
+ * MUGA — Firefox MV2 page-world injection contract (#509 / B12).
+ *
+ * Chrome MV3 loads `history-defuser-mainworld.js` and
+ * `window-name-defuser-mainworld.js` automatically via the
+ * `world: "MAIN"` content-script directive in `src/manifest.json`.
+ * Firefox MV2 (the manifest currently shipped to AMO) has no such
+ * directive — the page-world wrap must be injected by the matching
+ * isolated-world content script as a `<script src=...>` element
+ * pointing at the extension's web-accessible resource.
+ *
+ * This test pins three facts that must hold together for the
+ * Firefox path to actually wrap the page world:
+ *
+ *   1. The MV2 `web_accessible_resources` array exposes both
+ *      mainworld scripts so the page can load them by URL.
+ *   2. Each isolated-world dispatcher contains the inject helper
+ *      gated on `manifest_version === 2` (so MV3 doesn't double-
+ *      bootstrap).
+ *   3. Each isolated-world dispatcher names the matching mainworld
+ *      file in the `chrome.runtime.getURL` argument — typo-proofs
+ *      the linkage between the two halves.
+ *
+ * If any of these break, Firefox users silently lose the active-
+ * defense layer (B10/B11) — the unit tests stub the page world so
+ * they don't catch this; only Playwright Firefox would, and that
+ * spec is a follow-up to this slice.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "../..");
+
+const mv2Manifest = JSON.parse(readFileSync(resolve(ROOT, "src/manifest.v2.json"), "utf8"));
+const mv3Manifest = JSON.parse(readFileSync(resolve(ROOT, "src/manifest.json"), "utf8"));
+const histDefuserSrc = readFileSync(resolve(ROOT, "src/content/history-defuser.js"), "utf8");
+const winNameDefuserSrc = readFileSync(resolve(ROOT, "src/content/window-name-defuser.js"), "utf8");
+
+describe("Firefox MV2 web_accessible_resources expose the mainworld scripts (#509)", () => {
+  test("manifest.v2.json declares web_accessible_resources as an array", () => {
+    assert.ok(Array.isArray(mv2Manifest.web_accessible_resources),
+      "MV2 web_accessible_resources must be an array");
+  });
+
+  test("history-defuser-mainworld.js is web-accessible in MV2", () => {
+    assert.ok(
+      mv2Manifest.web_accessible_resources.includes("content/history-defuser-mainworld.js"),
+      "MV2 must expose history-defuser-mainworld.js so the isolated-world script can <script src> it",
+    );
+  });
+
+  test("window-name-defuser-mainworld.js is web-accessible in MV2", () => {
+    assert.ok(
+      mv2Manifest.web_accessible_resources.includes("content/window-name-defuser-mainworld.js"),
+      "MV2 must expose window-name-defuser-mainworld.js for the same reason",
+    );
+  });
+
+  test("MV3 keeps the world: 'MAIN' content_scripts entry — native page-world load (no inject needed)", () => {
+    // MV3 doesn't need web_accessible_resources for the mainworld
+    // scripts — it loads them as content scripts with world: MAIN.
+    // This test is a regression guard: removing the world: MAIN entry
+    // would silently break Chrome.
+    const mainWorldEntries = (mv3Manifest.content_scripts || []).filter((e) => e.world === "MAIN");
+    assert.ok(
+      mainWorldEntries.length > 0,
+      "MV3 manifest must have at least one content_scripts entry with world: 'MAIN'",
+    );
+    const allMainJs = mainWorldEntries.flatMap((e) => e.js || []);
+    assert.ok(allMainJs.includes("content/history-defuser-mainworld.js"));
+    assert.ok(allMainJs.includes("content/window-name-defuser-mainworld.js"));
+  });
+});
+
+describe("Isolated-world dispatchers inject the mainworld script when running on MV2 (#509)", () => {
+  test("history-defuser.js gates the inject on manifest_version === 2", () => {
+    assert.match(
+      histDefuserSrc,
+      /manifest_version[^]*===[^]*2/,
+      "history-defuser.js must check manifest_version === 2 before injecting",
+    );
+  });
+
+  test("history-defuser.js injects the matching mainworld script via chrome.runtime.getURL", () => {
+    assert.match(
+      histDefuserSrc,
+      /chrome\.runtime\.getURL\(["'`]content\/history-defuser-mainworld\.js["'`]\)/,
+      "history-defuser.js must reference the mainworld resource by exact path",
+    );
+    assert.match(
+      histDefuserSrc,
+      /document\.createElement\(["'`]script["'`]\)/,
+      "history-defuser.js must create a <script> element to inject the wrap",
+    );
+  });
+
+  test("window-name-defuser.js gates the inject on manifest_version === 2", () => {
+    assert.match(
+      winNameDefuserSrc,
+      /manifest_version[^]*===[^]*2/,
+      "window-name-defuser.js must check manifest_version === 2 before injecting",
+    );
+  });
+
+  test("window-name-defuser.js injects the matching mainworld script via chrome.runtime.getURL", () => {
+    assert.match(
+      winNameDefuserSrc,
+      /chrome\.runtime\.getURL\(["'`]content\/window-name-defuser-mainworld\.js["'`]\)/,
+      "window-name-defuser.js must reference the mainworld resource by exact path",
+    );
+    assert.match(
+      winNameDefuserSrc,
+      /document\.createElement\(["'`]script["'`]\)/,
+      "window-name-defuser.js must create a <script> element to inject the wrap",
+    );
+  });
+
+  test("inject helpers append the script synchronously (async=false) so it runs before page scripts", () => {
+    for (const [name, src] of [["history-defuser.js", histDefuserSrc], ["window-name-defuser.js", winNameDefuserSrc]]) {
+      assert.match(
+        src,
+        /\.async\s*=\s*false/,
+        `${name} must set script.async=false so the page-world wrap installs before any page script runs`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #509 (Camino B B12). Restores the History Defuser (#444 / B10) and Window-Name Defuser (#451 / B11) on Firefox AMO.

## What was broken on Firefox

Firefox MV2 (the manifest currently shipped to AMO) has no `world: "MAIN"` content-script directive. Both mainworld scripts (`history-defuser-mainworld.js`, `window-name-defuser-mainworld.js`) ran in the isolated world only — silently inert because the page-world `history.pushState` and `window.name` accessor were never wrapped. Unit tests stub the page world so this gap was invisible there; only real-browser instrumentation catches it.

## Fix

At `document_start`, the isolated-world dispatchers detect `manifest_version === 2` and inject the matching mainworld script as a `<script src="…">` element pointing at the extension's web-accessible resource. The injected script runs in the page world (that's where `<script>` tags execute by default). The `web_accessible_resources` declaration in `manifest.v2.json` makes the resource URL loadable cross-origin from the page. Synchronous insert (`script.async = false`) at document_start runs the wrap before any page script can call `pushState` or read `window.name`.

MV3 (Chrome) is unchanged — the `world: "MAIN"` entry in `src/manifest.json` keeps loading both mainworld scripts natively. The MV2 inject is gated to skip MV3 so we don't double-bootstrap.

## Files changed

| File | Change |
|---|---|
| `src/manifest.v2.json` | Adds the two mainworld files to `web_accessible_resources` |
| `src/content/history-defuser.js` | New MV2-only `<script>` inject for the history wrap |
| `src/content/window-name-defuser.js` | Same for the window.name accessor |
| `tests/unit/firefox-mv2-mainworld-injection.test.mjs` | Structural contract: web-accessible entries exist, MV2-only gate present, exact resource path used, `async=false` invariant held |

## Out of scope

Per issue AC #3, a Playwright Firefox spec mirroring `history-defuser.spec.mjs` is its own slice — the existing `playwright.config.mjs` only defines a `chromium` project. Adding a Firefox project requires a separate web-ext flow + Firefox-specific extension load fixture. The structural unit tests added here pin the contract strongly enough to make a Firefox regression hard to ship; the Playwright Firefox spec would be the third defense layer.

## Test plan

- [x] `npm test` → 3441/3441 unit tests pass
- [x] `npm run lint` → 0 errors (pre-existing innerHTML warnings unchanged)
- [ ] CI passes both `test` and `e2e` jobs
- [ ] Manual verification (per issue AC #2): `npm run dev:firefox`, load a page that calls `history.pushState` with a tracked param, inspect the URL post-call to confirm the mainworld wrap fired

## Refs

- Parent: PRD #421 (closed)
- Sibling: #444 (B10 History Defuser, Chrome) / #451 (B11 Window-Name Defuser, Chrome) — both shipped