### PR TITLE
feat(tests): MVP synthetic affiliate-flow harness for tier-1 networks (#650)

### DIFF
--- a/docs/affiliate-test-harness.md
+++ b/docs/affiliate-test-harness.md
@@ -1,0 +1,80 @@
+# Affiliate Synthetic Test Harness
+
+Source of truth for the matrix-to-code contract under the 2.1 denoise pivot.
+
+The harness lives in `tests/integration/affiliate-harness.test.mjs` and reads per-network fixtures from `tests/integration/affiliate-harness/fixtures/`. It runs on every PR as part of `npm run test:integration` (the same CI step that exercises the live `unwrap.muga.app` Worker contract).
+
+## What it guards
+
+Three guards, one per matrix invariant:
+
+| Guard | Question it asks | Status today |
+|---|---|---|
+| **G1** | Does the cleaner treat every fixture's redirect host as pass-through (affiliate-redirect, NOT a generic shortener)? | HARD — must always pass |
+| **G2** | Does the cleaner strip every "tracking noise" param the fixture lists on a landing URL? | HARD — must always pass |
+| **G3** | Does the cleaner preserve every "required-at-landing" attribution param the matrix lists? | SKIPPED — blocked on [#655](https://github.com/yocreoquesi/muga/issues/655) TRACKING_PARAMS audit |
+
+G3 is skipped intentionally. The matrix v1.0 documents the attribution params that must survive landing, but the 2.0-era cleaner still strips them universally via `TRACKING_PARAMS`. #655 is the audit that migrates them out of universal-strip into the per-network `getLandingPolicy()` lookup (#656). When #655 lands, flip the skip in G3 and the harness becomes a strict gate.
+
+## MVP scope (today)
+
+Tier-1 only:
+
+- **Awin** — `awin1.com`, `www.awin1.com`
+- **CJ Affiliate** — 8 redirect domains (`anrdoezrs.net`, `dpbolvw.net`, `jdoqocy.com`, `kqzyfj.com`, `tkqlhce.com`, `emjcd.com`, `qksrv.net`, `cj.dotomi.com`)
+- **AliExpress (Portals)** — `s.click.aliexpress.com`
+
+The matrix documents six more networks (Impact, Partnerize, Admitad, A8.net, Rakuten, TradeTracker). Adding any of them is a single JSON file under `fixtures/` — no test code changes required.
+
+## How to add a network
+
+1. Confirm the network has a "Recommended cleaner policy" block in [`docs/affiliate-networks-matrix.md`](affiliate-networks-matrix.md). If not, the network is research-stage and is not ready for the harness.
+2. Create a new fixture at `tests/integration/affiliate-harness/fixtures/<slug>.json`. Use one of the existing tier-1 fixtures as a template. Fields:
+   - `network` — display name shown in the summary table.
+   - `matrix_section` — relative link to the matrix entry (for review traceability).
+   - `redirect_hosts` — every host the network uses as a click endpoint. The harness asserts each one is in `AFFILIATE_REDIRECT_NETWORKS` and NOT in `GENERIC_SHORTENERS`.
+   - `redirect_url_samples` — synthetic redirect URLs in the network's documented shape. Used by G1 to assert pass-through on real URL parsing.
+   - `landing_samples` — for each sample, a `url` plus an `expected` object listing `preserve` params (the network's attribution params from the matrix) and `strip` params (utm/fbclid/gclid/etc. that should be removed universally). `blocked_on` references the issue gating G3.
+3. Run `npm run test:integration` locally. G1 and G2 must pass; G3 will skip.
+4. Open the PR. The harness summary table will show the new network alongside the existing tier-1 ones.
+
+## The `pending_resolution` escape hatch
+
+When a fixture documents a network that the codebase does NOT yet handle the way the matrix prescribes (a known design conflict, not a bug-to-fix-in-this-PR), set a top-level `pending_resolution` string on the fixture. The runner will skip G1 for that network and surface `PENDING` in the summary table instead of `PASS`/`FAIL`.
+
+Today **Awin** is the only fixture using this flag. Awin's redirect (`awin1.com/cread.php?p=<encoded URL>`) embeds the merchant URL in the query string, so MUGA currently local-unwraps it via `src/lib/wrapper-engine.js`. Under the matrix v1.0 recommended policy, Awin should instead be in `AFFILIATE_REDIRECT_NETWORKS` (pass-through), with the `awc`/`wt_mc` preservation handled by `getLandingPolicy()` (#656) at the merchant landing. Resolving that requires a design decision (Awin wrapper retire vs. preserve the local-unwrap as a creator-fair shortcut). Until then, Awin is in the harness for G2/G3 coverage but skipped for G1.
+
+When that decision lands, remove the `pending_resolution` field from `fixtures/awin.json` and the runner will start enforcing G1 against Awin.
+
+## How to retire G3's skip
+
+When [#655](https://github.com/yocreoquesi/muga/issues/655) ships:
+
+1. Remove the `blocked_on` field from every fixture's `landing_samples[i]`.
+2. Remove the `{ skip: ... }` option from G3 in `affiliate-harness.test.mjs`.
+3. Verify the suite passes. If any G3 assertion fails, that's a real regression — investigate and either:
+   - Fix the cleaner to preserve the param at landing (likely scope of #656 `getLandingPolicy()`), or
+   - Re-verify against the matrix entry (the matrix may have shifted; the doc is the contract).
+
+## Reading the summary
+
+The runner ends with a per-network verdict block:
+
+```
+  affiliate-harness summary:
+  - Awin                          pass-through:PASS  strip:PASS  preserve:BLOCKED on #655
+  - CJ Affiliate                  pass-through:PASS  strip:PASS  preserve:BLOCKED on #655
+  - AliExpress (Portals direct)   pass-through:PASS  strip:PASS  preserve:BLOCKED on #655
+```
+
+A `FAIL` in `pass-through` means a fixture host disagrees with `AFFILIATE_REDIRECT_NETWORKS` — either the fixture needs updating or the source-of-truth list does.
+
+A `FAIL` in `strip` means a param the fixture lists as tracking noise is NOT in `TRACKING_PARAMS` — the cleaner has lost coverage and the universal-strip needs to be widened.
+
+## Why the harness lives in `tests/integration/`
+
+It depends on the live source-of-truth modules (`opaque-networks.js`, `affiliates.js`) but does NOT exercise the network or the production Worker. It belongs alongside `proxy-client-contract.test.mjs` for the same reason: contract-level checks that are too coarse for unit tests but cheap enough to run on every PR.
+
+## Weekly scheduled run (future)
+
+The issue calls for a weekly scheduled run against `rules.muga.app`. That's not part of the MVP — the current `TRACKING_PARAMS` source-of-truth is bundled, not fetched. A scheduled run becomes meaningful once `rules.muga.app` starts shipping the per-network landing policy as a signed payload. Track in a follow-up issue.

--- a/tests/integration/affiliate-harness.test.mjs
+++ b/tests/integration/affiliate-harness.test.mjs
@@ -1,0 +1,206 @@
+/** MUGA: Synthetic affiliate-flow harness (#650 MVP — tier-1) */
+//
+// Drives a contract test for the 2.1 denoise pivot's load-bearing
+// invariants on affiliate-redirect networks. Reads per-network fixtures
+// from tests/integration/affiliate-harness/fixtures/ and asserts the
+// matrix v1.0 (docs/affiliate-networks-matrix.md) policies hold against
+// the actual codebase.
+//
+// MVP scope (tier-1):
+//   - Awin       (awin1.com)
+//   - CJ         (8 redirect domains)
+//   - AliExpress (s.click.aliexpress.com)
+//
+// The other six networks (Impact, Partnerize, Admitad, A8.net, Rakuten,
+// TradeTracker) follow the same fixture shape — adding them is a JSON edit.
+// See tests/integration/affiliate-harness/README.md.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import {
+  isAffiliateRedirectNetwork,
+  isGenericShortener,
+  AFFILIATE_REDIRECT_NETWORKS,
+} from "../../src/lib/opaque-networks.js";
+import { TRACKING_PARAMS } from "../../src/lib/affiliates.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, "affiliate-harness", "fixtures");
+
+const TRACKING_PARAM_SET = new Set(TRACKING_PARAMS);
+
+function loadFixtures() {
+  return readdirSync(FIXTURE_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => ({
+      file: f,
+      data: JSON.parse(readFileSync(join(FIXTURE_DIR, f), "utf8")),
+    }));
+}
+
+const fixtures = loadFixtures();
+
+assert.ok(fixtures.length > 0, "harness must load at least one fixture");
+
+// ── G1: Redirect-host pass-through invariants ────────────────────────────────
+//
+// Every redirect host listed in the fixture must:
+//   (a) be classified as an affiliate-redirect network (so cleaner preserves
+//       it untouched — the click IS the attribution event).
+//   (b) NOT be a generic shortener (so the URL Unwrapper client gate at
+//       service-worker.js refuses to send it to unwrap.muga.app — #659).
+//   (c) be present in AFFILIATE_REDIRECT_NETWORKS (the source of truth).
+//
+// If any of these fail, an affiliate creator's commission is at risk.
+
+describe("affiliate-harness — G1: redirect-host pass-through (HARD)", () => {
+  for (const { file, data } of fixtures) {
+    const pending = data.pending_resolution;
+    const suiteName = pending
+      ? `${data.network} (${file}) — PENDING: ${pending}`
+      : `${data.network} (${file})`;
+    describe(suiteName, () => {
+      for (const host of data.redirect_hosts) {
+        test(`${host} is classified as an affiliate-redirect network`, pending ? { skip: pending } : {}, () => {
+          assert.equal(
+            isAffiliateRedirectNetwork(host),
+            true,
+            `${host} must be in AFFILIATE_REDIRECT_NETWORKS — otherwise the cleaner won't preserve it`,
+          );
+        });
+
+        test(`${host} is NOT a generic shortener (URL Unwrapper rejects it)`, pending ? { skip: pending } : {}, () => {
+          assert.equal(
+            isGenericShortener(host),
+            false,
+            `${host} must NOT be in GENERIC_SHORTENERS — otherwise the Worker would resolve it and break attribution`,
+          );
+        });
+
+        test(`${host} appears in the AFFILIATE_REDIRECT_NETWORKS export`, pending ? { skip: pending } : {}, () => {
+          // www-prefixed entries are normalised by the helper, but the raw
+          // export uses bare hosts. Strip the www. for the membership check.
+          const bare = host.replace(/^www\./, "");
+          assert.ok(
+            AFFILIATE_REDIRECT_NETWORKS.includes(bare),
+            `${bare} missing from AFFILIATE_REDIRECT_NETWORKS — fixture and source disagree`,
+          );
+        });
+      }
+
+      for (const sampleUrl of data.redirect_url_samples) {
+        test(`sample redirect URL ${sampleUrl} preserves its host as an affiliate redirect`, pending ? { skip: pending } : {}, () => {
+          const u = new URL(sampleUrl);
+          assert.equal(
+            isAffiliateRedirectNetwork(u.hostname),
+            true,
+            `redirect URL host must remain on an AFFILIATE_REDIRECT_NETWORKS entry`,
+          );
+        });
+      }
+    });
+  }
+});
+
+// ── G2: Tracking-noise is universally stripped at landing (HARD) ─────────────
+//
+// For every landing sample, the params marked `strip` must be in the
+// canonical TRACKING_PARAMS list — i.e., the cleaner removes them on any
+// site. This guards against accidental removal of utm_*/fbclid/gclid
+// coverage during refactors of TRACKING_PARAMS.
+
+describe("affiliate-harness — G2: tracking noise stripped at landing (HARD)", () => {
+  for (const { file, data } of fixtures) {
+    for (const sample of data.landing_samples) {
+      for (const param of sample.expected.strip) {
+        test(`${data.network} landing strips ${param}`, () => {
+          assert.ok(
+            TRACKING_PARAM_SET.has(param),
+            `${param} must be in TRACKING_PARAMS so the cleaner strips it on ${sample.url}`,
+          );
+        });
+      }
+    }
+  }
+});
+
+// ── G3: Attribution params are NOT in universal-strip (SKIP pending #655) ────
+//
+// For every landing sample, the params marked `preserve` (the matrix's
+// required-at-landing list) must NOT currently be inside TRACKING_PARAMS,
+// because being there means the cleaner strips them universally — killing
+// the merchant's first-party cookie sync.
+//
+// Today most of these ARE in TRACKING_PARAMS (the universal strip is the
+// 2.0 behavior). #655 is the audit that removes them and migrates the
+// per-network preservation to `getLandingPolicy()` (#656). This guard is
+// the gate that confirms #655 actually shipped — flip the skip when it does.
+
+describe("affiliate-harness — G3: attribution params preserved at landing (BLOCKED on #655)", () => {
+  for (const { file, data } of fixtures) {
+    for (const sample of data.landing_samples) {
+      const blockedOn = sample.blocked_on || "(unspecified)";
+      for (const param of sample.expected.preserve) {
+        test(
+          `${data.network} landing preserves ${param} (gated on #655)`,
+          { skip: `blocked on ${blockedOn} TRACKING_PARAMS audit — unskip when ${blockedOn} ships` },
+          () => {
+            assert.ok(
+              !TRACKING_PARAM_SET.has(param),
+              `${param} must NOT be in universal-strip TRACKING_PARAMS once ${blockedOn} lands`,
+            );
+          },
+        );
+      }
+    }
+  }
+});
+
+// ── Diagnostic: per-network verdict summary ──────────────────────────────────
+//
+// Not an assertion. Prints a readable table to the test output so reviewers
+// can scan the per-network state at a glance, satisfying the issue's
+// "Output legible: tabla per-red con verdict pass/fail" requirement.
+
+describe("affiliate-harness — per-network summary", () => {
+  test("summary table", () => {
+    const rows = [];
+    for (const { file, data } of fixtures) {
+      const stripOK = data.landing_samples.every((s) =>
+        s.expected.strip.every((p) => TRACKING_PARAM_SET.has(p)),
+      );
+      const preserveBlockedOn = data.landing_samples
+        .map((s) => s.blocked_on)
+        .filter(Boolean)
+        .pop() || "—";
+      let passThrough;
+      if (data.pending_resolution) {
+        passThrough = "PENDING";
+      } else {
+        const hostsOK = data.redirect_hosts.every(
+          (h) => isAffiliateRedirectNetwork(h) && !isGenericShortener(h),
+        );
+        passThrough = hostsOK ? "PASS" : "FAIL";
+      }
+      rows.push({
+        network: data.network,
+        pass_through: passThrough,
+        strip_at_landing: stripOK ? "PASS" : "FAIL",
+        preserve_at_landing: `BLOCKED on ${preserveBlockedOn}`,
+      });
+    }
+    const out = ["", "  affiliate-harness summary:"];
+    for (const r of rows) {
+      out.push(
+        `  - ${r.network.padEnd(30)} pass-through:${r.pass_through.padEnd(8)} strip:${r.strip_at_landing.padEnd(5)} preserve:${r.preserve_at_landing}`,
+      );
+    }
+    out.push("");
+    process.stdout.write(out.join("\n"));
+    assert.ok(rows.length > 0);
+  });
+});

--- a/tests/integration/affiliate-harness/README.md
+++ b/tests/integration/affiliate-harness/README.md
@@ -1,0 +1,29 @@
+# Affiliate Synthetic Harness — Fixtures
+
+This directory holds the per-network fixtures consumed by
+`tests/integration/affiliate-harness.test.mjs`.
+
+For the full contract and how to add a new network, see
+[`docs/affiliate-test-harness.md`](../../../docs/affiliate-test-harness.md).
+
+Quick reference — fixture shape:
+
+```json
+{
+  "network": "Display name",
+  "matrix_section": "docs/affiliate-networks-matrix.md#anchor",
+  "pending_resolution": "(optional) free-text reason why G1 should skip for this network — set only when there is a known design conflict between the matrix recommendation and the current codebase",
+  "redirect_hosts": ["redirect1.example", "redirect2.example"],
+  "redirect_url_samples": ["https://redirect1.example/click?id=1"],
+  "landing_samples": [
+    {
+      "url": "https://merchant.example/product?attribution=x&utm_source=y",
+      "expected": {
+        "preserve": ["attribution"],
+        "strip": ["utm_source"]
+      },
+      "blocked_on": "#655"
+    }
+  ]
+}
+```

--- a/tests/integration/affiliate-harness/fixtures/aliexpress.json
+++ b/tests/integration/affiliate-harness/fixtures/aliexpress.json
@@ -1,0 +1,21 @@
+{
+  "network": "AliExpress (Portals direct)",
+  "matrix_section": "docs/affiliate-networks-matrix.md#aliexpress-portals-multi-network",
+  "redirect_hosts": [
+    "s.click.aliexpress.com"
+  ],
+  "redirect_url_samples": [
+    "https://s.click.aliexpress.com/e/_oBtAfD",
+    "https://s.click.aliexpress.com/e/abc12345"
+  ],
+  "landing_samples": [
+    {
+      "url": "https://www.aliexpress.com/item/1005006789012345.html?aff_trace_key=abc&aff_request_id=def&algo_pvid=p1&algo_expid=e1&btsid=bts1&ws_ab_test=ab1&afsmartredirect=y&gatewayadapt=glo2esp&mall_affr=ali&utm_source=blog",
+      "expected": {
+        "preserve": ["aff_trace_key", "aff_request_id", "algo_pvid", "algo_expid", "btsid", "ws_ab_test"],
+        "strip": ["afsmartredirect", "gatewayadapt", "mall_affr", "utm_source"]
+      },
+      "blocked_on": "#655"
+    }
+  ]
+}

--- a/tests/integration/affiliate-harness/fixtures/awin.json
+++ b/tests/integration/affiliate-harness/fixtures/awin.json
@@ -1,0 +1,24 @@
+{
+  "network": "Awin",
+  "matrix_section": "docs/affiliate-networks-matrix.md#awin",
+  "pending_resolution": "Awin's redirect carries the merchant URL in `p=` / `ued=`, so MUGA currently local-unwraps it via wrapper-engine.js. Under 2.1 (matrix v1.0) the recommended policy is referrer-based preservation of `awc` / `wt_mc` at the merchant landing — which requires Awin to be in AFFILIATE_REDIRECT_NETWORKS (pass-through), not in the wrapper engine. Needs a design decision (separate issue) before the harness can validate G1 against Awin.",
+  "redirect_hosts": [
+    "awin1.com",
+    "www.awin1.com"
+  ],
+  "redirect_url_samples": [
+    "https://awin1.com/cread.php?awinmid=12345&awinaffid=99999&p=https%3A%2F%2Fwww.example.com%2Fproduct",
+    "https://awin1.com/cread.php?ued=https%3A%2F%2Fwww.example.com%2Fproduct",
+    "https://www.awin1.com/awclick.php?id=abc&clickref=def"
+  ],
+  "landing_samples": [
+    {
+      "url": "https://www.example.com/product?awc=11111-12345-67890&wt_mc=campaign-spring&utm_source=newsletter&utm_medium=email&fbclid=xyz",
+      "expected": {
+        "preserve": ["awc", "wt_mc"],
+        "strip": ["utm_source", "utm_medium", "fbclid"]
+      },
+      "blocked_on": "#655"
+    }
+  ]
+}

--- a/tests/integration/affiliate-harness/fixtures/cj.json
+++ b/tests/integration/affiliate-harness/fixtures/cj.json
@@ -1,0 +1,28 @@
+{
+  "network": "CJ Affiliate",
+  "matrix_section": "docs/affiliate-networks-matrix.md#cj-affiliate-commission-junction",
+  "redirect_hosts": [
+    "anrdoezrs.net",
+    "dpbolvw.net",
+    "jdoqocy.com",
+    "kqzyfj.com",
+    "tkqlhce.com",
+    "emjcd.com",
+    "qksrv.net",
+    "cj.dotomi.com"
+  ],
+  "redirect_url_samples": [
+    "https://anrdoezrs.net/click-1234567-12345678?url=https%3A%2F%2Fwww.example.com%2Fproduct",
+    "https://jdoqocy.com/click-7654321-87654321"
+  ],
+  "landing_samples": [
+    {
+      "url": "https://www.example.com/product?cjevent=abc-def-1234-5678&cjdata=encoded-extras&utm_source=affiliate&utm_campaign=summer&gclid=xyz123",
+      "expected": {
+        "preserve": ["cjevent", "cjdata"],
+        "strip": ["utm_source", "utm_campaign", "gclid"]
+      },
+      "blocked_on": "#655"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #650 (MVP scope — tier-1). Adds a fixture-driven integration harness that contractualises the matrix v1.0 invariants for the 2.1 denoise pivot. Runs on every PR via `npm run test:integration`.

## Scope (MVP)

Tier-1 only: **Awin**, **CJ Affiliate**, **AliExpress (Portals direct)**.

The other six matrix networks (Impact, Partnerize, Admitad, A8.net, Rakuten, TradeTracker) follow the same fixture shape — adding any is a single JSON file. Per-network summary table prints at end of run.

## Three guards

| Guard | Question | Status |
|---|---|---|
| **G1** | Does the cleaner treat every fixture's redirect host as pass-through (affiliate-redirect, NOT a generic shortener)? | HARD — must pass |
| **G2** | Does the cleaner strip every \"tracking noise\" param the fixture lists at landing? | HARD — must pass |
| **G3** | Does the cleaner preserve every \"required-at-landing\" attribution param? | SKIP — blocked on #655 audit |

G3 is intentionally skipped today. The matrix documents what MUST survive landing, but the 2.0-era cleaner still strips those params universally via `TRACKING_PARAMS`. When #655 lands, flip the skip and the harness becomes a strict gate.

## Hallazgo durante el build — Awin

While building this, I discovered **Awin is NOT in `AFFILIATE_REDIRECT_NETWORKS`**. Awin's redirect carries the merchant URL in `?p=<encoded URL>`, so MUGA currently local-unwraps it via `src/lib/wrapper-engine.js`. The matrix v1.0 recommended policy is pass-through with referrer-based preservation of `awc`/`wt_mc` at the merchant landing — **incompatible** with the current wrapper.

Resolving this is a design decision outside the MVP scope of this PR (\"retire the Awin wrapper, move host to AFFILIATE_REDIRECT_NETWORKS\" vs \"preserve local-unwrap as a creator-fair shortcut for Awin specifically\"). The fixture schema gains an optional `pending_resolution` field so the runner skips G1 for known design conflicts and surfaces `PENDING` in the summary table.

**Suggested follow-up issue**: \"Resolve Awin redirect model: local-unwrap (current) vs pass-through (matrix v1.0)\" — to be opened separately, references this PR.

## Per-network summary

```
  affiliate-harness summary:
  - AliExpress (Portals direct)    pass-through:PASS     strip:PASS  preserve:BLOCKED on #655
  - Awin                           pass-through:PENDING  strip:PASS  preserve:BLOCKED on #655
  - CJ Affiliate                   pass-through:PASS     strip:PASS  preserve:BLOCKED on #655
```

## Acceptance criteria (from issue)

- [x] Harness ejecuta en CI (runs in PR via `test:integration` step in `.github/workflows/ci.yml:66`)
- [ ] Cubre todas las redes documentadas en la matriz P1.4 — **3/9 (tier-1 MVP)**. The other 6 are additive issues.
- [x] Falla cuando una preservación crítica de la matriz se rompe — G1 and G2 fail loudly; G3 will once #655 ships.
- [x] Doc `docs/affiliate-test-harness.md` explica cómo agregar una red
- [x] Output legible: per-network table at end of run

Weekly scheduled run against `rules.muga.app` (also in the issue) is **not** in this PR — that becomes meaningful once `rules.muga.app` ships the per-network landing policy as a signed payload. Tracked as a follow-up.

## Test plan

- [x] `npm run test:integration` — 45 pass / 19 skip / 0 fail (the 19 skips are G3 pending #655 plus G1 for Awin pending design)
- [x] `npm test` (unit) — unchanged, still 3785/3785

## Notes

- Awin's `pending_resolution` field could also be useful for tier-3 networks that aren't yet implemented at all — the same skip path applies.
- The harness is intentionally **static** (asserts against `TRACKING_PARAMS` / `AFFILIATE_REDIRECT_NETWORKS`) rather than invoking `processUrl()`. A `processUrl()`-driven harness becomes useful once `getLandingPolicy()` (#656) lands and the cleaner gains referrer-aware behavior — at that point G3 can move from \"param NOT in universal-strip\" to \"param survives a real `processUrl()` call with referrer set\".