### PR TITLE
test(audit): structural parity/drift guards (#723/#724/#725)

### DIFF
--- a/tests/unit/bounce-state-wrappers-parity.test.mjs
+++ b/tests/unit/bounce-state-wrappers-parity.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * MUGA — bounce-state WRAPPERS parity guard (#725, spin-off from #709 item 6)
+ *
+ * `src/content/bounce-state-cleaner.js` carries an inline `WRAPPERS` table that
+ * must mirror `src/lib/wrapper-engine.js` minus the AFFILIATE_REDIRECT_NETWORKS
+ * pass-through bucket (those hosts must NOT have their storage wiped — the
+ * network needs landing state to attribute the click).
+ *
+ * #703 added a test for the INVERSE (no pass-through host leaks into the inline
+ * table — bounce-state-affiliate-redirect.test.mjs). Parity in the other
+ * direction (every non-pass-through wrapper IS mirrored) was still unenforced:
+ * a new wrapper added to wrapper-engine.js without mirroring it here would
+ * silently lose storage cleanup on that host.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import { WRAPPERS } from "../../src/lib/wrapper-engine.js";
+import { isAffiliateRedirectNetwork } from "../../src/lib/opaque-networks.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BOUNCE_SRC = readFileSync(
+  join(__dirname, "../../src/content/bounce-state-cleaner.js"),
+  "utf8",
+);
+
+// Isolate the inline `const WRAPPERS = [ ... ];` block so host-literal matches
+// don't pick up the unrelated INLINE_AFFILIATE_REDIRECT_NETWORKS list.
+const wStart = BOUNCE_SRC.indexOf("const WRAPPERS = [");
+const wEnd = BOUNCE_SRC.indexOf("];", wStart);
+const INLINE_WRAPPERS_SRC = BOUNCE_SRC.slice(wStart, wEnd);
+
+test("inline WRAPPERS block is found in bounce-state-cleaner.js", () => {
+  assert.ok(wStart !== -1 && wEnd > wStart, "could not locate the inline const WRAPPERS = [ ... ] table");
+});
+
+test("every non-pass-through wrapper host is mirrored in bounce-state inline WRAPPERS (#725)", () => {
+  const missing = [];
+  for (const wrapper of WRAPPERS) {
+    for (const pattern of wrapper.hostPatterns) {
+      // Regex host patterns (`^...$`) are the wildcard affiliate-redirect
+      // networks (e.g. *.pxf.io) — pass-through by design, never cleaned.
+      if (typeof pattern !== "string") continue;
+      // Pass-through bucket: must NOT be wiped, so it is correctly absent.
+      if (isAffiliateRedirectNetwork(pattern)) continue;
+      if (!INLINE_WRAPPERS_SRC.includes(`"${pattern}"`)) {
+        missing.push(`${pattern}  (wrapper id: ${wrapper.id})`);
+      }
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    "bounce-state-cleaner.js inline WRAPPERS is missing host(s) present in " +
+      "wrapper-engine.js — storage cleanup would silently skip them:\n  " +
+      missing.join("\n  "),
+  );
+});

--- a/tests/unit/proxy-navigate-drift.test.mjs
+++ b/tests/unit/proxy-navigate-drift.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * MUGA — proxy-navigate drift guard (#724, spin-off from #709 item 3)
+ *
+ * `src/lib/proxy-navigate.js` (`handleProxyNavigation`) is the pure,
+ * unit-tested version of the privacy-proxy navigation logic. The runtime
+ * copy lives inline in `src/content/cleaner.js` (content scripts are IIFEs
+ * and can't import ES modules). The two differ structurally — the lib takes
+ * an `opts` object, the inline copy uses closure vars — so byte/AST equality
+ * is impossible. Instead this pins the shared CONTRACT both copies must agree
+ * on. Drift in any invariant (message type, timeout, cap, scheme guard) breaks
+ * one path while the other keeps working — exactly the silent divergence #709
+ * item 3 flagged.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIB = readFileSync(join(__dirname, "../../src/lib/proxy-navigate.js"), "utf8");
+const CONTENT = readFileSync(join(__dirname, "../../src/content/cleaner.js"), "utf8");
+
+// Isolate the inline proxy block in cleaner.js so generic fragments (e.g. the
+// literal 2000, which appears in many length caps) are matched only here.
+const proxyStart = CONTENT.indexOf("SYNC NOTE: the proxy-navigation logic");
+const proxyEnd = CONTENT.indexOf("navigate(cleanUrl, opensNewTab)", proxyStart);
+const CONTENT_PROXY = CONTENT.slice(proxyStart, proxyEnd);
+
+// Fragments that must be byte-identical in BOTH copies.
+const SHARED = [
+  { name: "UNWRAP_VIA_PROXY message type", frag: '{ type: "UNWRAP_VIA_PROXY", url' },
+  { name: "timeout rejection error", frag: 'new Error("proxy-navigate timeout")' },
+  { name: "response ok gate", frag: "response?.ok === true" },
+  { name: "destination scheme guard", frag: 'dest.startsWith("https://") || dest.startsWith("http://")' },
+];
+
+describe("#724 — proxy-navigate.js ↔ cleaner.js inline copy contract", () => {
+  for (const { name, frag } of SHARED) {
+    test(`shared invariant present in both copies: ${name}`, () => {
+      assert.ok(
+        LIB.includes(frag),
+        `src/lib/proxy-navigate.js drifted — missing ${name}: ${frag}`,
+      );
+      assert.ok(
+        CONTENT_PROXY.includes(frag),
+        `src/content/cleaner.js inline proxy copy drifted — missing ${name}: ${frag}`,
+      );
+    });
+  }
+
+  test("both copies cap the destination at 2000 chars", () => {
+    assert.ok(LIB.includes("MAX_DESTINATION_LENGTH = 2000"), "lib must define MAX_DESTINATION_LENGTH = 2000");
+    assert.ok(LIB.includes("dest.length <= MAX_DESTINATION_LENGTH"), "lib must enforce the cap");
+    assert.ok(CONTENT_PROXY.includes("dest.length <= 2000"), "inline copy must enforce the 2000-char cap");
+  });
+
+  test("both copies use the same 6000ms outer timeout", () => {
+    assert.ok(LIB.includes("DEFAULT_TIMEOUT_MS = 6000"), "lib must default the outer timeout to 6000ms");
+    assert.ok(CONTENT_PROXY.includes("_PROXY_TIMEOUT_MS = 6000"), "inline copy must use a 6000ms outer timeout");
+  });
+});

--- a/tests/unit/strip-table-parity.test.mjs
+++ b/tests/unit/strip-table-parity.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * MUGA — STRIP table parity guard (#723, spin-off from #709 item 1)
+ *
+ * The hot-path UTM/click-id strip subset is hand-copied into four
+ * content scripts (content scripts can't import ES modules):
+ *
+ *   - src/content/dom-link-rewriter.js
+ *   - src/content/dom-link-rewriter-click.js
+ *   - src/content/history-defuser-mainworld.js
+ *   - src/content/window-name-defuser-mainworld.js
+ *
+ * Each comment claims "kept in sync" but nothing enforced it — adding a new
+ * high-volume tracker meant editing four files in lockstep. This test pins
+ * that the four `const STRIP = Object.freeze({ ... })` literals are
+ * byte-identical, the same way cleaner-bundle-sync / sign-rules-denylist-sync
+ * pin their respective duplications.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const FILES = [
+  "dom-link-rewriter.js",
+  "dom-link-rewriter-click.js",
+  "history-defuser-mainworld.js",
+  "window-name-defuser-mainworld.js",
+];
+
+/**
+ * Extracts the `Object.freeze({ ... })` object literal that follows
+ * `const STRIP =` in a content-script source file, brace-matched so the
+ * full table (including trailing entries) is captured verbatim.
+ */
+function extractStripTable(relPath) {
+  const src = readFileSync(join(__dirname, "../../src/content", relPath), "utf8");
+  const decl = src.indexOf("const STRIP = Object.freeze({");
+  assert.ok(decl !== -1, `${relPath} must declare const STRIP = Object.freeze({ ... })`);
+  const open = src.indexOf("{", decl);
+  let depth = 0;
+  let i = open;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  assert.ok(i < src.length, `${relPath}: unbalanced braces in STRIP table`);
+  return src.slice(open, i + 1);
+}
+
+test("all four content-script STRIP tables are byte-identical (#723)", () => {
+  const tables = FILES.map((f) => ({ file: f, body: extractStripTable(f) }));
+  const reference = tables[0];
+
+  for (const { file, body } of tables.slice(1)) {
+    if (body !== reference.body) {
+      assert.fail(
+        `STRIP table in src/content/${file} has drifted from ` +
+          `src/content/${reference.file}.\n\n` +
+          `--- ${reference.file} ---\n${reference.body}\n\n` +
+          `--- ${file} ---\n${body}\n\n` +
+          `Add new trackers to ALL FOUR files in lockstep, or the hot-path ` +
+          `cleaners diverge silently.`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
Closes #723, #724, #725 — the three #709 follow-up structural-drift guards. **Test-only.**

- **#723** `strip-table-parity.test.mjs` — the hot-path UTM/click-id `STRIP` table is hand-copied into 4 content scripts (dom-link-rewriter, dom-link-rewriter-click, history-defuser-mainworld, window-name-defuser-mainworld). Brace-extracts each `Object.freeze({...})` and asserts all four are **byte-identical**; failure names the divergent file + both bodies.
- **#724** `proxy-navigate-drift.test.mjs` — `cleaner.js` carries a runtime copy of `proxy-navigate.js`'s logic (IIFE can't import). They differ structurally (closure vars vs `opts`), so byte/AST equality is impossible — instead pins the shared **contract**: `UNWRAP_VIA_PROXY` message type, `proxy-navigate timeout` error, `response?.ok === true` gate, the http/https scheme guard, the 2000-char cap, and the 6000ms outer timeout. (Chose Option A; Option B — delegating to the bundle export — left as the longer-term refactor.)
- **#725** `bounce-state-wrappers-parity.test.mjs` — asserts every **non-pass-through** host in `wrapper-engine.js` `WRAPPERS` (skipping regex/wildcard affiliate-redirect networks, filtering `isAffiliateRedirectNetwork`) is mirrored in the inline bounce-state `WRAPPERS`. Complements the inverse guard #703 added; failure names the missing host(s).

All three pass on current main (parity holds today). Full suite: 4018. Refs #728.