### PR TITLE
feat(ingestion): scaffold tools/rule-ingestion + quarantine gate (#772)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Verify browser-polyfill integrity (#97)
         run: node tools/verify-polyfill-integrity.mjs
 
+      - name: Verify rule-ingestion quarantine (#772)
+        # Clean-room gate: raw upstream signals must never be committed or
+        # bundled. Fails CI if anything is tracked under the quarantine dir,
+        # if the path drops out of .gitignore, or if it moves under src/.
+        run: npm run verify:quarantine
+
       - name: Check i18n quality (no FIXME / stubs / empty locale slots) (#621)
         run: npm run check:i18n
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ test-results/
 tests/benchmark/reports/*.json
 tests/benchmark/reports/*.md
 tests/benchmark/reports/*.html
+
+# Rule-ingestion quarantine (#772): raw upstream signals — never committed.
+# Clean-room posture: upstream bytes stay ephemeral; only re-derived candidates
+# may land. Enforced by tools/rule-ingestion/verify-quarantine.mjs in CI.
+tools/rule-ingestion/quarantine/

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "node --test --test-reporter=spec tests/unit/*.mjs",
     "test:integration": "node --test --test-reporter=spec tests/integration/*.mjs",
     "check:i18n": "node tools/check-i18n-fixme.mjs",
+    "verify:quarantine": "node tools/rule-ingestion/verify-quarantine.mjs",
     "conformance:contextual": "node --test --test-reporter=spec tests/unit/conformance-contextual.test.mjs",
     "test:serve": "npx serve tests/browser --listen 5555 --no-clipboard",
     "brand": "npx serve tools --listen 5556 --no-clipboard",

--- a/tests/unit/rule-ingestion-quarantine.test.mjs
+++ b/tests/unit/rule-ingestion-quarantine.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * MUGA — Quarantine gate tests for the rule-ingestion clean-room scaffold (#772).
+ *
+ * Locks the three invariants that keep raw upstream signals out of the repo and
+ * the distributed bundle:
+ *   1. nothing is git-tracked under the quarantine dir,
+ *   2. the quarantine path is gitignored,
+ *   3. the quarantine path lives outside src/ (the bundle source root).
+ *
+ * The first two assert against the REAL repo state, so a future commit that
+ * accidentally stages a raw upstream file or drops the .gitignore line fails
+ * here as well as in the standalone CI gate.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  QUARANTINE_PATH,
+  isGitignored,
+  isOutsideSrc,
+  listTrackedQuarantineFiles,
+} from "../../tools/rule-ingestion/verify-quarantine.mjs";
+
+test("QUARANTINE_PATH is the rule-ingestion quarantine dir", () => {
+  assert.equal(QUARANTINE_PATH, "tools/rule-ingestion/quarantine/");
+});
+
+test("isOutsideSrc: quarantine path is not under src/", () => {
+  assert.equal(isOutsideSrc(), true);
+});
+
+test("isOutsideSrc: a path under src/ is flagged as bundle-reachable", () => {
+  assert.equal(isOutsideSrc("src/rules/quarantine/"), false);
+  assert.equal(isOutsideSrc("/src/anything"), false);
+});
+
+test("isGitignored: matches the directory with or without slashes/anchor", () => {
+  assert.equal(isGitignored("tools/rule-ingestion/quarantine/"), true);
+  assert.equal(isGitignored("tools/rule-ingestion/quarantine"), true);
+  assert.equal(isGitignored("/tools/rule-ingestion/quarantine/"), true);
+});
+
+test("isGitignored: ignores comments and unrelated entries", () => {
+  const gitignore = [
+    "# tools/rule-ingestion/quarantine/",
+    "node_modules/",
+    "dist/",
+  ].join("\n");
+  assert.equal(isGitignored(gitignore), false);
+});
+
+test("the real .gitignore lists the quarantine path", () => {
+  const gitignore = readFileSync(
+    new URL("../../.gitignore", import.meta.url),
+    "utf8",
+  );
+  assert.equal(isGitignored(gitignore), true);
+});
+
+test("no raw upstream is git-tracked under the quarantine dir", () => {
+  assert.deepEqual(listTrackedQuarantineFiles(), []);
+});

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -1,0 +1,62 @@
+# `tools/rule-ingestion/` — clean-room ingestion pipeline (EPIC B/C)
+
+In-repo tooling that scales MUGA's `TRACKING_PARAMS` list **without depending on
+active user reports**, while preserving the CAPS affiliate moat. Tracking issue:
+[#785](https://github.com/yocreoquesi/muga/issues/785).
+
+This directory is the **scaffold** (B1, [#772](https://github.com/yocreoquesi/muga/issues/772)).
+Fetch/normalize adapters (B2, #773), provenance discipline (B3, #774) and the
+gate stack (EPIC C) land on top of it.
+
+## Core principle — signals, not copies
+
+Upstream tracker lists are used as **signals only**. A candidate parameter is
+*corroborated* by upstream presence, then **independently re-derived** against
+MUGA's own data — it is never copied verbatim into the distributed ruleset.
+
+**Legal posture (verified):** individual param facts are not copyrightable
+(Feist v. Rural); the EU sui generis right is limited to *obtaining* data
+(BHB v. William Hill). DuckDuckGo's list (CC BY-NC-SA, NonCommercial) is
+**off-limits** and excluded from every adapter.
+
+## Asymmetric risk → asymmetric automation
+
+Stripping a tracker by mistake is cheap; stripping an affiliate/functional
+param is catastrophic. The pipeline is **aggressive toward _preserve_** and
+**conservative toward _strip_**. The human leaves the critical path, replaced by
+deterministic gates — never by accepting affiliate-deletion risk.
+
+## Quarantine zone — raw upstream NEVER lands in the repo or the bundle
+
+```
+tools/rule-ingestion/
+├── README.md              # this file
+├── verify-quarantine.mjs  # CI gate (see below)
+└── quarantine/            # gitignored working dir, created at runtime
+    └── …                  # raw upstream downloads — ephemeral, never committed
+```
+
+Raw upstream data (the literal bytes of an upstream list) lives ONLY in
+`quarantine/`, which is:
+
+1. **Gitignored** — `tools/rule-ingestion/quarantine/` is in `.gitignore`, so
+   raw bytes are never committed.
+2. **Outside `src/`** — the extension bundle is built exclusively from `src/`
+   (`web-ext build --source-dir src/`), so quarantined raw data physically
+   cannot reach `dist/`.
+3. **Ephemeral in CI** — adapters `mkdir -p` it at runtime; the scheduled
+   action discards it after deriving candidates.
+
+What may be committed is the *derived, re-authored* candidate set with its
+provenance metadata — never the raw source.
+
+## CI gate
+
+`verify-quarantine.mjs` runs in CI ([`ci.yml`](../../.github/workflows/ci.yml))
+and fails the build if the quarantine invariants are violated:
+
+- no tracked files exist under `quarantine/`,
+- the quarantine path is listed in `.gitignore`,
+- the quarantine path lives outside `src/`.
+
+Run it locally with `npm run verify:quarantine`.

--- a/tools/rule-ingestion/verify-quarantine.mjs
+++ b/tools/rule-ingestion/verify-quarantine.mjs
@@ -1,0 +1,110 @@
+/**
+ * MUGA: verify-quarantine — CI gate for the rule-ingestion quarantine zone (#772).
+ *
+ * Asserts that raw upstream data can never be committed to the repo or shipped
+ * in the extension bundle. The quarantine working dir holds the literal bytes of
+ * upstream tracker lists during ingestion; those bytes are signals only and must
+ * stay ephemeral (see tools/rule-ingestion/README.md for the clean-room rationale).
+ *
+ * Three invariants, any failure exits non-zero:
+ *
+ *   1. NO TRACKED FILES — `git ls-files` reports nothing under quarantine/.
+ *   2. GITIGNORED       — the quarantine path is listed in .gitignore.
+ *   3. OUTSIDE src/     — the bundle is built from src/ only, so a quarantine
+ *                         path outside src/ physically cannot reach dist/.
+ *
+ * Run with: node tools/rule-ingestion/verify-quarantine.mjs  (npm run verify:quarantine)
+ *
+ * Pure helpers are exported for unit testing; the git invocation and process
+ * exit live in main() so the module is import-safe.
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/** Repo-relative quarantine working dir. Trailing slash = directory match. */
+export const QUARANTINE_PATH = "tools/rule-ingestion/quarantine/";
+
+/**
+ * Invariant 2: is the quarantine path gitignored?
+ *
+ * Matches the directory pattern with or without a trailing slash and tolerates
+ * a leading `/` anchor, so `tools/rule-ingestion/quarantine/`,
+ * `/tools/rule-ingestion/quarantine`, etc. all count.
+ *
+ * @param {string} gitignoreText Raw .gitignore contents.
+ * @param {string} [quarantinePath=QUARANTINE_PATH] Path to look for.
+ * @returns {boolean}
+ */
+export function isGitignored(gitignoreText, quarantinePath = QUARANTINE_PATH) {
+  const bare = quarantinePath.replace(/\/+$/, "");
+  for (const rawLine of gitignoreText.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const normalized = line.replace(/^\/+/, "").replace(/\/+$/, "");
+    if (normalized === bare) return true;
+  }
+  return false;
+}
+
+/**
+ * Invariant 3: does the quarantine path live outside src/?
+ *
+ * @param {string} [quarantinePath=QUARANTINE_PATH] Path to check.
+ * @returns {boolean} True when the path is NOT under src/.
+ */
+export function isOutsideSrc(quarantinePath = QUARANTINE_PATH) {
+  const normalized = quarantinePath.replace(/^\/+/, "");
+  return !normalized.startsWith("src/");
+}
+
+/**
+ * Invariant 1: list git-tracked files under the quarantine path.
+ *
+ * @param {string} [quarantinePath=QUARANTINE_PATH] Path to scan.
+ * @returns {string[]} Tracked file paths (empty when the invariant holds).
+ */
+export function listTrackedQuarantineFiles(quarantinePath = QUARANTINE_PATH) {
+  const out = execSync(`git ls-files -- "${quarantinePath}"`, {
+    encoding: "utf8",
+  });
+  return out
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+function main() {
+  const errors = [];
+
+  const tracked = listTrackedQuarantineFiles();
+  if (tracked.length > 0) {
+    errors.push(
+      `Quarantine contains ${tracked.length} tracked file(s) — raw upstream must never be committed:\n` +
+        tracked.map((f) => `  - ${f}`).join("\n"),
+    );
+  }
+
+  const gitignore = readFileSync(".gitignore", "utf8");
+  if (!isGitignored(gitignore)) {
+    errors.push(`Quarantine path '${QUARANTINE_PATH}' is not listed in .gitignore.`);
+  }
+
+  if (!isOutsideSrc()) {
+    errors.push(
+      `Quarantine path '${QUARANTINE_PATH}' is under src/ — it could be bundled into dist/.`,
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error("Quarantine invariant violation(s):\n");
+    console.error(errors.join("\n\n"));
+    process.exit(1);
+  }
+
+  console.log("Quarantine gate OK: no tracked raw upstream, gitignored, outside src/.");
+}
+
+if (process.argv[1]?.endsWith("verify-quarantine.mjs")) {
+  main();
+}


### PR DESCRIPTION
Closes #772. EPIC B1 of the Self-scaling ruleset initiative (#785).

## What

Scaffolds the clean-room ingestion home so EPIC B2 (#773 adapters) and the gate stack (EPIC C) have a place to live, and locks the **quarantine invariant** before any fetch code exists.

Raw upstream lists are **signals only** — corroborated, then independently re-derived, never copied (Feist v. Rural; DuckDuckGo CC BY-NC-SA stays off-limits). The literal upstream bytes live exclusively in a quarantine working dir that is gitignored, outside `src/`, and created at runtime — so they can never be committed or shipped in `dist/`.

## Changes

- **`tools/rule-ingestion/README.md`** — clean-room posture, legal basis, quarantine layout.
- **`tools/rule-ingestion/verify-quarantine.mjs`** — CI gate enforcing 3 invariants: (1) no git-tracked files under `quarantine/`, (2) path is gitignored, (3) path is outside `src/`. Pure helpers exported for testing.
- **`.github/workflows/ci.yml`** — new `Verify rule-ingestion quarantine (#772)` step.
- **`package.json`** — `verify:quarantine` script.
- **`.gitignore`** — `tools/rule-ingestion/quarantine/`.
- **`tests/unit/rule-ingestion-quarantine.test.mjs`** — locks the invariants against real repo state.

## Acceptance

- [x] `tools/rule-ingestion/` skeleton + README
- [x] Quarantine path gitignored; CI verifies raw upstream never lands in the bundle

## Verification

```
npm run verify:quarantine   → Quarantine gate OK
node --test tests/unit/rule-ingestion-quarantine.test.mjs → 7 pass / 0 fail
```

No runtime/extension code touched — tooling + CI + docs only.