### PR TITLE
docs: tier-1 affiliate networks attribution matrix v0 (#646)

### DIFF
--- a/docs/affiliate-networks-matrix.md
+++ b/docs/affiliate-networks-matrix.md
@@ -1,0 +1,296 @@
+# Affiliate networks attribution matrix
+
+**Version**: v0 (tier-1 only)
+**Last updated**: 2026-05-24
+**Next quarterly review**: 2026-08-24
+**Owner**: Antonio Rodriguez ([@yocreoquesi](https://github.com/yocreoquesi))
+**Scope**: redirect-based affiliate networks that MUGA used to exclude in 2.0 and now treats as first-class under [ADR-0002](adr/0002-denoise-pivot-creator-agnostic.md)
+
+## Purpose
+
+This document is the source of truth for how MUGA 2.1 treats post-redirect attribution. It feeds three code surfaces:
+
+- `src/lib/opaque-networks.js` — which redirect hosts pass through vs get unwrapped ([#653](https://github.com/yocreoquesi/muga/issues/653))
+- `src/lib/affiliates.js` `TRACKING_PARAMS` — which params can be stripped universally vs must be preserved on certain landings ([#655](https://github.com/yocreoquesi/muga/issues/655))
+- `src/content/cleaner.js` `getLandingPolicy()` — runtime policy that decides per-page whether to preserve or strip ([#656](https://github.com/yocreoquesi/muga/issues/656))
+
+It is also the contract the synthetic test harness ([#650](https://github.com/yocreoquesi/muga/issues/650)) validates on every PR. Matrix changes that are not reflected in the harness will silently regress creator attribution — every entry below has a corresponding fixture target.
+
+## Methodology
+
+Per-network entries draw from three sources, listed in order of trust:
+
+1. **Direct codebase signal** — what MUGA already knows from its own integration history (TRACKING_PARAMS comments, vendored caps-spec data, redirect-unwrap tests, CHANGELOG).
+2. **Network public docs** — official help center, developer portal, publisher FAQ articles that are reachable without an account.
+3. **Third-party affiliate-marketing publications** — used only to corroborate or to surface mechanics that the networks themselves only document inside account-gated portals.
+
+For every claim, the source is cited inline with a fetch date. Claims that cannot be verified from sources 1–3 are tagged **`[NEEDS PARTNER-ACCOUNT VERIFICATION]`** and must be confirmed before the corresponding code change ships. The synthetic harness will treat unverified entries as advisory until the tag is removed.
+
+## How to read each section
+
+Each network section has the same shape:
+
+- **Surface** — the redirect host(s) and the merchant landing domain(s).
+- **Click flow** — what happens between the user clicking and the page rendering, in concrete steps.
+- **Attribution mechanism** — what carries the commission claim (cookie, URL param, S2S postback).
+- **Cookie TTL / lookback window** — when the credit window expires.
+- **Param table** — for every URL parameter the network appends, the verdict: `cookie-only`, `required-at-landing`, `required-at-checkout`, or `safe-to-strip`.
+- **Recommended cleaner policy** — the per-network rule for `getLandingPolicy()`.
+- **Verification status** — which lines are confirmed vs flagged for partner-account follow-up.
+
+The param verdicts encode the load-bearing detail of the matrix. Their meanings:
+
+| Verdict | Meaning |
+|---|---|
+| `cookie-only` | Network sets a cookie at the redirect step; the URL param is informational. Safe to strip immediately after landing. |
+| `required-at-landing` | Merchant's first-party tag reads the param from the URL on landing and persists it. **Stripping at `document_start` kills the commission.** Must preserve until the merchant tag fires. |
+| `required-at-checkout` | The param itself must remain in the URL across the entire session up to checkout — the conversion pixel reads it from the live URL, not from a cookie. Strictest preservation tier. |
+| `safe-to-strip` | Independent of attribution; cleanable on every navigation. |
+
+## Cross-cutting policy decisions
+
+These apply across all tier-1 networks unless a section overrides:
+
+1. **Redirect domains in `AFFILIATE_REDIRECT_NETWORKS` are passed through unmodified.** The redirect must execute in the browser so the network can set its own cookie. MUGA does **not** unwrap these client-side, and the URL Unwrapper feature (`unwrap.muga.app`) does **not** accept them either ([#659](https://github.com/yocreoquesi/muga/issues/659)).
+2. **First landing is detected by document.referrer.** If `document.referrer.hostname` matches a known redirect host for the network, the landing is "first-touch" and `required-at-landing` params are preserved on that initial document only. On subsequent same-site navigations (referrer is same-origin), preserved params are eligible for cleanup — the merchant's first-party cookie has already captured them.
+3. **`required-at-checkout` params are preserved across the entire session on the merchant's domain.** Stripping is gated until the user leaves the domain or the session times out.
+4. **When in doubt, preserve.** A false-positive strip silently breaks creator payouts that surface weeks later. A false-positive preserve leaves a few extra characters in the URL bar. The asymmetry is enormous — the matrix biases toward preservation.
+
+---
+
+## Awin
+
+**Surface**
+
+- Redirect host: `awin1.com` (primary), `www.awin1.com`. Variants `awinmid.com`, `aweur.com` exist in some legacy integrations and are out of scope until observed in the wild.
+- Merchant landing: any advertiser onboarded to Awin (broad — fashion, telecom, finance, retail). Awin does not own a single merchant domain; the landing is the merchant's own.
+- Redirect endpoint shapes:
+  - `awin1.com/cread.php?awinmid=<mid>&awinaffid=<aid>&p=<encoded merchant URL>` — most common publisher-generated link.
+  - `awin1.com/cread.php?ued=<encoded merchant URL>` — newer "URL encoded destination" variant.
+  - `awin1.com/awclick.php` — alternate click endpoint used in some MasterTag flows.
+
+**Click flow**
+
+1. User clicks publisher's Awin-wrapped link.
+2. Browser hits `awin1.com/cread.php` (or `awclick.php`).
+3. Awin's server logs the click with `awinmid` + `awinaffid` + timestamp; **sets a cookie on the `awin1.com` domain** and issues a 30x redirect.
+4. Browser follows redirect to the merchant landing URL with `?awc=<encoded click context>` appended.
+5. Merchant's site (typically via Awin MasterTag JS or a server-side tag) reads `awc` from the URL and stores it in a **first-party cookie on the merchant's domain**, configured `Secure` and `HttpOnly`.
+6. At checkout, the merchant's conversion pixel sends the stored `awc` back to Awin to claim the commission.
+
+**Attribution mechanism**
+
+Hybrid. The Awin-side cookie on `awin1.com` is informational (it does not survive third-party-cookie blocking like ITP). The load-bearing piece is the **merchant's first-party cookie populated from the `awc` URL param at landing**. S2S (server-to-server) is offered as a more recent ITP-resilient alternative that does not change the `awc`-at-landing requirement.
+
+Source: Awin help center, ["Cookie Tracking – Publisher FAQs"](https://success.awin.com/s/article/Cookie-Tracking-Publisher-FAQs) and ["Understanding Awin MasterTag"](https://help.awin.com/advertisers/docs/en/understanding-awin-mastertag), fetched 2026-05-24. Cross-referenced with [Awin's public attribution overview](https://www.awin.com/us/affiliate-marketing/everything-you-need-to-know-about-affiliate-tracking).
+
+**Cookie TTL / lookback window**
+
+- Retail programmes: **30 days** (industry default).
+- Travel and finance programmes: **60–90 days**, varies by advertiser.
+- Last-click attribution by default. Some advertisers run first-click or custom models — those are advertiser-configured, not network-default.
+
+**Param table**
+
+| Param | Verdict | Notes |
+|---|---|---|
+| `awc` | **required-at-landing** | Merchant MasterTag reads this on the landing page to populate the first-party cookie. Currently in `TRACKING_PARAMS` — MUST be removed from universal strip in [#655](https://github.com/yocreoquesi/muga/issues/655). |
+| `awinmid` | `cookie-only` | Merchant ID. Stored in Awin's own log; not consumed by the merchant tag. Safe to strip post-landing. |
+| `awinaffid` | `cookie-only` | Affiliate ID. Same as awinmid. Safe to strip post-landing. |
+| `p` (in cread.php URLs) | n/a (redirect-internal) | This is the encoded destination on the redirect URL itself, not on the landing page. Never strip — stripping breaks the redirect. |
+| `ued` (in cread.php URLs) | n/a (redirect-internal) | Same as `p`, newer variant. Never strip. |
+| `wt_mc` | **required-at-landing** | Webtrekk/Awin campaign tracking, used by MediaMarkt and other Awin advertisers. Currently in `TRACKING_PARAMS` — MUST be removed from universal strip. |
+
+**Recommended cleaner policy**
+
+```
+hostname matches an Awin advertiser merchant domain
+  AND document.referrer.hostname matches awin1.com (or known variant)
+  → preserve awc and wt_mc on this document
+  → safe-to-strip on subsequent same-site navigations
+```
+
+In practice, "Awin advertiser merchant domain" is open-ended — Awin does not publish the full merchant list publicly. The matrix entry for the cleaner pivots on the **referrer**, not on the merchant domain: if the user just came from `awin1.com`, treat the landing as first-touch regardless of what merchant they landed on.
+
+**Verification status**
+
+- ✅ `awc` is required at landing — confirmed by Awin publisher FAQ wording ("configure your site to record the awc value in a cookie when the user lands on your site").
+- ✅ Cookie TTL ranges — confirmed across multiple Awin help articles + third-party publishers.
+- ⚠️ **`wt_mc` is required-at-landing** — **[NEEDS PARTNER-ACCOUNT VERIFICATION]**. The MediaMarkt/Webtrekk integration is documented inside Awin's advertiser portal, not public. The current MUGA codebase comment ([`src/lib/affiliates.js:66`](../src/lib/affiliates.js)) treats it as Awin click ID by association. Treat as preserve until confirmed.
+- ⚠️ Behavior of `awc` after the MasterTag fires — **[NEEDS PARTNER-ACCOUNT VERIFICATION]**. Confidence is high that subsequent strips are safe, but the synthetic harness ([#650](https://github.com/yocreoquesi/muga/issues/650)) should specifically exercise "first landing → preserve, second navigation → strip" before this policy lands in production.
+
+---
+
+## CJ Affiliate (Commission Junction)
+
+**Surface**
+
+- Redirect hosts: 8 CJ-owned domains, all in `OPAQUE_NETWORKS` today:
+  - `anrdoezrs.net`, `dpbolvw.net`, `jdoqocy.com`, `kqzyfj.com`, `tkqlhce.com`, `emjcd.com`, `qksrv.net`, `cj.dotomi.com`
+- Merchant landing: any CJ-onboarded advertiser. Same broad coverage as Awin.
+- Endpoint shape: `<cj-domain>/click-<pid>-<aid>` plus query params, with the destination encoded in `url=` on some templates.
+
+**Click flow**
+
+1. User clicks publisher's CJ-wrapped link.
+2. Browser hits one of the 8 CJ redirect domains.
+3. CJ logs the click and **sets the `cje` cookie** on the redirect domain (this is the network-side cookie; ITP-vulnerable).
+4. Browser is redirected to the merchant landing URL with `?cjevent=<event-id>` appended (sometimes `cjdata=<encoded-extras>` too).
+5. Merchant's site reads `cjevent` from the URL and stores it in a **first-party cookie on the merchant's domain** (CJ's docs recommend a 365-day TTL for identity sync, with a 395-day PHP example).
+6. At checkout, the merchant's CJ Universal Tag reads the value from the `cje` cookie (either the network-set one if it survived, or the merchant-set first-party one) and passes it back to CJ.
+
+**Attribution mechanism**
+
+Hybrid, same family as Awin. The load-bearing piece is the **merchant's first-party cookie populated from `cjevent` at landing**. S2S is offered as an ITP-resilient alternative; it still requires the advertiser to capture, store, and pass back the Event ID — meaning `cjevent` still needs to land on the merchant page in the URL.
+
+Source: ["Commission Junction Tracking" — Trackingplan, 2026](https://webflow.trackingplan.com/blog/commission-junction-tracking), [CJ's own "HTTP Response Cookie" advertiser docs](https://developers.cj.com/docs/advertiser-site-tracking/http-response-cookie), and [CJ's ITP 2.2 advisory](https://junction.cj.com/article/advertiser-integration-solutions-for-itp-2.2-and-beyond), all fetched 2026-05-24.
+
+**Cookie TTL / lookback window**
+
+- Recommended first-party storage: **365 days** (identity sync recommendation) or 395 days per CJ's published PHP example.
+- Actual attribution window is **per advertiser**, typically 30 days for retail, longer for high-consideration verticals.
+- Last-click attribution by default. ITP 2.2: cookies set by `document.cookie` are deleted after 24 hours, hence CJ's push toward HTTP response cookies and S2S.
+
+**Param table**
+
+| Param | Verdict | Notes |
+|---|---|---|
+| `cjevent` | **required-at-landing** | The CJ Event ID. Merchant tag reads this on landing to populate the first-party cookie. Currently in `TRACKING_PARAMS` — MUST be removed from universal strip in [#655](https://github.com/yocreoquesi/muga/issues/655). |
+| `cjdata` | **required-at-landing** | Encoded extras (frequently includes additional click context). Same handling as cjevent. Currently in `TRACKING_PARAMS`. |
+| `cje` (cookie value) | n/a | This is a cookie, not a URL param. Not visible to MUGA. |
+
+**Recommended cleaner policy**
+
+```
+hostname is any merchant domain
+  AND document.referrer.hostname matches one of the 8 CJ redirect domains
+  → preserve cjevent and cjdata on this document
+  → safe-to-strip on subsequent same-site navigations
+```
+
+Same referrer-based pivot as Awin. The merchant list is not publicly enumerable, so the policy keys on the redirect domain, not on the merchant.
+
+**Verification status**
+
+- ✅ `cjevent` is required at landing — confirmed by CJ's own developer docs and multiple third-party explainers.
+- ✅ `cjdata` is in the same family — confirmed by CJ's advanced integration HTML example.
+- ✅ Cookie TTL recommendation (365–395 days) — confirmed by CJ's own example code.
+- ⚠️ Whether `cjevent` can be safely stripped after the CJ tag has fired on the merchant page — **[NEEDS PARTNER-ACCOUNT VERIFICATION]**. High confidence yes, but the synthetic harness must specifically test "first landing → preserve, second navigation → strip" before policy lands.
+- ⚠️ Whether `cjdata` is strictly required or merely informational — **[NEEDS PARTNER-ACCOUNT VERIFICATION]**. Treat as required until confirmed otherwise (bias toward preservation).
+
+---
+
+## AliExpress (Portals + multi-network)
+
+**Surface**
+
+- Redirect hosts:
+  - `s.click.aliexpress.com` — direct AliExpress Portals affiliate redirect (in `OPAQUE_NETWORKS` today).
+  - AliExpress also runs through CJ, Awin, and Admitad in some markets. Those flows are covered by the corresponding network's section above, **not** by this AliExpress-direct section.
+- Merchant landing: `aliexpress.com`, regional TLDs (`aliexpress.es`, `aliexpress.fr`, `aliexpress.de`, `aliexpress.it`, `aliexpress.com.br`, etc.), and the AliExpress mobile-app deep links.
+
+**Click flow**
+
+1. User clicks publisher's Portals affiliate link (e.g. `s.click.aliexpress.com/e/<encoded-shortcode>`).
+2. Browser hits `s.click.aliexpress.com`.
+3. AliExpress logs the click, **sets a session cookie on `.aliexpress.com`** (first-party since AliExpress owns both the redirect domain and the merchant domain — this is a structural advantage over Awin/CJ).
+4. Browser is redirected to the AliExpress product or storefront page with one or more of: `aff_trace_key`, `aff_request_id`, `algo_pvid`, `algo_expid`, `btsid`, `ws_ab_test`, `afsmartredirect`, `gatewayadapt`, `mall_affr` appended.
+5. AliExpress's own front-end tags read these params for analytics, A/B test attribution, and reinforcement of the cookie set at step 3.
+6. At checkout, AliExpress's first-party stack handles attribution — no merchant integration is needed since AliExpress IS the merchant.
+
+**Attribution mechanism**
+
+**Self-hosted, single-domain.** AliExpress is structurally different from Awin/CJ: because the redirect domain (`s.click.aliexpress.com`) and the merchant domain (`aliexpress.com`) share the eTLD+1 `aliexpress.com`, the cookie set at step 3 is already first-party from the merchant's perspective. The URL params at landing are **mostly informational/analytics rather than load-bearing for commission attribution**.
+
+That said: AliExpress is notorious for opaque, frequently-changing internal tagging. Some params *may* be used to disambiguate attribution in edge cases (cookie clearing between click and purchase, multi-publisher last-click decisions). The conservative read is: preserve on first landing; strip on subsequent same-site navigations once the cookie has settled.
+
+Source: [Strackr, "Affiliate Marketing with AliExpress"](https://strackr.com/blog/aliexpress-affiliate-program), [Avelon Network's attribution-windows reference](https://avelonetwork.com/support/brand/affiliate-attribution-windows-first-party-cookies), [AffCaptain's program review](https://affcaptain.com/affiliate-program/aliexpress-affiliate-program/), all fetched 2026-05-24.
+
+**Cookie TTL / lookback window**
+
+- **3 days** (much shorter than Awin or CJ). Industry-known short window.
+- Last-click attribution by default.
+- AliExpress's own model is specifically described as "last click — first order": the credit goes to the affiliate whose link was the last clicked before the customer's first purchase within the 3-day window.
+
+**Param table**
+
+| Param | Verdict | Notes |
+|---|---|---|
+| `aff_trace_key` | **required-at-landing** | Currently in `TRACKING_PARAMS` ([affiliates.js:95](../src/lib/affiliates.js)) — MUST be removed from universal strip in [#655](https://github.com/yocreoquesi/muga/issues/655). On first landing the AliExpress tag may use it to reinforce the cookie. |
+| `aff_request_id` | **required-at-landing** | Same family as aff_trace_key. Currently in TRACKING_PARAMS. |
+| `algo_pvid` | **required-at-landing** | A/B/algorithm tracking. Treated as required-at-landing on conservative bias; partner-account verification pending. |
+| `algo_expid` | **required-at-landing** | Same as algo_pvid. |
+| `btsid` | **required-at-landing** | Bucket/test session ID. Same handling. |
+| `ws_ab_test` | **required-at-landing** | Site A/B test bucket. Same handling. |
+| `afsmartredirect` | `cookie-only` | Redirect-internal flag, not consumed by merchant tag. Safe-to-strip post-landing. |
+| `gatewayadapt` | `cookie-only` | Same as afsmartredirect. |
+| `mall_affr` | `cookie-only` | Mall-affiliate flag, redirect-internal. |
+
+**Recommended cleaner policy**
+
+```
+hostname is *.aliexpress.* (regional TLDs included)
+  AND document.referrer.hostname is s.click.aliexpress.com
+  → preserve aff_trace_key, aff_request_id, algo_pvid, algo_expid, btsid, ws_ab_test on this document
+  → safe-to-strip on subsequent same-site navigations
+```
+
+A second policy branch covers AliExpress arriving through CJ/Awin/Admitad: in those flows, the network-side section above takes precedence (`cjevent` / `awc` matter; the AliExpress-specific params are noise).
+
+**Verification status**
+
+- ✅ 3-day cookie window — confirmed across multiple third-party publications.
+- ✅ Last-click-first-order attribution model — confirmed.
+- ⚠️ Whether `aff_trace_key` is strictly required at landing or whether the first-party cookie alone suffices — **[NEEDS PARTNER-ACCOUNT VERIFICATION]**. Inference is "required-at-landing" based on AliExpress's known frequent A/B testing of its attribution stack; conservative preservation chosen.
+- ⚠️ Whether `algo_pvid` / `algo_expid` / `btsid` / `ws_ab_test` carry attribution weight or are purely analytics — **[NEEDS PARTNER-ACCOUNT VERIFICATION]**. Treated as required-at-landing on bias.
+- ⚠️ AliExpress mobile-app deep link behavior — **[NEEDS PARTNER-ACCOUNT VERIFICATION]**. Out of scope for v0; the deep-link surface is different enough that it deserves its own matrix entry once observed.
+
+---
+
+## Quarterly review checklist
+
+To run at the **2026-08-24** review (and every quarter after):
+
+1. Re-fetch the citation URLs above and diff against the snapshot version in this doc. Network help-center pages change without notice — silently outdated citations are the failure mode this checklist exists to catch.
+2. Pull the synthetic harness results for the prior quarter ([#650](https://github.com/yocreoquesi/muga/issues/650)). Any test that flipped from green to red is a matrix-update trigger.
+3. Audit `src/lib/affiliates.js` `TRACKING_PARAMS` diffs against this matrix — any new param added by `npm run add-rule` since the last review must be cross-checked against the per-network tables above.
+4. Spot-check 5 random creator-affiliate flows in real browsers (one per tier-1 network, one through an aggregator like CJ-AliExpress, one fresh-discovery). Documented in the next QA report under `docs/qa/`.
+5. Update **Last updated** and **Next quarterly review** at the top of this file. Commit the diff as `docs: q3 review of affiliate networks matrix (#<issue>)`.
+
+## Out of scope for v0
+
+- **Tier-2 networks** (Impact Radius, Partnerize, Admitad) — covered by [#647](https://github.com/yocreoquesi/muga/issues/647).
+- **Tier-3 networks** (A8.net, Rakuten/LinkShare, TradeTracker) — covered by [#648](https://github.com/yocreoquesi/muga/issues/648).
+- **The non-redirect direct-injection programs** (Amazon Associates, eBay Partner Network, Vercel, DigitalOcean, Lemon Squeezy, Apple Performance Partners) — these use simple `?tag=` injection, are already handled correctly by `AFFILIATE_PATTERNS`, and are not affected by the 2.1 pivot.
+- **MUGA's own affiliate partnerships** with redirect networks — explicitly out of scope per ADR-0002. The matrix describes how to preserve **creator** attribution; MUGA opening its own AliExpress / CJ / Awin accounts is a 2.2+ roadmap question.
+
+## References
+
+Fetched 2026-05-24 unless otherwise noted.
+
+**Awin**
+- [Cookie Tracking — Publisher FAQs (Awin Success)](https://success.awin.com/s/article/Cookie-Tracking-Publisher-FAQs)
+- [Understanding Awin MasterTag (Awin Help)](https://help.awin.com/advertisers/docs/en/understanding-awin-mastertag)
+- [Everything you need to know about affiliate tracking (Awin)](https://www.awin.com/us/affiliate-marketing/everything-you-need-to-know-about-affiliate-tracking)
+- [Awin cookie types and attribution hierarchy (Awin Help)](https://help.awin.com/docs/awin-cookie-types-and-attribution-hierarchy)
+- [Tracking FAQs (Awin)](https://help.awin.com/advertisers/docs/en/tracking-faqs)
+
+**CJ Affiliate**
+- [Commission Junction Tracking (Trackingplan blog, 2026)](https://webflow.trackingplan.com/blog/commission-junction-tracking)
+- [HTTP Response Cookie (CJ Developer Portal)](https://developers.cj.com/docs/advertiser-site-tracking/http-response-cookie)
+- [Advertiser Integration Solutions for ITP 2.2 and Beyond (Junction by CJ)](https://junction.cj.com/article/advertiser-integration-solutions-for-itp-2.2-and-beyond)
+- [CJ's Approach to In-App, Cookieless, and Cross-Device Tracking (Junction by CJ)](https://junction.cj.com/article/cjs-approach-app-cookieless-and-cross-device-tracking)
+- [Advanced Conversion Tracking Integration HTML Example (CJ)](https://developers.cj.com/docs/advertiser-site-tracking/advanced-integration)
+
+**AliExpress**
+- [Affiliate Marketing with AliExpress: A Comprehensive Guide (Strackr)](https://strackr.com/blog/aliexpress-affiliate-program)
+- [Understanding Affiliate Attribution Windows (Avelon Network)](https://avelonetwork.com/support/brand/affiliate-attribution-windows-first-party-cookies)
+- [AliExpress Affiliate Program Review & Details (AFFCaptain)](https://affcaptain.com/affiliate-program/aliexpress-affiliate-program/)
+- [How to Start AliExpress Affiliate Marketing 2026 (Afflow)](https://afflow.co/blog/start-aliexpress-affiliate)
+
+**Internal codebase signals**
+- [`src/lib/opaque-networks.js`](../src/lib/opaque-networks.js) — current redirect host list and per-host source comments
+- [`src/lib/affiliates.js`](../src/lib/affiliates.js) — TRACKING_PARAMS with per-param notes
+- [`src/vendor/caps-spec/wrappers.json`](../src/vendor/caps-spec/wrappers.json) — Awin wrapper rule
+- [`src/vendor/caps-spec/manifest.json`](../src/vendor/caps-spec/manifest.json) — CJ affiliate program entry
+- [`tests/e2e/redirect-unwrap-merged.spec.mjs`](../tests/e2e/redirect-unwrap-merged.spec.mjs) — existing Awin/ShareASale unwrap tests (to be repurposed or retired under [#658](https://github.com/yocreoquesi/muga/issues/658))


### PR DESCRIPTION
## Summary

Closes part of [#646](https://github.com/yocreoquesi/muga/issues/646) — tier-1 sections of the affiliate networks attribution matrix.

This PR creates `docs/affiliate-networks-matrix.md`, the canonical doc that feeds:

- [#653](https://github.com/yocreoquesi/muga/issues/653) — `OPAQUE_NETWORKS` split (which redirects pass through vs unwrap)
- [#655](https://github.com/yocreoquesi/muga/issues/655) — `TRACKING_PARAMS` audit (which params can be stripped universally vs must be preserved on certain landings)
- [#656](https://github.com/yocreoquesi/muga/issues/656) — `getLandingPolicy()` implementation
- [#650](https://github.com/yocreoquesi/muga/issues/650) — synthetic harness fixtures

Documents **Awin, CJ Affiliate, and AliExpress**: redirect surface, click flow, attribution mechanism, cookie TTL, per-param verdicts, and recommended cleaner policy. Tier-2 ([#647](https://github.com/yocreoquesi/muga/issues/647)) and tier-3 ([#648](https://github.com/yocreoquesi/muga/issues/648)) follow as separate slices.

## Key finding (load-bearing for the whole pivot)

The mechanism is consistent across all three networks:

1. Redirect server logs the click and sets **its own cookie** on the redirect domain.
2. Browser is redirected to merchant landing URL with attribution params appended (`awc`, `cjevent`, `aff_trace_key`, etc.).
3. **Merchant's tag on the landing page reads those params and stores them in a first-party cookie on the merchant's domain.**
4. Conversion pixel at checkout reads from the merchant's first-party cookie.

**Stripping at `document_start` kills creator commissions** because the merchant tag has not yet captured the params. The matrix prescribes a **referrer-based `getLandingPolicy`**: preserve on first landing (referrer is the network redirect), strip on subsequent same-site navigations. This is the contract `getLandingPolicy()` will implement and the harness will enforce.

This finding inverts the 2.0 behavior: today `awc`, `wt_mc`, `cjevent`, `cjdata`, `aff_trace_key`, `algo_pvid` (and others) are in `TRACKING_PARAMS`, stripped universally and immediately. #655 must remove them from the universal list per the matrix.

## Methodology — honest about limits

Per-network entries draw from three trust tiers, in order:
1. **Direct codebase signal** (TRACKING_PARAMS comments, caps-spec data, redirect-unwrap tests, CHANGELOG).
2. **Network public docs** (help center, developer portal, publisher FAQs reachable without an account).
3. **Third-party affiliate-marketing publications** for corroboration where the networks themselves only document inside account-gated portals.

Public attribution mechanics are partially knowable. Every claim that cannot be verified from sources 1–3 is tagged **`[NEEDS PARTNER-ACCOUNT VERIFICATION]`**. The synthetic harness ([#650](https://github.com/yocreoquesi/muga/issues/650)) treats unverified entries as advisory until the tag is removed.

The doc includes a quarterly review schedule with the next checkpoint at **2026-08-24**.

## What needs partner-account verification before code changes ship

These items are flagged in the matrix and MUST be confirmed before [#655](https://github.com/yocreoquesi/muga/issues/655) or [#656](https://github.com/yocreoquesi/muga/issues/656) merges:

- Awin: `wt_mc` (Webtrekk/Awin) — currently inferred required-at-landing for MediaMarkt-style integrations.
- Awin: behavior of `awc` after the MasterTag fires (subsequent-navigation strip).
- CJ: `cjdata` strict requirement vs informational.
- CJ: behavior of `cjevent` after CJ tag fires (subsequent-navigation strip).
- AliExpress: every `aff_*` / `algo_*` / `btsid` / `ws_ab_test` is treated as required-at-landing on conservative bias; partner-account confirmation would tighten the table.
- AliExpress: mobile-app deep-link surface — out of scope for v0.

## Test plan

- [ ] Verify the doc renders correctly on GitHub (param tables, code blocks)
- [ ] Verify all internal links resolve (#646–#659, ADR-0002, source files in `src/lib/`)
- [ ] Verify all external citation links return content (no dead links at the time of PR)

No code changes → existing test suite unaffected. The matrix becomes test-enforced once [#650](https://github.com/yocreoquesi/muga/issues/650) lands.

## Followups (not blocking this PR)

- Tier-2 research → [#647](https://github.com/yocreoquesi/muga/issues/647)
- Tier-3 research → [#648](https://github.com/yocreoquesi/muga/issues/648)
- Partner-account verification rounds — will be ad-hoc PRs that remove `[NEEDS PARTNER-ACCOUNT VERIFICATION]` tags and tighten the param verdicts, each citing the verification source.