### PR TITLE
test(canary): complete EPIC A — tradedoubler, drift guard, runner, dedup (#769 #770 #771)

### DIFF
--- a/tests/fixtures/affiliate-canaries.mjs
+++ b/tests/fixtures/affiliate-canaries.mjs
@@ -100,4 +100,6 @@ export const LANDING_CANARIES = Object.freeze([
   { name: "a8net", landingHost: "rakuten.co.jp", referrer: "https://px.a8.net/svt/ejp?id=1", mustPreserve: ["a8"], network: "a8net" },
   { name: "rakuten-linkshare", landingHost: "ebay.com", referrer: "https://click.linksynergy.com/deeplink?id=1", mustPreserve: ["raneaid", "ranmid", "ransiteid"], network: "rakuten-linkshare" },
   { name: "tradetracker", landingHost: "merchant.de", referrer: "https://tc.tradetracker.net/?c=1&m=2", mustPreserve: ["ttaid", "ttcid", "ttrk"], network: "tradetracker" },
+  // #770: Tradedoubler was the one matrix-v1.0 network with zero canary coverage.
+  { name: "tradedoubler", landingHost: "merchant.com", referrer: "https://clk.tradedoubler.com/click?p=1&a=2&url=https%3A%2F%2Fmerchant.com", mustPreserve: ["tduid"], network: "tradedoubler" },
 ]);

--- a/tests/fixtures/canary-runner.mjs
+++ b/tests/fixtures/canary-runner.mjs
@@ -1,0 +1,61 @@
+/**
+ * MUGA — Programmatic affiliate-canary runner (#771 / epic #785).
+ *
+ * Runs every affiliate-survival canary against the LIVE cleaner and returns a
+ * structured verdict — no test harness required. This is what the rule-ingestion
+ * pipeline's GATE 3 (#777) calls: after a candidate strip rule is applied, it
+ * runs this and rejects the candidate if any affiliate canary broke.
+ *
+ * Pure: imports only the cleaner + the fixtures. Safe to call from CLI, tests,
+ * or the pipeline.
+ */
+
+import { processUrl, getLandingPolicy } from "../../src/lib/cleaner.js";
+import { PRESERVE_CANARIES, LANDING_CANARIES } from "./affiliate-canaries.mjs";
+
+/**
+ * @typedef {{ name: string, kind: "preserve"|"landing", reason: string }} CanaryFailure
+ *
+ * @returns {{ ok: boolean, total: number, failures: CanaryFailure[] }}
+ *   `ok` is true iff every canary held. `failures` names each broken canary and
+ *   exactly why (which param, expected vs actual) so the caller can report it.
+ */
+export function runAffiliateCanaries() {
+  const failures = [];
+
+  for (const c of PRESERVE_CANARIES) {
+    let params;
+    try {
+      params = new URL(processUrl(c.url, c.prefs).cleanUrl).searchParams;
+    } catch (err) {
+      failures.push({ name: c.name, kind: "preserve", reason: `processUrl threw: ${err.message}` });
+      continue;
+    }
+    for (const [param, value] of Object.entries(c.mustSurvive)) {
+      const got = params.get(param);
+      if (got !== value) {
+        failures.push({ name: c.name, kind: "preserve", reason: `${param} expected "${value}", got "${got}"` });
+      }
+    }
+    for (const param of c.mustStrip) {
+      if (params.has(param)) {
+        failures.push({ name: c.name, kind: "preserve", reason: `${param} should have been stripped` });
+      }
+    }
+  }
+
+  for (const c of LANDING_CANARIES) {
+    const policy = getLandingPolicy(c.landingHost, c.referrer);
+    for (const param of c.mustPreserve) {
+      if (!policy.preserve.has(param)) {
+        failures.push({ name: c.name, kind: "landing", reason: `${param} not preserved (network ${c.network})` });
+      }
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    total: PRESERVE_CANARIES.length + LANDING_CANARIES.length,
+    failures,
+  };
+}

--- a/tests/unit/affiliate-canaries.test.mjs
+++ b/tests/unit/affiliate-canaries.test.mjs
@@ -13,7 +13,9 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { processUrl, getLandingPolicy } from "../../src/lib/cleaner.js";
+import { REDIRECT_NETWORK_PATTERNS } from "../../src/lib/affiliates.js";
 import { PRESERVE_CANARIES, LANDING_CANARIES } from "../fixtures/affiliate-canaries.mjs";
+import { runAffiliateCanaries } from "../fixtures/canary-runner.mjs";
 
 describe("affiliate canaries — preserve (processUrl)", () => {
   for (const canary of PRESERVE_CANARIES) {
@@ -56,12 +58,39 @@ describe("affiliate canaries — fixture shape", () => {
   });
 
   test("landing canaries are well-formed and non-empty", () => {
-    assert.ok(LANDING_CANARIES.length >= 9, "expected one canary per matrix v1.0 network");
+    assert.ok(LANDING_CANARIES.length >= 10, "expected one canary per matrix v1.0 network");
     for (const c of LANDING_CANARIES) {
       assert.equal(typeof c.landingHost, "string");
       assert.equal(typeof c.referrer, "string");
       assert.ok(Array.isArray(c.mustPreserve) && c.mustPreserve.length > 0);
       assert.equal(typeof c.network, "string");
     }
+  });
+});
+
+// #770 — drift guard: every declared redirect network must have a canary.
+describe("affiliate canaries — REDIRECT_NETWORK_PATTERNS coverage", () => {
+  test("every redirect network has a named LANDING canary (no silent gaps)", () => {
+    const covered = new Set(LANDING_CANARIES.map((c) => c.network));
+    for (const net of REDIRECT_NETWORK_PATTERNS) {
+      assert.ok(covered.has(net.id), `redirect network "${net.id}" has no LANDING canary`);
+    }
+  });
+});
+
+// #771 — the programmatic runner the pipeline's GATE 3 will call.
+describe("affiliate canaries — programmatic runner", () => {
+  test("runAffiliateCanaries() passes against the current cleaner", () => {
+    const result = runAffiliateCanaries();
+    assert.equal(result.ok, true, `canary failures: ${JSON.stringify(result.failures, null, 2)}`);
+    assert.equal(result.failures.length, 0);
+    assert.equal(result.total, PRESERVE_CANARIES.length + LANDING_CANARIES.length);
+  });
+
+  test("runAffiliateCanaries() returns the structured verdict shape", () => {
+    const result = runAffiliateCanaries();
+    assert.equal(typeof result.ok, "boolean");
+    assert.ok(Array.isArray(result.failures));
+    assert.equal(typeof result.total, "number");
   });
 });

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -570,14 +570,7 @@ describe("Amazon affiliate tags — real tag injection per marketplace", () => {
       assert.equal(new URL(cleanUrl).searchParams.get("tag"), tag);
     });
 
-    test(`amazon.${name}: does NOT replace existing foreign tag`, () => {
-      const { cleanUrl } = processUrl(
-        `https://${domain}/dp/B08N5WRWNW?tag=creator-21`,
-        INJECT_PREFS
-      );
-      assert.equal(new URL(cleanUrl).searchParams.get("tag"), "creator-21");
-    });
-
+    // (foreign-tag-survives canary moved to tests/fixtures/affiliate-canaries.mjs, #769)
     test(`amazon.${name}: own tag is not flagged as foreign`, () => {
       const { action } = processUrl(
         `https://${domain}/dp/B08N5WRWNW?tag=${tag}`,
@@ -613,14 +606,7 @@ describe("eBay affiliate tags — real tag injection per marketplace", () => {
       assert.equal(new URL(cleanUrl).searchParams.get("campid"), "5339147108");
     });
 
-    test(`ebay.${name}: does NOT replace existing foreign campid`, () => {
-      const { cleanUrl } = processUrl(
-        `https://${domain}/itm/123456789?campid=9999999999`,
-        INJECT_PREFS
-      );
-      assert.equal(new URL(cleanUrl).searchParams.get("campid"), "9999999999");
-    });
-
+    // (foreign-campid-survives canary moved to tests/fixtures/affiliate-canaries.mjs, #769)
     test(`ebay.${name}: own campid is not flagged as foreign`, () => {
       const { action } = processUrl(
         `https://${domain}/itm/123456789?campid=5339147108`,
@@ -1455,32 +1441,8 @@ describe("whitelist priority over stripAllAffiliates", () => {
 // ---------------------------------------------------------------------------
 describe("affiliate param / tracking param collision", () => {
 
-  test("pccomponentes: ref= param is NOT stripped when pccomponentes is a matched host", () => {
-    const { cleanUrl, removedTracking } = processUrl(
-      "https://www.pccomponentes.com/producto?ref=some-affiliate-tag&utm_source=google",
-      { ...PREFS, injectOwnAffiliate: false }
-    );
-    const clean = new URL(cleanUrl);
-    assert.equal(clean.searchParams.get("ref"), "some-affiliate-tag",
-      "ref= must be preserved as affiliate param on pccomponentes");
-    assert.ok(removedTracking.includes("utm_source"),
-      "utm_source must still be stripped");
-  });
-
-  test("eBay: campid= param is NOT stripped when eBay is a matched host", () => {
-    const { cleanUrl, removedTracking } = processUrl(
-      "https://www.ebay.es/itm/123456?campid=some-affiliate-id&mkevt=1&utm_source=google",
-      { ...PREFS, injectOwnAffiliate: false }
-    );
-    const clean = new URL(cleanUrl);
-    assert.equal(clean.searchParams.get("campid"), "some-affiliate-id",
-      "campid= must be preserved as affiliate param on eBay");
-    assert.ok(removedTracking.includes("mkevt"),
-      "mkevt must still be stripped");
-    assert.ok(removedTracking.includes("utm_source"),
-      "utm_source must still be stripped");
-  });
-
+  // (pccomponentes ref + eBay campid collisions moved to the shared canary
+  //  fixtures — tests/fixtures/affiliate-canaries.mjs, #769)
   test("ref= is NOT stripped on a non-affiliate host (e.g., example.com) — ref removed from global TRACKING_PARAMS (#160)", () => {
     // 'ref' was removed from TRACKING_PARAMS because it is the affiliate param for
     // PcComponentes and MediaMarkt. Applying it globally stripped it before the

--- a/tests/unit/get-landing-policy.test.mjs
+++ b/tests/unit/get-landing-policy.test.mjs
@@ -11,6 +11,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { getLandingPolicy, processUrl } from "../../src/lib/cleaner.js";
+import { LANDING_CANARIES } from "../fixtures/affiliate-canaries.mjs";
 
 const PREFS = Object.freeze({
   enabled: true,
@@ -61,78 +62,16 @@ describe("getLandingPolicy — empty policy contract", () => {
 });
 
 describe("getLandingPolicy — first-touch from each matrix v1.0 network", () => {
-  test("awin1.com referrer → preserve awc + wt_mc, network=awin", () => {
-    const policy = getLandingPolicy("zalando.es", "https://www.awin1.com/cread.php?id=1");
-    assert.deepStrictEqual([...policy.preserve].sort(), ["awc", "wt_mc"]);
-    assert.equal(policy.network, "awin");
-  });
-
-  test("CJ redirect referrer → preserve cjevent + cjdata", () => {
-    const policy = getLandingPolicy("walmart.com", "https://anrdoezrs.net/click-123-456");
-    assert.deepStrictEqual([...policy.preserve].sort(), ["cjdata", "cjevent"]);
-    assert.equal(policy.network, "cj-affiliate");
-  });
-
-  test("s.click.aliexpress.com referrer → preserve aff_* + algo_* family", () => {
-    const policy = getLandingPolicy(
-      "aliexpress.com",
-      "https://s.click.aliexpress.com/e/_DnZbqGr",
-    );
-    assert.deepStrictEqual(
-      [...policy.preserve].sort(),
-      ["aff_request_id", "aff_trace_key", "algo_expid", "algo_pvid", "btsid", "ws_ab_test"],
-    );
-    assert.equal(policy.network, "aliexpress-affiliate");
-  });
-
-  test("Impact *.pxf.io subdomain → preserve irclickid + irgwc + iclid", () => {
-    const policy = getLandingPolicy(
-      "target.com",
-      "https://target.pxf.io/c/1234/abc",
-    );
-    assert.deepStrictEqual([...policy.preserve].sort(), ["iclid", "irclickid", "irgwc"]);
-    assert.equal(policy.network, "impact-radius");
-  });
-
-  test("prf.hn referrer → preserve clickref + pubref + adref", () => {
-    const policy = getLandingPolicy("partner.com", "https://prf.hn/click/123");
-    assert.deepStrictEqual([...policy.preserve].sort(), ["adref", "clickref", "pubref"]);
-    assert.equal(policy.network, "partnerize");
-  });
-
-  test("Admitad redirect (both hosts) → preserve admitad_uid + tagtag_uid", () => {
-    const a = getLandingPolicy("shop.com", "https://ad.admitad.com/g/abc");
-    assert.deepStrictEqual([...a.preserve].sort(), ["admitad_uid", "tagtag_uid"]);
-    assert.equal(a.network, "admitad");
-
-    const b = getLandingPolicy("aliexpress.com", "https://alitems.com/g/xyz");
-    assert.deepStrictEqual([...b.preserve].sort(), ["admitad_uid", "tagtag_uid"]);
-    assert.equal(b.network, "admitad");
-  });
-
-  test("px.a8.net referrer → preserve a8", () => {
-    const policy = getLandingPolicy("rakuten.co.jp", "https://px.a8.net/svt/ejp?id=1");
-    assert.deepStrictEqual([...policy.preserve], ["a8"]);
-    assert.equal(policy.network, "a8net");
-  });
-
-  test("click.linksynergy.com referrer → preserve ranmid + ransiteid + raneaid", () => {
-    const policy = getLandingPolicy(
-      "ebay.com",
-      "https://click.linksynergy.com/deeplink?id=1",
-    );
-    assert.deepStrictEqual([...policy.preserve].sort(), ["raneaid", "ranmid", "ransiteid"]);
-    assert.equal(policy.network, "rakuten-linkshare");
-  });
-
-  test("tc.tradetracker.net referrer → preserve ttaid + ttrk + ttcid", () => {
-    const policy = getLandingPolicy(
-      "merchant.de",
-      "https://tc.tradetracker.net/?c=1&m=2",
-    );
-    assert.deepStrictEqual([...policy.preserve].sort(), ["ttaid", "ttcid", "ttrk"]);
-    assert.equal(policy.network, "tradetracker");
-  });
+  // Cases are the shared canary fixtures — single source of truth (#768/#769).
+  // Exact-set equality keeps the original strength; coverage now also includes
+  // Tradedoubler (tduid), which previously had none.
+  for (const c of LANDING_CANARIES) {
+    test(`${c.network}: ${c.referrer} preserves ${c.mustPreserve.join(" + ")}`, () => {
+      const policy = getLandingPolicy(c.landingHost, c.referrer);
+      assert.deepStrictEqual([...policy.preserve].sort(), [...c.mustPreserve].sort());
+      assert.equal(policy.network, c.network);
+    });
+  }
 });
 
 describe("getLandingPolicy — defensive parsing of the referrer arg", () => {


### PR DESCRIPTION
Completes **EPIC A** of the Self-scaling ruleset safety net (epic #785), building on the fixtures from #768.

## #770 — close the Tradedoubler gap + drift guard
- Add the Tradedoubler (`tduid`) LANDING canary — the one matrix-v1.0 redirect network that had **zero** coverage. Now 10/10.
- New test asserts **every** `REDIRECT_NETWORK_PATTERNS` entry has a named LANDING canary → a future network can't be added without one.

## #771 — programmatic runner
- **`tests/fixtures/canary-runner.mjs`** → `runAffiliateCanaries()` runs every canary against the live cleaner and returns `{ ok, total, failures[] }` (each failure names the canary + the exact param/expected/actual). This is the API the ingestion pipeline's **GATE 3 (#777)** calls to reject any candidate that breaks affiliate attribution.

## #769 — dedupe onto the single source of truth
- `get-landing-policy.test.mjs`: the 9 inline network tests now iterate `LANDING_CANARIES` (exact-set equality kept; gains Tradedoubler).
- `cleaner.test.mjs`: removed the pure foreign-tag/foreign-campid survival dupes (×12) + pccomponentes/eBay collision dupes — now in the fixtures. Injection, foreign-detection, and junk-count assertions are kept (no coverage loss).

Test-only change. Full suite: **4106 pass / 0 fail**.

Closes #769, #770, #771.
