### PR TITLE
docs(readme): correct test count — closes #620

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.16.0-blue)](#)
-[![Tests](https://img.shields.io/badge/tests-2531_pass-brightgreen)](#development)
+[![Tests](https://img.shields.io/badge/tests-3804_pass-brightgreen)](#development)
 [![CAPS](https://img.shields.io/badge/CAPS-Basic%20%2B%20Contextual-2ea44f)](CONFORMANCE.md)
 # MUGA: Privacy Without Breaking Creator Links
 
@@ -199,8 +199,8 @@ Load unpacked from `chrome://extensions` (Developer mode) or `about:debugging` i
 ## Development
 
 ```bash
-npm test               # 964 unit tests
-npm run test:e2e       # 37 E2E tests (Playwright, requires headed Chromium)
+npm test               # 3804 unit tests
+npm run test:e2e       # 90 E2E tests (Playwright, requires headed Chromium; 13 skipped)
 npm run build:chrome
 npm run build:firefox
 ```


### PR DESCRIPTION
## Summary
- Fixes #620 (P0 audit finding).
- Badge: `tests-2531_pass` → `tests-3804_pass`.
- Dev section: `964 unit tests` → `3804`, `37 E2E tests` → `90` (with `13 skipped`).

## Direction of the discrepancy
The audit hypothesised "declared ~3800, real ~298" — investigation found the **inverse**. Latest runner output: `tests 3804`, `suites 526`, `pass 3804` (unit) and `90 passed, 13 skipped` (Playwright). README was understated, not overstated.

## Test plan
- [x] `npm test` → 3804 pass, 526 suites
- [x] `npm run test:e2e` → 90 pass, 13 skipped
- [ ] Visual check that the shields.io badge renders correctly on GitHub