### PR TITLE
fix(lib): input-validation hardening (#728 items 21/24/28)

### DIFF
--- a/src/lib/migration-evaluator.js
+++ b/src/lib/migration-evaluator.js
@@ -77,6 +77,11 @@ export function evaluateMigrations({
     // would require NOT persisting it (a separate UX decision).
     if (responses[m.id]) continue;
 
+    // A migration with no proposedValue map cannot be evaluated for "already
+    // matches" — skip defensively instead of throwing on Object.keys(undefined).
+    // Matters at the override boundary (custom `migrations` arg in tests). (#728 item 21)
+    if (!m.proposedValue || typeof m.proposedValue !== "object") continue;
+
     // Pref state already matches the proposed value? Skip — nothing to ask.
     let alreadyMatches = true;
     for (const key of Object.keys(m.proposedValue)) {

--- a/src/lib/per-device-prefs.js
+++ b/src/lib/per-device-prefs.js
@@ -18,6 +18,8 @@
  * `synced-affiliate-pref-guard.js`.
  */
 
+import { GUARDED_PREFS } from "./synced-affiliate-pref-guard.js";
+
 const STORAGE_KEY = "mugaPerDevicePrefs";
 
 /**
@@ -50,6 +52,18 @@ export async function getOverrides() {
 export async function setOverrides(partial) {
   if (!partial || typeof partial !== "object") {
     throw new TypeError("per-device-prefs.setOverrides: partial must be an object");
+  }
+  // Enforce the documented {Object<string, boolean>} shape (#728 item 24): only
+  // GUARDED_PREFS keys, only boolean values. Silently merging arbitrary keys or
+  // non-boolean values would smuggle junk into the local overrides map that
+  // getPrefs() later overlays on top of the synced prefs.
+  for (const [key, value] of Object.entries(partial)) {
+    if (!GUARDED_PREFS.includes(key)) {
+      throw new TypeError(`per-device-prefs.setOverrides: unknown override key "${key}"`);
+    }
+    if (typeof value !== "boolean") {
+      throw new TypeError(`per-device-prefs.setOverrides: override "${key}" must be a boolean`);
+    }
   }
   const current = await getOverrides();
   const next = { ...current, ...partial };

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -647,6 +647,15 @@ function addEntry(listKey, inputId, containerId) {
     try { prefs = await chrome.storage.sync.get({ [listKey]: [] }); } catch (err) { console.error("[MUGA] load list:", err); return; }
     const list = prefs[listKey];
     if (!list.includes(value)) {
+      // Enforce the same per-list caps the import path applies (#728 item 28):
+      // customParams 200, blacklist/whitelist 500. Without this, the UI add path
+      // could grow a list past the size the importer would ever accept.
+      const cap = listKey === "customParams" ? 200 : 500;
+      if (list.length >= cap) {
+        showToast(t("import_error", _currentLang));
+        input.value = "";
+        return;
+      }
       list.push(value);
       try { await setPrefs({ [listKey]: list }); } catch (err) { console.error("[MUGA] save entry:", err); }
       renderList(containerId, list, listKey);

--- a/tests/unit/migration-evaluator.test.mjs
+++ b/tests/unit/migration-evaluator.test.mjs
@@ -27,6 +27,31 @@ const FIXTURE_NETWORK = {
   bannerCopyKey: "fixture_network_banner",
 };
 
+describe("evaluateMigrations — malformed migration guard (#728 item 21)", () => {
+  test("a migration with undefined proposedValue is skipped, not thrown", () => {
+    const malformed = {
+      id: "no-proposed-value",
+      fromVersion: "1.0.0",
+      toVersion: "2.0.0",
+      prefs: [],
+      networkRelated: false,
+      bannerCopyKey: "x",
+      // proposedValue intentionally omitted
+    };
+    let result;
+    assert.doesNotThrow(() => {
+      result = evaluateMigrations({
+        previousVersion: "1.0.0",
+        currentVersion: "2.0.0",
+        responses: {},
+        prefs: {},
+        migrations: [malformed],
+      });
+    });
+    assert.deepEqual(result, [], "a migration without proposedValue must be skipped, not presented");
+  });
+});
+
 describe("compareVersions", () => {
   test("returns negative for a < b", () => {
     assert.ok(compareVersions("1.0.0", "1.0.1") < 0);

--- a/tests/unit/options-patterns.test.mjs
+++ b/tests/unit/options-patterns.test.mjs
@@ -376,3 +376,27 @@ describe("T3.3 chrome.permissions.request is the first await in the enable branc
     );
   });
 });
+
+describe("addEntry — list-size caps mirror the import path (#728 item 28)", () => {
+  test("addEntry enforces the per-list cap before pushing", () => {
+    // The import path caps blacklist/whitelist at 500 and customParams at 200
+    // (options.js: `data.blacklist.length > 500 || ... customParams.length > 200`).
+    // The manual UI add path (addEntry) must apply the same ceiling.
+    assert.ok(
+      optionsJs.includes('listKey === "customParams" ? 200 : 500'),
+      "addEntry must derive the per-list cap (200 for customParams, 500 otherwise)"
+    );
+    assert.ok(
+      optionsJs.includes("list.length >= cap"),
+      "addEntry must reject when the list already sits at its cap"
+    );
+  });
+
+  test("import path still enforces its 500/500/200 caps (parity anchor)", () => {
+    assert.ok(
+      optionsJs.includes("data.blacklist.length > 500") &&
+        optionsJs.includes("data.customParams.length > 200"),
+      "import-path caps must remain the source of truth the UI path mirrors"
+    );
+  });
+});

--- a/tests/unit/per-device-prefs.test.mjs
+++ b/tests/unit/per-device-prefs.test.mjs
@@ -97,4 +97,20 @@ describe("per-device-prefs", () => {
     await assert.rejects(() => mod.setOverrides(null));
     await assert.rejects(() => mod.setOverrides("string"));
   });
+
+  test("setOverrides rejects an unknown (non-guarded) override key (#728 item 24)", async () => {
+    await assert.rejects(() => mod.setOverrides({ enabled: false }));
+    await assert.rejects(() => mod.setOverrides({ notAPref: true }));
+  });
+
+  test("setOverrides rejects a non-boolean value for a guarded key (#728 item 24)", async () => {
+    await assert.rejects(() => mod.setOverrides({ injectOwnAffiliate: "false" }));
+    await assert.rejects(() => mod.setOverrides({ remoteRulesEnabled: 0 }));
+  });
+
+  test("a rejected setOverrides writes nothing (validation runs before the store write) (#728 item 24)", async () => {
+    await assert.rejects(() => mod.setOverrides({ injectOwnAffiliate: "nope" }));
+    const o = await mod.getOverrides();
+    assert.deepEqual(o, {}, "a rejected setOverrides must not persist a partial record");
+  });
 });


### PR DESCRIPTION
Part of the #728 P3 tier. Three independent input-validation gaps + regression tests.

- **item 21** `migration-evaluator.js`: `evaluateMigrations` did `Object.keys(m.proposedValue)` with no guard — a migration passed via the `migrations` override (test boundary) without `proposedValue` threw a TypeError. Now skipped defensively. Test: malformed migration → `[]`, no throw.
- **item 24** `per-device-prefs.js`: `setOverrides` promised `{Object<string, boolean>}` but accepted any key/type, silently merging junk into the local overrides map that `getPrefs()` overlays. Now validates against `GUARDED_PREFS` (keys) and `boolean` (values), throwing before any store write. The sole real caller (onboarding) only ever passes `injectOwnAffiliate`/`remoteRulesEnabled` booleans — unaffected. Tests: unknown key rejected, non-boolean rejected, nothing persisted on rejection.
- **item 28** `options.js`: `addEntry` (manual UI add) had no length ceiling, so a user could grow a list past the 500/500/200 caps the import path enforces. Added the matching cap. Source-pattern test pins both the new cap and the import-path caps it mirrors.

Full unit suite: 3995 passing. Refs #728.