### PR TITLE
fix(content): dom-link-rewriter reads cleanUrl + bounce-state 2.1 pass-through guard (closes #703)

### DIFF
--- a/src/content/bounce-state-cleaner.js
+++ b/src/content/bounce-state-cleaner.js
@@ -62,7 +62,6 @@
   // shape of each entry, and any new wrapper added there should be
   // mirrored here for storage cleanup to apply.
   const WRAPPERS = [
-    { hostPatterns: ["awin1.com", "www.awin1.com"], pathPatterns: ["/cread.php", "/awclick.php"] },
     { hostPatterns: ["go.redirectingat.com", "go.skimresources.com"], pathPatterns: null },
     { hostPatterns: ["shareasale.com", "www.shareasale.com"], pathPatterns: ["/r.cfm"] },
     { hostPatterns: ["t.co"], pathPatterns: null },
@@ -75,19 +74,66 @@
     { hostPatterns: ["exit.sc"], pathPatterns: null },
     { hostPatterns: ["href.li"], pathPatterns: null },
     { hostPatterns: ["anonym.to"], pathPatterns: null },
-    // Impact Radius (*.pxf.io), Rakuten (click.linksynergy.com), and
-    // TradeTracker (tc.tradetracker.net) previously lived in this list.
-    // Retired in #692 per ADR-0003 follow-up: those hosts are now in
-    // AFFILIATE_REDIRECT_NETWORKS (pass-through), and bounce-state cleanup
-    // must NOT wipe their localStorage during the redirect step — the
-    // network needs that state to attribute the click on landing.
+    // Awin (awin1.com), Impact Radius (*.pxf.io), Rakuten
+    // (click.linksynergy.com), and TradeTracker (tc.tradetracker.net)
+    // previously lived in this list. Retired per ADR-0003 / #684 / #692:
+    // those hosts now live in AFFILIATE_REDIRECT_NETWORKS (pass-through),
+    // and bounce-state cleanup must NOT wipe their localStorage during
+    // the redirect step — the network needs that state to attribute the
+    // click on landing. The inlineDetectWrapper() guard below
+    // (INLINE_AFFILIATE_REDIRECT_NETWORKS) enforces the same invariant
+    // at runtime as defense-in-depth.
   ];
+
+  // ── Inline AFFILIATE_REDIRECT_NETWORKS guard (#703) ──────────────────
+  // Mirrors src/lib/opaque-networks.js AFFILIATE_REDIRECT_NETWORKS so the
+  // inline detector can hard-NULL any host that is in the 2.1 pass-through
+  // bucket — even if a future change accidentally re-adds one to WRAPPERS.
+  // Kept in sync by tests/unit/bounce-state-affiliate-redirect.test.mjs.
+  // Wildcard entries use the `*.suffix` shape (matches `endsWith(".suffix")`).
+  const INLINE_AFFILIATE_REDIRECT_NETWORKS = [
+    "s.click.aliexpress.com",
+    "awin1.com",
+    "www.awin1.com",
+    "anrdoezrs.net",
+    "dpbolvw.net",
+    "jdoqocy.com",
+    "kqzyfj.com",
+    "tkqlhce.com",
+    "emjcd.com",
+    "qksrv.net",
+    "cj.dotomi.com",
+    "ad.admitad.com",
+    "prf.hn",
+    "px.a8.net",
+    "*.pxf.io",
+    "click.linksynergy.com",
+    "tc.tradetracker.net",
+    "clk.tradedoubler.com",
+    "alitems.com",
+    "redirect.viglink.com",
+  ];
+
+  function isInlineAffiliateRedirectNetwork(host) {
+    for (const entry of INLINE_AFFILIATE_REDIRECT_NETWORKS) {
+      if (entry.startsWith("*.")) {
+        if (host.endsWith(entry.slice(1))) return true;
+      } else if (host === entry) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   function inlineDetectWrapper(rawUrl) {
     let url;
     try { url = new URL(rawUrl); } catch { return null; }
     if (url.protocol !== "https:" && url.protocol !== "http:") return null;
     const host = url.hostname.toLowerCase();
+    // 2.1 pass-through invariant: never report an affiliate-redirect host
+    // as a wrapper. The merchant's first-party cookie depends on landing
+    // state surviving the bounce; wiping it would silently break attribution.
+    if (isInlineAffiliateRedirectNetwork(host)) return null;
     for (const wrapper of WRAPPERS) {
       const hostMatch = wrapper.hostPatterns.some((p) =>
         typeof p === "string" ? host === p.toLowerCase() : p.test(host)

--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -94,7 +94,7 @@
       try {
         const out = bundled.processUrl(raw);
         if (typeof out === "string") return out;
-        if (out && typeof out.url === "string") return out.url;
+        if (out && typeof out.cleanUrl === "string") return out.cleanUrl;
       } catch {
         // fall through to inline subset
       }

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -114,11 +114,11 @@
     if (bundled && typeof bundled.processUrl === "function") {
       try {
         const out = bundled.processUrl(raw);
-        // processUrl returns an object on hit; the rewriter wants a
-        // string. Be defensive — if the bundled API ever changes shape,
+        // processUrl returns { cleanUrl, ... } on hit; the rewriter wants
+        // a string. Be defensive — if the bundled API ever changes shape,
         // we silently fall through to the inline subset.
         if (typeof out === "string") return out;
-        if (out && typeof out.url === "string") return out.url;
+        if (out && typeof out.cleanUrl === "string") return out.cleanUrl;
       } catch {
         // fall through to the inline subset
       }

--- a/tests/unit/bounce-state-affiliate-redirect.test.mjs
+++ b/tests/unit/bounce-state-affiliate-redirect.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * MUGA — Regression tests for the #703 invariants (bounce-state-cleaner).
+ *
+ * Two related invariants pinned here:
+ *
+ * 1. No host in `AFFILIATE_REDIRECT_NETWORKS` (the 2.1 pass-through bucket)
+ *    may appear in the inline `WRAPPERS` table inside
+ *    `src/content/bounce-state-cleaner.js`. If one did, `inlineDetectWrapper`
+ *    would match it during the race window before the bundle attaches and
+ *    `cleanIfIntermediary` would wipe the network's localStorage — silently
+ *    breaking the merchant's first-party attribution at landing.
+ *
+ *    The runtime guard `INLINE_AFFILIATE_REDIRECT_NETWORKS` is defense in
+ *    depth; this test catches the regression at CI time.
+ *
+ * 2. The inline `INLINE_AFFILIATE_REDIRECT_NETWORKS` mirror must contain
+ *    every host listed in the source-of-truth `AFFILIATE_REDIRECT_NETWORKS`
+ *    from `src/lib/opaque-networks.js`. Drift here would defeat the guard
+ *    silently — adding a new affiliate-redirect network without mirroring
+ *    it into the inline list leaves the race-window gap open.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import { AFFILIATE_REDIRECT_NETWORKS } from "../../src/lib/opaque-networks.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BOUNCE_SOURCE = readFileSync(
+  join(__dirname, "../../src/content/bounce-state-cleaner.js"),
+  "utf8",
+);
+
+/**
+ * Pulls the WRAPPERS array literal from the IIFE source. The array can't
+ * be imported (content scripts have no ES exports), so we parse the text.
+ */
+function parseInlineWrappers() {
+  const match = BOUNCE_SOURCE.match(/const WRAPPERS\s*=\s*\[([\s\S]*?)\];/);
+  assert.ok(match, "bounce-state-cleaner.js must contain a WRAPPERS array literal");
+  const hostRe = /hostPatterns:\s*\[([^\]]+)\]/g;
+  const hosts = [];
+  let m;
+  while ((m = hostRe.exec(match[1])) !== null) {
+    for (const raw of m[1].split(",")) {
+      const trimmed = raw.trim();
+      if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+        hosts.push(trimmed.slice(1, -1).toLowerCase());
+      }
+    }
+  }
+  return hosts;
+}
+
+function parseInlineAffiliateMirror() {
+  const match = BOUNCE_SOURCE.match(
+    /const INLINE_AFFILIATE_REDIRECT_NETWORKS\s*=\s*\[([\s\S]*?)\];/,
+  );
+  assert.ok(
+    match,
+    "bounce-state-cleaner.js must contain an INLINE_AFFILIATE_REDIRECT_NETWORKS array literal (the inline guard mirror)",
+  );
+  const entries = [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1].toLowerCase());
+  return entries;
+}
+
+describe("#703 — bounce-state WRAPPERS does not overlap AFFILIATE_REDIRECT_NETWORKS", () => {
+  const inlineWrapperHosts = parseInlineWrappers();
+
+  test("the WRAPPERS array is non-empty (sanity check)", () => {
+    assert.ok(
+      inlineWrapperHosts.length > 0,
+      "bounce-state WRAPPERS is empty — did the parser find the right literal?",
+    );
+  });
+
+  test("no WRAPPERS host appears in AFFILIATE_REDIRECT_NETWORKS", () => {
+    const affiliateSet = new Set(
+      AFFILIATE_REDIRECT_NETWORKS.map((h) => h.toLowerCase()),
+    );
+    for (const host of inlineWrapperHosts) {
+      assert.ok(
+        !affiliateSet.has(host),
+        `${host} is in bounce-state WRAPPERS AND in AFFILIATE_REDIRECT_NETWORKS — wiping its storage would break 2.1 pass-through attribution`,
+      );
+    }
+  });
+
+  test("awin1.com specifically is NOT in WRAPPERS (#684 / #703)", () => {
+    assert.ok(
+      !inlineWrapperHosts.includes("awin1.com"),
+      "awin1.com was retired from bounce-state WRAPPERS per #684 — see ADR-0003",
+    );
+  });
+});
+
+describe("#703 — INLINE_AFFILIATE_REDIRECT_NETWORKS mirrors the source-of-truth", () => {
+  const inlineMirror = parseInlineAffiliateMirror();
+
+  test("the inline mirror is non-empty", () => {
+    assert.ok(
+      inlineMirror.length > 0,
+      "INLINE_AFFILIATE_REDIRECT_NETWORKS is empty — the guard is a no-op",
+    );
+  });
+
+  test("every host in AFFILIATE_REDIRECT_NETWORKS is in the inline mirror", () => {
+    const mirrorSet = new Set(inlineMirror);
+    for (const host of AFFILIATE_REDIRECT_NETWORKS) {
+      assert.ok(
+        mirrorSet.has(host.toLowerCase()),
+        `${host} is in AFFILIATE_REDIRECT_NETWORKS but missing from INLINE_AFFILIATE_REDIRECT_NETWORKS — the race-window guard will not cover it`,
+      );
+    }
+  });
+
+  test("the inline mirror does not contain entries beyond AFFILIATE_REDIRECT_NETWORKS", () => {
+    const sourceSet = new Set(
+      AFFILIATE_REDIRECT_NETWORKS.map((h) => h.toLowerCase()),
+    );
+    for (const host of inlineMirror) {
+      assert.ok(
+        sourceSet.has(host),
+        `${host} is in INLINE_AFFILIATE_REDIRECT_NETWORKS but not in AFFILIATE_REDIRECT_NETWORKS — drift means the mirror is stale`,
+      );
+    }
+  });
+
+  test("inlineDetectWrapper short-circuits with isInlineAffiliateRedirectNetwork", () => {
+    // Structural check: the early-return guard must be wired into the
+    // detector. Without this call, the mirror is a dead constant.
+    assert.ok(
+      /isInlineAffiliateRedirectNetwork\(host\)/.test(BOUNCE_SOURCE),
+      "inlineDetectWrapper must call isInlineAffiliateRedirectNetwork(host) and return null when true",
+    );
+  });
+});

--- a/tests/unit/dom-link-rewriter-cleanurl.test.mjs
+++ b/tests/unit/dom-link-rewriter-cleanurl.test.mjs
@@ -1,0 +1,47 @@
+/**
+ * MUGA — Regression test for the #703 fix (dom-link-rewriter).
+ *
+ * Both `src/content/dom-link-rewriter.js` and
+ * `src/content/dom-link-rewriter-click.js` call the bundled
+ * `window.__mugaCleaner.processUrl(raw)` and consume the result. The
+ * bundled API returns `{ cleanUrl, ... }` — see `src/lib/cleaner.js`
+ * `processUrl` JSDoc and the IIFE bundle. Before the #703 fix both files
+ * read `out.url`, a property that does not exist, so the bundled cleaner
+ * was silently ignored and the inline UTM-subset ran instead at click
+ * time. DNR still caught most cases on navigation, but the click path
+ * lost the full 459-pattern cleaner.
+ *
+ * This test pins the correct property name at the source level so a
+ * future contributor cannot reintroduce the bug.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REWRITER_PATHS = [
+  join(__dirname, "../../src/content/dom-link-rewriter.js"),
+  join(__dirname, "../../src/content/dom-link-rewriter-click.js"),
+];
+
+describe("#703 — dom-link-rewriter consumes the bundled cleaner correctly", () => {
+  for (const path of REWRITER_PATHS) {
+    const source = readFileSync(path, "utf8");
+    const fileLabel = path.replace(/^.*[\\/]/, "");
+
+    test(`${fileLabel} reads out.cleanUrl, not out.url`, () => {
+      assert.ok(
+        source.includes("out.cleanUrl"),
+        `${fileLabel} must consume the bundled processUrl's cleanUrl property`,
+      );
+      assert.ok(
+        !/\bout\.url\b/.test(source),
+        `${fileLabel} must not read out.url — that property does not exist on the bundled processUrl result and silently ignores the bundle`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #703 (P1 audit bug — distribution-blocking). Three closely-related defects in \`src/content/\` that all bypassed or contradicted the 2.1 pass-through contract.

### 1. \`dom-link-rewriter*.js\`: \`out.url\` → \`out.cleanUrl\`

Both rewriters called the bundled \`processUrl()\` and consumed \`out.url\` — a property that does not exist (the bundled API returns \`cleanUrl\`, per \`src/lib/cleaner.js\` JSDoc). The branch never fired, so click-time rewriting silently fell back to the inline UTM subset and the full 459-pattern cleaner was bypassed at click time. DNR still cleaned on navigation; the user-visible breakage was narrow but real (click path lost the broader strip).

### 2. \`bounce-state-cleaner.js\`: drop \`awin1.com\` from inline WRAPPERS

Awin was retired from local-unwrap into \`AFFILIATE_REDIRECT_NETWORKS\` in #684 (ADR-0003); #692 retired Impact/Rakuten/TradeTracker the same way. The bounce-state script was missed in those PRs and would still wipe \`awin1.com\` localStorage during the race window before the bundle attaches — breaking the merchant's first-party attribution at landing.

### 3. \`bounce-state-cleaner.js\`: add \`INLINE_AFFILIATE_REDIRECT_NETWORKS\` guard

\`inlineDetectWrapper\` now hard-NULLs any host in a hardcoded mirror of \`AFFILIATE_REDIRECT_NETWORKS\`, even if a future change accidentally re-adds one to WRAPPERS. Preserves the file's documented defense-in-depth purpose (race-window coverage when the bundle hasn't attached) without coupling the content script to the bundle.

## Regression tests (9 new)

- \`tests/unit/dom-link-rewriter-cleanurl.test.mjs\` (2 tests): pins \`out.cleanUrl\` read in both rewriter files; forbids the stale \`out.url\` shape.
- \`tests/unit/bounce-state-affiliate-redirect.test.mjs\` (7 tests):
  - WRAPPERS / AFFILIATE_REDIRECT_NETWORKS disjoint invariant
  - Explicit awin1.com regression case
  - Mirror sync between \`INLINE_AFFILIATE_REDIRECT_NETWORKS\` and the source-of-truth list (both directions)
  - Structural assertion that \`inlineDetectWrapper\` calls \`isInlineAffiliateRedirectNetwork\`

## Test plan

- [x] \`npm test\` — 3858 tests, 0 failures (3849 baseline + 9 new).
- [ ] CI runs full test + e2e suites.
- [ ] Manual smoke (when 2.1 cuts beta): visit a real Awin click, confirm \`localStorage\` survives the bounce; click an Amazon link, confirm 459-pattern cleaner runs at click time (was previously only DNR-cleaning).

## Risk notes

- Content bundle (\`src/content/cleaner-bundle.js\`) NOT regenerated — verified that \`cleaner-bundle-src.mjs\` only imports from \`src/lib/\`, so changes to \`src/content/*.js\` do not affect the bundle.
- \`INLINE_AFFILIATE_REDIRECT_NETWORKS\` is a drift surface against \`AFFILIATE_REDIRECT_NETWORKS\`. The new sync test catches drift in both directions at CI time. Defense-in-depth justifies the duplication: the inline list runs during the race window when the bundle hasn't attached.
- Pure content-script fixes; no service-worker or rules changes.