### PR TITLE
docs(readme): inline comparison table + drop Honey from full comparison — closes #623

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,36 @@ Privacy Proxy can be toggled on and off at any time from Settings. Disabling it 
 
 ---
 
+## How it differs from other URL cleaners
+
+> Other cleaners treat every parameter as junk and strip aggressively. MUGA distinguishes a tracking parameter (`fbclid`, `utm_source`) from a creator's affiliate tag — the YouTuber who recommended the link still gets paid.
+
+| Feature                          | MUGA       | uBlock Origin   | ClearURLs   | Brave Shields  |
+|----------------------------------|:----------:|:---------------:|:-----------:|:--------------:|
+| Strips tracking params           | ✓ 450+ [^1]| ✓ via filter list [^2] | ✓ ~150 [^3] | ✓ ~200 [^4]   |
+| Preserves creator affiliate tags | **✓** [^5] | ✗               | ✗           | ✗              |
+| Per-URL "what was removed" UI    | ✓ [^6]     | ✗ (logger only) | ✗           | ✗              |
+| Refuses redirect-based affiliate networks | ✓ [^7] | n/a       | n/a         | n/a            |
+| Signed remote rule updates       | ✓ Ed25519, opt-in [^8] | filter-list-dependent | unsigned [^9] | bundled with browser updates |
+| Ad / script blocking             | ✗ (out of scope) | ✓         | ✗           | ✓ (Shields)    |
+| Works on any Chromium / Firefox  | ✓          | ✓               | ✓           | Brave browser only |
+
+The wedge in one sentence: **MUGA is the only one of the four that distinguishes a tracker from a creator's affiliate tag, and the only one whose popup tells you that distinction was made.** Full comparison with sources and counts: [rules.muga.app/comparison.html](https://rules.muga.app/comparison.html).
+
+[^1]: MUGA tracking-param universe: [`src/rules/tracking-params.json`](src/rules/tracking-params.json) (universal DNR set) + [`src/rules/domain-rules.json`](src/rules/domain-rules.json) (per-domain rules across 150+ hosts).
+[^2]: uBlock Origin strips params via the `removeparam` static filter. Coverage depends on enabled filter lists. See [uBO docs](https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#removeparam).
+[^3]: ClearURLs rules: [github.com/ClearURLs/Rules](https://github.com/ClearURLs/Rules/blob/master/data.min.json). Approximate count based on the current global rule set.
+[^4]: Brave's curated list ships with the browser: [brave-core query_filter/utils.cc](https://github.com/brave/brave-core/blob/master/components/query_filter/utils.cc). Brave strips creator affiliate parameters indiscriminately along with trackers.
+[^5]: MUGA preservation logic — see the `AFFILIATE_PATTERNS` table in [`src/lib/affiliates.js`](src/lib/affiliates.js) and the cleaner branch that gates injection on `!url.searchParams.has(pattern.param)` ([`src/lib/cleaner.js`](src/lib/cleaner.js)). The popup surfaces a "Creator referral preserved" badge whenever this branch fires.
+[^6]: MUGA popup renders the cleaned-param breakdown for the current URL — see [`src/popup/`](src/popup/). uBO's logger reaches the same data but requires opening a separate panel and is not URL-scoped by default.
+[^7]: MUGA's rejected-networks list (Awin, ShareASale, Admitad, Skimlinks, Sovrn, CJ, Impact Radius, Rakuten LinkShare, AliExpress redirect, Temu) is documented in [`src/lib/affiliates.js`](src/lib/affiliates.js). MUGA still **strips** their tracking params on encounter; it just refuses to inject through them.
+[^8]: Remote rules: Ed25519-signed payload, max 1 fetch per 7 days, opt-in. Verification entry: [`src/lib/remote-rules.js`](src/lib/remote-rules.js). Off by default while signing infrastructure stabilises.
+[^9]: ClearURLs fetches its ruleset from a remote URL on install/update; the file is not cryptographically signed. See [ClearURLs/Addon](https://github.com/ClearURLs/Addon).
+
+> uBlock Origin is not strictly a URL cleaner — it's a full content blocker that happens to do URL param stripping. The two are complementary: uBO filters network requests, MUGA cleans the URL bar and preserves creator credit. The table above scopes uBO to its URL-cleaning behaviour for an apples-to-apples comparison.
+
+---
+
 ## Affiliate model: the honest version
 
 MUGA is an open-source project maintained by real people. To keep it maintained and improving over time, it uses a simple affiliate model.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -265,70 +265,62 @@
           <th>Brave (built-in)</th>
           <th>Neat URL</th>
           <th>uBlock Origin</th>
-          <th>Honey (PayPal)</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td><strong>Surfaces preserved creator tag in UI</strong></td>
-          <td class="muga yes">Yes, visible badge<sup>16</sup></td>
+          <td class="muga yes">Yes, visible badge<sup>14</sup></td>
           <td class="no">No</td>
           <td class="no">No</td>
           <td class="no">No</td>
           <td class="no">No</td>
-          <td class="bad">No (silently overwrites)<sup>7</sup></td>
         </tr>
         <tr>
           <td>Replaces creator affiliates</td>
           <td class="muga yes">Never</td>
-          <td class="partial">Sometimes (rule-dependent)<sup>17</sup></td>
-          <td class="partial">Sometimes<sup>18</sup></td>
-          <td class="partial">Sometimes<sup>17</sup></td>
+          <td class="partial">Sometimes (rule-dependent)<sup>15</sup></td>
+          <td class="partial">Sometimes<sup>16</sup></td>
+          <td class="partial">Sometimes<sup>15</sup></td>
           <td class="partial">Filter-list-dependent</td>
-          <td class="bad">Yes (silently)<sup>7</sup></td>
         </tr>
         <tr>
           <td>Refuses redirect-based affiliate networks</td>
-          <td class="muga yes">Yes, rejected 10+<sup>19</sup></td>
+          <td class="muga yes">Yes, rejected 10+<sup>17</sup></td>
           <td class="na">N/A (no affiliate model)</td>
           <td class="na">N/A</td>
           <td class="na">N/A</td>
           <td class="na">N/A</td>
-          <td class="bad">No (uses them)</td>
         </tr>
         <tr>
           <td>Tracker count celebration in popup</td>
-          <td class="muga yes">"Removed N trackers"<sup>16</sup></td>
+          <td class="muga yes">"Removed N trackers"<sup>14</sup></td>
           <td class="no">No</td>
           <td class="no">No (browser-level)</td>
           <td class="no">No</td>
           <td class="partial">Badge counter only</td>
-          <td class="no">No</td>
         </tr>
         <tr>
           <td>Tracking params stripped</td>
           <td class="muga">450+ params<sup>1</sup></td>
           <td>~300<sup>2</sup></td>
-          <td>~150<sup>18</sup></td>
+          <td>~150<sup>16</sup></td>
           <td>~200<sup>3</sup></td>
           <td class="partial">Limited (via filter lists)<sup>4</sup></td>
-          <td class="na">0</td>
         </tr>
         <tr>
           <td>Domain-specific rules</td>
           <td class="muga">150+ domains<sup>1</sup></td>
           <td>~100<sup>2</sup></td>
-          <td>Built-in list<sup>18</sup></td>
+          <td>Built-in list<sup>16</sup></td>
           <td>Manual (user-defined)</td>
           <td class="partial">Via filter lists</td>
-          <td class="na">N/A</td>
         </tr>
         <tr>
           <td>AMP redirect</td>
           <td class="yes muga">Yes</td>
           <td class="no">No</td>
           <td class="yes">Yes (browser-level)</td>
-          <td class="no">No</td>
           <td class="no">No</td>
           <td class="no">No</td>
         </tr>
@@ -339,7 +331,6 @@
           <td class="partial">Limited</td>
           <td class="no">No</td>
           <td class="partial">Partial (via filters)</td>
-          <td class="no">No</td>
         </tr>
         <tr>
           <td>Ping blocking</td>
@@ -348,70 +339,62 @@
           <td class="yes">Yes (Shields)</td>
           <td class="no">No</td>
           <td class="yes">Yes</td>
-          <td class="no">No</td>
         </tr>
         <tr>
           <td>Signed remote-rules updates (opt-in)</td>
-          <td class="muga yes">Ed25519, weekly, opt-in<sup>20</sup></td>
-          <td class="partial">Unsigned, on-demand<sup>11</sup></td>
+          <td class="muga yes">Ed25519, weekly, opt-in<sup>18</sup></td>
+          <td class="partial">Unsigned, on-demand<sup>10</sup></td>
           <td class="partial">Browser updates</td>
           <td class="no">Manual</td>
           <td class="partial">Filter list updates</td>
-          <td class="bad">Continuous (browsing data)</td>
         </tr>
         <tr>
           <td>Open source</td>
           <td class="muga">GPL v3</td>
-          <td>LGPL v3<sup>8</sup></td>
-          <td>MPL 2.0 (browser)<sup>21</sup></td>
-          <td>GPL v2<sup>9</sup></td>
-          <td>GPL v3<sup>10</sup></td>
-          <td class="bad">No</td>
+          <td>LGPL v3<sup>7</sup></td>
+          <td>MPL 2.0 (browser)<sup>19</sup></td>
+          <td>GPL v2<sup>8</sup></td>
+          <td>GPL v3<sup>9</sup></td>
         </tr>
         <tr>
           <td>External server calls (default)</td>
           <td class="muga yes">0</td>
-          <td class="yes">0<sup>11</sup></td>
+          <td class="yes">0<sup>10</sup></td>
           <td class="partial">Browser telemetry (configurable)</td>
           <td class="yes">0</td>
           <td class="partial">Filter list updates</td>
-          <td class="bad">Yes (PayPal servers)<sup>12</sup></td>
         </tr>
         <tr>
           <td>Data collected</td>
           <td class="muga yes">None</td>
           <td class="yes">None</td>
-          <td class="partial">Anonymous metrics<sup>21</sup></td>
+          <td class="partial">Anonymous metrics<sup>19</sup></td>
           <td class="yes">None</td>
           <td class="yes">None</td>
-          <td class="bad">Browsing data<sup>12</sup></td>
         </tr>
         <tr>
           <td>Manifest V3</td>
           <td class="muga yes">Yes (native)</td>
-          <td class="partial">Partial (MV3 branch in progress)<sup>13</sup></td>
+          <td class="partial">Partial (MV3 branch in progress)<sup>11</sup></td>
           <td class="na">N/A (browser)</td>
           <td class="no">No (Firefox only)</td>
-          <td class="yes">Yes</td>
           <td class="yes">Yes</td>
         </tr>
         <tr>
           <td>Works in any browser</td>
           <td class="muga">Chrome, Firefox</td>
-          <td>Chrome, Firefox, Edge, Opera<sup>14</sup></td>
+          <td>Chrome, Firefox, Edge, Opera<sup>12</sup></td>
           <td class="bad">Brave only</td>
-          <td>Firefox only<sup>9</sup></td>
+          <td>Firefox only<sup>8</sup></td>
           <td>Chrome, Firefox, Edge, Opera</td>
-          <td>Chrome, Firefox, Edge, Opera, Safari</td>
         </tr>
         <tr>
           <td>Interface languages (i18n)</td>
           <td class="muga">EN, ES, PT, DE</td>
-          <td>EN, DE (partial)<sup>15</sup></td>
+          <td>EN, DE (partial)<sup>13</sup></td>
           <td>50+ languages</td>
           <td>EN</td>
           <td>50+ languages</td>
-          <td>10+ languages</td>
         </tr>
         <tr>
           <td>Per-domain param stats</td>
@@ -420,12 +403,10 @@
           <td class="no">No</td>
           <td class="no">No</td>
           <td class="no">No</td>
-          <td class="no">No</td>
         </tr>
         <tr>
           <td>Param breakdown (education)</td>
           <td class="muga yes">Yes</td>
-          <td class="no">No</td>
           <td class="no">No</td>
           <td class="no">No</td>
           <td class="no">No</td>
@@ -488,17 +469,6 @@
     filter list) has the advantage.
   </div>
 
-  <div class="note honest">
-    <strong>About Honey.</strong>
-    Honey was acquired by PayPal for $4 billion. That price reflects the value of the browsing
-    data it collects, not the coupons it finds. Honey's own privacy policy confirms it collects
-    information about every page you visit on shopping sites.<sup>12</sup>
-    Additionally, multiple independent reports found that Honey silently overwrites affiliate
-    links created by content creators without notifying the user or the creator.<sup>7</sup>
-    MUGA takes the opposite approach: all processing is local, nothing leaves your browser
-    on a default install, and affiliate tag handling is always disclosed with a visible notification.
-  </div>
-
   <h2>Methodology</h2>
   <p>MUGA numbers (tracking params, domain rules, redirect networks) are taken directly from the
   source files in the <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">public repository</a>.
@@ -515,12 +485,10 @@
       <li>uBlock Origin strips tracking params via the <code>removeparam</code> filter cosmetic option. Coverage depends on the filter lists the user has enabled. <a href="https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#removeparam" target="_blank" rel="noopener noreferrer">uBlock Origin docs: removeparam</a>.</li>
       <li>MUGA unwraps redirects from: Awin, ShareASale, Admitad, Admitad/AliExpress (alitems.com), Sovrn/VigLink, and Tradedoubler. See <a href="https://github.com/yocreoquesi/muga/blob/main/src/content/redirect-unwrap.js" target="_blank" rel="noopener noreferrer">src/content/redirect-unwrap.js</a>.</li>
       <li>ClearURLs redirect handling: <a href="https://github.com/ClearURLs/Rules/blob/master/data.min.json" target="_blank" rel="noopener noreferrer">github.com/ClearURLs/Rules</a>. Includes <code>redirections</code> entries.</li>
-      <li>Honey affiliate replacement reports: <a href="https://www.pcmag.com/news/paypal-honey-browser-extension-is-stealing-credit-from-influencers" target="_blank" rel="noopener noreferrer">PCMag: PayPal Honey stealing credit from influencers</a>; <a href="https://megaphone.fm/ADL9840478058" target="_blank" rel="noopener noreferrer">MegaLag: video investigation</a>. Honey's own ToS does not prohibit this behavior.</li>
       <li>ClearURLs license: <a href="https://github.com/ClearURLs/Addon/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">github.com/ClearURLs/Addon/LICENSE</a>.</li>
       <li>Neat URL license and browser support: <a href="https://github.com/Smile4ever/Neat-URL" target="_blank" rel="noopener noreferrer">github.com/Smile4ever/Neat-URL</a>. Firefox Add-ons only; no Chrome version available.</li>
       <li>uBlock Origin license: <a href="https://github.com/gorhill/uBlock/blob/master/LICENSE.txt" target="_blank" rel="noopener noreferrer">github.com/gorhill/uBlock/LICENSE</a>.</li>
       <li>ClearURLs external calls: the extension fetches its rules from a remote URL on first install and on updates. No browsing data is sent. See <a href="https://github.com/ClearURLs/Addon" target="_blank" rel="noopener noreferrer">github.com/ClearURLs/Addon</a>.</li>
-      <li>Honey privacy policy: <a href="https://www.joinhoney.com/privacy" target="_blank" rel="noopener noreferrer">joinhoney.com/privacy</a>. Honey collects page visit data on shopping sites and transmits it to PayPal servers.</li>
       <li>ClearURLs MV3 status: <a href="https://github.com/ClearURLs/Addon/issues" target="_blank" rel="noopener noreferrer">github.com/ClearURLs/Addon issues</a>. MV3 migration is tracked but not yet complete as of early 2026.</li>
       <li>ClearURLs browser support: available on Chrome Web Store, Firefox Add-ons, and Edge Add-ons. <a href="https://clearurls.xyz" target="_blank" rel="noopener noreferrer">clearurls.xyz</a>.</li>
       <li>ClearURLs i18n: the extension ships with English and German UI strings. Community translations exist but are incomplete.</li>

--- a/landing/index.html
+++ b/landing/index.html
@@ -397,6 +397,28 @@
     font-family: var(--mono); font-size: 12px; color: var(--ink-3);
   }
 
+  /* ---------- comparison table ---------- */
+  .compare-wrap { overflow-x: auto; margin: 24px 0 12px; }
+  .compare-tbl {
+    width: 100%; border-collapse: collapse; font-size: 14px;
+    font-family: var(--sans, system-ui);
+  }
+  .compare-tbl th, .compare-tbl td {
+    text-align: left; padding: 10px 12px;
+    border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+  }
+  .compare-tbl thead th {
+    font-weight: 600; font-size: 12px;
+    letter-spacing: .04em; text-transform: uppercase;
+    color: var(--ink-3); background: var(--bg-2);
+  }
+  .compare-tbl tbody td:not(:first-child) { text-align: center; }
+  .compare-tbl .yes { color: var(--accent); font-weight: 600; }
+  .compare-tbl .no  { color: var(--ink-3); }
+  .compare-tbl .muga-col { background: rgba(37,99,235,0.04); }
+  .compare-note { font-size: 13px; color: var(--ink-3); margin-top: 12px; }
+
   :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
 </style>
 </head>
@@ -550,6 +572,80 @@
           <div class="row"><span class="k">action</span><span class="v">redirect → preserve referral · show toast</span></div>
         </div>
       </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrap">
+      <div class="section-label">Side by side</div>
+      <h2>How MUGA differs from other URL cleaners.</h2>
+      <p>Other cleaners treat every parameter as junk and strip aggressively. MUGA distinguishes a tracking parameter from a creator's affiliate tag — the YouTuber who recommended the link still gets paid.</p>
+
+      <div class="compare-wrap">
+        <table class="compare-tbl">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th class="muga-col">MUGA</th>
+              <th>uBlock Origin</th>
+              <th>ClearURLs</th>
+              <th>Brave Shields</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Strips tracking params</td>
+              <td class="muga-col yes">✓ 450+</td>
+              <td class="yes">✓ via filter list</td>
+              <td class="yes">✓ ~150</td>
+              <td class="yes">✓ ~200</td>
+            </tr>
+            <tr>
+              <td><strong>Preserves creator affiliate tags</strong></td>
+              <td class="muga-col yes">✓</td>
+              <td class="no">✗</td>
+              <td class="no">✗</td>
+              <td class="no">✗</td>
+            </tr>
+            <tr>
+              <td>Per-URL "what was removed" UI</td>
+              <td class="muga-col yes">✓</td>
+              <td class="no">logger only</td>
+              <td class="no">✗</td>
+              <td class="no">✗</td>
+            </tr>
+            <tr>
+              <td>Refuses redirect-based affiliate networks</td>
+              <td class="muga-col yes">✓</td>
+              <td class="no">n/a</td>
+              <td class="no">n/a</td>
+              <td class="no">n/a</td>
+            </tr>
+            <tr>
+              <td>Signed remote rule updates</td>
+              <td class="muga-col yes">✓ Ed25519, opt-in</td>
+              <td class="no">filter-list-dependent</td>
+              <td class="no">unsigned</td>
+              <td class="no">bundled w/ browser</td>
+            </tr>
+            <tr>
+              <td>Ad / script blocking</td>
+              <td class="muga-col no">✗ (out of scope)</td>
+              <td class="yes">✓</td>
+              <td class="no">✗</td>
+              <td class="yes">✓ (Shields)</td>
+            </tr>
+            <tr>
+              <td>Works on Chromium &amp; Firefox</td>
+              <td class="muga-col yes">✓</td>
+              <td class="yes">✓</td>
+              <td class="yes">✓</td>
+              <td class="no">Brave only</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="compare-note">MUGA is the only one of the four that distinguishes a tracker from a creator's affiliate tag — and the only one whose popup tells you that distinction was made. Full comparison with sources and counts: <a href="https://rules.muga.app/comparison.html">rules.muga.app/comparison.html</a>.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
Closes #623. Two changes shipped together because they're the same surface:

1. **README**: new "How it differs from other URL cleaners" section between the Mode model and Affiliate model. 7-row inline table vs uBlock Origin / ClearURLs / Brave Shields, with inline GitHub-flavored footnotes citing both local repo paths and competitor sources (uBO `removeparam` docs, ClearURLs rule repo, brave-core `query_filter/utils.cc`).
2. **landing/index.html**: mirrored "Side by side" section between the wedge and "Trust, not trust-us". Minimal table CSS added to the existing `<style>` block.
3. **docs/comparison.html**: removed Honey (PayPal) — not a URL cleaner, doesn't belong in the comparison. Per maintainer call in this PR's review.

## Honey removal details (docs/comparison.html)
- `<th>Honey (PayPal)</th>` column removed from the table header.
- Last `<td>` removed from every body row (18 rows × 1 cell = -18 cells). Each row now has 6 columns instead of 7.
- "About Honey" `<div class="note honest">` block removed entirely.
- Footnotes 7 (PCMag/MegaLag) and 12 (Honey privacy policy) removed from the `<ol>`.
- All `<sup>` references renumbered 8→7 through 21→19. Verified zero "honey" mentions, zero `<sup>20</sup>` or `<sup>21</sup>` left.
- File: 537 → 505 lines.

## README inline table rows
| Row | Why it's there |
|---|---|
| Strips tracking params | Baseline parity claim. All four do this; counts differ. |
| **Preserves creator affiliate tags** | The wedge. Only MUGA does this. |
| Per-URL "what was removed" UI | MUGA's popup vs uBO logger (panel, not URL-scoped). |
| Refuses redirect-based affiliate networks | MUGA-only stance; documented in `affiliates.js`. |
| Signed remote rule updates | Ed25519 opt-in vs unsigned ClearURLs vs bundled-with-browser Brave. |
| Ad / script blocking | Honest about MUGA's out-of-scope here. uBO + Brave win. |
| Works on Chromium & Firefox | Brave-only is a real footgun if you don't run Brave. |

## Acceptance criteria
- [x] Table inline in README.md (GitHub-flavored markdown, renders on github.com).
- [x] Each row has a source citation via footnote (`[^1]` ... `[^9]`).
- [x] Link to the full comparison page below the table.
- [x] Mirrored in landing/index.html as a new "Side by side" section.

## Test plan
- [x] `npm test` → 3804/3804 pass (no code paths touched).
- [x] `grep -i honey docs/comparison.html` → 0.
- [x] Footnote sup values now span 1-19 only; 19 `<li>` items in the footnotes `<ol>`.
- [ ] Render README on GitHub, click each `[^N]` footnote link, verify each target is the correct citation.
- [ ] Smoke landing page locally, check the table renders with the new CSS in both light and dark mode.