### PR TITLE
fix(landing): stop URL params overlapping during fade-out animation

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -218,15 +218,14 @@
     transition: right .4s ease;
   }
   .url-box .junk.struck::after { right: 0; }
-  .url-box .junk.gone { opacity: 0; max-width: 0; display: inline-block; overflow: hidden; }
 
-  /* sequence: junk1..7 strike at staggered times, then collapse, then "after" reveals */
+  /* sequence: junk1..7 strike at staggered times, then fade to a faint
+     retired state. Layout stays stable — collapsing max-width while
+     siblings are still visible caused them to overlap mid-animation. */
   @keyframes strike { from { right: 100%; } to { right: 0; } }
-  @keyframes fade  { 0%, 60% { opacity: .6; } 100% { opacity: 0; max-width: 0; } }
-  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .5; } }
+  @keyframes fade  { 0%, 60% { opacity: .6; } 100% { opacity: .14; } }
 
   .url-box.before .junk {
-    display: inline-block;
     animation: fade 9s infinite;
   }
   .url-box.before .junk::after {
@@ -241,7 +240,7 @@
   .url-box.before .junk:nth-of-type(7) { animation-delay: 3.4s; } .url-box.before .junk:nth-of-type(7)::after { animation-delay: 3.4s; }
 
   @media (prefers-reduced-motion: reduce) {
-    .url-box.before .junk, .url-box.before .junk::after { animation: none; opacity: .55; }
+    .url-box.before .junk, .url-box.before .junk::after { animation: none; opacity: .35; }
     .url-box.before .junk { text-decoration: line-through; text-decoration-color: var(--accent); }
   }
 


### PR DESCRIPTION
## Summary

The before/after URL demo on \`muga.app\` had a layout bug: \`.junk\` params collapsed to \`max-width: 0\` in the last phase of the \`fade\` keyframe while sibling params were still mid-animation. With \`display: inline-block\` on every junk, the resulting mid-collapse reflow made params slide into each other before they fully faded out — the visible "elements overlapping during deletion" the user reported.

## Fix (5 +6 −, all in CSS)

- \`@keyframes fade\` no longer collapses \`max-width\`. Final state is \`opacity: .14\`, layout untouched.
- \`.url-box.before .junk\` drops \`display: inline-block\` — wasn't needed once the collapse is gone, and inline lets the URL wrap normally on narrow viewports.
- Removed the dead \`.junk.gone\` class (JS never applied it — leftover from an earlier design draft).
- \`prefers-reduced-motion\` fallback opacity adjusted to \`.35\` so the static \`line-through\` stays the primary visual signal.

## Visual story unchanged

Each tracking param strikes through (orange line crosses left to right) → fades to a near-invisible state. The "After" row below shows the clean URL. Animation loops every 9s. Layout now stable through the full loop.

## Test plan

- [x] Diff is local CSS only, no JS or HTML structure changes
- [ ] CI green (no production-code change so should pass)
- [ ] After CF Pages auto-deploy: load https://muga.app/, watch the demo run for 2-3 cycles, confirm no overlap during fade-out, confirm layout stays stable
- [ ] Toggle dark mode in browser, verify the strikethrough orange line is still visible
- [ ] Test \`prefers-reduced-motion: reduce\` (DevTools rendering panel) — junks should stay statically line-through'd at opacity .35