### PR TITLE
chore(audit): stale comments + dead ternary (#728 items 19/20/22/23)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1292,8 +1292,9 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
 }
 
 // --- Remote-rules deps factory ---
-// Builds the deps object for runRemoteRulesFetch. Centralised so onAlarm
-// and ENABLE_REMOTE_RULES message handler use exactly the same deps.
+// Builds the deps object for runRemoteRulesFetch. Centralised so the
+// ENABLE_REMOTE_RULES message handler and the startup/wake fetch paths
+// (maybeFetchRemoteRules) use exactly the same deps.
 //
 // Test-only key override (design §13.5, T7.2):
 //   When globalThis.__MUGA_TRUSTED_KEYS__ is set, use it instead of the

--- a/src/content/bounce-state-cleaner.js
+++ b/src/content/bounce-state-cleaner.js
@@ -223,8 +223,9 @@
   // decision and only act once the gate confirms enabled. Because the
   // storage state is persistent, a late-arriving gate event (after the
   // page has already loaded) still has work to do — we re-attempt on
-  // each gate-open event until we successfully observe a non-zero
-  // cleanup OR the URL stops being an intermediary.
+  // each gate-open event until the first time the cleaner acts on an
+  // intermediary URL (result.cleaned === true), which performs the clear
+  // regardless of how many keys were present. After that we latch off.
   let _haveCleaned = false;
 
   function attemptCleanup() {

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -427,8 +427,10 @@ export async function fetchWithCap(url, { timeoutMs, maxBytes, fetchImpl }) {
         signal: ac.signal,
       });
     } catch (err) {
-      const msg = err?.name === "AbortError" ? ERR.NETWORK_ERROR : ERR.NETWORK_ERROR;
-      const e = new Error(msg);
+      // fetch() rejects on transport failure AND on timeout abort (err.name
+      // === "AbortError"); both collapse to NETWORK_ERROR — there is no
+      // distinct timeout code in ERR, so they are deliberately the same.
+      const e = new Error(ERR.NETWORK_ERROR);
       e.code = ERR.NETWORK_ERROR;
       throw e;
     }

--- a/tests/unit/wrapper-dnr-rules-sync.test.mjs
+++ b/tests/unit/wrapper-dnr-rules-sync.test.mjs
@@ -13,11 +13,9 @@
  *   npm run build:dnr
  *   git add src/rules/wrapper-dnr-rules.json
  *
- * and re-run the suite. The CI gate path was *not* configured for this
- * artifact at all (build:dnr is missing from .github/workflows/ci.yml's
- * sync checks — the gate at lines 33-48 only covers tracking-params.json
- * and cleaner-bundle.js); this is the only line of defense for #504's
- * artifact.
+ * and re-run the suite. CI also gates this artifact: .github/workflows/ci.yml
+ * runs `npm run build:dnr` and fails on any `git diff` in `src/rules/` (added
+ * in #722), so drift is caught both here and in the pipeline.
  */
 
 import { test } from "node:test";


### PR DESCRIPTION
Part of the #728 P3 tier. Pure documentation / dead-code cleanup — **no behavior change**.

- **item 22** `remote-rules.js`: collapse the dead `AbortError` ternary (both arms were `ERR.NETWORK_ERROR`; there is no distinct timeout code, so they're deliberately equal). Comment added explaining why.
- **item 19** `bounce-state-cleaner.js`: docblock said "non-zero cleanup" but the code latches on the first intermediary match (`result.cleaned === true`) regardless of how many keys cleared. Comment now matches the code.
- **item 20** `wrapper-dnr-rules-sync.test.mjs`: comment claimed CI didn't gate `build:dnr`; #722 added the `src/rules/` diff gate. Updated.
- **item 23** `service-worker.js`: `_remoteRulesDeps` comment referenced `onAlarm`, but the alarm path was removed. Now references the real callers (ENABLE_REMOTE_RULES handler + maybeFetchRemoteRules wake/startup).

Refs #728.