### PR TITLE
feat(cleaner): preserve Steam curator_clanid as creator-referral attribution (closes #614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to MUGA will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Steam Curator attribution preservation** (#614). Adds an explicit `steampowered.com` entry to `src/rules/domain-rules.json` preserving `curator_clanid` — the query param Steam uses to surface a curator's recommendation card inline on the store page. Steam Curator is functionally analogous to the Bookshop `/a/{id}/` creator-referral pattern shipped in #612: non-monetary, but real attribution value (analytics, follower-conversion surfacing). Subdomain-aware match covers `store.steampowered.com` automatically. Out of scope: Steam's internal nav telemetry (`snr`, host-emitted `utm_*`) and MUGA-own curator injection — see the issue for the rationale.
+
 ## [1.16.0] - 2026-05-11
 
 Feature release. Headline: full Bookshop.org affiliate support — both creator-referral preservation (`/a/{id}/` and `/shop/{slug}` entry paths) and MUGA's own affiliate injection on unattributed product pages. Out-of-band escape hatch authorised by caps-spec#46 itself. Also bundled: three additional opaque redirector hosts (lnkd.in, fb.me, ebay.to), a live end-to-end integration test against the production Worker contract, and a toolbar polish (drop icon variant + per-tab junk badge counter).

--- a/src/rules/domain-rules.json
+++ b/src/rules/domain-rules.json
@@ -3266,6 +3266,13 @@
     "note": "Shinsegae Group online department store"
   },
   {
+    "domain": "steampowered.com",
+    "preserveParams": [
+      "curator_clanid"
+    ],
+    "note": "Steam Curator attribution (#614). curator_clanid identifies the curator account whose recommendation card is surfaced inline on the store page when the visitor arrives with this param. Non-monetary creator attribution — same MUGA philosophy as Bookshop /a/{id}/ referrals (#612). Subdomain-aware match covers store.steampowered.com."
+  },
+  {
     "domain": "stackoverflow.com",
     "preserveParams": [
       "tab",

--- a/tests/unit/cleaner-domains.test.mjs
+++ b/tests/unit/cleaner-domains.test.mjs
@@ -11,7 +11,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
-import { processUrl } from "../../src/lib/cleaner.js";
+import { processUrl, getDomainParamSets } from "../../src/lib/cleaner.js";
 
 const require = createRequire(import.meta.url);
 const domainRules = require("../../src/rules/domain-rules.json");
@@ -463,6 +463,47 @@ describe("Namu.wiki URL cleaning", () => {
     const u = new URL(cleanUrl);
     assert.equal(u.searchParams.get("q"), "Python");
     assert.equal(u.searchParams.has("from"), false);
+  });
+});
+
+describe("Steam Curator — curator_clanid preserved as creator attribution (#614)", () => {
+  test("preserves curator_clanid standalone on store.steampowered.com", () => {
+    const { cleanUrl } = clean(
+      "https://store.steampowered.com/app/2769240/Wax_Heads/?curator_clanid=2540"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("curator_clanid"), "2540");
+  });
+
+  test("preserves curator_clanid while stripping co-occurring utm_*", () => {
+    const { cleanUrl } = clean(
+      "https://store.steampowered.com/app/2769240/Wax_Heads/?curator_clanid=2540&utm_source=newsletter&utm_campaign=promo"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("curator_clanid"), "2540");
+    assert.ok(!u.searchParams.has("utm_source"), "utm_source must be stripped");
+    assert.ok(!u.searchParams.has("utm_campaign"), "utm_campaign must be stripped");
+  });
+
+  test("preserves curator_clanid on apex steampowered.com (subdomain-aware rule)", () => {
+    const { cleanUrl } = clean(
+      "https://steampowered.com/app/2769240/?curator_clanid=2540"
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(u.searchParams.get("curator_clanid"), "2540");
+  });
+
+  test("rule is host-scoped: curator_clanid is NOT in the preserve set for non-Steam hosts", () => {
+    const steam = getDomainParamSets("store.steampowered.com", domainRules).preserved;
+    assert.ok(steam.has("curator_clanid"), "Steam rule must preserve curator_clanid");
+
+    for (const host of ["example.com", "store.epicgames.com", "www.google.com"]) {
+      const preserved = getDomainParamSets(host, domainRules).preserved;
+      assert.ok(
+        !preserved.has("curator_clanid"),
+        `Rule must NOT preserve curator_clanid on ${host}`
+      );
+    }
   });
 });
 

--- a/tests/unit/config-integrity.test.mjs
+++ b/tests/unit/config-integrity.test.mjs
@@ -17,8 +17,8 @@ const domainRules = require("../../src/rules/domain-rules.json");
 // Domain rules JSON integrity
 // ---------------------------------------------------------------------------
 describe("domain-rules.json integrity", () => {
-  test("all 168 entries have domain, preserveParams (non-empty array), and note", () => {
-    assert.equal(domainRules.length, 168, `Expected 168 entries, got ${domainRules.length}`);
+  test("all 169 entries have domain, preserveParams (non-empty array), and note", () => {
+    assert.equal(domainRules.length, 169, `Expected 169 entries, got ${domainRules.length}`);
     for (const rule of domainRules) {
       assert.equal(typeof rule.domain, "string", `domain must be string: ${JSON.stringify(rule)}`);
       assert.ok(Array.isArray(rule.preserveParams), `preserveParams must be array: ${rule.domain}`);


### PR DESCRIPTION
## Summary

- Adds an explicit `steampowered.com` entry to `src/rules/domain-rules.json` preserving `curator_clanid` — the query param Steam uses to surface a curator's recommendation card inline on the store page when a visitor arrives with it.
- Subdomain-aware match in `getDomainParamSets` (`src/lib/cleaner.js:88-98`) covers `store.steampowered.com` automatically.
- Functionally analogous to the Bookshop `/a/{id}/` creator-referral pattern shipped in #612: non-monetary attribution, but real value to the curator (analytics, surfacing, follower-conversion). Before this change, `curator_clanid` survived the cleaner only by accident (not in any `TRACKING_PARAMS_SET`, not matched by `TRACKING_PREFIXES`, not in `AFFILIATE_PATTERNS`); the bounded-scope param classifier (#530) could plausibly strip it in URLs with co-occurring anchor trackers. Explicit declaration is honest.

## Out of scope (matches the issue)

- MUGA-own curator injection on unattributed Steam URLs — ROI is reputational only; no money flows from Steam to curators.
- Other Steam params (`snr`, host-emitted `utm_*`) — internal nav telemetry, strip-eligible.

## Files

- `src/rules/domain-rules.json` — new entry between `ssg.com` and `stackoverflow.com`.
- `tests/unit/cleaner-domains.test.mjs` — 4 new test cases.
- `tests/unit/config-integrity.test.mjs` — entry count bumped 168 → 169.
- `CHANGELOG.md` — `[Unreleased]` section opened (1.16.0 just shipped).

## Test plan

- [x] `node --test tests/unit/cleaner-domains.test.mjs` — 4 new Steam tests pass.
- [x] `npm test` — 3782/3782 passing locally (no regressions).
- [x] `tests/unit/changelog-links.test.mjs` — guard for the new `[Unreleased]` section passes.
- [x] No bundle rebuild needed (`cleaner-bundle.js` does not embed `domain-rules.json`; rules are loaded at runtime by `cleaner.js`).

Closes #614.