### PR TITLE
fix(options): zombie cleanup + aria-label i18n + dynamic lang select (closes #707)

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -246,6 +246,18 @@ export const TRANSLATIONS = {
     it: "Dimentica i parametri segnalati",
     ja: "報告済みパラメータをリセット",
   },
+  // #707: row label paired with forget_reported_params_btn. Previously both
+  // the row strong and the button reused forget_reported_params_btn, which
+  // rendered "Forget reported params" twice on the row.
+  forget_reported_params_label: {
+    en: "Reported params",
+    es: "Parámetros reportados",
+    pt: "Parâmetros reportados",
+    de: "Gemeldete Parameter",
+    fr: "Paramètres signalés",
+    it: "Parametri segnalati",
+    ja: "報告済みパラメータ",
+  },
   forget_reported_params_done: {
     en: "Reported list cleared",
     es: "Lista de reportes borrada",
@@ -400,7 +412,6 @@ export const TRANSLATIONS = {
   optionsRemoteRulesErrVersion:   { en: "Update was older than current. Ignored.",                                                                           es: "La actualización era más antigua que la actual. Ignorada.", pt: "Atualização era mais antiga que a atual. Ignorada.", de: "Aktualisierung war älter als die aktuelle. Ignoriert.", fr: "La mise à jour était plus ancienne que la version actuelle. Ignorée.", it: "L'aggiornamento era più vecchio di quello attuale. Ignorato.", ja: "更新が現在のバージョンより古いものでした。無視しました。" },
   optionsRemoteRulesErrStale:     { en: "Update file was too old. Ignored.",                                                                                 es: "El archivo de actualización era demasiado antiguo. Ignorado.", pt: "Arquivo de atualização era muito antigo. Ignorado.", de: "Aktualisierungsdatei war zu alt. Ignoriert.", fr: "Le fichier de mise à jour était trop ancien. Ignoré.", it: "Il file di aggiornamento era troppo vecchio. Ignorato.", ja: "更新ファイルが古すぎました。無視しました。" },
   optionsRemoteRulesErrUnknown:   { en: "Update failed. Check the console for details.",                                                                     es: "La actualización falló. Consulta la consola para más detalles.", pt: "Atualização falhou. Verifique o console para detalhes.", de: "Aktualisierung fehlgeschlagen. Details in der Konsole.", fr: "Échec de la mise à jour. Consultez la console pour plus de détails.", it: "Aggiornamento fallito. Controlla la console per i dettagli.", ja: "更新に失敗しました。詳細はコンソールを確認してください。" },
-  whatsNewRemoteRules:            { en: "New: you can enable optional updates to the tracking-parameter list in Settings. Off by default.",                                     es: "Novedad: podés activar actualizaciones opcionales de la lista de parámetros en Ajustes. Desactivado por defecto.", pt: "Novo: você pode ativar atualizações opcionais da lista de parâmetros em Configurações. Desativado por padrão.", de: "Neu: Optionale Aktualisierungen der Tracking-Parameter-Liste können in den Einstellungen aktiviert werden. Standardmäßig deaktiviert.", fr: "Nouveau : vous pouvez activer les mises à jour facultatives de la liste des paramètres de pistage dans Paramètres. Désactivé par défaut.", it: "Novità: puoi attivare aggiornamenti opzionali dell'elenco dei parametri di tracciamento nelle Impostazioni. Disattivato per impostazione predefinita.", ja: "新機能: トラッキングパラメータリストのオプション更新を設定で有効にできます。デフォルトでオフ。" },
   muga_disabled_for_domain:       { en: "MUGA is disabled on this site",                                                                                     es: "MUGA está desactivado en este sitio",                       pt: "MUGA está desativado neste site",             de: "MUGA ist auf dieser Seite deaktiviert", fr: "MUGA est désactivé sur ce site", it: "MUGA è disattivato su questo sito", ja: "MUGAはこのサイトで無効です" },
 
   // ── Advanced / Developer options ──────────────────────────────────────────
@@ -581,6 +592,17 @@ export const TRANSLATIONS = {
     it: "Attiva URL Unwrapper",
     ja: "URL Unwrapperを有効にする",
   },
+  // #707: section heading distinct from the toggle label so the section
+  // title and the row label don't both render "Enable URL Unwrapper".
+  privacy_proxy_section_title: {
+    en: 'URL Unwrapper',
+    es: 'Desempaquetador de URL',
+    pt: 'Desempacotador de URL',
+    de: 'URL Unwrapper',
+    fr: 'URL Unwrapper',
+    it: 'URL Unwrapper',
+    ja: 'URL Unwrapper',
+  },
   mode_strict_local: {
     en: 'Strict Local',
     es: 'Estricto Local',
@@ -724,6 +746,30 @@ export const TRANSLATIONS = {
     ja: "%s日前",
   },
 
+  // ── #707: aria-labels for options.html controls ─────────────────────────
+  // Until #707, these aria-labels were hardcoded English in options.html
+  // and screen-reader users on non-EN locales heard them untranslated.
+  // applyTranslations now resolves data-i18n-aria-label attributes; each
+  // control in options.html points at the matching key below.
+  aria_inject:               { en: "Enable affiliate injection",                es: "Activar la inyección de afiliado",               pt: "Ativar injeção de afiliado",                  de: "Affiliate-Injection aktivieren",                fr: "Activer l'injection d'affiliation",                it: "Attiva iniezione affiliato",                ja: "アフィリエイト注入を有効にする" },
+  aria_notify:               { en: "Enable foreign affiliate notification",     es: "Activar el aviso de afiliado ajeno",             pt: "Ativar aviso de afiliado externo",            de: "Hinweis auf fremden Affiliate aktivieren",      fr: "Activer la notification d'affiliation externe",    it: "Attiva avviso affiliato esterno",           ja: "外部アフィリエイト通知を有効にする" },
+  aria_strip_affiliates:     { en: "Remove all third-party affiliate tags",     es: "Eliminar todas las etiquetas de afiliado de terceros", pt: "Remover todas as tags de afiliado de terceiros", de: "Alle Affiliate-Tags von Dritten entfernen", fr: "Supprimer toutes les balises d'affiliation tierces", it: "Rimuovi tutti i tag di affiliazione di terzi", ja: "サードパーティのアフィリエイトタグをすべて削除" },
+  aria_context_menu:         { en: "Right-click copy clean link",               es: "Copiar enlace limpio con el botón derecho",      pt: "Copiar link limpo com clique direito",        de: "Sauberen Link per Rechtsklick kopieren",        fr: "Copier le lien propre par clic droit",             it: "Copia link pulito col tasto destro",        ja: "右クリックでクリーンリンクをコピー" },
+  aria_bl_entry:             { en: "Blacklist entry",                           es: "Entrada de la lista negra",                      pt: "Entrada da blacklist",                        de: "Blacklist-Eintrag",                             fr: "Entrée de la blacklist",                          it: "Voce della blacklist",                      ja: "ブラックリストの項目" },
+  aria_wl_entry:             { en: "Whitelist entry",                           es: "Entrada de la lista blanca",                     pt: "Entrada da whitelist",                        de: "Whitelist-Eintrag",                             fr: "Entrée de la whitelist",                          it: "Voce della whitelist",                      ja: "ホワイトリストの項目" },
+  aria_lang_select:          { en: "Display language",                          es: "Idioma de la interfaz",                          pt: "Idioma da interface",                         de: "Anzeigesprache",                                fr: "Langue d'affichage",                              it: "Lingua dell'interfaccia",                   ja: "表示言語" },
+  aria_remote_rules_toggle:  { en: "Enable remote rule updates",                es: "Activar las actualizaciones de reglas remotas",  pt: "Ativar atualizações de regras remotas",       de: "Updates externer Regeln aktivieren",            fr: "Activer les mises à jour de règles distantes",     it: "Attiva aggiornamenti regole remote",        ja: "リモートルール更新を有効にする" },
+  aria_honor_creator:        { en: "Honor Creator Mode",                        es: "Respetar el modo creador",                       pt: "Honrar Modo Criador",                         de: "Creator-Modus respektieren",                    fr: "Respecter le mode créateur",                      it: "Rispetta la modalità creatore",             ja: "クリエイターモードを尊重" },
+  aria_cal_entry:            { en: "Creator allowlist entry",                   es: "Entrada de la lista de creadores permitidos",    pt: "Entrada da lista de criadores",               de: "Eintrag der Creator-Allowlist",                 fr: "Entrée de la liste blanche des créateurs",         it: "Voce dell'allowlist creatori",              ja: "クリエイター許可リストの項目" },
+  aria_experimental_params:  { en: "Experimental shape-based param stripping",  es: "Eliminación experimental de parámetros por forma", pt: "Remoção experimental de parâmetros por forma", de: "Experimentelles formbasiertes Parameter-Stripping", fr: "Suppression expérimentale de paramètres par forme", it: "Rimozione sperimentale di parametri per forma", ja: "実験的な形状ベースのパラメータ除去" },
+  aria_dev_mode:             { en: "Show advanced settings",                    es: "Mostrar ajustes avanzados",                      pt: "Mostrar configurações avançadas",             de: "Erweiterte Einstellungen anzeigen",             fr: "Afficher les paramètres avancés",                 it: "Mostra impostazioni avanzate",              ja: "高度な設定を表示" },
+  aria_dnr_enabled:          { en: "Strip tracking parameters before navigation", es: "Eliminar parámetros de rastreo antes de navegar", pt: "Remover parâmetros de rastreamento antes de navegar", de: "Tracking-Parameter vor der Navigation entfernen", fr: "Supprimer les paramètres de pistage avant navigation", it: "Rimuovi parametri di tracciamento prima della navigazione", ja: "ナビゲーション前にトラッキングパラメータを削除" },
+  aria_unwrap_redirects:     { en: "Unwrap redirect wrappers",                  es: "Desempaquetar redirecciones",                    pt: "Desempacotar redirecionamentos",              de: "Weiterleitungs-Wrapper auflösen",               fr: "Désencapsuler les redirections",                  it: "Sbroglia i redirect",                       ja: "リダイレクトラッパーを展開" },
+  aria_block_pings:          { en: "Block tracking beacons",                    es: "Bloquear balizas de rastreo",                    pt: "Bloquear beacons de rastreamento",            de: "Tracking-Beacons blockieren",                   fr: "Bloquer les balises de pistage",                  it: "Blocca beacon di tracciamento",             ja: "トラッキングビーコンをブロック" },
+  aria_amp_redirect:         { en: "Redirect AMP pages to canonical URL",       es: "Redirigir páginas AMP a la URL canónica",        pt: "Redirecionar páginas AMP para URL canônica",  de: "AMP-Seiten zur kanonischen URL umleiten",       fr: "Rediriger les pages AMP vers l'URL canonique",     it: "Reindirizza pagine AMP all'URL canonico",   ja: "AMPページを正規URLにリダイレクト" },
+  aria_toast_duration:       { en: "Notification duration",                     es: "Duración de la notificación",                    pt: "Duração da notificação",                      de: "Benachrichtigungsdauer",                        fr: "Durée de la notification",                        it: "Durata della notifica",                     ja: "通知の表示時間" },
+  aria_cp_entry:             { en: "Custom tracking parameter",                 es: "Parámetro de rastreo personalizado",             pt: "Parâmetro de rastreamento personalizado",     de: "Eigener Tracking-Parameter",                    fr: "Paramètre de pistage personnalisé",               it: "Parametro di tracciamento personalizzato",  ja: "カスタムトラッキングパラメータ" },
+  aria_dev_url_input:        { en: "URL to test",                               es: "URL para probar",                                pt: "URL para testar",                             de: "Test-URL",                                      fr: "URL à tester",                                    it: "URL da testare",                            ja: "テスト用URL" },
 };
 
 /**
@@ -855,6 +901,14 @@ export function applyTranslations(lang) {
   document.querySelectorAll("[data-i18n-title]").forEach(el => {
     const key = el.getAttribute("data-i18n-title");
     el.title = t(key, lang);
+  });
+  // #707: data-i18n-aria-label handles screen-reader labels. Without this,
+  // every aria-label in markup is locked in source-language English and
+  // ES/PT/DE/FR/IT/JA users hear untranslated text. Always plain-string
+  // (aria-label is a text attribute, never HTML).
+  document.querySelectorAll("[data-i18n-aria-label]").forEach(el => {
+    const key = el.getAttribute("data-i18n-aria-label");
+    el.setAttribute("aria-label", t(key, lang));
   });
 }
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -304,6 +304,10 @@ input[type="text"]:not(.add-row input) {
   margin-top: 10px;
   line-height: 1.5;
 }
+/* #707: HTML applies `.hint.warn` and `.error` for semantic emphasis but
+   the rules were missing. Without them the classes are dead in the markup. */
+.hint.warn { color: var(--warning); }
+.error { color: var(--danger); }
 
 .empty {
   font-size: 12.5px;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -19,21 +19,21 @@
           <strong data-i18n="row_inject_label">Inject our affiliate tag when a link has none</strong>
           <small data-i18n="row_inject_hint">Off by default. You always pay the same price. This is how you support an independent developer at zero cost to you.</small>
         </div>
-        <label class="toggle"><input type="checkbox" id="inject" aria-label="Enable affiliate injection"><span class="slider"></span></label>
+        <label class="toggle"><input type="checkbox" id="inject" data-i18n-aria-label="aria_inject"><span class="slider"></span></label>
       </div>
       <div class="row">
         <div class="row-label">
           <strong data-i18n="row_notify_label">Alert me when a link has someone else's affiliate tag</strong>
           <small data-i18n="row_notify_hint">Shows a quick notification with options. Auto-dismisses in 15 seconds</small>
         </div>
-        <label class="toggle"><input type="checkbox" id="notify" aria-label="Enable foreign affiliate notification"><span class="slider"></span></label>
+        <label class="toggle"><input type="checkbox" id="notify" data-i18n-aria-label="aria_notify"><span class="slider"></span></label>
       </div>
       <div class="row">
         <div class="row-label">
           <strong data-i18n="row_strip_affiliates_label">Remove all affiliate tags from other sources</strong>
           <small data-i18n="row_strip_affiliates_hint">Removes affiliate tags placed by others from all links. If MUGA's affiliate injection is enabled, our tag is preserved; otherwise it is removed too.</small>
         </div>
-        <label class="toggle"><input type="checkbox" id="strip-affiliates" aria-label="Remove all third-party affiliate tags"><span class="slider"></span></label>
+        <label class="toggle"><input type="checkbox" id="strip-affiliates" data-i18n-aria-label="aria_strip_affiliates"><span class="slider"></span></label>
       </div>
     </div>
   </section>
@@ -46,7 +46,7 @@
           <strong data-i18n="row_context_menu_label">Right-click → Copy clean link or selection</strong>
           <small data-i18n="row_context_menu_hint">Works on a single link, a text selection with multiple URLs, or plain-text URLs. Alt+Shift+C copies the current tab's clean URL. Ctrl+C also auto-cleans URLs in your selection.</small>
         </div>
-        <label class="toggle"><input type="checkbox" id="context-menu-toggle" aria-label="Right-click copy clean link"><span class="slider"></span></label>
+        <label class="toggle"><input type="checkbox" id="context-menu-toggle" data-i18n-aria-label="aria_context_menu"><span class="slider"></span></label>
       </div>
     </div>
   </section>
@@ -57,7 +57,7 @@
       <div class="list-section">
         <div class="list-items" id="blacklist-items"></div>
         <div class="add-row">
-          <input id="bl-input" type="text" data-i18n-placeholder="bl_placeholder" aria-label="Blacklist entry">
+          <input id="bl-input" type="text" data-i18n-placeholder="bl_placeholder" data-i18n-aria-label="aria_bl_entry">
           <button class="add-btn" id="bl-add-btn" data-i18n="add_btn">+ Add</button>
         </div>
         <p class="hint" id="bl-hint" data-i18n="bl_hint"></p>
@@ -71,7 +71,7 @@
       <div class="list-section">
         <div class="list-items" id="whitelist-items"></div>
         <div class="add-row">
-          <input id="wl-input" type="text" data-i18n-placeholder="wl_placeholder" aria-label="Whitelist entry">
+          <input id="wl-input" type="text" data-i18n-placeholder="wl_placeholder" data-i18n-aria-label="aria_wl_entry">
           <button class="add-btn" id="wl-add-btn" data-i18n="add_btn">+ Add</button>
         </div>
         <p class="hint" id="wl-hint" data-i18n="wl_hint"></p>
@@ -88,12 +88,9 @@
           <small data-i18n="lang_hint">Affects the popup and settings page. Does not affect URL processing.</small>
           <small id="lang-community-note" class="hint" data-i18n="lang_community_note" hidden>Community-maintained — contributions welcome.</small>
         </div>
-        <select class="lang-select" id="lang-select" aria-label="Display language">
-          <option value="en">English</option>
-          <option value="es">Español</option>
-          <option value="pt">Português</option>
-          <option value="de">Deutsch</option>
-        </select>
+        <!-- #707: <option>s populated at init from SUPPORTED_LANGS so new
+             locales added in i18n.js light up automatically. -->
+        <select class="lang-select" id="lang-select" data-i18n-aria-label="aria_lang_select"></select>
       </div>
     </div>
   </section>
@@ -110,7 +107,7 @@
       </div>
       <div class="row">
         <div class="row-label">
-          <strong data-i18n="forget_reported_params_btn">Forget reported params</strong>
+          <strong data-i18n="forget_reported_params_label">Reported params</strong>
           <small data-i18n="forget_reported_params_hint">Clears the local list of params you've already reported. The same param can then be reported again.</small>
         </div>
         <button class="add-btn" id="forget-reported-params-btn" data-i18n="forget_reported_params_btn">Forget reported params</button>
@@ -118,17 +115,17 @@
     </div>
   </section>
 
-  <section class="options-section" id="remote-rules-section" hidden>
+  <section id="remote-rules-section" hidden>
     <h2 data-i18n="optionsRemoteRulesTitle"></h2>
     <div class="card">
       <div class="row">
         <div class="row-label">
-          <p class="section-desc" data-i18n="optionsRemoteRulesDesc"></p>
+          <p data-i18n="optionsRemoteRulesDesc"></p>
         </div>
       </div>
       <div class="row">
         <label class="toggle">
-          <input type="checkbox" id="remote-rules-toggle" aria-label="Enable remote rule updates">
+          <input type="checkbox" id="remote-rules-toggle" data-i18n-aria-label="aria_remote_rules_toggle">
           <span class="slider"></span>
         </label>
         <span data-i18n="optionsRemoteRulesToggle"></span>
@@ -157,16 +154,16 @@
   </section>
 
   <section id="privacy-proxy">
-    <h2 data-i18n="privacy_proxy_enabled"></h2>
+    <h2 data-i18n="privacy_proxy_section_title"></h2>
     <div class="card">
       <div class="row">
         <div class="row-label">
-          <p class="section-desc" data-i18n="privacy_proxy_disclosure"></p>
+          <p data-i18n="privacy_proxy_disclosure"></p>
         </div>
       </div>
       <div class="row">
         <label class="toggle">
-          <input type="checkbox" id="privacyProxyEnabled" aria-label="Enable URL Unwrapper">
+          <input type="checkbox" id="privacyProxyEnabled" data-i18n-aria-label="enable_privacy_proxy_cta">
           <span class="slider"></span>
         </label>
         <span data-i18n="privacy_proxy_enabled"></span>
@@ -204,13 +201,13 @@
           <strong data-i18n="honor_creator_mode_label">Honor Creator Mode</strong>
           <small data-i18n="honor_creator_mode_hint">Preserve creator referral chains on trusted redirect networks. Off by default; enable to support creators you follow.</small>
         </div>
-        <label class="toggle"><input type="checkbox" id="honor-creator-mode" aria-label="Honor Creator Mode"><span class="slider"></span></label>
+        <label class="toggle"><input type="checkbox" id="honor-creator-mode" data-i18n-aria-label="aria_honor_creator"><span class="slider"></span></label>
       </div>
       <div class="list-section creator-allowlist-section">
         <strong class="creator-allowlist-title" data-i18n="creator_allowlist_label">Creators you support</strong>
         <div class="list-items creator-allowlist-list" id="creator-allowlist-items"></div>
         <div class="add-row">
-          <input id="cal-input" type="text" data-i18n-placeholder="creator_allowlist_placeholder" aria-label="Creator allowlist entry">
+          <input id="cal-input" type="text" data-i18n-placeholder="creator_allowlist_placeholder" data-i18n-aria-label="aria_cal_entry">
           <button class="add-btn" id="cal-add-btn" data-i18n="creator_allowlist_add_btn">+ Add creator</button>
         </div>
         <p class="hint" id="cal-error" role="alert" hidden></p>
@@ -222,14 +219,14 @@
           <small data-i18n="exp_param_classes_hint">Strips params whose value shape matches a tracker pattern (long, high-entropy, base64/hex/uuid). Ships behind this flag because false positives can break some sites.</small>
           <small class="hint warn" data-i18n="exp_param_classes_warn">May break some sites. Disable if you see issues.</small>
         </div>
-        <label class="toggle"><input type="checkbox" id="experimental-param-classes" aria-label="Experimental shape-based param stripping"><span class="slider"></span></label>
+        <label class="toggle"><input type="checkbox" id="experimental-param-classes" data-i18n-aria-label="aria_experimental_params"><span class="slider"></span></label>
       </div>
       <div class="row">
         <div class="row-label">
           <strong data-i18n="advanced_mode_label">Show advanced settings</strong>
           <small data-i18n="advanced_mode_hint">Fine-grained control over URL cleaning, privacy, and developer tools</small>
         </div>
-        <label class="toggle"><input type="checkbox" id="dev-mode" aria-label="Show advanced settings"><span class="slider"></span></label>
+        <label class="toggle"><input type="checkbox" id="dev-mode" data-i18n-aria-label="aria_dev_mode"><span class="slider"></span></label>
       </div>
     </div>
     <div id="dev-tools-card" style="display:none;">
@@ -254,35 +251,35 @@
             <strong data-i18n="row_dnr_label">Denoise links before navigation</strong>
             <small data-i18n="row_dnr_hint">Cleans URLs as you type in the address bar, from bookmarks, and links from other apps. Before the page loads.</small>
           </div>
-          <label class="toggle"><input type="checkbox" id="dnr-enabled" aria-label="Strip tracking parameters before navigation"><span class="slider"></span></label>
+          <label class="toggle"><input type="checkbox" id="dnr-enabled" data-i18n-aria-label="aria_dnr_enabled"><span class="slider"></span></label>
         </div>
         <div class="row">
           <div class="row-label">
             <strong data-i18n="row_unwrap_label">Unwrap redirect wrappers</strong>
             <small data-i18n="row_unwrap_hint">Extracts the real destination from redirect-wrapper URLs (e.g., ?redirect=https://example.com)</small>
           </div>
-          <label class="toggle"><input type="checkbox" id="unwrap-redirects" aria-label="Unwrap redirect wrappers"><span class="slider"></span></label>
+          <label class="toggle"><input type="checkbox" id="unwrap-redirects" data-i18n-aria-label="aria_unwrap_redirects"><span class="slider"></span></label>
         </div>
         <div class="row">
           <div class="row-label">
             <strong data-i18n="row_pings_label">Block &lt;a ping&gt; beacons</strong>
             <small data-i18n="row_pings_hint">Removes ping attributes from links so the browser doesn't send tracking beacons on click</small>
           </div>
-          <label class="toggle"><input type="checkbox" id="block-pings" aria-label="Block tracking beacons"><span class="slider"></span></label>
+          <label class="toggle"><input type="checkbox" id="block-pings" data-i18n-aria-label="aria_block_pings"><span class="slider"></span></label>
         </div>
         <div class="row">
           <div class="row-label">
             <strong data-i18n="row_amp_label">Skip AMP detours</strong>
             <small data-i18n="row_amp_hint">Replaces AMP links with the original article URL</small>
           </div>
-          <label class="toggle"><input type="checkbox" id="amp-redirect" aria-label="Redirect AMP pages to canonical URL"><span class="slider"></span></label>
+          <label class="toggle"><input type="checkbox" id="amp-redirect" data-i18n-aria-label="aria_amp_redirect"><span class="slider"></span></label>
         </div>
         <div class="row">
           <div class="row-label">
             <strong data-i18n="row_toast_duration_label">Toast duration when a creator tag is detected</strong>
             <small data-i18n="row_toast_duration_hint">How long the notification stays visible before auto-dismissing</small>
           </div>
-          <select class="lang-select" id="toast-duration-select" aria-label="Notification duration">
+          <select class="lang-select" id="toast-duration-select" data-i18n-aria-label="aria_toast_duration">
             <option value="5">5s</option>
             <option value="10">10s</option>
             <option value="15" selected>15s</option>
@@ -302,7 +299,7 @@
         <div class="list-section">
           <div class="list-items" id="custom-params-items"></div>
           <div class="add-row">
-            <input id="cp-input" type="text" data-i18n-placeholder="cp_placeholder" aria-label="Custom tracking parameter">
+            <input id="cp-input" type="text" data-i18n-placeholder="cp_placeholder" data-i18n-aria-label="aria_cp_entry">
             <button class="add-btn" id="cp-add-btn" data-i18n="add_btn">+ Add</button>
           </div>
           <p class="hint" data-i18n="cp_hint"></p>
@@ -369,7 +366,7 @@
           <strong style="font-size:13.5px;font-weight:500;display:block;margin-bottom:6px;" data-i18n="dev_url_tester_label">URL tester</strong>
           <small style="color:var(--text2);font-size:12px;display:block;margin-bottom:10px;" data-i18n="dev_url_tester_hint">Paste any URL to see what MUGA will clean</small>
           <div class="add-row">
-            <input id="dev-url-input" type="text" style="font-family:monospace;" placeholder="https://example.com?utm_source=google&amp;fbclid=..." data-i18n-placeholder="dev_url_tester_placeholder" aria-label="URL to test">
+            <input id="dev-url-input" type="text" style="font-family:monospace;" placeholder="https://example.com?utm_source=google&amp;fbclid=..." data-i18n-placeholder="dev_url_tester_placeholder" data-i18n-aria-label="aria_dev_url_input">
             <button class="add-btn" id="dev-url-test-btn" data-i18n="dev_url_test_btn">Test</button>
           </div>
           <div id="dev-url-result" style="margin-top:10px;display:none;">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -2,9 +2,8 @@
  * MUGA: Options page
  */
 
-import { applyTranslations, getStoredLang, t } from "../lib/i18n.js";
+import { applyTranslations, getStoredLang, t, SUPPORTED_LANGS } from "../lib/i18n.js";
 import { deriveModeLabel } from "../lib/mode-label.js";
-export { deriveModeLabel };
 import { formatRelativeTime } from "../lib/relative-time.js";
 import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
 import { PREF_DEFAULTS, setPrefs, getDevMode, setDevMode } from "../lib/storage.js";
@@ -583,10 +582,22 @@ function renderStores() {
 function initLanguageSelect() {
   const select = document.getElementById("lang-select");
   const communityNote = document.getElementById("lang-community-note");
-  // Community-maintained languages (#360 / #351). Visible in the language
-  // section so users selecting PT or DE understand the support level they
-  // should expect.
-  const COMMUNITY_LANGS = new Set(["pt", "de"]);
+  // #707: populate <option>s from SUPPORTED_LANGS so every language registered
+  // in i18n.js shows up here automatically. Previously hardcoded en/es/pt/de
+  // hid fr/it/ja from the picker even though their translations were complete.
+  select.replaceChildren(
+    ...SUPPORTED_LANGS.map(({ code, label }) => {
+      const opt = document.createElement("option");
+      opt.value = code;
+      opt.textContent = label;
+      return opt;
+    }),
+  );
+  // Community-maintained languages (#360 / #351 / #707). Visible in the
+  // language section so users selecting one of these understand the support
+  // level they should expect. PT/DE were the original two; FR/IT/JA join
+  // them now that the picker exposes them.
+  const COMMUNITY_LANGS = new Set(["pt", "de", "fr", "it", "ja"]);
   function updateCommunityNote(lang) {
     if (communityNote) communityNote.hidden = !COMMUNITY_LANGS.has(lang);
   }
@@ -1150,15 +1161,6 @@ async function testUrl() {
 
 // ── Error-code → i18n-key map for remote-rules status rendering ──────────────
 
-/**
- * i18n key used in the onboarding what's-new splash (REQ-UI-6).
- * Defined here so it is trackable by the orphan-key linter until Phase 4
- * wires it into the onboarding update splash.
- * @see {@link ../onboarding/onboarding.js}
- */
-const WHATS_NEW_REMOTE_RULES_KEY = "whatsNewRemoteRules";
-void WHATS_NEW_REMOTE_RULES_KEY; // prevent lint unused-var warning
-
 /** Maps remote-rules error codes to i18n keys (design §5). */
 const REMOTE_ERR_KEYS = Object.freeze({
   NETWORK_ERROR:      "optionsRemoteRulesErrNetwork",
@@ -1410,8 +1412,9 @@ async function initPrivacyProxy(prefs) {
   const checkbox = document.getElementById("privacyProxyEnabled");
   if (!checkbox) return;
   checkbox.checked = !!prefs.privacyProxyEnabled;
-  // Set aria-label from the CTA key so screen readers announce the action
-  checkbox.setAttribute("aria-label", t("enable_privacy_proxy_cta", _currentLang));
+  // aria-label is now handled by data-i18n-aria-label="enable_privacy_proxy_cta"
+  // on the input element (#707). applyTranslations sets it on every lang
+  // change; no manual setAttribute needed here.
 
   // Initial render of the build-hash + last-verified cluster
   renderWorkerBuildHashState();

--- a/tests/e2e/options.spec.mjs
+++ b/tests/e2e/options.spec.mjs
@@ -134,9 +134,14 @@ test.describe("Options — whitelist", () => {
 });
 
 test.describe("Options — language", () => {
-  test("language selector has 4 options", async ({ optionsPage: page }) => {
+  test("language selector covers every SUPPORTED_LANGS entry", async ({ optionsPage: page }) => {
+    // #707: options are populated at init from SUPPORTED_LANGS (en/es/pt/de/fr/it/ja).
+    // Test asserts the picker is fully data-driven — a new locale added to
+    // i18n.js lights up here automatically.
     const options = page.locator("#lang-select option");
-    await expect(options).toHaveCount(4);
+    await expect(options).toHaveCount(7);
+    const codes = await options.evaluateAll((els) => els.map((e) => e.value));
+    expect(codes).toEqual(["en", "es", "pt", "de", "fr", "it", "ja"]);
   });
 
   test("switching language updates UI text", async ({ optionsPage: page }) => {

--- a/tests/unit/options-aria-i18n.test.mjs
+++ b/tests/unit/options-aria-i18n.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * MUGA — Regression tests for the #707 options-page i18n + a11y cleanup.
+ *
+ * Two invariants pinned at the source level:
+ *
+ * 1. No hardcoded `aria-label="..."` attributes in `src/options/options.html`.
+ *    Every aria-label must come from `data-i18n-aria-label="<key>"` so
+ *    screen-reader users on every supported locale hear the label in their
+ *    own language. Hardcoded English aria-labels are an a11y regression for
+ *    ES/PT/DE/FR/IT/JA users.
+ *
+ * 2. Every `data-i18n-aria-label` key resolves to a real TRANSLATIONS entry
+ *    in `src/lib/i18n.js`. A dangling key would result in the
+ *    aria-label being set to the bare key name (or empty), defeating the
+ *    purpose of the data-i18n-aria-label dance entirely.
+ *
+ * Also asserts the language `<select>` is fully data-driven from
+ * `SUPPORTED_LANGS` and no longer hardcodes a subset of locales (item 9).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import { TRANSLATIONS, SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OPTIONS_HTML = readFileSync(
+  join(__dirname, "../../src/options/options.html"),
+  "utf8",
+);
+const OPTIONS_JS = readFileSync(
+  join(__dirname, "../../src/options/options.js"),
+  "utf8",
+);
+
+describe("#707 — options-page aria-labels are i18n-driven", () => {
+  test("no hardcoded aria-label= attributes remain in options.html", () => {
+    // Negative lookbehind avoids matching the `aria-label` substring inside
+    // `data-i18n-aria-label="..."`. We only flag bare `aria-label="..."`.
+    const hardcoded = OPTIONS_HTML.match(/(?<!data-i18n-)aria-label="[^"]*"/g) || [];
+    assert.equal(
+      hardcoded.length,
+      0,
+      `options.html still contains ${hardcoded.length} hardcoded aria-label attributes: ${hardcoded.join(", ")}.\n` +
+        "Every aria-label must use data-i18n-aria-label=\"<key>\" so non-EN screen-reader users hear the translated label.",
+    );
+  });
+
+  test("every data-i18n-aria-label key resolves to a TRANSLATIONS entry", () => {
+    const keyRe = /data-i18n-aria-label="([^"]+)"/g;
+    const keys = [];
+    let m;
+    while ((m = keyRe.exec(OPTIONS_HTML)) !== null) keys.push(m[1]);
+    assert.ok(keys.length > 0, "expected at least one data-i18n-aria-label in options.html");
+    for (const key of keys) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(TRANSLATIONS, key),
+        `data-i18n-aria-label="${key}" but TRANSLATIONS["${key}"] is missing in src/lib/i18n.js`,
+      );
+    }
+  });
+
+  test("every data-i18n-aria-label entry covers all SUPPORTED_LANGS", () => {
+    const keyRe = /data-i18n-aria-label="([^"]+)"/g;
+    const keys = new Set();
+    let m;
+    while ((m = keyRe.exec(OPTIONS_HTML)) !== null) keys.add(m[1]);
+    for (const key of keys) {
+      const entry = TRANSLATIONS[key];
+      for (const { code } of SUPPORTED_LANGS) {
+        assert.ok(
+          typeof entry?.[code] === "string" && entry[code].length > 0,
+          `TRANSLATIONS["${key}"] is missing a non-empty "${code}" value — screen-reader users in ${code} would hear a blank label`,
+        );
+      }
+    }
+  });
+
+  test("options.js no longer manually overrides aria-label for privacyProxyEnabled", () => {
+    // The override at the privacyProxyEnabled init path was redundant once
+    // data-i18n-aria-label="enable_privacy_proxy_cta" was added in HTML
+    // (#707). Re-adding setAttribute("aria-label", ...) on that checkbox
+    // would shadow applyTranslations on every lang change.
+    assert.ok(
+      !/setAttribute\(\s*["']aria-label["']\s*,\s*t\(\s*["']enable_privacy_proxy_cta["']/.test(
+        OPTIONS_JS,
+      ),
+      "options.js must not manually setAttribute aria-label on #privacyProxyEnabled — let data-i18n-aria-label handle it",
+    );
+  });
+});
+
+describe("#707 — language selector is data-driven from SUPPORTED_LANGS", () => {
+  test("options.html lang-select has no hardcoded <option> children", () => {
+    const selectMatch = OPTIONS_HTML.match(
+      /<select[^>]*id="lang-select"[^>]*>([\s\S]*?)<\/select>/,
+    );
+    assert.ok(selectMatch, "lang-select must exist in options.html");
+    const inner = selectMatch[1].replace(/<!--[\s\S]*?-->/g, "").trim();
+    assert.equal(
+      inner,
+      "",
+      `lang-select must be empty in HTML (populated at runtime from SUPPORTED_LANGS); found:\n${inner}`,
+    );
+  });
+
+  test("options.js populates lang-select from SUPPORTED_LANGS at init", () => {
+    assert.ok(
+      /SUPPORTED_LANGS\.map/.test(OPTIONS_JS) || /for\s*\([^)]*SUPPORTED_LANGS/.test(OPTIONS_JS),
+      "options.js must iterate SUPPORTED_LANGS to populate the lang-select dropdown (otherwise the picker silently drops fr/it/ja)",
+    );
+  });
+});
+
+describe("#707 — i18n keys retired or added by this change", () => {
+  test("whatsNewRemoteRules key is retired (#707 dead delete)", () => {
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(TRANSLATIONS, "whatsNewRemoteRules"),
+      "whatsNewRemoteRules was a Phase-4 placeholder never wired into the UI; retired in #707",
+    );
+  });
+
+  test("forget_reported_params_label is added (#707 i18n key split)", () => {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(TRANSLATIONS, "forget_reported_params_label"),
+      "forget_reported_params_label must exist — split from forget_reported_params_btn so the row label and button label differ",
+    );
+  });
+
+  test("privacy_proxy_section_title is added (#707 i18n key split)", () => {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(TRANSLATIONS, "privacy_proxy_section_title"),
+      "privacy_proxy_section_title must exist — split from privacy_proxy_enabled so the section h2 and the toggle label differ",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #707 (P2 audit cluster). Nine items in the options/ surface — mix of dead-code deletes and small but real UX/a11y fixes.

## Dead deletes

1. \`options.js\`: drop the \`deriveModeLabel\` re-export — zero importers.
2. \`options.js\`: drop \`WHATS_NEW_REMOTE_RULES_KEY\` + matching \`whatsNewRemoteRules\` entry in \`i18n.js\`. Phase-4 placeholder that never landed.
3. \`options.html\`: drop dead-CSS-hook class attributes (\`options-section\`, \`section-desc\`) — no matching rules.

## i18n key splits (de-duplicating label + section title reuse)

4. New \`privacy_proxy_section_title\` key — section h2 and toggle both rendered \"Enable URL Unwrapper\".
7. New \`forget_reported_params_label\` key — row strong and button both rendered \"Forget reported params\".

## CSS

6. \`options.css\`: add \`.error\` and \`.hint.warn\` rules. HTML applied them for semantic emphasis but rules were missing.

## A11y — aria-labels are now i18n-driven (biggest item)

8. Until this PR, every aria-label in \`options.html\` was a hardcoded English string. \`applyTranslations\` in \`i18n.js\` did not handle \`data-i18n-aria-label\`, so screen-reader users on ES/PT/DE/FR/IT/JA heard untranslated labels.

   - \`applyTranslations\` now resolves \`data-i18n-aria-label\` attributes (same pattern as the existing \`data-i18n-placeholder\` / \`data-i18n-title\` handlers).
   - All 19 hardcoded \`aria-label\` attributes in \`options.html\` replaced with \`data-i18n-aria-label=\"<key>\"\`.
   - 18 new \`aria_*\` keys added to \`TRANSLATIONS\`. \`#privacyProxyEnabled\` reuses the existing \`enable_privacy_proxy_cta\` key.
   - The manual \`setAttribute(\"aria-label\", t(...))\` in \`options.js\` is removed.

## Dynamic language selector

9. \`lang-select\` no longer hardcodes \`en/es/pt/de\` \`<option>\`s. Populated at init from \`SUPPORTED_LANGS\`, so \`fr/it/ja\` (full translations already shipped) light up automatically. \`COMMUNITY_LANGS\` expanded to include them.

## Spanish style

All new Spanish strings (es) are **Castilian (es-ES)**, not Argentine voseo or LATAM-leaning vocabulary. Per project convention: \`tags\` → \`etiquetas\`, \`clic derecho\` → \`botón derecho\`, \`honrar\` → \`respetar\`, etc.

## Note on item 5 (bl_hint / wl_hint)

Audit claim was wrong — both keys have full content in \`i18n.js\` and are registered in \`HTML_KEYS\`, so \`applyTranslations\` renders them via \`sanitizeHTML(innerHTML)\`. Documented in commit message so a future audit doesn't re-flag.

## Regression tests (10 new)

\`tests/unit/options-aria-i18n.test.mjs\`:

- No hardcoded \`aria-label=\` attributes remain
- Every \`data-i18n-aria-label\` key resolves to a \`TRANSLATIONS\` entry
- Every aria entry has non-empty strings for every \`SUPPORTED_LANGS\` code
- \`options.js\` no longer overrides aria-label manually
- \`lang-select\` has no hardcoded \`<option>\` children
- \`options.js\` iterates \`SUPPORTED_LANGS\` to populate the dropdown
- \`whatsNewRemoteRules\` retired; \`forget_reported_params_label\` + \`privacy_proxy_section_title\` added

## Test plan

- [x] \`npm test\` — 3952 / 0 (3943 baseline + 9 new tests in this file).
- [ ] CI runs full test + e2e suites.