### PR TITLE
test(privacy-proxy): extension-Worker contract integration test (#608)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+      - name: Run integration tests against live Worker (#608)
+        # Hits unwrap.muga.app to verify the extension-Worker contract
+        # (path, param shape, Origin gate, signed-envelope verifiability).
+        # Catches contract drift that the unit-level fetch stubs cannot —
+        # specifically the v1.15.1 hotfix class of bugs.
+        # If transient flakiness becomes a problem, investigate the Worker
+        # availability rather than disabling — stub coverage already exists.
+        run: npm run test:integration
+
       - name: CAPS-Contextual conformance gate (#543)
         run: npm run conformance:contextual
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "npm run build:chrome && npm run build:firefox",
     "lint": "bash scripts/with-firefox-manifest.sh npx --no-install web-ext lint --source-dir src/",
     "test": "node --test --test-reporter=spec tests/unit/*.mjs",
+    "test:integration": "node --test --test-reporter=spec tests/integration/*.mjs",
     "conformance:contextual": "node --test --test-reporter=spec tests/unit/conformance-contextual.test.mjs",
     "test:serve": "npx serve tests/browser --listen 5555 --no-clipboard",
     "brand": "npx serve tools --listen 5556 --no-clipboard",

--- a/tests/integration/proxy-client-contract.test.mjs
+++ b/tests/integration/proxy-client-contract.test.mjs
@@ -1,0 +1,146 @@
+/** MUGA: Integration test — proxy-client end-to-end contract (#608) */
+//
+// Calls the LIVE production Worker at unwrap.muga.app and verifies the
+// extension-Worker contract holds end-to-end:
+//
+//   1. PROXY_URL path is what the Worker actually serves (catches /v1/unwrap
+//      vs /unwrap drift like the v1.15.1 hotfix bug).
+//   2. base64UrlEncode produces what the Worker can decode (catches param
+//      shape drift like the ?url= vs ?u= bug from the same hotfix).
+//   3. Worker accepts an extension-style Origin header.
+//   4. Response is a signed envelope verifiable with PROXY_TRUSTED_PUBLIC_KEYS
+//      (catches public-key rotation drift between extension and Worker).
+//
+// This is the integration-level counterpart to the unit-level regression
+// tests added in PR #606 (which assert on the request shape via fetch stub
+// but cannot detect public-key drift or live Worker availability).
+//
+// Network dependency: this test hits https://unwrap.muga.app over the public
+// Internet. In normal conditions the Worker has 99.9%+ uptime and the test
+// is stable. If CI shows transient flakiness in this test, the right answer
+// is to investigate WHY (the Worker is the production endpoint users hit) —
+// not to disable the test. Stub coverage already exists at unit level.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import {
+  PROXY_URL,
+  base64UrlEncode,
+  verifyUnwrapResponse,
+} from "../../src/lib/proxy-client.js";
+import { PROXY_TRUSTED_PUBLIC_KEYS } from "../../src/lib/remote-rules-keys.js";
+
+// Stable test URL — an AliExpress affiliate click ID that resolves to a
+// real product page. Used because:
+//   - s.click.aliexpress.com has been in OPAQUE_NETWORKS since B20 (#453),
+//     so it would have caught the v1.14.0 contract bugs.
+//   - AliExpress affiliate URLs are not user-deletable like vanity bit.ly
+//     paths, so the test won't break if a third party unregisters a slug.
+//   - The Worker caches successful resolutions for 30 days; even if the
+//     upstream destination changes, signed-envelope round-trip stays
+//     verifiable. The test does NOT assert on destination value.
+const TEST_URL = "https://s.click.aliexpress.com/e/_oBtAfD";
+
+// Synthetic extension origin. Real extensions send a chrome-extension:// or
+// moz-extension:// scheme URL (the Worker accepts either prefix per the
+// origin gate in src/lib/origin.ts).
+const ORIGIN = "chrome-extension://muga-integration-test";
+
+// Generous timeout: the Worker may follow up to 5 redirect hops with a 5s
+// per-hop budget, so a cold cache miss can take 10–15s end-to-end.
+const TIMEOUT_MS = 20_000;
+
+/**
+ * Imports a raw 32-byte Ed25519 public key (standard base64) into a CryptoKey
+ * usable by verifyUnwrapResponse. Mirrors what the extension does at runtime
+ * when it boots — keeps this test path identical to production.
+ */
+async function importPublicKey(rawBase64) {
+  const bytes = Uint8Array.from(atob(rawBase64), (c) => c.charCodeAt(0));
+  return webcrypto.subtle.importKey(
+    "raw",
+    bytes,
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+}
+
+describe("integration: proxy-client end-to-end contract (#608)", () => {
+  test("Worker accepts extension request shape and returns verifiable signed envelope", async () => {
+    // Build the URL the same way fetchUnwrap would. If PROXY_URL or
+    // base64UrlEncode regress, this constructed URL will not match what the
+    // Worker serves.
+    const u = base64UrlEncode(TEST_URL);
+    const endpoint = `${PROXY_URL}?u=${u}`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    let response;
+    try {
+      response = await fetch(endpoint, {
+        signal: controller.signal,
+        headers: { Origin: ORIGIN },
+        cache: "no-store",
+        redirect: "error",
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // 200 = signed envelope. Anything else means the contract drifted.
+    //   404 → path drift (e.g., /v1/unwrap vs /unwrap)
+    //   400 → param drift (e.g., ?url= vs ?u=)
+    //   403 → origin-gate change
+    //   429 → rate limit (transient — retry locally if you hit this)
+    //   502/504 → upstream resolution failure (separate from the contract)
+    assert.strictEqual(
+      response.status,
+      200,
+      `Worker returned HTTP ${response.status} for ${endpoint} with Origin=${ORIGIN}. ` +
+        `Expected 200 with a signed envelope. The extension–Worker contract may have drifted.`,
+    );
+
+    const payload = await response.json();
+
+    // Required envelope fields — same set the extension's verifyUnwrapResponse
+    // expects. If the Worker drops or renames any of these, signature
+    // verification will fail downstream.
+    for (const field of ["destination", "hops", "network", "cached", "signature"]) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(payload, field),
+        `Worker response missing required field: ${field}. Payload was: ${JSON.stringify(payload)}`,
+      );
+    }
+
+    assert.strictEqual(typeof payload.destination, "string");
+    assert.ok(
+      payload.destination.startsWith("http://") || payload.destination.startsWith("https://"),
+      `destination has unexpected scheme: ${payload.destination}`,
+    );
+
+    // Signature verification — proves the public key in the extension matches
+    // the private key the Worker is signing with. Iterate every key in
+    // PROXY_TRUSTED_PUBLIC_KEYS; pass if ANY verifies (mirrors the rotation
+    // window pattern documented in remote-rules-keys.js).
+    let verified = false;
+    for (const rawKey of PROXY_TRUSTED_PUBLIC_KEYS) {
+      const publicKey = await importPublicKey(rawKey);
+      if (await verifyUnwrapResponse(payload, publicKey)) {
+        verified = true;
+        break;
+      }
+    }
+
+    assert.strictEqual(
+      verified,
+      true,
+      "Signature verification failed against every key in PROXY_TRUSTED_PUBLIC_KEYS. " +
+        "This signals public-key drift between the extension and the Worker — " +
+        "either the Worker rotated and the extension did not pick up the new key, " +
+        "or vice versa. See engram://muga-unwrap/abuse-mitigation for rotation procedure.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes the integration-level testing gap revealed by the v1.15.1 hotfix (PR #606). Adds a single integration test that exercises the extension-Worker contract end-to-end against the live production Worker on every PR.

## Why this matters

The v1.14.0 / v1.15.0 contract bugs (\`/v1/unwrap\` path, \`?url=\` param) silently shipped to production because:

- Pre-existing unit tests stubbed \`globalThis.fetch\` and asserted on **response** shape only.
- Nothing asserted on the **request** shape (URL, params, headers).
- Nothing exercised the contract against the live Worker.

PR #606 added three static regression tests (PROXY_URL value, \`?u=\` param name, base64url round-trip). This PR adds the dynamic counterpart.

## What the integration test checks

A single test calling \`https://unwrap.muga.app/unwrap?u=base64UrlEncode("https://s.click.aliexpress.com/e/_oBtAfD")\` with \`Origin: chrome-extension://muga-integration-test\` and asserting:

1. **HTTP 200** — proves path + param shape are accepted by Worker. Drift surfaces as 404 (path), 400 (param), or 403 (Origin).
2. **All envelope fields present** — \`destination\`, \`hops\`, \`network\`, \`cached\`, \`signature\`. Catches Worker schema changes.
3. **\`destination\` has http(s) scheme** — sanity check on resolution output.
4. **Signature verifies against \`PROXY_TRUSTED_PUBLIC_KEYS\`** — catches public-key rotation drift between repos. This is the most valuable check no unit test can do.

## Why s.click.aliexpress.com (not bit.ly)

AliExpress affiliate URLs are not user-deletable like vanity bit.ly slugs. Worker caches results for 30 days; even if upstream destination changes, signed-envelope round-trip stays verifiable. Test does not assert on destination value.

## Network dependency

Hits production \`unwrap.muga.app\` over public Internet on every PR. If CI shows transient flakiness, the right answer is to investigate Worker availability (the production endpoint users hit) — not to disable the test.

## Test plan

- [x] Local: \`npm run test:integration\` passes in ~640ms
- [x] Same Worker that real users hit; same URL shape that the extension constructs
- [ ] CI run on this PR will be the first end-to-end validation in pipeline (this PR is the change introducing it)

## Files

- \`tests/integration/proxy-client-contract.test.mjs\` (new, 156 LOC)
- \`package.json\` — new \`test:integration\` script
- \`.github/workflows/ci.yml\` — new step after \`Run unit tests\`

## Out of scope

- Stubbed-Worker integration variant (e.g., miniflare). Live Worker is simpler + catches real key/path/origin drift; only downside is transient flakiness which is investigable.
- The complementary Worker-side smoke probe in muga-unwrap deploy.yml (closed by muga-unwrap#30 already).
- Mocking signature verification for offline test runs.

Closes #608.