### PR TITLE
feat(landing): apex landing page for muga.app (closes #331)

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,672 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>MUGA — Strip trackers without breaking referrals</title>
+<meta name="description" content="MUGA is an open-source browser extension that strips 450+ tracking parameters from URLs while preserving creator affiliate referrals. 100% local, GPL v3.">
+<meta name="color-scheme" content="light dark">
+
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://muga.app/">
+<meta property="og:title" content="MUGA — Strip trackers without breaking referrals">
+<meta property="og:description" content="450+ tracking parameters stripped automatically. Creator affiliate referrals preserved. Open source, 100% local.">
+<meta property="og:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="MUGA — Strip trackers without breaking referrals">
+<meta name="twitter:description" content="450+ tracking parameters stripped automatically. Creator affiliate referrals preserved. Open source, 100% local.">
+<meta name="twitter:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
+
+<link rel="icon" href="https://rules.muga.app/assets/mascot-icon-m.png">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "MUGA",
+  "applicationCategory": "BrowserApplication",
+  "operatingSystem": "Chrome, Firefox",
+  "description": "Open-source browser extension that strips 450+ tracking parameters from URLs while preserving creator affiliate referrals.",
+  "offers": { "@type": "Offer", "price": "0" },
+  "softwareVersion": "1.13.5",
+  "license": "https://www.gnu.org/licenses/gpl-3.0.html"
+}
+</script>
+
+<style>
+  :root {
+    --bg: oklch(99% 0.005 70);
+    --bg-2: oklch(96.5% 0.008 70);
+    --bg-inset: oklch(94% 0.01 70);
+    --ink: oklch(20% 0.01 60);
+    --ink-2: oklch(42% 0.012 60);
+    --ink-3: oklch(60% 0.012 60);
+    --rule: oklch(88% 0.012 70);
+    --rule-2: oklch(82% 0.015 70);
+    --accent: #d97706;
+    --accent-ink: #b45309;
+    --accent-soft: oklch(94% 0.05 65);
+    --good: #16a34a;
+    --good-soft: oklch(94% 0.05 145);
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    --maxw: 1080px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0a0a0a;
+      --bg-2: #141414;
+      --bg-inset: #1c1c1e;
+      --ink: #f0f0f0;
+      --ink-2: #aaa;
+      --ink-3: #777;
+      --rule: #262626;
+      --rule-2: #333;
+      --accent: #f59e0b;
+      --accent-ink: #fbbf24;
+      --accent-soft: #2a1c0c;
+      --good: #22c55e;
+      --good-soft: #0c2614;
+    }
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: var(--sans);
+    background: var(--bg); color: var(--ink);
+    font-size: 16px; line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: inherit; text-underline-offset: 3px; }
+  a:hover { color: var(--accent-ink); }
+  ::selection { background: var(--accent); color: #fff; }
+  img { max-width: 100%; display: block; }
+
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* ---------- header (non-sticky) ---------- */
+  header.top { padding: 22px 0; }
+  .top-inner { display: flex; align-items: center; justify-content: space-between; }
+  .brand {
+    display: inline-flex; align-items: center; gap: 10px;
+    font-family: var(--mono); font-size: 13px; letter-spacing: .02em;
+    text-decoration: none; color: var(--ink);
+  }
+  .brand-mark { width: 22px; height: 22px; }
+  .brand .ver { color: var(--ink-3); border-left: 1px solid var(--rule); padding-left: 10px; margin-left: 4px; }
+  .nav-links { display: flex; align-items: center; gap: 22px; font-family: var(--mono); font-size: 13px; }
+  .nav-links a { color: var(--ink-2); text-decoration: none; }
+  .nav-links a:hover { color: var(--ink); }
+  @media (max-width: 520px) {
+    .nav-links a:not(.gh) { display: none; }
+    .brand .ver { display: none; }
+  }
+
+  /* ---------- hero ---------- */
+  .hero { padding: 64px 0 56px; }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--mono); font-size: 12px; color: var(--ink-3);
+    border: 1px solid var(--rule); border-radius: 999px;
+    padding: 4px 10px; margin-bottom: 24px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 999px; background: var(--good); box-shadow: 0 0 0 3px color-mix(in oklab, var(--good), transparent 80%); }
+  h1 {
+    font-size: clamp(40px, 6.4vw, 68px);
+    line-height: 1.02; letter-spacing: -0.028em; font-weight: 600;
+    margin: 0 0 22px; max-width: 14ch;
+    text-wrap: balance;
+  }
+  h1 .mark { color: var(--accent); }
+  .lede {
+    font-size: clamp(17px, 1.9vw, 19.5px);
+    color: var(--ink-2); max-width: 56ch;
+    margin: 0 0 32px;
+    text-wrap: pretty;
+  }
+  .lede b { color: var(--ink); font-weight: 600; }
+
+  .install { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 18px; }
+  .btn {
+    appearance: none; cursor: pointer;
+    background: var(--ink); color: var(--bg);
+    border: 1px solid var(--ink);
+    font-family: var(--sans); font-size: 15px; font-weight: 500;
+    padding: 12px 18px; border-radius: 10px;
+    display: inline-flex; align-items: center; gap: 10px;
+    text-decoration: none;
+    transition: transform .14s ease, box-shadow .14s ease;
+  }
+  .btn:hover { transform: translateY(-1px); box-shadow: 0 6px 0 -2px var(--accent); color: var(--bg); }
+  .btn:active { transform: translateY(0); box-shadow: 0 2px 0 -1px var(--accent); }
+  .btn .ico { width: 18px; height: 18px; flex: none; }
+  .btn .sub { font-family: var(--mono); font-size: 11px; opacity: .55; margin-left: 4px; font-weight: 400; }
+  .btn.ghost { background: transparent; color: var(--ink); border-color: var(--rule-2); }
+  .btn.ghost:hover { border-color: var(--ink); color: var(--ink); }
+
+  .install-meta {
+    font-family: var(--mono); font-size: 12px; color: var(--ink-3);
+    display: flex; flex-wrap: wrap; gap: 6px 14px; align-items: center;
+  }
+  .install-meta .sep { color: var(--rule-2); }
+
+  /* backronym understated */
+  .bk-slot {
+    margin-top: 28px;
+    font-family: var(--mono); font-size: 12.5px; color: var(--ink-3);
+    display: inline-flex; align-items: baseline; gap: 8px;
+  }
+  .bk-slot .bk-prefix { color: var(--ink-3); }
+  .bk-slot .bk-text {
+    color: var(--ink-2);
+    border-bottom: 1px dashed var(--rule-2);
+    padding-bottom: 1px;
+    transition: opacity .35s ease;
+  }
+  .bk-slot .bk-text.fade { opacity: 0; }
+
+  /* ---------- demo (animated URL clean) ---------- */
+  .demo {
+    margin-top: 48px;
+    border: 1px solid var(--rule); border-radius: 14px;
+    background: var(--bg-2); overflow: hidden;
+  }
+  .demo-head {
+    display: flex; align-items: center; gap: 14px;
+    padding: 10px 14px; border-bottom: 1px solid var(--rule);
+    font-family: var(--mono); font-size: 12px; color: var(--ink-3);
+    background: var(--bg);
+  }
+  .demo-head .lights { display: flex; gap: 6px; }
+  .demo-head .lights span { width: 10px; height: 10px; border-radius: 999px; background: var(--rule-2); }
+  .demo-head .label { margin-left: auto; }
+
+  .demo-body { padding: 18px; display: grid; gap: 12px; }
+  .url-row { display: grid; grid-template-columns: 64px 1fr; gap: 12px; align-items: center; }
+  .url-tag {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .04em;
+    text-transform: uppercase; color: var(--ink-3); text-align: right;
+  }
+  .url-box {
+    font-family: var(--mono); font-size: 13px;
+    background: var(--bg); border: 1px solid var(--rule);
+    border-radius: 8px; padding: 12px 14px;
+    overflow-x: auto; white-space: nowrap;
+    line-height: 1.5;
+  }
+  .url-box::-webkit-scrollbar { height: 6px; }
+  .url-box::-webkit-scrollbar-thumb { background: var(--rule-2); border-radius: 999px; }
+  .url-box .domain { color: var(--ink); }
+  .url-box .path   { color: var(--ink-2); }
+  .url-box .keep {
+    color: var(--good);
+    background: color-mix(in oklab, var(--good), transparent 88%);
+    padding: 1px 4px; border-radius: 4px;
+    border: 1px dashed color-mix(in oklab, var(--good), transparent 60%);
+  }
+
+  /* param-by-param strikethrough animation */
+  .url-box .junk {
+    color: var(--ink-3);
+    position: relative;
+    transition: opacity .4s ease, color .4s ease;
+  }
+  .url-box .junk::after {
+    content: ""; position: absolute; left: 0; right: 100%; top: 50%;
+    height: 1px; background: var(--accent);
+    transition: right .4s ease;
+  }
+  .url-box .junk.struck::after { right: 0; }
+  .url-box .junk.gone { opacity: 0; max-width: 0; display: inline-block; overflow: hidden; }
+
+  /* sequence: junk1..7 strike at staggered times, then collapse, then "after" reveals */
+  @keyframes strike { from { right: 100%; } to { right: 0; } }
+  @keyframes fade  { 0%, 60% { opacity: .6; } 100% { opacity: 0; max-width: 0; } }
+  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .5; } }
+
+  .url-box.before .junk {
+    display: inline-block;
+    animation: fade 9s infinite;
+  }
+  .url-box.before .junk::after {
+    animation: strike 9s infinite;
+  }
+  .url-box.before .junk:nth-of-type(1) { animation-delay: 1.0s; } .url-box.before .junk:nth-of-type(1)::after { animation-delay: 1.0s; }
+  .url-box.before .junk:nth-of-type(2) { animation-delay: 1.4s; } .url-box.before .junk:nth-of-type(2)::after { animation-delay: 1.4s; }
+  .url-box.before .junk:nth-of-type(3) { animation-delay: 1.8s; } .url-box.before .junk:nth-of-type(3)::after { animation-delay: 1.8s; }
+  .url-box.before .junk:nth-of-type(4) { animation-delay: 2.2s; } .url-box.before .junk:nth-of-type(4)::after { animation-delay: 2.2s; }
+  .url-box.before .junk:nth-of-type(5) { animation-delay: 2.6s; } .url-box.before .junk:nth-of-type(5)::after { animation-delay: 2.6s; }
+  .url-box.before .junk:nth-of-type(6) { animation-delay: 3.0s; } .url-box.before .junk:nth-of-type(6)::after { animation-delay: 3.0s; }
+  .url-box.before .junk:nth-of-type(7) { animation-delay: 3.4s; } .url-box.before .junk:nth-of-type(7)::after { animation-delay: 3.4s; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .url-box.before .junk, .url-box.before .junk::after { animation: none; opacity: .55; }
+    .url-box.before .junk { text-decoration: line-through; text-decoration-color: var(--accent); }
+  }
+
+  .demo-foot {
+    display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: center;
+    padding: 10px 14px; border-top: 1px solid var(--rule);
+    font-family: var(--mono); font-size: 12px; color: var(--ink-2);
+    background: var(--bg);
+  }
+  .toast {
+    display: inline-flex; align-items: center; gap: 8px;
+    background: var(--good-soft); color: var(--good);
+    border: 1px solid color-mix(in oklab, var(--good), transparent 70%);
+    padding: 4px 10px; border-radius: 999px;
+    font-family: var(--mono); font-size: 11.5px;
+  }
+  .toast::before { content: ""; width: 6px; height: 6px; border-radius: 999px; background: var(--good); }
+
+  /* ---------- stats ---------- */
+  .stats {
+    border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule);
+    margin: 88px 0;
+  }
+  .stats-grid { display: grid; grid-template-columns: repeat(3, 1fr); }
+  .stat { padding: 36px 24px; border-right: 1px solid var(--rule); }
+  .stat:last-child { border-right: 0; }
+  .stat .num {
+    font-size: clamp(40px, 5vw, 56px); font-weight: 600;
+    letter-spacing: -0.02em; line-height: 1; margin: 0 0 10px;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat .num .unit { color: var(--accent); }
+  .stat .label {
+    font-family: var(--mono); font-size: 12px; color: var(--ink-3);
+    text-transform: uppercase; letter-spacing: .05em;
+  }
+  .stat .desc { margin-top: 8px; color: var(--ink-2); font-size: 14px; max-width: 32ch; }
+  @media (max-width: 720px) {
+    .stats-grid { grid-template-columns: 1fr; }
+    .stat { border-right: 0; border-bottom: 1px solid var(--rule); }
+    .stat:last-child { border-bottom: 0; }
+  }
+
+  /* ---------- sections ---------- */
+  .section { padding: 80px 0; }
+  .section + .section { border-top: 1px solid var(--rule); }
+  .section-label {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .12em;
+    text-transform: uppercase; color: var(--ink-3); margin: 0 0 14px;
+    display: flex; align-items: center; gap: 10px;
+  }
+  .section-label::before { content: ""; width: 18px; height: 1px; background: var(--accent); }
+  h2 {
+    font-size: clamp(28px, 3.4vw, 36px); font-weight: 600;
+    letter-spacing: -0.02em; line-height: 1.15; margin: 0 0 16px;
+    text-wrap: balance;
+  }
+  .section p { color: var(--ink-2); font-size: 16.5px; max-width: 62ch; text-wrap: pretty; }
+  .section p + p { margin-top: 14px; }
+
+  /* ---------- creator-fair wedge ---------- */
+  .wedge { background: var(--bg-2); }
+  .wedge-grid { display: grid; grid-template-columns: 1.1fr 1fr; gap: 56px; align-items: start; }
+  @media (max-width: 820px) { .wedge-grid { grid-template-columns: 1fr; gap: 36px; } }
+  .wedge-card {
+    border: 1px solid var(--rule); border-radius: 12px;
+    background: var(--bg); padding: 18px;
+    font-family: var(--mono); font-size: 13px;
+  }
+  .wedge-card .row {
+    display: grid; grid-template-columns: 64px 1fr; gap: 10px;
+    padding: 10px 0; border-top: 1px dashed var(--rule);
+  }
+  .wedge-card .row:first-of-type { border-top: 0; }
+  .wedge-card .k { color: var(--ink-3); }
+  .wedge-card .v { color: var(--ink); word-break: break-all; }
+  .wedge-card .v .keep { color: var(--good); }
+  .wedge-card .v .junk-static { color: var(--ink-3); text-decoration: line-through; opacity: .6; }
+  .wedge-card .header {
+    display: flex; justify-content: space-between; align-items: center;
+    margin: -2px 0 10px; padding-bottom: 10px; border-bottom: 1px solid var(--rule);
+  }
+  .wedge-card .header .ttl { color: var(--ink); }
+  .wedge-card .header .meta { color: var(--ink-3); font-size: 11px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-family: var(--mono); font-size: 11.5px;
+    border: 1px solid var(--rule-2); border-radius: 999px;
+    padding: 3px 10px; color: var(--ink-2);
+  }
+  .chip.warm {
+    color: var(--accent-ink); background: var(--accent-soft);
+    border-color: color-mix(in oklab, var(--accent), transparent 60%);
+  }
+
+  /* ---------- trust ---------- */
+  .trust-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    border: 1px solid var(--rule); border-radius: 14px; overflow: hidden;
+    margin-top: 32px;
+  }
+  .trust-cell { padding: 22px; border-right: 1px solid var(--rule); }
+  .trust-cell:last-child { border-right: 0; }
+  .trust-cell h3 { font-size: 16px; font-weight: 600; margin: 0 0 6px; }
+  .trust-cell p { font-size: 14px; color: var(--ink-2); margin: 0; }
+  .trust-cell .ic {
+    font-family: var(--mono); font-size: 11px; color: var(--accent-ink);
+    margin-bottom: 12px; display: inline-block;
+    border: 1px solid color-mix(in oklab, var(--accent), transparent 70%);
+    background: var(--accent-soft);
+    padding: 2px 8px; border-radius: 4px;
+  }
+  @media (max-width: 720px) {
+    .trust-grid { grid-template-columns: 1fr; }
+    .trust-cell { border-right: 0; border-bottom: 1px solid var(--rule); }
+    .trust-cell:last-child { border-bottom: 0; }
+  }
+
+  /* ---------- screenshots ---------- */
+  .shots {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px;
+    margin-top: 32px;
+  }
+  @media (max-width: 720px) { .shots { grid-template-columns: 1fr; } }
+  .shot {
+    border: 1px solid var(--rule); border-radius: 12px;
+    background: var(--bg-inset); aspect-ratio: 4 / 3;
+    position: relative; overflow: hidden;
+  }
+  .shot img { width: 100%; height: 100%; object-fit: cover; object-position: top; }
+  .shot figcaption {
+    position: absolute; left: 10px; bottom: 10px;
+    font-family: var(--mono); font-size: 10.5px; color: var(--ink);
+    background: color-mix(in oklab, var(--bg), transparent 15%);
+    padding: 3px 7px; border-radius: 4px;
+    border: 1px solid var(--rule);
+    backdrop-filter: blur(4px);
+  }
+
+  /* ---------- footer ---------- */
+  footer { border-top: 1px solid var(--rule); padding: 56px 0 40px; font-size: 14px; }
+  .footer-grid { display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; gap: 32px; margin-bottom: 36px; }
+  @media (max-width: 720px) { .footer-grid { grid-template-columns: 1fr 1fr; } }
+  .footer-col h4 {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .1em;
+    text-transform: uppercase; color: var(--ink-3); margin: 0 0 14px; font-weight: 500;
+  }
+  .footer-col ul { list-style: none; padding: 0; margin: 0; display: grid; gap: 8px; }
+  .footer-col a { color: var(--ink-2); text-decoration: none; }
+  .footer-col a:hover { color: var(--ink); text-decoration: underline; }
+  .footer-meta {
+    display: flex; flex-wrap: wrap; justify-content: space-between; gap: 12px;
+    padding-top: 24px; border-top: 1px solid var(--rule);
+    font-family: var(--mono); font-size: 12px; color: var(--ink-3);
+  }
+
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
+</style>
+</head>
+<body data-screen-label="A · Technical Clean">
+
+<header class="top">
+  <div class="wrap top-inner">
+    <a href="/" class="brand" aria-label="MUGA home">
+      <img class="brand-mark" src="https://rules.muga.app/assets/mascot-icon-m.png" alt="" width="22" height="22">
+      <span>muga.app</span>
+      <span class="ver">v1.13.5</span>
+    </a>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="https://rules.muga.app/comparison.html">Compare</a>
+      <a href="https://rules.muga.app/transparency.html">Transparency</a>
+      <a href="https://github.com/yocreoquesi/muga" class="gh" aria-label="GitHub repository">GitHub ↗</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+
+  <section class="hero">
+    <div class="wrap">
+      <div class="eyebrow"><span class="dot"></span> v1.13.5 · Chrome + Firefox · GPL v3</div>
+      <h1>Clean URLs.<br><span class="mark">Fair to creators.</span></h1>
+      <p class="lede">
+        MUGA strips <b>450+ tracking parameters</b> from every link you open — locally, in your browser.
+        Unlike other URL cleaners, it preserves the affiliate referrals that fund the creators you actually follow.
+      </p>
+
+      <div class="install">
+        <a class="btn" href="https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh">
+          <svg class="ico" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.6"/>
+            <circle cx="12" cy="12" r="3.5" stroke="currentColor" stroke-width="1.6"/>
+            <path d="M12 8.5h8.5M7.6 14.2l-4.3 7.4M16.4 14.2l-4.3 7.4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+          </svg>
+          Add to Chrome <span class="sub">·web store</span>
+        </a>
+        <a class="btn" href="https://addons.mozilla.org/firefox/addon/muga/">
+          <svg class="ico" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M5 9c1-3 4-5 7-5 4 0 7 3 7 7 0 5-4 9-9 9-3 0-6-2-7-5 1 1 3 2 5 1-3-1-4-4-3-6 1 1 3 2 5 1-2-1-3-3-2-5 1 2 3 3 5 3" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+          </svg>
+          Add to Firefox <span class="sub">·addons.mozilla</span>
+        </a>
+        <a class="btn ghost" href="https://github.com/yocreoquesi/muga">
+          <svg class="ico" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.69-.22.69-.48v-1.69c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.12-1.47-1.12-1.47-.92-.62.07-.61.07-.61 1.01.07 1.55 1.04 1.55 1.04.9 1.55 2.37 1.1 2.95.84.09-.65.35-1.1.64-1.35-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.99 1.03-2.69-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.03A9.6 9.6 0 0 1 12 6.84a9.6 9.6 0 0 1 2.5.34c1.91-1.3 2.75-1.03 2.75-1.03.55 1.38.2 2.4.1 2.65.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.69-4.57 4.93.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2z"/>
+          </svg>
+          View source
+        </a>
+      </div>
+
+      <div class="install-meta">
+        <span>Free · GPL v3</span><span class="sep">/</span>
+        <span>No telemetry</span><span class="sep">/</span>
+        <span>Zero requests on default install</span>
+      </div>
+
+      <div class="bk-slot" aria-live="polite">
+        <span class="bk-prefix">muga ≈</span>
+        <span class="bk-text" id="bk">Making URLs Good Again.</span>
+      </div>
+
+      <!-- Animated demo -->
+      <div class="demo" aria-label="Before and after URL cleaning">
+        <div class="demo-head">
+          <div class="lights"><span></span><span></span><span></span></div>
+          <span class="label">muga · live · before / after</span>
+        </div>
+        <div class="demo-body">
+          <div class="url-row">
+            <span class="url-tag">Before</span>
+            <div class="url-box before" id="url-before">
+              <span class="domain">amazon.com</span><span class="path">/dp/B0C123ABCD</span><span class="path">?</span><span class="junk">utm_source=newsletter</span><span class="junk">&amp;utm_medium=email</span><span class="junk">&amp;utm_campaign=may26</span><span class="junk">&amp;fbclid=IwAR0xY2</span><span class="junk">&amp;gclid=Cj0KCQjw</span><span class="junk">&amp;ref_=nav_search</span><span class="junk">&amp;mc_cid=a1b2</span><span class="keep">&amp;tag=ytcreator-21</span>
+            </div>
+          </div>
+          <div class="url-row">
+            <span class="url-tag">After</span>
+            <div class="url-box">
+              <span class="domain">amazon.com</span><span class="path">/dp/B0C123ABCD</span><span class="keep">?tag=ytcreator-21</span>
+            </div>
+          </div>
+        </div>
+        <div class="demo-foot">
+          <span class="toast">Creator referral preserved · ytcreator-21</span>
+          <span style="margin-left:auto">7 trackers stripped · 1 affiliate kept</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap">
+    <div class="stats">
+      <div class="stats-grid">
+        <div class="stat">
+          <div class="num">450<span class="unit">+</span></div>
+          <div class="label">Tracking params</div>
+          <div class="desc">utm_*, fbclid, gclid, mc_cid, igshid and 446 more — stripped at request time.</div>
+        </div>
+        <div class="stat">
+          <div class="num">6</div>
+          <div class="label">Affiliate programs preserved</div>
+          <div class="desc">Amazon, eBay, Vercel, DigitalOcean, Lemon Squeezy, Apple Performance Partners.</div>
+        </div>
+        <div class="stat">
+          <div class="num">100<span class="unit">%</span></div>
+          <div class="label">Local processing</div>
+          <div class="desc">Zero data sent. Zero requests on default install. Runs entirely in your browser.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <section class="section wedge" id="creator-fair">
+    <div class="wrap">
+      <div class="wedge-grid">
+        <div>
+          <div class="section-label">The wedge</div>
+          <h2>URL cleaners shouldn't punish the creators you follow.</h2>
+          <p>
+            When you click a YouTuber's Amazon link, that <code>?tag=…</code> parameter is how they get paid — usually a few cents per sale, no extra cost to you.
+            Most cleaners strip it along with the trackers. MUGA doesn't.
+          </p>
+          <p>
+            We maintain an explicit allowlist of <b>6 affiliate programs</b>: Amazon, eBay, Vercel, DigitalOcean, Lemon Squeezy and Apple Performance Partners.
+            When MUGA detects one of those tags, it preserves the referral and shows a small <span class="chip warm">Creator referral preserved</span> toast so you know it happened.
+          </p>
+          <p>
+            We've open-sourced the rules as <b>CAPS</b> — the Creator Affiliate Preservation Standard — so any URL cleaner can do the same.
+          </p>
+        </div>
+
+        <div class="wedge-card" aria-label="Example URL with creator tag preserved">
+          <div class="header">
+            <span class="ttl">caps://example</span>
+            <span class="meta">amazon · partner-program</span>
+          </div>
+          <div class="row"><span class="k">host</span><span class="v">www.amazon.com</span></div>
+          <div class="row"><span class="k">path</span><span class="v">/dp/B0C123ABCD</span></div>
+          <div class="row">
+            <span class="k">strip</span>
+            <span class="v">
+              <span class="junk-static">utm_source</span>, <span class="junk-static">utm_campaign</span>,
+              <span class="junk-static">fbclid</span>, <span class="junk-static">gclid</span>,
+              <span class="junk-static">ref_</span>
+            </span>
+          </div>
+          <div class="row"><span class="k">keep</span><span class="v"><span class="keep">tag=ytcreator-21</span></span></div>
+          <div class="row"><span class="k">action</span><span class="v">redirect → preserve referral · show toast</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrap">
+      <div class="section-label">Trust, not trust-us</div>
+      <h2>Read the source. Watch the network tab.</h2>
+      <p>Three claims, three verifiable receipts.</p>
+
+      <div class="trust-grid">
+        <div class="trust-cell">
+          <span class="ic">01 · open</span>
+          <h3>GPL v3, every line</h3>
+          <p>Full source on GitHub. Build it yourself, audit it, fork it. Reproducible builds for both stores. <a href="https://github.com/yocreoquesi/muga">Repo →</a></p>
+        </div>
+        <div class="trust-cell">
+          <span class="ic">02 · quiet</span>
+          <h3>No telemetry, no analytics</h3>
+          <p>Default install makes zero outbound requests. The optional weekly rule update is opt-in and disclosed during onboarding. <a href="https://rules.muga.app/transparency.html">Transparency →</a></p>
+        </div>
+        <div class="trust-cell">
+          <span class="ic">03 · honest</span>
+          <h3>We document the tradeoffs</h3>
+          <p>Including the cases where MUGA may inject its own affiliate tag if a page has none — opt-in, fully disclosed. <a href="https://rules.muga.app/privacy-page.html">Privacy →</a></p>
+        </div>
+      </div>
+
+      <div class="shots" aria-label="Extension screenshots">
+        <figure class="shot">
+          <img src="https://rules.muga.app/assets/cws-ss1-popup-amazon.png" alt="MUGA popup on amazon.com showing the preserved creator tag" loading="lazy">
+          <figcaption>popup · amazon.com</figcaption>
+        </figure>
+        <figure class="shot">
+          <img src="https://rules.muga.app/assets/cws-ss4-toast.png" alt="Toast notification: Creator referral preserved" loading="lazy">
+          <figcaption>toast · referral preserved</figcaption>
+        </figure>
+        <figure class="shot">
+          <img src="https://rules.muga.app/assets/cws-ss3-options.png" alt="MUGA options page with per-site rules" loading="lazy">
+          <figcaption>settings · per-site rules</figcaption>
+        </figure>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div class="footer-col">
+        <a href="/" class="brand" style="margin-bottom:12px">
+          <img class="brand-mark" src="https://rules.muga.app/assets/mascot-icon-m.png" alt="" width="22" height="22">
+          <span>muga.app</span>
+        </a>
+        <p style="font-size:13px; color:var(--ink-3); margin: 8px 0 0; max-width: 320px;">
+          Open-source URL cleaner that preserves creator affiliate referrals.
+          Built by independent developers. Free forever.
+        </p>
+      </div>
+      <div class="footer-col">
+        <h4>Install</h4>
+        <ul>
+          <li><a href="https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh">Chrome Web Store</a></li>
+          <li><a href="https://addons.mozilla.org/firefox/addon/muga/">Firefox Add-ons</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Docs</h4>
+        <ul>
+          <li><a href="https://rules.muga.app/privacy-page.html">Privacy policy</a></li>
+          <li><a href="https://rules.muga.app/comparison.html">Compare cleaners</a></li>
+          <li><a href="https://rules.muga.app/transparency.html">Transparency</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Code</h4>
+        <ul>
+          <li><a href="https://github.com/yocreoquesi/muga">GitHub repo</a></li>
+          <li><a href="https://github.com/yocreoquesi/muga">CAPS spec</a></li>
+          <li><a href="https://www.gnu.org/licenses/gpl-3.0.html">GPL v3 license</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-meta">
+      <span>© 2026 muga.app · Released under GPL v3</span>
+      <span>v1.13.5 · published 2026-05-05</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // Backronym rotator (understated single slot)
+  (function () {
+    const lines = [
+      'Most URLs Get Abused.',
+      'Mercilessly Undoing Garbage Attachments.',
+      'Making URLs Good Again.'
+    ];
+    const el = document.getElementById('bk');
+    let i = 2;
+    setInterval(() => {
+      el.classList.add('fade');
+      setTimeout(() => {
+        i = (i + 1) % lines.length;
+        el.textContent = lines[i];
+        el.classList.remove('fade');
+      }, 360);
+    }, 4200);
+  })();
+
+  // Console easter egg
+  console.log(
+    "%cMUGA%c  Welcome to muga.app — view source, you'll like what you see.\nNo analytics. No third-party requests. No build step.\nhttps://github.com/yocreoquesi/muga",
+    "background:#d97706;color:#fff;padding:4px 8px;border-radius:4px;font-weight:600;",
+    "color:#555;font-family:ui-monospace,monospace;font-size:12px;line-height:1.6;"
+  );
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Single-file static landing page for `muga.app` apex, designed via Claude Design (direction **A — "Technical Clean"** selected over a character-driven alternative). Intended to be served via Cloudflare Pages from `landing/`, distinct from the privacy / transparency / comparison docs that already live on `rules.muga.app`.

The hero leads with the wedge headline **"Clean URLs. Fair to creators."** and pairs install buttons (CWS + AMO) with a CSS-only animated before/after URL demo: 7 tracking params strike-through one by one, the Amazon `?tag=ytcreator-21` creator referral is preserved.

## What's in `landing/index.html`

| Section | Notes |
|---|---|
| **Hero** | Eyebrow status pill (v1.13.5 · Chrome + Firefox · GPL v3), headline, lede, install row (Chrome / Firefox / View source), install meta (Free / No telemetry / Zero requests on default), backronym rotator (single understated slot, 4.2s interval), animated URL demo |
| **Stats** | 450+ tracking params, 6 affiliate programs preserved, 100% local processing — full-bleed grid bordered top/bottom |
| **The Wedge** | Creator-fair narrative + a `caps://example` mock card showing strip vs keep, links to CAPS spec |
| **Trust grid** | 01 · open (GPL v3) / 02 · quiet (no telemetry) / 03 · honest (we document the tradeoffs), each with a verifiable receipt link |
| **Screenshots** | Three real CWS screenshots referenced via `rules.muga.app/assets/*` (no asset duplication) |
| **Footer** | Install links / Docs links / Code links / Meta line with version + date |

## Constraints respected

- ✅ Single file, vanilla HTML/CSS/JS, **no frameworks**, no build step
- ✅ **29.4 KB total** (budget was 50 KB)
- ✅ System font stack — zero external font requests
- ✅ Dark mode via `@media (prefers-color-scheme: dark)`
- ✅ `prefers-reduced-motion` fallback for the URL strikethrough animation (line-through static)
- ✅ Open Graph + Twitter Card + JSON-LD `SoftwareApplication` schema
- ✅ Mobile-first — tested layout collapses cleanly at < 720px and again at < 520px
- ✅ All asset URLs reference `rules.muga.app/assets/*` (already public, CORS allowed)
- ✅ All install URLs match live store listings:
  - CWS: `chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh`
  - AMO: `addons.mozilla.org/firefox/addon/muga/`
- ✅ Console easter egg: `view source, you'll like what you see`
- ✅ Favicon (`mascot-icon-m.png`)
- ✅ No analytics, no third-party requests, zero outbound

## Hosting follow-up — NOT in this PR

This PR is just the static file. The Cloudflare wiring is a separate HITL step:

1. Cloudflare Pages → New project → Connect Git → `yocreoquesi/muga` → Build output: `landing/`
2. Bind custom domains `muga.app` and `www.muga.app`
3. Clean up the four stale Porkbun records on the `muga.app` zone (apex A ×2, wildcard CNAME, www CNAME) once Pages is bound — those are the records currently triggering the 525 error on the apex
4. Verify HTTPS smoke check on `muga.app` and `www.muga.app`

## What this closes

- **#331** — `feat(brand): acquire muga.app domain + minimal landing page via GitHub Pages CNAME` (P0 strategic, marketing). Acceptance criteria: domain registered ✓ (already), CNAME pointing to a destination with valid HTTPS ✓ (this PR enables it via CF Pages), landing page deployed at `muga.app/` with headline / install buttons / source link ✓.
- The last pending piece of **#481** domain-wiring umbrella (apex was the final unresolved subdomain).

## Test plan

- [x] File parses, all key URLs present, all metadata complete (verified via local lint)
- [ ] CI: full suite green (no production-code change so should be a no-op)
- [ ] After Cloudflare Pages wiring: `curl -I https://muga.app/` returns 200 with the new landing
- [ ] Manual: open the page in Chrome and Firefox; verify the URL animation, the backronym rotator, dark-mode adaptation, mobile breakpoint, and all install / docs / GitHub links resolve