### PR TITLE
test(canary): affiliate-survival fixtures — single source of truth (#768)

### DIFF
--- a/tests/fixtures/affiliate-canaries.mjs
+++ b/tests/fixtures/affiliate-canaries.mjs
@@ -1,0 +1,103 @@
+/**
+ * MUGA — Affiliate-survival canaries (single source of truth) — #768 / epic #785.
+ *
+ * The canary safety net: a curated set of real affiliate URLs whose attribution
+ * MUST survive MUGA's cleaning. This module is PURE DATA — no imports, no logic —
+ * so it can be consumed by:
+ *   - the test runner (tests/unit/affiliate-canaries.test.mjs), and
+ *   - the future programmatic canary runner / pipeline GATE 3 (#771, #777).
+ *
+ * Two kinds:
+ *   PRESERVE_CANARIES — run processUrl(url, prefs). Every key in `mustSurvive`
+ *     must remain on the cleaned URL with its EXACT value; every param in
+ *     `mustStrip` must be removed.
+ *   LANDING_CANARIES — run getLandingPolicy(landingHost, referrer). The returned
+ *     `preserve` set must be a superset of `mustPreserve`, and `network` must
+ *     match.
+ *
+ * Extracted verbatim from the assertions previously scattered across
+ * cleaner.test.mjs and get-landing-policy.test.mjs (deduped by #769).
+ *
+ * NOTE: amzn.to is intentionally absent — it sits in opaque-networks'
+ * PENDING_VERDICT bucket awaiting #665. The Tradedoubler `tduid` canary is added
+ * by #770 (it has no coverage yet).
+ */
+
+/** Base prefs: cleaning on, no own-tag injection. Mirrors cleaner.test.mjs PREFS. */
+const PRESERVE_PREFS = Object.freeze({
+  enabled: true,
+  injectOwnAffiliate: false,
+  notifyForeignAffiliate: false,
+  blacklist: [],
+  whitelist: [],
+});
+
+/** Injection ON — proves an EXISTING (foreign) affiliate tag is never replaced. */
+const INJECT_PREFS = Object.freeze({ ...PRESERVE_PREFS, injectOwnAffiliate: true });
+
+const AMAZON_MARKETS = ["www.amazon.es", "www.amazon.de", "www.amazon.fr", "www.amazon.it", "www.amazon.co.uk", "www.amazon.com"];
+const EBAY_MARKETS = ["www.ebay.com", "www.ebay.es", "www.ebay.de", "www.ebay.co.uk", "www.ebay.fr", "www.ebay.it"];
+
+export const PRESERVE_CANARIES = Object.freeze([
+  // Amazon `tag` across 6 TLDs: a creator's existing tag is never replaced,
+  // even with our own-tag injection enabled.
+  ...AMAZON_MARKETS.map((host) => ({
+    name: `${host}: foreign affiliate tag survives (even with injection on)`,
+    url: `https://${host}/dp/B08N5WRWNW?tag=creator-21`,
+    prefs: INJECT_PREFS,
+    mustSurvive: { tag: "creator-21" },
+    mustStrip: [],
+  })),
+
+  // eBay `campid` across 6 marketplaces: existing campid never replaced.
+  ...EBAY_MARKETS.map((host) => ({
+    name: `${host}: foreign campid survives (even with injection on)`,
+    url: `https://${host}/itm/123456789?campid=9999999999`,
+    prefs: INJECT_PREFS,
+    mustSurvive: { campid: "9999999999" },
+    mustStrip: [],
+  })),
+
+  // Affiliate / tracking collisions: the affiliate param wins, noise is stripped.
+  {
+    name: "amazon.es: tag preserved, UTM stripped",
+    url: "https://www.amazon.es/dp/B08N5WRWNW?tag=someaffiliate-21&utm_source=email&utm_medium=cpc",
+    prefs: PRESERVE_PREFS,
+    mustSurvive: { tag: "someaffiliate-21" },
+    mustStrip: ["utm_source", "utm_medium"],
+  },
+  {
+    name: "amazon.es: tag preserved, internal noise stripped",
+    url: "https://www.amazon.es/dp/B08N5WRWNW?tag=someaffiliate-21&psc=1&pd_rd_r=abc&linkCode=ll1",
+    prefs: PRESERVE_PREFS,
+    mustSurvive: { tag: "someaffiliate-21" },
+    mustStrip: ["psc", "pd_rd_r", "linkCode"],
+  },
+  {
+    name: "ebay.es: campid preserved, mkevt + UTM stripped",
+    url: "https://www.ebay.es/itm/123456?campid=some-affiliate-id&mkevt=1&utm_source=google",
+    prefs: PRESERVE_PREFS,
+    mustSurvive: { campid: "some-affiliate-id" },
+    mustStrip: ["mkevt", "utm_source"],
+  },
+  {
+    name: "pccomponentes: ref preserved (host-matched affiliate param), UTM stripped",
+    url: "https://www.pccomponentes.com/producto?ref=some-affiliate-tag&utm_source=google",
+    prefs: PRESERVE_PREFS,
+    mustSurvive: { ref: "some-affiliate-tag" },
+    mustStrip: ["utm_source"],
+  },
+]);
+
+export const LANDING_CANARIES = Object.freeze([
+  { name: "awin", landingHost: "zalando.es", referrer: "https://www.awin1.com/cread.php?id=1", mustPreserve: ["awc", "wt_mc"], network: "awin" },
+  { name: "cj-affiliate", landingHost: "walmart.com", referrer: "https://anrdoezrs.net/click-123-456", mustPreserve: ["cjdata", "cjevent"], network: "cj-affiliate" },
+  { name: "aliexpress-affiliate", landingHost: "aliexpress.com", referrer: "https://s.click.aliexpress.com/e/_DnZbqGr", mustPreserve: ["aff_request_id", "aff_trace_key", "algo_expid", "algo_pvid", "btsid", "ws_ab_test"], network: "aliexpress-affiliate" },
+  { name: "impact-radius", landingHost: "target.com", referrer: "https://target.pxf.io/c/1234/abc", mustPreserve: ["iclid", "irclickid", "irgwc"], network: "impact-radius" },
+  { name: "partnerize", landingHost: "partner.com", referrer: "https://prf.hn/click/123", mustPreserve: ["adref", "clickref", "pubref"], network: "partnerize" },
+  { name: "admitad (ad.admitad.com)", landingHost: "shop.com", referrer: "https://ad.admitad.com/g/abc", mustPreserve: ["admitad_uid", "tagtag_uid"], network: "admitad" },
+  { name: "admitad (alitems.com)", landingHost: "aliexpress.com", referrer: "https://alitems.com/g/xyz", mustPreserve: ["admitad_uid", "tagtag_uid"], network: "admitad" },
+  { name: "a8net", landingHost: "rakuten.co.jp", referrer: "https://px.a8.net/svt/ejp?id=1", mustPreserve: ["a8"], network: "a8net" },
+  { name: "rakuten-linkshare", landingHost: "ebay.com", referrer: "https://click.linksynergy.com/deeplink?id=1", mustPreserve: ["raneaid", "ranmid", "ransiteid"], network: "rakuten-linkshare" },
+  { name: "tradetracker", landingHost: "merchant.de", referrer: "https://tc.tradetracker.net/?c=1&m=2", mustPreserve: ["ttaid", "ttcid", "ttrk"], network: "tradetracker" },
+]);

--- a/tests/unit/affiliate-canaries.test.mjs
+++ b/tests/unit/affiliate-canaries.test.mjs
@@ -1,0 +1,67 @@
+/**
+ * MUGA — Affiliate-survival canary validation (#768 / epic #785).
+ *
+ * Proves every fixture in tests/fixtures/affiliate-canaries.mjs holds against
+ * the live cleaner. This is the safety net the rule-ingestion pipeline (GATE 3,
+ * #777) will reuse via the programmatic runner (#771): if any candidate strip
+ * rule ever breaks one of these, the affiliate moat is at risk.
+ *
+ * The scattered originals in cleaner.test.mjs / get-landing-policy.test.mjs are
+ * deduped against this single source of truth in #769.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { processUrl, getLandingPolicy } from "../../src/lib/cleaner.js";
+import { PRESERVE_CANARIES, LANDING_CANARIES } from "../fixtures/affiliate-canaries.mjs";
+
+describe("affiliate canaries — preserve (processUrl)", () => {
+  for (const canary of PRESERVE_CANARIES) {
+    test(canary.name, () => {
+      const { cleanUrl } = processUrl(canary.url, canary.prefs);
+      const params = new URL(cleanUrl).searchParams;
+
+      for (const [param, value] of Object.entries(canary.mustSurvive)) {
+        assert.equal(params.get(param), value, `${param}= must survive with its exact value`);
+      }
+      for (const param of canary.mustStrip) {
+        assert.equal(params.has(param), false, `${param} must be stripped`);
+      }
+    });
+  }
+});
+
+describe("affiliate canaries — landing policy (getLandingPolicy)", () => {
+  for (const canary of LANDING_CANARIES) {
+    test(canary.name, () => {
+      const policy = getLandingPolicy(canary.landingHost, canary.referrer);
+      for (const param of canary.mustPreserve) {
+        assert.ok(policy.preserve.has(param), `${param} must be preserved for ${canary.network}`);
+      }
+      assert.equal(policy.network, canary.network, "network must match");
+    });
+  }
+});
+
+// Structural floor: keep the fixtures honest as the file grows.
+describe("affiliate canaries — fixture shape", () => {
+  test("preserve canaries are well-formed and non-empty", () => {
+    assert.ok(PRESERVE_CANARIES.length >= 14, "expected the 6 Amazon + 6 eBay + collision canaries");
+    for (const c of PRESERVE_CANARIES) {
+      assert.equal(typeof c.url, "string");
+      assert.ok(c.prefs && typeof c.prefs === "object");
+      assert.ok(c.mustSurvive && typeof c.mustSurvive === "object");
+      assert.ok(Array.isArray(c.mustStrip));
+    }
+  });
+
+  test("landing canaries are well-formed and non-empty", () => {
+    assert.ok(LANDING_CANARIES.length >= 9, "expected one canary per matrix v1.0 network");
+    for (const c of LANDING_CANARIES) {
+      assert.equal(typeof c.landingHost, "string");
+      assert.equal(typeof c.referrer, "string");
+      assert.ok(Array.isArray(c.mustPreserve) && c.mustPreserve.length > 0);
+      assert.equal(typeof c.network, "string");
+    }
+  });
+});


### PR DESCRIPTION
First slice of the **Self-scaling ruleset** safety net (epic #785, issue #768).

Extracts the affiliate-survival assertions — previously scattered across `cleaner.test.mjs` and `get-landing-policy.test.mjs` — into one **pure-data** module so both the test runner and the future pipeline gate consume a single source of truth.

## What's here
- **`tests/fixtures/affiliate-canaries.mjs`** — `PRESERVE_CANARIES` (Amazon `tag` ×6 TLDs, eBay `campid` ×6 markets, affiliate/tracking collisions incl. pccomponentes `ref`) + `LANDING_CANARIES` (9 matrix-v1.0 redirect networks: Awin, CJ, AliExpress, Impact, Partnerize, Admitad, A8.net, Rakuten, TradeTracker).
- **`tests/unit/affiliate-canaries.test.mjs`** — validates all 28 against the live `processUrl` / `getLandingPolicy` (proves the extraction is faithful) + a structural floor.

## Scope / notes
- **No behaviour change, no refactor of the scattered originals** — that dedup is #769. The programmatic runner (#771) and GATE 3 (#777) build on these fixtures.
- `amzn.to` intentionally excluded (PENDING_VERDICT, #665). The Tradedoubler `tduid` canary (no current coverage) lands in #770.
- Full suite: **4114 pass / 0 fail**.

Closes #768.
