### PR TITLE
fix(popup): reset #tab-badge + surface async storage failures (#728 items 26/27)

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -165,7 +165,9 @@ async function init() {
   enabledToggle.checked = prefs.enabled;
 
   enabledToggle.addEventListener("change", async () => {
-    try { chrome.storage.sync.set({ enabled: enabledToggle.checked }); } catch (err) { console.error("[MUGA] save enabled:", err); }
+    // storage.sync.set returns a Promise in MV3 — a sync try/catch can't catch
+    // its async rejection, so surface failures via .catch (#728 item 27).
+    chrome.storage.sync.set({ enabled: enabledToggle.checked }).catch((err) => console.error("[MUGA] save enabled:", err));
     // Optimistic re-render — the storage.onChanged listener below will also fire
     // once the write lands, but we don't want the user to wait for that roundtrip.
     try {
@@ -240,7 +242,8 @@ async function init() {
       ? "https://addons.mozilla.org/firefox/addon/muga/"
       : "https://chromewebstore.google.com/detail/muga/";
     rateBtn.addEventListener("click", () => {
-      try { chrome.storage.local.set({ nudgeDismissed: true }); } catch (err) { console.error("[MUGA] save nudge dismiss:", err); }
+      // Async rejection can't be caught by a sync try/catch — use .catch (#728 item 27).
+      chrome.storage.local.set({ nudgeDismissed: true }).catch((err) => console.error("[MUGA] save nudge dismiss:", err));
       chrome.tabs.create({ url: storeUrl });
     });
   }
@@ -458,6 +461,15 @@ function _resetPreviewDom() {
   if (previewHonored) {
     previewHonored.hidden = true;
     previewHonored.textContent = "";
+  }
+  // #728 item 26: reset the per-tab badge (#89) too. It is only re-shown when
+  // the new render has count > 0, so without this a prior tab's badge would
+  // bleed into a later render with no count — breaking the idempotent-render
+  // invariant every other slot above upholds.
+  const tabBadge = el("tab-badge");
+  if (tabBadge) {
+    tabBadge.hidden = true;
+    tabBadge.textContent = "";
   }
   const reportLink = el("report-broken");
   if (reportLink) reportLink.hidden = true;

--- a/tests/unit/popup-rerender-leaks.test.mjs
+++ b/tests/unit/popup-rerender-leaks.test.mjs
@@ -86,3 +86,36 @@ describe("#705 — popup re-render leaks", () => {
     }
   });
 });
+
+describe("#728 P3 — popup robustness (items 26/27)", () => {
+  test("_resetPreviewDom resets #tab-badge so a prior count does not bleed across renders (item 26)", () => {
+    const resetBlock = POPUP_SOURCE.match(/function\s+_resetPreviewDom\s*\([\s\S]*?\n\}/);
+    assert.ok(resetBlock, "_resetPreviewDom function must exist in popup.js");
+    const body = resetBlock[0];
+    assert.ok(
+      /el\(\s*["']tab-badge["']\s*\)|getElementById\(\s*["']tab-badge["']\s*\)/.test(body),
+      "_resetPreviewDom must look up #tab-badge",
+    );
+    assert.ok(
+      /tabBadge\.hidden\s*=\s*true/.test(body),
+      "_resetPreviewDom must hide #tab-badge on reset (idempotent-render invariant)",
+    );
+  });
+
+  test("storage.set writes surface async rejection via .catch, not a sync try/catch (item 27)", () => {
+    assert.ok(
+      /storage\.sync\.set\(\{ enabled[\s\S]{0,80}?\}\)\.catch\(/.test(POPUP_SOURCE),
+      "the enabled-toggle write must chain .catch on the storage.set Promise",
+    );
+    assert.ok(
+      /storage\.local\.set\(\{ nudgeDismissed[\s\S]{0,40}?\}\)\.catch\(/.test(POPUP_SOURCE),
+      "the nudge-dismiss write must chain .catch on the storage.set Promise",
+    );
+    // Neither write may sit inside the old inline `try { chrome.storage.*.set(...) }` —
+    // a synchronous try/catch cannot observe the Promise rejection.
+    assert.ok(
+      !/try\s*\{\s*chrome\.storage\.(?:sync|local)\.set\(/.test(POPUP_SOURCE),
+      "no storage.set call may be wrapped in a synchronous try/catch (cannot catch async rejection)",
+    );
+  });
+});


### PR DESCRIPTION
Part of the #728 P3 tier.

- **item 26** `_resetPreviewDom` cleared every preview slot except `#tab-badge`. Since the badge is only re-shown when the new render has count > 0, a previous tab's badge bled into a later render with no count — breaking the idempotent-render invariant the rest of the reset upholds. Now hidden + cleared on every reset.
- **item 27** the enabled-toggle and nudge-dismiss writes called `chrome.storage.*.set(...)` inside a **synchronous** `try/catch`. In MV3 `set` returns a Promise, so a rejection (quota / `MAX_WRITE_OPERATIONS`) was silently dropped. Switched to `.catch()` — the same pattern the adjacent `nudgeLastShown` write already uses.

Source-pattern regression tests (popup.js runs against chrome.* in-browser; e2e covers observable behaviour). Refs #728.