### PR TITLE
refactor(sw): retire zombie code + fix INCREMENT_STAT port leak + log applyDnrState catches (closes #706)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -390,36 +390,6 @@ async function maybeFetchRemoteRules(deps) {
 // Firefox MV2 does not support declarativeNetRequest; guard all DNR calls.
 const hasDNR = typeof chrome.declarativeNetRequest !== "undefined";
 
-/**
- * Syncs remote params (signed payload) to DNR rule 1001.
- *
- * Mirrors syncCustomParamsDNR for rule 1000 but operates exclusively on
- * REMOTE_RULE_ID (1001). Rule 1000 MUST NOT appear in removeRuleIds or addRules
- * from this function. (REQ-MERGE-2, REQ-MERGE-4)
- *
- * No-op when DNR is unsupported (Firefox MV2 graceful degradation).
- *
- * @param {string[]} params - Remote params to sync. Empty array removes the rule.
- */
-async function syncRemoteParamsDNR(params) {
-  if (!hasDNR) return;
-  try {
-    if (!params || params.length === 0) {
-      await chrome.declarativeNetRequest.updateDynamicRules({
-        removeRuleIds: [REMOTE_RULE_ID],
-        addRules: [],
-      });
-      return;
-    }
-    await chrome.declarativeNetRequest.updateDynamicRules({
-      removeRuleIds: [REMOTE_RULE_ID],
-      addRules: [buildRemoteDnrRule(params)],
-    });
-  } catch (err) {
-    console.error("[MUGA] syncRemoteParamsDNR failed:", err);
-  }
-}
-
 async function syncCustomParamsDNR(customParams) {
   if (!hasDNR) return;
   try {
@@ -461,12 +431,12 @@ async function applyDnrState(prefs) {
   if (prefs.enabled && prefs.dnrEnabled && prefs.onboardingDone) {
     await chrome.declarativeNetRequest.updateEnabledRulesets({
       enableRulesetIds: ["tracking_params"],
-    }).catch(() => {}); // no-op if already enabled
+    }).catch(err => console.warn("[MUGA] applyDnrState enable:", err));
     await syncCustomParamsDNR(prefs.customParams);
   } else {
     await chrome.declarativeNetRequest.updateEnabledRulesets({
       disableRulesetIds: ["tracking_params"],
-    }).catch(() => { /* no-op if already disabled */ });
+    }).catch(err => console.warn("[MUGA] applyDnrState disable:", err));
     await syncCustomParamsDNR([]);
   }
 }
@@ -943,7 +913,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const ALLOWED_STAT_KEYS = ["urlsCleaned", "junkRemoved", "referralsSpotted"];
     if (ALLOWED_STAT_KEYS.includes(message.key)) incrementStat(message.key);
     sendResponse({ ok: true });
-    return true;
+    // incrementStat is fire-and-forget — the response above is synchronous.
+    // Returning true here keeps the message channel open for an async
+    // response that never comes, leaking one port slot per message (#706).
+    return false;
   }
 
   // exposed for future dev-tools use
@@ -1014,9 +987,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         });
         // Feature-detect flags (REQ-UI-5). Since v1.10.1 the feature no
         // longer requires chrome.alarms — the only remaining runtime gate
-        // is DNR availability. `supportsAlarms` is kept as `true` for
-        // backwards compat with any cached UI bundle that still inspects it.
-        const supportsAlarms = true;
+        // is DNR availability.
         const supportsDNR = hasDNR;
         try {
           sendResponse({
@@ -1024,7 +995,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             enabled,
             meta: localData.remoteRulesMeta,
             remoteParams: localData.remoteParams,
-            supportsAlarms,
             supportsDNR,
           });
         } catch { /* channel closed */ }

--- a/tests/unit/service-worker-patterns-drift-guard.test.mjs
+++ b/tests/unit/service-worker-patterns-drift-guard.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * MUGA — Drift guard for source-string assertions in
+ * tests/unit/service-worker-patterns.test.mjs (#706 follow-up).
+ *
+ * The audit (#706) flagged that the service-worker-patterns test file
+ * relies heavily on `swSource.includes(...)` / `.indexOf(...)` / `.slice(...)`
+ * / `.match(...)` to assert the existence of code in `service-worker.js`.
+ * This pattern creates zombie code: dead functions and fields stay alive
+ * because deleting them would break the assertions. A future contributor
+ * who tries to clean up sees red tests and reintroduces the zombie "to
+ * fix the test."
+ *
+ * This guard freezes the count of source-string assertions at the post-#706
+ * baseline. New behavioral tests (no swSource manipulation) are always OK;
+ * new source-string assertions require an explicit baseline bump in this
+ * file along with a justification.
+ *
+ * If you legitimately need to add a new source-string assertion (rare —
+ * prefer a behavioral test), update `MAX_SOURCE_STRING_ASSERTIONS` below
+ * and document WHY in the commit message. The reviewer should push back
+ * on every increment.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PATTERNS_TEST_PATH = join(
+  __dirname,
+  "service-worker-patterns.test.mjs",
+);
+
+// Baseline count after #706 cleanup. Decrement is always allowed
+// (behavioral migration of an existing assertion). Increment requires a
+// human override of this constant + commit-message rationale.
+const MAX_SOURCE_STRING_ASSERTIONS = 70;
+
+const SOURCE_STRING_PATTERN = /swSource\.(includes|indexOf|slice|match)\(/g;
+
+describe("#706 — source-string assertion drift guard", () => {
+  test(`service-worker-patterns.test.mjs has at most ${MAX_SOURCE_STRING_ASSERTIONS} swSource.* assertions`, () => {
+    const source = readFileSync(PATTERNS_TEST_PATH, "utf8");
+    const matches = source.match(SOURCE_STRING_PATTERN) || [];
+    assert.ok(
+      matches.length <= MAX_SOURCE_STRING_ASSERTIONS,
+      `service-worker-patterns.test.mjs has ${matches.length} swSource.{includes,indexOf,slice,match}() calls, ` +
+        `but the post-#706 baseline is ${MAX_SOURCE_STRING_ASSERTIONS}. ` +
+        `New source-string assertions create zombie code (#706). ` +
+        `Prefer a behavioral test. If a new source-string assertion is genuinely the right tool, ` +
+        `update MAX_SOURCE_STRING_ASSERTIONS in this file and explain the rationale in the commit.`,
+    );
+  });
+
+  test("the drift guard's baseline does not silently outpace the actual count", () => {
+    // Reverse check: if MAX is raised but the file shrinks, the constant
+    // is now wrong and someone forgot to drop it back down. This isn't
+    // load-bearing — just keeps the baseline honest as cleanups land.
+    const source = readFileSync(PATTERNS_TEST_PATH, "utf8");
+    const matches = source.match(SOURCE_STRING_PATTERN) || [];
+    const slack = MAX_SOURCE_STRING_ASSERTIONS - matches.length;
+    assert.ok(
+      slack <= 5,
+      `Baseline (${MAX_SOURCE_STRING_ASSERTIONS}) is ${slack} above the actual count (${matches.length}). ` +
+        `If a recent PR migrated source-string assertions to behavioral tests, ` +
+        `lower MAX_SOURCE_STRING_ASSERTIONS to ${matches.length} to keep the guard tight.`,
+    );
+  });
+});

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -160,24 +160,25 @@ describe("Bug #229 — whitelist/blacklist entry format", () => {
   });
 });
 
-// ── INCREMENT_STAT handler returns true ──────────────────────────────────────
+// ── INCREMENT_STAT handler returns false (#706) ──────────────────────────────
 
 describe("INCREMENT_STAT handler — response channel", () => {
-  test("INCREMENT_STAT handler returns true (keeps response channel open)", () => {
-    // All other branches return true to keep the sendResponse channel open.
-    // INCREMENT_STAT must also return true for consistency and future-safety.
+  test("INCREMENT_STAT handler returns false (fully synchronous response)", () => {
+    // incrementStat() is fire-and-forget; sendResponse({ ok: true }) is
+    // dispatched synchronously. Returning true here would keep the message
+    // channel open for an async response that never arrives, leaking one
+    // port slot per INCREMENT_STAT call (#706). Must return false.
     const handlerBlock = swSource.slice(
       swSource.indexOf('"INCREMENT_STAT"'),
       swSource.indexOf('"CLEAR_DEBUG_LOG"')
     );
-    // The block must NOT end with a bare `return;` (undefined)
     assert.ok(
-      !handlerBlock.includes("sendResponse({ ok: true });\n    return;\n"),
-      "INCREMENT_STAT must not use bare return (returns undefined, closes channel early)"
+      /return\s+false\s*;/.test(handlerBlock),
+      "INCREMENT_STAT handler must return false — sendResponse is synchronous, no async wait pending"
     );
     assert.ok(
-      handlerBlock.includes("return true;"),
-      "INCREMENT_STAT handler must return true to keep the sendResponse channel open"
+      !/return\s+true\s*;/.test(handlerBlock),
+      "INCREMENT_STAT handler must NOT return true — that would leak a port slot per call"
     );
   });
 });
@@ -550,12 +551,18 @@ describe("T2.3 — Message handler source patterns", () => {
     );
   });
 
-  test("GET_REMOTE_RULES_STATUS responds with enabled, meta, supportsAlarms, supportsDNR", () => {
+  test("GET_REMOTE_RULES_STATUS responds with enabled, meta, supportsDNR", () => {
+    // supportsAlarms was retired in #706 — zero consumers across the codebase.
+    // The field had been kept "for backwards compat with any cached UI bundle"
+    // but no such bundle existed; the assertion that pinned it was zombie code.
     const statusPos = swSource.indexOf('"GET_REMOTE_RULES_STATUS"');
     const statusBlock = swSource.slice(statusPos, statusPos + 1500);
-    assert.ok(statusBlock.includes("supportsAlarms"), "status must include supportsAlarms (REQ-UI-5)");
     assert.ok(statusBlock.includes("supportsDNR"), "status must include supportsDNR (REQ-UI-5)");
     assert.ok(statusBlock.includes("enabled"), "status must include enabled flag");
+    assert.ok(
+      !statusBlock.includes("supportsAlarms"),
+      "supportsAlarms must NOT be reintroduced — retired in #706 (zero consumers)"
+    );
   });
 
   test("all remote-rules message handlers return true (keep channel open)", () => {
@@ -660,25 +667,16 @@ describe("T2.4 — syncRemoteParamsDNR", () => {
     await assert.doesNotReject(() => syncRemoteParamsDNR(["utm_x"], undefined));
   });
 
-  test("service worker source defines syncRemoteParamsDNR function", () => {
+  test("service worker no longer defines syncRemoteParamsDNR (retired in #706)", () => {
+    // The SW-local syncRemoteParamsDNR had zero call sites — runRemoteRulesFetch
+    // in src/lib/remote-rules.js owns the rule-1001 DNR write directly. The
+    // helper was zombie code kept alive by source-presence test assertions
+    // (the audit pattern problem flagged in #706). The behavioral coverage of
+    // the operation lives in the T2.4 tests above against a local copy of the
+    // function shape, plus the integration coverage in remote-rules.test.mjs.
     assert.ok(
-      swSource.includes("syncRemoteParamsDNR"),
-      "SW must define syncRemoteParamsDNR function"
-    );
-  });
-
-  test("service worker syncRemoteParamsDNR only references REMOTE_RULE_ID (not custom)", () => {
-    // Find the syncRemoteParamsDNR function block in the SW source
-    const fnStart = swSource.indexOf("function syncRemoteParamsDNR");
-    assert.ok(fnStart !== -1, "syncRemoteParamsDNR must be defined in SW");
-    const fnBlock = swSource.slice(fnStart, fnStart + 600);
-    assert.ok(
-      fnBlock.includes("REMOTE_RULE_ID"),
-      "syncRemoteParamsDNR must use REMOTE_RULE_ID"
-    );
-    assert.ok(
-      !fnBlock.includes("DNR_CUSTOM_PARAMS_RULE_ID"),
-      "syncRemoteParamsDNR must NOT reference DNR_CUSTOM_PARAMS_RULE_ID"
+      !swSource.includes("function syncRemoteParamsDNR"),
+      "syncRemoteParamsDNR must NOT be reintroduced in SW — write happens inside runRemoteRulesFetch"
     );
   });
 });


### PR DESCRIPTION
## Summary

Closes #706 (P2 audit cluster). Four small fixes in \`src/background/service-worker.js\` whose common thread is the pattern flagged by the audit: source-string assertions in \`service-worker-patterns.test.mjs\` keep zombie code alive because deleting the code breaks the assertions.

## Code fixes

| # | Change | Impact |
|---|--------|--------|
| 1 | Delete \`syncRemoteParamsDNR\` (SW lines 404-421) | Zero call sites; real DNR write happens in \`runRemoteRulesFetch\` |
| 2 | Delete \`supportsAlarms: true\` field from \`GET_REMOTE_RULES_STATUS\` | Zero consumers across the codebase |
| 3 | \`INCREMENT_STAT\` \`return true\` → \`return false\` | Stops leaking one port slot per message (sendResponse is synchronous) |
| 4 | \`applyDnrState\` silent \`.catch(() => {})\` → \`console.warn\` | Idempotent DNR enables don't throw; the catch was absorbing real quota/policy errors |

## Test updates

- \`service-worker-patterns.test.mjs\`:
  - Two source-string assertions deleted (\`syncRemoteParamsDNR\` existence + REMOTE_RULE_ID-only content)
  - \`supportsAlarms\` assertion inverted: now asserts the field is NEVER reintroduced
  - \`INCREMENT_STAT\` assertion inverted: now asserts \`return false\` and forbids \`return true\` in the handler block

## Drift guard (new test file)

\`tests/unit/service-worker-patterns-drift-guard.test.mjs\` pins the count of \`swSource.{includes,indexOf,slice,match}(\` calls at the post-#706 baseline (**70**). New behavioral tests are always OK; new source-string assertions require an explicit baseline bump in the guard with rationale. A reverse check keeps the baseline tight if follow-ups migrate more assertions to behavioral form.

## Test plan

- [x] \`npm test\` — 3863/0 (3862 baseline + 2 guard tests − 1 dead assertion).
- [ ] CI runs full test + e2e suites.

## Risk notes

- Items 1-2 are pure deletions verified by grep across all \`src/\` consumers.
- Item 3 is a behavioral one-line change; the handler still calls \`sendResponse\` synchronously so the response shape is unchanged from the caller's POV.
- Item 4 changes log volume (will now emit warnings on real DNR errors that were previously silenced) — desired.
- The drift guard is intentionally strict to make zombie-resurrection costly. The baseline number can be lowered freely; raising requires intentional justification.