### PR TITLE
fix(privacy-proxy): align extension to Worker contract + bump 1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [1.15.1] - 2026-05-09
+
+Hotfix release. Headline: Privacy Proxy now actually works end-to-end. Three contract bugs were preventing the toggle from doing anything in v1.14.0 and v1.15.0 — the extension was calling the Worker on the wrong path (`/v1/unwrap` vs `/unwrap`) and with the wrong query param shape (`?url=raw` vs `?u=base64url`). Both were silent because the cleaner's failure mode is to fall back to the original navigation. The Worker contract is unchanged; this fix aligns the extension to it. Users who had Privacy Proxy enabled but never saw any difference will start getting actual server-side resolution after upgrading.
+
+### Fixed
+
+- **`src/lib/proxy-client.js` PROXY_URL path corrected** from `https://unwrap.muga.app/v1/unwrap` to `https://unwrap.muga.app/unwrap`. The `/v1/unwrap` path was never deployed on the Worker; every Privacy Proxy request returned `404 Not Found` and silently fell back to the wrapper navigation. Discovered via direct curl probe of the production Worker.
+- **`src/lib/proxy-client.js` query param contract corrected** from `?url=<raw>` to `?u=<base64url-encoded>`. The Worker handler reads the `u` param and base64url-decodes it (`muga-unwrap/src/handlers/unwrap.ts:110-111`); the extension was sending the raw URL under the wrong key, which would have returned `400 missing_u_parameter` even if the path had been correct.
+
+### Added
+
+- **`base64UrlEncode(str)` helper** exported from `src/lib/proxy-client.js`. Symmetric to the Worker's `decodeBase64Url` decoder. Uses `TextEncoder` for Unicode safety (theoretical IRIs in URLs).
+- **Endpoint-contract regression tests** in `tests/unit/proxy-client.test.mjs`. Three new assertions: PROXY_URL points to `/unwrap`, fetch is called with `?u=` (NOT `?url=`), and the encoded value round-trips through `atob` to the original input. The pre-existing fetch-stubbing tests asserted on response shape but not on request shape — that gap is now closed.
+
+### Operational notes
+
+- The Worker side (muga-unwrap) is unchanged. The canonical Worker contract `?u=<base64url>` was always correct; the bug was purely client-side.
+- Smoke probe in `muga-unwrap/.github/workflows/deploy.yml` (added in v0.2.x post-mortem hardening) was already exercising the correct path and param shape — that's why deploy CI never caught the extension-side bug. Future-proofing: a separate smoke probe on the *extension* side that verifies the actual request shape would have caught this; out of scope for this hotfix.
+
 ## [1.15.0] - 2026-05-09
 
 Redirector coverage release. Headline: Privacy Proxy now covers seven more redirector hosts — the generic shorteners `bit.ly`, `tinyurl.com`, `t.co`, and `link.medium.com`; the Partnerize affiliate redirector `prf.hn`; A8.net Japan's `px.a8.net`; and Amazon's branded shortener `amzn.to`. The toggle disclosure copy is reworded so the broader scope is honest — what was "opaque affiliate links" is now "opaque redirector links (affiliate networks and generic shorteners)." A foundational refactor eliminates the duplicate opaque-host list that previously lived in two files; adding a host now requires a one-line edit in `src/lib/opaque-networks.js`. The Worker side (cross-repo) landed first in [muga-unwrap#29](https://github.com/yocreoquesi/muga-unwrap/pull/29).
@@ -779,7 +798,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.15.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v1.15.1...HEAD
+[1.15.1]: https://github.com/yocreoquesi/muga/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/yocreoquesi/muga/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/yocreoquesi/muga/compare/v1.13.7...v1.14.0
 [1.13.7]: https://github.com/yocreoquesi/muga/compare/v1.13.6...v1.13.7

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.15.0-blue)](#)
+[![Version](https://img.shields.io/badge/version-1.15.1-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-2531_pass-brightgreen)](#development)
 [![CAPS](https://img.shields.io/badge/CAPS-Basic%20%2B%20Contextual-2ea44f)](CONFORMANCE.md)
 # MUGA: Privacy Without Breaking Creator Links

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://rules.muga.app/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "1.15.0"
+    "softwareVersion": "1.15.1"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-09 &nbsp;·&nbsp; Version 1.15.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-09 &nbsp;·&nbsp; Version 1.15.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 1.15.0
+> Version: 1.15.1
 > Last updated: 2026-05-09
 > Status: Final listing for Chrome Web Store and Firefox AMO. Lead headline rewritten to surface the "fair to creators" wedge per the 2026-04-26 strategic review (consensus across three independent analyses). Aligned with the post-grill privacy-policy and ToS rollout (#399, #400): per-device consent, local cleaning architecture, and #353 conditional preservation of MUGA's own tag.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.15.0 &nbsp;&middot;&nbsp; 2026-05-09 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;&middot;&nbsp; Version 1.15.1 &nbsp;&middot;&nbsp; 2026-05-09 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim: what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">1.15.0</span>
+      <span class="at-a-glance-value">1.15.1</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -206,7 +206,7 @@
   <hr>
 
   <div class="footer">
-    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.15.0 (2026-05-09) &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
+    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v1.15.1 (2026-05-09) &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
   </div>
 
 </body>

--- a/landing/index.html
+++ b/landing/index.html
@@ -28,7 +28,7 @@
   "operatingSystem": "Chrome, Firefox",
   "description": "Open-source browser extension that strips 450+ tracking parameters from URLs while preserving creator affiliate referrals.",
   "offers": { "@type": "Offer", "price": "0" },
-  "softwareVersion": "1.15.0",
+  "softwareVersion": "1.15.1",
   "license": "https://www.gnu.org/licenses/gpl-3.0.html"
 }
 </script>
@@ -407,7 +407,7 @@
     <a href="/" class="brand" aria-label="MUGA home">
       <img class="brand-mark" src="https://rules.muga.app/assets/mascot-icon-m.png" alt="" width="22" height="22">
       <span>muga.app</span>
-      <span class="ver">v1.15.0</span>
+      <span class="ver">v1.15.1</span>
     </a>
     <nav class="nav-links" aria-label="Primary">
       <a href="https://rules.muga.app/comparison.html">Compare</a>
@@ -421,7 +421,7 @@
 
   <section class="hero">
     <div class="wrap">
-      <div class="eyebrow"><span class="dot"></span> v1.15.0 · Chrome + Firefox · GPL v3</div>
+      <div class="eyebrow"><span class="dot"></span> v1.15.1 · Chrome + Firefox · GPL v3</div>
       <h1>Clean URLs.<br><span class="mark">Fair to creators.</span></h1>
       <p class="lede">
         MUGA strips <b>450+ tracking parameters</b> from every link you open. Locally, in your browser.
@@ -635,7 +635,7 @@
     </div>
     <div class="footer-meta">
       <span>© 2026 muga.app · Released under GPL v3</span>
-      <span>v1.15.0 · published 2026-05-09</span>
+      <span>v1.15.1 · published 2026-05-09</span>
     </div>
   </div>
 </footer>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Privacy without breaking creator links. Strips 450+ tracking params, preserves creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {

--- a/src/lib/proxy-client.js
+++ b/src/lib/proxy-client.js
@@ -15,7 +15,27 @@
 import { PROXY_TRUSTED_PUBLIC_KEYS } from "./remote-rules-keys.js";
 
 /** Proxy endpoint — compile-time constant, NOT user-configurable. */
-export const PROXY_URL = "https://unwrap.muga.app/v1/unwrap";
+export const PROXY_URL = "https://unwrap.muga.app/unwrap";
+
+/**
+ * Encodes a string as base64url (RFC 4648 §5) — URL-safe base64 with no padding.
+ * The Worker decodes the `u` query param this way (`decodeBase64Url` in
+ * `muga-unwrap/src/lib/base64url.ts`); symmetric encoding here is required for
+ * the round-trip to succeed.
+ *
+ * Uses TextEncoder so non-ASCII chars in URLs (theoretical IRIs) survive.
+ *
+ * @param {string} str - The string to encode.
+ * @returns {string} base64url-encoded string (no padding, `-_` instead of `+/`).
+ */
+export function base64UrlEncode(str) {
+  const bytes = new TextEncoder().encode(str);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
 
 /** Default fetch timeout in milliseconds. */
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -230,7 +250,7 @@ export async function fetchUnwrap(url, opts) {
   let responseBody;
   try {
     const endpoint = new URL(PROXY_URL);
-    endpoint.searchParams.set("url", url);
+    endpoint.searchParams.set("u", base64UrlEncode(url));
 
     const response = await fetch(endpoint.toString(), {
       signal: controller.signal,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "MUGA: Clean URLs, Fair to Every Click",
   "short_name": "MUGA",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Strip tracking. Keep creator referrals. 450+ params auto-removed (utm, fbclid, gclid). 100% local, zero data sent. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-09 &nbsp;·&nbsp; Version 1.15.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, Fair to Every Click &nbsp;·&nbsp; Effective date: 2026-05-09 &nbsp;·&nbsp; Version 1.15.1 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/tests/unit/proxy-client.test.mjs
+++ b/tests/unit/proxy-client.test.mjs
@@ -59,6 +59,8 @@ import {
   canonicalJSON,
   verifyUnwrapResponse,
   fetchUnwrap,
+  PROXY_URL,
+  base64UrlEncode,
 } from "../../src/lib/proxy-client.js";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -180,6 +182,70 @@ describe("verifyUnwrapResponse — missing required fields", () => {
       assert.strictEqual(ok, false);
     });
   }
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// fetchUnwrap — endpoint contract (regression: v1.15.1 hotfix)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("base64UrlEncode — round-trip with Worker decoder", () => {
+  test("encodes ASCII URL to base64url that round-trips through atob", () => {
+    const input = "https://s.click.aliexpress.com/e/abc123";
+    const encoded = base64UrlEncode(input);
+    // No padding, no + or /
+    assert.strictEqual(encoded.indexOf("="), -1);
+    assert.strictEqual(encoded.indexOf("+"), -1);
+    assert.strictEqual(encoded.indexOf("/"), -1);
+    // Round-trip through standard base64
+    const stdB64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = stdB64 + "=".repeat((4 - stdB64.length % 4) % 4);
+    const decoded = atob(padded);
+    assert.strictEqual(decoded, input);
+  });
+
+  test("encodes URL with query string + path correctly", () => {
+    const input = "https://amzn.to/dp/B0?tag=mycreator-20";
+    const encoded = base64UrlEncode(input);
+    const stdB64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = stdB64 + "=".repeat((4 - stdB64.length % 4) % 4);
+    assert.strictEqual(atob(padded), input);
+  });
+});
+
+describe("fetchUnwrap — endpoint contract (Worker API alignment)", () => {
+  test("PROXY_URL points to /unwrap (NOT /v1/unwrap)", () => {
+    assert.strictEqual(PROXY_URL, "https://unwrap.muga.app/unwrap");
+  });
+
+  test("calls Worker with `u` param holding base64url-encoded URL (NOT raw `url`)", async () => {
+    const inputUrl = "https://s.click.aliexpress.com/e/abc123";
+    const savedFetch = globalThis.fetch;
+    let capturedUrl;
+    globalThis.fetch = async (callUrl) => {
+      capturedUrl = callUrl;
+      // Return a 404 to short-circuit the rest — we only care about the request shape
+      return { ok: false, status: 404, json: async () => ({}) };
+    };
+    try {
+      await fetchUnwrap(inputUrl);
+
+      const parsed = new URL(capturedUrl);
+      assert.strictEqual(parsed.origin, "https://unwrap.muga.app");
+      assert.strictEqual(parsed.pathname, "/unwrap");
+
+      const u = parsed.searchParams.get("u");
+      assert.ok(u, "must include `u` param");
+      assert.strictEqual(parsed.searchParams.get("url"), null,
+        "must NOT include `url` param (legacy contract bug)");
+
+      // u must base64url-decode to the original input URL
+      const stdB64 = u.replace(/-/g, "+").replace(/_/g, "/");
+      const padded = stdB64 + "=".repeat((4 - stdB64.length % 4) % 4);
+      assert.strictEqual(atob(padded), inputUrl);
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Privacy Proxy was non-operational in v1.14.0 and v1.15.0 due to two silent client-side contract bugs (in addition to the SIGNING_PRIVATE_KEY format bug fixed yesterday in muga-unwrap). Both fail to the same fallback path (original navigation), so users saw no broken behavior — but the toggle did nothing.

## Bugs fixed

- **Path mismatch**: extension called `https://unwrap.muga.app/v1/unwrap` → 404. Worker route is `/unwrap`. Verified with curl against production.
- **Param contract mismatch**: extension sent `?url=<raw URL>` → Worker reads `?u=<base64url>` and rejects with `400 missing_u_parameter`. Even with path fixed, request would never resolve.

## Changes

- `src/lib/proxy-client.js`:
  - `PROXY_URL`: `https://unwrap.muga.app/v1/unwrap` → `https://unwrap.muga.app/unwrap`.
  - New exported helper `base64UrlEncode(str)` (TextEncoder + btoa, RFC 4648 §5 URL-safe alphabet, no padding).
  - `fetchUnwrap` now calls `endpoint.searchParams.set("u", base64UrlEncode(url))` instead of `set("url", url)`.
- `tests/unit/proxy-client.test.mjs`:
  - Three new regression tests that capture the fetch call URL and assert path + param shape + base64url round-trip.
  - Existing fetch-stub tests asserted on response shape; nothing asserted on request shape, which is how this slipped to production.

## Why no Worker change

The Worker contract has been correct all along. Aligning the extension to it is the smallest fix and avoids permanent server-side compat-shim cruft. v1.14.0/v1.15.0 in stores already trust the same public key — once they upgrade to v1.15.1, signed envelopes verify immediately.

## Test plan

- [x] `npm test` — 3770/3770 pass (3 new tests added, no regressions)
- [x] `npm run lint` — clean
- [ ] Manual smoke on Firefox: enable Privacy Proxy, click an `s.click.aliexpress.com` link, confirm tab navigates to resolved destination
- [ ] Manual smoke on Chrome: same as above

## Out of scope

- Worker-side changes (Worker is correct).
- Adding an extension-side smoke probe in CI that verifies request shape end-to-end against a stubbed Worker — would have caught this; tracked separately.
- Any rotation of keys or secrets.

Closes the silent-failure window that B20 shipped with.