### PR TITLE
chore(release): bump version to 1.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.5] - 2026-05-05
+
+Branded-domain release. The signed remote-rules endpoint moves under `rules.muga.app` so the public surface no longer depends on a personal GitHub username. No user-visible behavior change on a default install.
+
 ### Changed
 
-- **Remote rules endpoint moved to `rules.muga.app`** (#481). The signed `params.json` is now served from `https://rules.muga.app/rules/v1/params.json` (was `https://yocreoquesi.github.io/muga/rules/v1/params.json`). DNS-only CNAME points at GitHub Pages — same hosting, branded subdomain, no public-facing dependency on a personal GitHub username. The optional permission users grant when enabling Remote rule updates is now scoped to `https://rules.muga.app/*` (Chrome MV3 `optional_host_permissions` / Firefox MV2 `optional_permissions`). Existing installs that opted in to remote rules will need to re-grant on first 7-day refresh after upgrading — the host changed, so the previous grant no longer applies. Files: [`src/manifest.json`](src/manifest.json), [`src/manifest.v2.json`](src/manifest.v2.json), [`src/lib/remote-rules.js`](src/lib/remote-rules.js), [`src/options/options.js`](src/options/options.js), [`docs/CNAME`](docs/CNAME), [`.github/workflows/publish-rules.yml`](.github/workflows/publish-rules.yml).
+- **Remote rules endpoint moved to `rules.muga.app`** (#481, landed via #596). The signed `params.json` is now served from `https://rules.muga.app/rules/v1/params.json` (was `https://yocreoquesi.github.io/muga/rules/v1/params.json`). DNS-only CNAME points at GitHub Pages — same hosting, branded subdomain. The optional permission users grant when enabling Remote rule updates is now scoped to `https://rules.muga.app/*` (Chrome MV3 `optional_host_permissions` / Firefox MV2 `optional_permissions`). Existing installs that opted in to remote rules on v1.13.4 or earlier will be re-prompted to grant the new host on the next 7-day refresh — the host changed, so the previous grant no longer applies. Files: [`src/manifest.json`](src/manifest.json), [`src/manifest.v2.json`](src/manifest.v2.json), [`src/lib/remote-rules.js`](src/lib/remote-rules.js), [`src/options/options.js`](src/options/options.js), [`docs/CNAME`](docs/CNAME), [`.github/workflows/publish-rules.yml`](.github/workflows/publish-rules.yml).
 
 ## [1.13.4] - 2026-05-05
 
@@ -671,7 +675,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.4...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.13.5...HEAD
+[1.13.5]: https://github.com/yocreoquesi/muga/compare/v1.13.4...v1.13.5
 [1.13.4]: https://github.com/yocreoquesi/muga/compare/v1.13.3...v1.13.4
 [1.13.3]: https://github.com/yocreoquesi/muga/compare/v1.13.2...v1.13.3
 [1.13.2]: https://github.com/yocreoquesi/muga/compare/v1.13.1...v1.13.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.13.4-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.13.5-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-2531_pass-brightgreen)](#development)
 [![CAPS](https://img.shields.io/badge/CAPS-Basic%20%2B%20Contextual-2ea44f)](CONFORMANCE.md)
 # MUGA: Privacy Without Breaking Creator Links

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://rules.muga.app/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.13.4"
+    "softwareVersion": "1.13.5"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.4 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-05 &nbsp;·&nbsp; Version 1.13.5 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 1.13.4
+> Version: 1.13.5
 > Last updated: 2026-05-04
 > Status: Final listing for Chrome Web Store and Firefox AMO. Lead headline rewritten to surface the "fair to creators" wedge per the 2026-04-26 strategic review (consensus across three independent analyses). Aligned with the post-grill privacy-policy and ToS rollout (#399, #400) — per-device consent, local cleaning architecture, and #353 conditional preservation of MUGA's own tag.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.4 &nbsp;&middot;&nbsp; 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.13.5 &nbsp;&middot;&nbsp; 2026-05-05 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim — what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.13.4</span>
+      <span class="at-a-glance-value">1.13.5</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -206,7 +206,7 @@
   <hr>
 
   <div class="footer">
-    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.4 — 2026-05-04 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
+    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.13.5 — 2026-05-05 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
   </div>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "Privacy without breaking creator links. Strips 450+ tracking params, preserves creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-01 &nbsp;·&nbsp; Version 1.13.4 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-05 &nbsp;·&nbsp; Version 1.13.5 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.


### PR DESCRIPTION
## Summary

Cuts **v1.13.5** — branded-domain release.

The signed remote-rules endpoint moves under `rules.muga.app` so the public surface no longer depends on a personal GitHub username. Same GitHub Pages backend, DNS-only CNAME, identical signed payload format. No user-visible behavior change on a default install.

This is the publish-trigger PR for #481 — the code-side wiring landed in #596. Pre-flight verification of the new endpoint was done before bumping:

```
$ curl -sI https://rules.muga.app/rules/v1/params.json
HTTP/1.1 200 OK
Server: GitHub.com
Content-Type: application/json; charset=utf-8

$ openssl s_client -connect rules.muga.app:443 -servername rules.muga.app
subject=CN=rules.muga.app
issuer=Let's Encrypt R12
```

## Migration impact for existing users

Users on v1.13.0–v1.13.4 who opted into Remote rule updates will be re-prompted to grant the new host (`rules.muga.app`) on the next 7-day refresh. The previous optional-permission grant was scoped to `yocreoquesi.github.io` and no longer applies after this update.

The fetch will fail once with a permission error, the UI flags it (existing copy already covers this case), and the user re-grants from Settings.

Default-install users are unaffected (Remote rule updates is off by default).

## Files updated

- `package.json`, `src/manifest.json`, `src/manifest.v2.json` — 1.13.4 → 1.13.5
- `README.md` — version badge
- `docs/index.html` — schema.org `softwareVersion`
- `docs/store-listing.md` — header version line
- `docs/transparency.html` — header, at-a-glance, footer
- `docs/privacy-page.html`, `src/privacy/privacy.html` — version + effective date
- `CHANGELOG.md` — `[Unreleased]` → `[1.13.5]` with full migration notes; compare links updated

## Test plan

- [ ] CI test + e2e green
- [ ] After merge: tag `v1.13.5` triggers `release.yml` → AMO + Chrome Web Store submission
- [ ] AMO publish succeeds (or returns "version already submitted" — idempotent gate from #557 handles both)
- [ ] CWS publish succeeds (same)
- [ ] Manual smoke after publish: install fresh in Chrome / Firefox, enable Remote rule updates, observe permission prompt asking for `rules.muga.app/*`, confirm fetch succeeds and the params.json contents are merged