### PR TITLE
ci(rules): gate src/rules/ against drift via compile:rules diff (closes #626)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate DNR rules
-        run: npm run build:rules
+      - name: Compile rules artifacts (#626)
+        run: npm run compile:rules
 
-      - name: Check DNR rules are up to date
+      - name: Check src/rules/ is up to date (#626)
+        # Asserts every generated rules artifact matches its committed form.
+        # Covers tracking-params.json, rules-manifest.json, and any future
+        # files the generator emits. The manifest is byte-deterministic — no
+        # timestamps or SHAs — so a clean diff is achievable.
         run: |
-          if ! git diff --exit-code src/rules/tracking-params.json; then
-            echo "ERROR: tracking-params.json is out of sync with affiliates.js. Run 'npm run build:rules' and commit the result."
+          if ! git diff --exit-code -- src/rules/; then
+            echo "ERROR: src/rules/ artifacts are out of sync with their source."
+            echo "Run 'npm run compile:rules' locally and commit the resulting changes."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Manual path (if you prefer):
 2. Regenerate the DNR rules file: `npm run build:rules`.
 3. Commit both `affiliates.js` and `src/rules/tracking-params.json`.
 
-`src/rules/tracking-params.json` is a **generated artifact** — do not edit it by hand. The single source of truth is `TRACKING_PARAMS` in `affiliates.js`. The CI pipeline runs `npm run build:rules` and fails if the generated file differs from what is committed.
+`src/rules/tracking-params.json` and `src/rules/rules-manifest.json` are **generated artifacts** — do not edit them by hand. The single source of truth is `TRACKING_PARAMS` (+ `TRACKING_PARAM_CATEGORIES`, `TRACKING_PREFIXES`) in `affiliates.js` and the input JSON files under `src/rules/` (e.g. `domain-rules.json`). The CI pipeline runs `npm run compile:rules` on every PR and fails if **any** file under `src/rules/` differs from what is committed (#626). The manifest is byte-deterministic (no timestamps, no SHAs) so a clean diff is always achievable.
 
 ### When to use per-domain `stripParams`
 

--- a/src/rules/rules-manifest.json
+++ b/src/rules/rules-manifest.json
@@ -1,7 +1,5 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-26T23:51:18.922Z",
-  "generator": "tools/generate-rules.mjs@2391d52",
   "tracking": [
     {
       "param": "__hsfp",

--- a/tests/unit/rules-manifest-sync.test.mjs
+++ b/tests/unit/rules-manifest-sync.test.mjs
@@ -5,9 +5,9 @@
  * consistent with the live affiliates.js source. Drift is caught at npm test
  * time so a forgotten `npm run compile:rules` doesn't silently ship stale data.
  *
- * The test ignores generatedAt and generator (both change on every run) and
- * compares all structural fields: version, tracking length, prefix_rules length,
- * all category keys, and path_rules emptiness.
+ * Compares all structural fields: version, tracking length, prefix_rules length,
+ * all category keys, and path_rules emptiness. The manifest is byte-deterministic
+ * (no timestamps or SHAs) so deepEqual against a freshly-built manifest is exact.
  *
  * Run with: node --test tests/unit/rules-manifest-sync.test.mjs
  */
@@ -122,20 +122,13 @@ describe("rules-manifest.json — structural integrity (TA-3)", () => {
 // ── Sync check: committed manifest matches freshly-built manifest ─────────────
 
 describe("rules-manifest.json — sync with live affiliates.js source", () => {
-  test("committed manifest is structurally equal to buildManifest() output (ignores generatedAt/generator)", () => {
+  test("committed manifest is deeply equal to buildManifest() output", () => {
     const committed = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
     const rebuilt = buildManifest();
 
-    // Mask volatile fields before comparison
-    const normalize = (m) => ({
-      ...m,
-      generatedAt: "MASKED",
-      generator: "MASKED",
-    });
-
     assert.deepEqual(
-      normalize(committed),
-      normalize(rebuilt),
+      committed,
+      rebuilt,
       "committed rules-manifest.json is out of sync with affiliates.js — run npm run compile:rules"
     );
   });

--- a/tools/generate-rules.mjs
+++ b/tools/generate-rules.mjs
@@ -14,7 +14,6 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, resolve } from "node:path";
-import { execSync } from "node:child_process";
 
 import {
   TRACKING_PARAMS,
@@ -86,20 +85,6 @@ function resolveCategory(param, categoriesMap) {
     );
   }
   return hits[0];
-}
-
-/**
- * Returns the git short SHA for the generator field.
- * Falls back to "local" if git is unavailable.
- *
- * @returns {string}
- */
-function getShortSha() {
-  try {
-    return execSync("git rev-parse --short HEAD", { cwd: ROOT, encoding: "utf8" }).trim();
-  } catch {
-    return "local";
-  }
 }
 
 /**
@@ -184,10 +169,11 @@ export function buildManifest() {
     note: prefixNotes.get(prefix),
   }));
 
+  // Manifest is byte-deterministic — no timestamps, no SHAs. CI gate (#626)
+  // re-runs `compile:rules` and asserts `git diff --exit-code -- src/rules/`
+  // is clean. Any volatile field added here would defeat that gate.
   const manifest = {
     version: 1,
-    generatedAt: new Date().toISOString(),
-    generator: `tools/generate-rules.mjs@${getShortSha()}`,
     tracking,
     prefix_rules,
     domains: domainRules,


### PR DESCRIPTION
## Summary

Closes #626 (audit-tier P2). Expands the existing tracking-params-only sync check into a directory-wide gate so every generated artifact under `src/rules/` is asserted to match its committed form on every PR.

**Before** — `ci.yml` ran `npm run build:rules` and `git diff --exit-code` against `src/rules/tracking-params.json` only. As the rules surface grew (`rules-manifest.json`, future path rules from #625), drift in other files slipped through silently.

**After** — `ci.yml` runs `npm run compile:rules` and `git diff --exit-code -- src/rules/`. Covers tracking-params.json, rules-manifest.json, and any future generated file by construction.

## The volatile-field gotcha

The previous manifest carried two fields that broke byte-idempotency:
- `generatedAt: new Date().toISOString()` — changed on every run.
- `generator: tools/generate-rules.mjs@<HEAD-sha>` — changed on every commit.

The sync unit test masked them; CI `git diff` could not. To make a clean directory-wide diff achievable, both are removed. They were purely informational — zero consumers in the codebase, zero load-bearing behavior.

## Changes

- `tools/generate-rules.mjs` — drop `generatedAt`, `generator`, the now-unused `getShortSha` helper, and the `node:child_process` import. Comment at the manifest object documents the determinism contract.
- `src/rules/rules-manifest.json` — regenerated without the two fields.
- `tests/unit/rules-manifest-sync.test.mjs` — drop the MASKED normalize step; `deepEqual` is now exact against `buildManifest()` output.
- `.github/workflows/ci.yml` — replace the narrow step with a directory-wide diff + clearer error message.
- `CONTRIBUTING.md` — updated the generated-artifacts note to cover `rules-manifest.json` and the directory-wide gate.

## Test plan

- [x] `npm test` — 3833 unit tests, 0 failures.
- [x] `npm run compile:rules` twice in a row → `git diff --exit-code -- src/rules/` is clean on the second run (idempotency verified locally).
- [x] CI workflow YAML syntactically valid (no parser errors).
- [ ] First CI run on this PR exercises the new gate end-to-end.

## Risk notes

- Removing `generatedAt` / `generator` is a behavioral no-op for every runtime consumer; the manifest is read for its `tracking`, `prefix_rules`, `domains`, and `path_rules` content only. Removing them only changes the shape of a doc-grade artifact whose only mention outside the generator was in the sync test that previously masked them.
- The new gate is strict — any contributor who hand-edits a file under `src/rules/` (which is the long-standing convention NOT to do) will get a clear CI failure with a "run compile:rules and commit" message.
- Independent of PR #713 (#625 path-rules extraction). When #713 merges, this PR may need a trivial rebase of `rules-manifest.json` (different content, same shape) — no functional conflict.