### PR TITLE
feat(rules): extract inline TRACKING_PREFIXES comments as note field (closes #642)

### DIFF
--- a/src/rules/rules-manifest.json
+++ b/src/rules/rules-manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-26T23:50:04.146Z",
-  "generator": "tools/generate-rules.mjs@5719fee",
+  "generatedAt": "2026-05-26T23:51:18.922Z",
+  "generator": "tools/generate-rules.mjs@2391d52",
   "tracking": [
     {
       "param": "__hsfp",
@@ -1818,43 +1818,56 @@
   ],
   "prefix_rules": [
     {
-      "prefix": "utm_"
+      "prefix": "utm_",
+      "note": "Google Analytics: utm_source, utm_medium, utm_campaign, etc."
     },
     {
-      "prefix": "cm_sw_"
+      "prefix": "cm_sw_",
+      "note": "Amazon: click/share tracking (cm_sw_r_cp_api_*, cm_sw_r_cso_*)"
     },
     {
-      "prefix": "pd_rd_"
+      "prefix": "pd_rd_",
+      "note": "Amazon: product display referral data"
     },
     {
-      "prefix": "pf_rd_"
+      "prefix": "pf_rd_",
+      "note": "Amazon: placement referral data"
     },
     {
-      "prefix": "__mk_"
+      "prefix": "__mk_",
+      "note": "Amazon: marketplace/keyboard locale selector"
     },
     {
-      "prefix": "hsa_"
+      "prefix": "hsa_",
+      "note": "HubSpot: ad tracking (hsa_acc, hsa_cam, hsa_grp, hsa_kw, etc.)"
     },
     {
-      "prefix": "mt_"
+      "prefix": "mt_",
+      "note": "Matomo: campaign tracking (mt_campaign, mt_adset, mt_click_id, etc.)"
     },
     {
-      "prefix": "int_"
+      "prefix": "int_",
+      "note": "Internal campaign params (int_source, int_medium, int_campaign, etc.)"
     },
     {
-      "prefix": "ir_"
+      "prefix": "ir_",
+      "note": "Impact Radius: affiliate tracking (ir_adid, ir_campaignid, etc.)"
     },
     {
-      "prefix": "asc_"
+      "prefix": "asc_",
+      "note": "Amazon: affiliate sub-tag variants (asc_contentid, asc_campaign, etc.)"
     },
     {
-      "prefix": "cv_ct_"
+      "prefix": "cv_ct_",
+      "note": "Amazon: conversion tracking"
     },
     {
-      "prefix": "scm_"
+      "prefix": "scm_",
+      "note": "AliExpress / Alibaba: SCM tracking variants"
     },
     {
-      "prefix": "sb-ci-"
+      "prefix": "sb-ci-",
+      "note": "Amazon: search bar click ID"
     }
   ],
   "domains": [

--- a/tests/unit/rules-manifest-sync.test.mjs
+++ b/tests/unit/rules-manifest-sync.test.mjs
@@ -76,6 +76,47 @@ describe("rules-manifest.json — structural integrity (TA-3)", () => {
       `prefix_rules[] has ${manifest.prefix_rules.length} entries but TRACKING_PREFIXES has ${TRACKING_PREFIXES.length}`
     );
   });
+
+  // ── #642: each prefix_rules entry carries a non-empty `note` field that
+  //          matches the inline // comment in src/lib/affiliates.js. The note
+  //          is the only human-readable documentation of what each prefix
+  //          tracks, so its presence is load-bearing for the manifest's
+  //          "documentation-grade" promise.
+  test("every prefix_rules entry has a non-empty note field (#642)", () => {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    for (const entry of manifest.prefix_rules) {
+      assert.ok(
+        typeof entry.note === "string" && entry.note.length > 0,
+        `prefix_rules entry "${entry.prefix}" is missing a non-empty note field`
+      );
+    }
+  });
+
+  test("each prefix note matches the inline // comment in affiliates.js (#642)", () => {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    const affiliatesSource = readFileSync(
+      join(__dirname, "../../src/lib/affiliates.js"),
+      "utf8",
+    );
+    const blockMatch = affiliatesSource.match(
+      /export\s+const\s+TRACKING_PREFIXES\s*=\s*\[([\s\S]*?)\];/,
+    );
+    assert.ok(blockMatch, "TRACKING_PREFIXES block not found in affiliates.js");
+    const lineRe = /^\s*"([^"]+)"\s*,\s*\/\/\s*(.+?)\s*$/gm;
+    const sourceNotes = new Map();
+    let m;
+    while ((m = lineRe.exec(blockMatch[1])) !== null) {
+      sourceNotes.set(m[1], m[2]);
+    }
+    for (const entry of manifest.prefix_rules) {
+      const sourceNote = sourceNotes.get(entry.prefix);
+      assert.equal(
+        entry.note,
+        sourceNote,
+        `prefix_rules note for "${entry.prefix}" diverges from the inline comment in affiliates.js — run npm run compile:rules`,
+      );
+    }
+  });
 });
 
 // ── Sync check: committed manifest matches freshly-built manifest ─────────────

--- a/tools/generate-rules.mjs
+++ b/tools/generate-rules.mjs
@@ -28,6 +28,40 @@ const ROOT = resolve(__dirname, "..");
 const DOMAIN_RULES_PATH = resolve(ROOT, "src/rules/domain-rules.json");
 const MANIFEST_PATH = resolve(ROOT, "src/rules/rules-manifest.json");
 const DNR_PATH = resolve(ROOT, "src/rules/tracking-params.json");
+const AFFILIATES_PATH = resolve(ROOT, "src/lib/affiliates.js");
+
+/**
+ * Extracts inline `// comment` text next to each entry in the TRACKING_PREFIXES
+ * literal in src/lib/affiliates.js. Returns a Map<prefix, note>.
+ *
+ * Build-time only — at runtime the comments are gone, but this is a generator.
+ * Matches lines of the form `  "prefix",   // note text` inside the
+ * `TRACKING_PREFIXES = [ ... ];` block. Lines without an inline comment yield
+ * no entry; an entry without a note is a fatal build error per #642 acceptance.
+ *
+ * @returns {Map<string,string>}
+ */
+function extractPrefixNotes() {
+  const source = readFileSync(AFFILIATES_PATH, "utf8");
+  const blockMatch = source.match(
+    /export\s+const\s+TRACKING_PREFIXES\s*=\s*\[([\s\S]*?)\];/
+  );
+  if (!blockMatch) {
+    process.stderr.write(
+      "generate-rules.mjs: could not locate TRACKING_PREFIXES block in src/lib/affiliates.js — has the literal moved?\n"
+    );
+    process.exit(1);
+  }
+  const body = blockMatch[1];
+  const notes = new Map();
+  // "prefix",  // note text
+  const lineRe = /^\s*"([^"]+)"\s*,\s*\/\/\s*(.+?)\s*$/gm;
+  let m;
+  while ((m = lineRe.exec(body)) !== null) {
+    notes.set(m[1], m[2]);
+  }
+  return notes;
+}
 
 // Deterministic category priority for tie-break (specificity-first).
 const CATEGORY_PRIORITY = ["utm", "ads", "email", "social", "platform_noise", "generic"];
@@ -133,11 +167,22 @@ export function buildManifest() {
   }
 
   // Build prefix_rules[] in source order (semantic ordering intentional).
-  const prefix_rules = TRACKING_PREFIXES.map((prefix) => {
-    // Extract inline comment from affiliates.js as the note — not available at
-    // runtime, so we derive a functional note from the prefix shape itself.
-    return { prefix };
-  });
+  // Each entry carries the inline comment from src/lib/affiliates.js as its
+  // `note` field (#642). This is build-time parsing — runtime imports lose
+  // comments, but the generator reads the file as text.
+  const prefixNotes = extractPrefixNotes();
+  const missingNotes = TRACKING_PREFIXES.filter((p) => !prefixNotes.has(p));
+  if (missingNotes.length > 0) {
+    process.stderr.write(
+      `generate-rules.mjs: TRACKING_PREFIXES entries missing inline // note in affiliates.js: ${missingNotes.join(", ")}\n` +
+      `  Each prefix must have a trailing comment explaining what it tracks. See #642.\n`
+    );
+    process.exit(1);
+  }
+  const prefix_rules = TRACKING_PREFIXES.map((prefix) => ({
+    prefix,
+    note: prefixNotes.get(prefix),
+  }));
 
   const manifest = {
     version: 1,


### PR DESCRIPTION
Closes #642. Re-opened after #711 was auto-closed when its base branch (refactor/rules-engine-v2) was deleted upon #641 merge.

## Why

Follow-up from PR #641 (sdd-verify SUGGESTION-1). The original generator emitted bare \`{ "prefix": "utm_" }\` entries with a misleading comment saying inline notes "aren't available at runtime." True at runtime, irrelevant at build time — \`generate-rules.mjs\` already reads \`domain-rules.json\` from disk and can do the same for \`affiliates.js\`.

## What changes

**\`tools/generate-rules.mjs\`** gains \`extractPrefixNotes()\` that:
1. Reads \`src/lib/affiliates.js\` as text
2. Locates the \`TRACKING_PREFIXES = [ ... ];\` literal
3. Parses each \`"prefix",  // note text\` line via regex
4. Returns \`Map<prefix, note>\`

Build fails loudly if any \`TRACKING_PREFIXES\` entry lacks an inline comment — adding a prefix without explaining what it tracks is now a CI-blocking error.

**\`src/rules/rules-manifest.json\`** regenerated. All 13 prefix_rules entries now carry their note. Sample:

\`\`\`json
{ "prefix": "utm_",   "note": "Google Analytics: utm_source, utm_medium, utm_campaign, etc." },
{ "prefix": "cm_sw_", "note": "Amazon: click/share tracking (cm_sw_r_cp_api_*, cm_sw_r_cso_*)" },
{ "prefix": "ir_",    "note": "Impact Radius: affiliate tracking (ir_adid, ir_campaignid, etc.)" }
\`\`\`

## Test coverage

Two new tests in \`tests/unit/rules-manifest-sync.test.mjs\`:

1. Every \`prefix_rules\` entry has a non-empty \`note\` field
2. Each note matches the live inline comment in \`affiliates.js\` — catches drift the same way the existing \`buildManifest()\` round-trip test catches structural drift

## Test plan

- [x] \`npm run compile:rules\` regenerates the manifest with all 13 notes
- [x] \`npm test\` — 3833/3833 pass
- [ ] CI verifies on push