### PR TITLE
fix(rules): strip YouTube start_radio — redundant UI flag

### DIFF
--- a/src/rules/domain-rules.json
+++ b/src/rules/domain-rules.json
@@ -3628,17 +3628,17 @@
     "preserveParams": [
       "t",
       "list",
-      "index",
-      "start_radio"
+      "index"
     ],
     "stripParams": [
       "feature",
       "pp",
       "si",
       "cbrd",
-      "ucbcb"
+      "ucbcb",
+      "start_radio"
     ],
-    "note": "YouTube short links: timestamp and playlist functional. si (share token) stripped."
+    "note": "YouTube short links: timestamp and playlist functional. si (share token) stripped. start_radio is redundant UI flag — list=RD... already defines the radio mix."
   },
   {
     "domain": "youtube.com",
@@ -3647,7 +3647,6 @@
       "t",
       "list",
       "index",
-      "start_radio",
       "ab_channel",
       "search_query",
       "lc"
@@ -3662,9 +3661,10 @@
       "ucbcb",
       "embeds_referring_euri",
       "embeds_referring_origin",
-      "kw"
+      "kw",
+      "start_radio"
     ],
-    "note": "Video ID, timestamp, playlist, channel, comment link: functional. si (share token), feature/pp, embed referrer tracking stripped."
+    "note": "Video ID, timestamp, playlist, channel, comment link: functional. si (share token), feature/pp, embed referrer tracking stripped. start_radio is redundant UI flag — list=RD... already defines the radio mix."
   },
   {
     "domain": "zalando.de",


### PR DESCRIPTION
Closes #618.

## Summary

- `start_radio` was in `preserveParams` for both `youtube.com` and `youtu.be` entries in `src/rules/domain-rules.json`. The radio mix is fully driven by the `list=RD...` playlist id — `start_radio=1` only signals the UI to expand the radio side panel and has no effect on playback.
- Moves `start_radio` from `preserveParams` to `stripParams` on both entries and updates the `note` so the reasoning survives in the rule file (prevents a future PR from re-adding it).

## Test plan

- [x] `npm run build:rules` — no DNR drift (`start_radio` is not in `TRACKING_PARAMS`, so removing it from `preserveParams` does not change the global DNR strip; the per-domain content-script strip path now handles it).
- [x] `npm test` — 3804/3804 pass, including `dnr-rules-sync` (verifies tracking-params.json ↔ domain-rules.json preserveParams invariant) and `domain-rules` / `cleaner-domains` test files.
- [ ] Manual verification: `https://www.youtube.com/watch?v=X&list=RDX&start_radio=1` → cleaned to `https://www.youtube.com/watch?v=X&list=RDX`, still autoplays the radio mix.

## Out of scope

- Broader YouTube tracking surface — `kw`, `embeds_referring_*` already in `stripParams`, unchanged.
- Other platforms with similar redundant UI flags — separate audit if/when surfaced.