### PR TITLE
test: consent error paths + onboarding gated-CTA flash (#728 items 15/16/25)

### DIFF
--- a/tests/unit/consent-storage.test.mjs
+++ b/tests/unit/consent-storage.test.mjs
@@ -48,6 +48,26 @@ function installChromeStub() {
   return { localStore, syncStore };
 }
 
+/**
+ * Installs a chrome stub whose storage callbacks fail by setting
+ * chrome.runtime.lastError (the way the real chrome.* APIs signal errors).
+ * lastError is set just for the duration of the synchronous callback, then
+ * cleared — mirroring chrome's per-call error surface.
+ */
+function installFailingChromeStub(failMessage = "storage quota exceeded") {
+  const fail = (...args) => {
+    const cb = args[args.length - 1];
+    chrome.runtime.lastError = { message: failMessage };
+    if (cb) cb({});
+    chrome.runtime.lastError = null;
+  };
+  const area = { get: fail, set: fail, remove: fail };
+  globalThis.chrome = {
+    storage: { local: area, sync: area },
+    runtime: { lastError: null },
+  };
+}
+
 describe("consent-storage", () => {
   let stores;
   let consentStorage;
@@ -115,5 +135,42 @@ describe("consent-storage", () => {
       consentDate: null,
     });
     assert.equal(stores.localStore.has("mugaConsent"), false);
+  });
+});
+
+describe("consent-storage — error / reject paths (#728 items 15/16)", () => {
+  let consentStorage;
+
+  beforeEach(async () => {
+    installFailingChromeStub();
+    consentStorage = await import("../../src/lib/consent-storage.js?cb=" + Math.random());
+  });
+
+  test("getConsent swallows a storage error and returns CONSENT_DEFAULTS (item 15)", async () => {
+    // Documented contract: getConsent never throws — on any error it returns
+    // the defaults so callers render the never-onboarded state safely.
+    const c = await consentStorage.getConsent();
+    assert.deepEqual(c, {
+      onboardingDone: false,
+      consentVersion: null,
+      consentDate: null,
+    });
+  });
+
+  test("setConsent rejects when the storage write fails (item 16)", async () => {
+    // setConsent must propagate the failure so onboarding can surface a save
+    // error. The reject value is chrome.runtime.lastError (a plain object, not
+    // an Error), so assert it rejects and carries the failure message.
+    await assert.rejects(
+      () => consentStorage.setConsent({ onboardingDone: true }),
+      (err) => err && err.message === "storage quota exceeded",
+    );
+  });
+
+  test("clearConsent rejects when the storage remove fails (item 16)", async () => {
+    await assert.rejects(
+      () => consentStorage.clearConsent(),
+      (err) => err && err.message === "storage quota exceeded",
+    );
   });
 });

--- a/tests/unit/onboarding.test.mjs
+++ b/tests/unit/onboarding.test.mjs
@@ -172,3 +172,57 @@ describe("#741 — onboarding consent write ordering", () => {
     assert.ok(!/startBtn\.disabled\s*=\s*false/.test(tail), "must not use the no-op startBtn.disabled = false");
   });
 });
+
+describe("#728 item 25 — gated-CTA flash + aria-live announcement", () => {
+  const ONBOARDING_HTML = readFileSync(
+    join(__dirname, "../../src/onboarding/onboarding.html"),
+    "utf8",
+  );
+
+  test("flashTosGate exists and re-triggers the flash animation", () => {
+    const fnIdx = ONBOARDING_JS.indexOf("function flashTosGate(");
+    assert.ok(fnIdx !== -1, "flashTosGate must exist in onboarding.js");
+    const body = ONBOARDING_JS.slice(fnIdx, fnIdx + 700);
+    assert.ok(
+      /classList\.remove\(\s*["']is-flashing["']\s*\)/.test(body),
+      "flashTosGate must remove is-flashing to reset the animation",
+    );
+    assert.ok(
+      /void\s+tosLabel\.offsetWidth/.test(body),
+      "flashTosGate must force a reflow so the flash re-triggers on consecutive clicks",
+    );
+    assert.ok(
+      /classList\.add\(\s*["']is-flashing["']\s*\)/.test(body),
+      "flashTosGate must add is-flashing to flash the gate",
+    );
+  });
+
+  test("flashTosGate re-writes #cta-gated-msg on a tick so aria-live re-announces", () => {
+    const fnIdx = ONBOARDING_JS.indexOf("function flashTosGate(");
+    const body = ONBOARDING_JS.slice(fnIdx, fnIdx + 700);
+    assert.ok(
+      /ctaGatedMsg\.textContent\s*=\s*""/.test(body),
+      "flashTosGate must clear #cta-gated-msg first",
+    );
+    assert.ok(
+      /setTimeout\([\s\S]{0,160}ctaGatedMsg\.textContent\s*=\s*t\(\s*["']ob_cta_gated_msg["']/.test(body),
+      "flashTosGate must re-write the gated message on a tick so a live region announces even when the text is unchanged",
+    );
+  });
+
+  test("#cta-gated-msg is an aria-live region in onboarding.html", () => {
+    const tagMatch = ONBOARDING_HTML.match(/<p[^>]+id="cta-gated-msg"[^>]*>/);
+    assert.ok(tagMatch, "#cta-gated-msg must exist as a <p>");
+    assert.ok(
+      /aria-live="polite"/.test(tagMatch[0]),
+      "#cta-gated-msg must be an aria-live=polite region for screen-reader announcement",
+    );
+  });
+
+  test("the start button's gated path triggers flashTosGate when ToS is unchecked", () => {
+    assert.ok(
+      /if\s*\(\s*!tosCheck\.checked\s*\)\s*\{[\s\S]{0,80}flashTosGate\(\)/.test(ONBOARDING_JS),
+      "an unchecked ToS on start-click must trigger flashTosGate()",
+    );
+  });
+});


### PR DESCRIPTION
Part of the #728 P3 tier — **test-only**, closes the three test-gap items.

- **items 15/16** `consent-storage`: a new failing chrome stub (sets `runtime.lastError` for the call) exercises the previously-untested paths — `getConsent` swallows the error and returns `CONSENT_DEFAULTS` (never-throws contract), and `setConsent`/`clearConsent` reject so onboarding can surface a save failure.
- **item 25** `onboarding`: source-pattern coverage for `flashTosGate` — the flash re-trigger (remove → reflow → add `is-flashing`) and the `#cta-gated-msg` re-write on a tick so the aria-live region re-announces even when the text is unchanged; plus pinning `#cta-gated-msg` as `aria-live=polite` in onboarding.html.

No production code touched. Refs #728.