### PR TITLE
perf(content): runRedirectUnwrap reads _contentPrefs cache before messaging (#726)

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -887,8 +887,7 @@
   }
 
   function runRedirectUnwrap() {
-    chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
-      void chrome.runtime.lastError;
+    const apply = (prefs) => {
       if (!prefs || !prefs.enabled || !prefs.onboardingDone || !prefs.unwrapRedirects) return;
 
       const currentUrl = window.location.href;
@@ -1052,6 +1051,14 @@
         window.location.replace(destination.href);
         return;
       }
+    };
+    // #726: prefer the module-scoped prefs cache (populated by the IIFE init)
+    // and skip the getPrefs round-trip. Fall back to sendMessage only when the
+    // cache is still null (very early in the content-script lifecycle).
+    if (_contentPrefs) { apply(_contentPrefs); return; }
+    chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
+      void chrome.runtime.lastError;
+      apply(prefs);
     });
   }
 

--- a/tests/unit/redirect-unwrap.test.mjs
+++ b/tests/unit/redirect-unwrap.test.mjs
@@ -965,3 +965,30 @@ describe("C11 — replica sync verification (Pepper network)", () => {
     );
   });
 });
+
+describe("#726 — runRedirectUnwrap consults the prefs cache before messaging", () => {
+  // Pins acceptance criterion #1: when _contentPrefs is populated, no getPrefs
+  // round-trip happens. Protects the perf fix from silently regressing back to
+  // an unconditional sendMessage on every page load.
+  const fnIdx = REDIRECT_UNWRAP_SOURCE.indexOf("function runRedirectUnwrap(");
+  const deferIdx = REDIRECT_UNWRAP_SOURCE.indexOf("Defer redirect-unwrap", fnIdx);
+  const fnBody = REDIRECT_UNWRAP_SOURCE.slice(fnIdx, deferIdx);
+
+  test("runRedirectUnwrap checks _contentPrefs and applies it synchronously when present", () => {
+    assert.ok(fnIdx !== -1, "runRedirectUnwrap must exist in cleaner.js");
+    assert.ok(
+      /if\s*\(\s*_contentPrefs\s*\)\s*\{\s*apply\(\s*_contentPrefs\s*\)\s*;\s*return\s*;/.test(fnBody),
+      "runRedirectUnwrap must apply the cached _contentPrefs and return before any sendMessage",
+    );
+  });
+
+  test("the sendMessage round-trip is the fallback, placed AFTER the cache check", () => {
+    const cacheIdx = fnBody.indexOf("_contentPrefs");
+    const msgIdx = fnBody.indexOf('sendMessage({ type: "getPrefs"');
+    assert.ok(cacheIdx !== -1 && msgIdx !== -1, "both the cache check and the getPrefs fallback must exist");
+    assert.ok(
+      cacheIdx < msgIdx,
+      "the _contentPrefs cache check must come before the getPrefs sendMessage fallback",
+    );
+  });
+});


### PR DESCRIPTION
Closes #726 (promoted from #709 item 7 — confirmed a real perf bug, not a question).

`runRedirectUnwrap` fired a fresh `chrome.runtime.sendMessage({ type: "getPrefs" })` on every invocation, even though the IIFE init already caches the identical prefs object in module-scope `_contentPrefs`. That's a needless round-trip on every page load (Firefox MV2) and every redirect-unwrap candidate (Chrome MV3).

**Fix** (exactly as the issue proposed): extract the body into `apply(prefs)`; apply `_contentPrefs` synchronously when populated, fall back to `sendMessage` only when it's still `null` (very early in the lifecycle). Behaviour is identical — same prefs, same guards.

`src/content/cleaner.js` is NOT part of `cleaner-bundle.js` (that's `src/lib/cleaner.js`), so no bundle regen.

Despite the issue saying "no new tests needed", added a source-pattern guard to `redirect-unwrap.test.mjs` that pins acceptance criterion #1 (cache consulted before messaging) so the optimization can't silently regress. Full unit suite green (4009).

Refs #728.