### PR TITLE
feat(ingestion): source adapters + candidate format (#773)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:integration": "node --test --test-reporter=spec tests/integration/*.mjs",
     "check:i18n": "node tools/check-i18n-fixme.mjs",
     "verify:quarantine": "node tools/rule-ingestion/verify-quarantine.mjs",
+    "ingest:rules": "node tools/rule-ingestion/ingest.mjs",
     "conformance:contextual": "node --test --test-reporter=spec tests/unit/conformance-contextual.test.mjs",
     "test:serve": "npx serve tests/browser --listen 5555 --no-clipboard",
     "brand": "npx serve tools --listen 5556 --no-clipboard",

--- a/tests/unit/rule-ingestion-adapters.test.mjs
+++ b/tests/unit/rule-ingestion-adapters.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * MUGA — Source adapter + ingestion tests for rule-ingestion (#773).
+ *
+ * Covers the AdGuard TP adapter (delegates to the shared $removeparam parser),
+ * the registry (only AdGuard enabled; DuckDuckGo recorded as excluded), and the
+ * runIngestion flow with injected fetch + a temp quarantine dir (no network, no
+ * real FS layout).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { adguardTp } from "../../tools/rule-ingestion/adapters/adguard-tp.mjs";
+import {
+  ENABLED_ADAPTERS,
+  EXCLUDED_SOURCES,
+} from "../../tools/rule-ingestion/adapters/index.mjs";
+import { runIngestion } from "../../tools/rule-ingestion/ingest.mjs";
+
+const SAMPLE_ADGUARD = [
+  "! Title: AdGuard URL Tracking filter",
+  "[Adblock Plus 2.0]",
+  "$removeparam=utm_source",
+  "$removeparam=fbclid|gclid",
+  "$removeparam=/^utm_/", // regex spec — skipped by the parser
+  "||example.com^$removeparam=msclkid",
+].join("\n");
+
+test("adguardTp adapter has the expected identity + license", () => {
+  assert.equal(adguardTp.id, "adguard-tp");
+  assert.equal(adguardTp.license, "GPL-3.0");
+  assert.match(adguardTp.url, /adtidy\.org/);
+});
+
+test("adguardTp.parse extracts literal params and skips regex specs", () => {
+  const params = adguardTp.parse(SAMPLE_ADGUARD);
+  assert.ok(params instanceof Set);
+  assert.ok(params.has("utm_source"));
+  assert.ok(params.has("fbclid"));
+  assert.ok(params.has("gclid"));
+  assert.ok(params.has("msclkid"));
+  // The /^utm_/ regex spec must NOT leak in as a literal.
+  assert.ok(!params.has("/^utm_/"));
+});
+
+test("registry enables only AdGuard TP in B2", () => {
+  assert.deepEqual(
+    ENABLED_ADAPTERS.map((a) => a.id),
+    ["adguard-tp"],
+  );
+});
+
+test("DuckDuckGo is recorded as a deliberately excluded source", () => {
+  const ddg = EXCLUDED_SOURCES.find((s) => s.id === "duckduckgo");
+  assert.ok(ddg, "duckduckgo must be in EXCLUDED_SOURCES");
+  assert.match(ddg.license, /NC|NonCommercial|BY-NC/i);
+});
+
+test("runIngestion quarantines raw bytes and returns merged candidates", async () => {
+  const dir = mkdtempSync(resolve(tmpdir(), "muga-ingest-"));
+  try {
+    const fakeAdapter = {
+      id: "adguard-tp",
+      name: "fake",
+      license: "GPL-3.0",
+      url: "https://example.test/list.txt",
+      parse: adguardTp.parse,
+      async fetchRaw() {
+        return SAMPLE_ADGUARD;
+      },
+    };
+
+    const candidates = await runIngestion({
+      adapters: [fakeAdapter],
+      quarantineDir: dir,
+      now: "2026-05-31T00:00:00.000Z",
+    });
+
+    // Raw bytes were quarantined verbatim (never returned to the caller).
+    const rawPath = resolve(dir, "adguard-tp.raw");
+    assert.ok(existsSync(rawPath), "raw download must be quarantined");
+    assert.equal(readFileSync(rawPath, "utf8"), SAMPLE_ADGUARD);
+
+    // Candidates carry adguard-tp provenance.
+    const names = candidates.map((c) => c.param);
+    assert.ok(names.includes("fbclid"));
+    assert.ok(names.includes("utm_source"));
+    for (const c of candidates) {
+      assert.deepEqual(c.signals, ["adguard-tp"]);
+      assert.equal(c.firstSeenAt, "2026-05-31T00:00:00.000Z");
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runIngestion injects fetch into fetchRaw (no real network)", async () => {
+  const dir = mkdtempSync(resolve(tmpdir(), "muga-ingest-"));
+  try {
+    let sawInjectedFetch = false;
+    const fakeFetch = async () => {
+      sawInjectedFetch = true;
+      return { ok: true, async text() { return SAMPLE_ADGUARD; } };
+    };
+    const netAdapter = {
+      id: "adguard-tp",
+      name: "fake",
+      license: "GPL-3.0",
+      url: "https://example.test/list.txt",
+      parse: adguardTp.parse,
+      fetchRaw: adguardTp.fetchRaw,
+    };
+
+    const candidates = await runIngestion({
+      adapters: [netAdapter],
+      fetchImpl: fakeFetch,
+      quarantineDir: dir,
+      now: "2026-05-31T00:00:00.000Z",
+    });
+
+    assert.ok(sawInjectedFetch, "fetchRaw must use the injected fetch");
+    assert.ok(candidates.length > 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/rule-ingestion-candidate.test.mjs
+++ b/tests/unit/rule-ingestion-candidate.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * MUGA — Candidate format contract tests for rule-ingestion (#773).
+ *
+ * Locks the shared candidate shape the EPIC C gates consume: provenance in
+ * signals[], entropy/crossSiteFrequency null at B2, single-source survival, and
+ * deterministic merge ordering.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  makeCandidate,
+  mergeCandidates,
+} from "../../tools/rule-ingestion/candidate.mjs";
+
+const NOW = "2026-05-31T00:00:00.000Z";
+
+test("makeCandidate lowercases the param and carries one signal", () => {
+  const c = makeCandidate("UTM_Source", "adguard-tp", { now: NOW });
+  assert.deepEqual(c, {
+    param: "utm_source",
+    signals: ["adguard-tp"],
+    entropy: null,
+    crossSiteFrequency: null,
+    firstSeenAt: NOW,
+  });
+});
+
+test("mergeCandidates dedupes params and lowercases", () => {
+  const out = mergeCandidates(
+    [{ id: "adguard-tp", params: ["fbclid", "FBCLID", "gclid"] }],
+    { now: NOW },
+  );
+  assert.equal(out.length, 2);
+  assert.deepEqual(
+    out.map((c) => c.param).sort(),
+    ["fbclid", "gclid"],
+  );
+});
+
+test("mergeCandidates accumulates provenance across adapters without dup signals", () => {
+  const out = mergeCandidates(
+    [
+      { id: "adguard-tp", params: ["fbclid"] },
+      { id: "other", params: ["fbclid"] },
+      { id: "adguard-tp", params: ["fbclid"] }, // repeat adapter, same param
+    ],
+    { now: NOW },
+  );
+  assert.equal(out.length, 1);
+  assert.deepEqual(out[0].signals, ["adguard-tp", "other"]); // sorted, deduped
+});
+
+test("single-source candidates survive (corroboration is not a hard gate)", () => {
+  const out = mergeCandidates(
+    [{ id: "adguard-tp", params: ["only_here"] }],
+    { now: NOW },
+  );
+  assert.equal(out.length, 1);
+  assert.deepEqual(out[0].signals, ["adguard-tp"]);
+});
+
+test("entropy and crossSiteFrequency stay null at B2 (no corpus)", () => {
+  const out = mergeCandidates(
+    [{ id: "adguard-tp", params: ["x"] }],
+    { now: NOW },
+  );
+  assert.equal(out[0].entropy, null);
+  assert.equal(out[0].crossSiteFrequency, null);
+});
+
+test("merge sorts by signal count desc, then param asc", () => {
+  const out = mergeCandidates(
+    [
+      { id: "a", params: ["zeta", "shared"] },
+      { id: "b", params: ["shared", "alpha"] },
+    ],
+    { now: NOW },
+  );
+  // shared has 2 signals → first; rest single-signal, alphabetical.
+  assert.deepEqual(
+    out.map((c) => c.param),
+    ["shared", "alpha", "zeta"],
+  );
+});
+
+test("empty/whitespace params are dropped", () => {
+  const out = mergeCandidates(
+    [{ id: "a", params: ["", "  ", "real"] }],
+    { now: NOW },
+  );
+  assert.deepEqual(
+    out.map((c) => c.param),
+    ["real"],
+  );
+});

--- a/tools/import-upstream.mjs
+++ b/tools/import-upstream.mjs
@@ -30,8 +30,10 @@
 import { TRACKING_PARAMS } from "../src/lib/affiliates.js";
 import { writeFileSync } from "node:fs";
 
+// The `safari` platform path was deprecated by AdGuard and now 404s; `chromium`
+// serves the same Filter 17 (URL Tracking Protection) list.
 const ADGUARD_FILTER_17_URL =
-  "https://filters.adtidy.org/extension/safari/filters/17.txt";
+  "https://filters.adtidy.org/extension/chromium/filters/17.txt";
 
 /**
  * Parses an Adblock Plus filter list and extracts every removeparam parameter

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -32,6 +32,11 @@ deterministic gates — never by accepting affiliate-deletion risk.
 tools/rule-ingestion/
 ├── README.md              # this file
 ├── verify-quarantine.mjs  # CI gate (see below)
+├── candidate.mjs          # candidate format + mergeCandidates() (#773)
+├── ingest.mjs             # entry: run adapters → quarantine raw → merge (#773)
+├── adapters/
+│   ├── index.mjs          # registry: ENABLED_ADAPTERS + EXCLUDED_SOURCES
+│   └── adguard-tp.mjs     # AdGuard URL Tracking Protection (GPL-3.0)
 └── quarantine/            # gitignored working dir, created at runtime
     └── …                  # raw upstream downloads — ephemeral, never committed
 ```
@@ -49,6 +54,42 @@ Raw upstream data (the literal bytes of an upstream list) lives ONLY in
 
 What may be committed is the *derived, re-authored* candidate set with its
 provenance metadata — never the raw source.
+
+## Source adapters & candidate format (#773)
+
+Each adapter fetches one upstream list, quarantines the raw bytes, and normalizes
+them into a SET of **literal param-name facts** — never the curated compilation.
+`ingest.mjs` folds every adapter's set into the shared candidate shape:
+
+```js
+{
+  param:             "fbclid",       // normalized lowercase name
+  signals:           ["adguard-tp"], // provenance: which adapters reported it
+  entropy:           null,           // derived in EPIC C (no corpus here)
+  crossSiteFrequency:null,           // derived in EPIC C (#776)
+  firstSeenAt:       "<iso8601>"
+}
+```
+
+`signals[]` is an array so a second source slots in without a contract change.
+B2 ships a **single source** — AdGuard URL Tracking Protection (Filter 17,
+GPL-3.0): a large, consolidated list. Cross-source **corroboration scoring is
+deliberately deferred to #776**, where the corroboration gate actually adds a
+second source and consumes the score — building it now would be machinery that
+carries no weight and a false sense of safety. Real safety lives in the EPIC C
+gates (affiliate-guard #775, canary #777), not in source agreement.
+
+`entropy` / `crossSiteFrequency` are part of the contract but stay `null`: B2 has
+no URL corpus to derive them honestly (#776 fills them — never fabricated here).
+
+Run locally with `npm run ingest:rules` (writes `quarantine/candidates.json`).
+
+### Excluded sources
+
+`adapters/index.mjs` records sources excluded **on purpose**. DuckDuckGo
+(tracker-radar / tracker-blocklists) is CC BY-NC-SA 4.0 — the **NonCommercial**
+clause makes it off-limits for MUGA, a commercial extension. Do NOT add a DDG
+adapter. Full ledger: `PROVENANCE.md` (#774).
 
 ## CI gate
 

--- a/tools/rule-ingestion/adapters/adguard-tp.mjs
+++ b/tools/rule-ingestion/adapters/adguard-tp.mjs
@@ -1,0 +1,56 @@
+/**
+ * MUGA rule-ingestion adapter: AdGuard URL Tracking Protection (Filter 17) (#773).
+ *
+ * License: GPL-3.0 (strong copyleft, compatible with MUGA's GPL v3).
+ * Used as a SIGNAL only — we extract individual param-name facts (not the
+ * curated compilation) and re-derive independently. See PROVENANCE.md (#774).
+ *
+ * Reuses `parseRemoveparamRules` from tools/import-upstream.mjs rather than
+ * duplicating the Adblock-Plus $removeparam parser — one parser, one place.
+ */
+
+import { parseRemoveparamRules } from "../../import-upstream.mjs";
+
+// Filter 17 = AdGuard URL Tracking Protection. The `safari` platform path was
+// deprecated (404s); `chromium` serves the same list and is what we use here.
+const SOURCE_URL =
+  "https://filters.adtidy.org/extension/chromium/filters/17.txt";
+
+const USER_AGENT =
+  "muga-rule-ingestion/1.0 (+https://github.com/yocreoquesi/muga)";
+
+/** @type {import("./index.mjs").Adapter} */
+export const adguardTp = {
+  id: "adguard-tp",
+  name: "AdGuard URL Tracking Protection (Filter 17)",
+  license: "GPL-3.0",
+  url: SOURCE_URL,
+
+  /**
+   * Extract literal tracking param names from an AdGuard filter list.
+   * @param {string} rawText Raw filter-list contents.
+   * @returns {Set<string>} Lowercased param names.
+   */
+  parse(rawText) {
+    return parseRemoveparamRules(rawText);
+  },
+
+  /**
+   * Fetch the raw filter list. Returns the raw text so the caller can quarantine
+   * it before parsing (raw bytes are ephemeral — never committed/bundled).
+   * @param {object} [opts]
+   * @param {typeof fetch} [opts.fetchImpl] Injectable fetch for testing.
+   * @returns {Promise<string>}
+   */
+  async fetchRaw({ fetchImpl = fetch } = {}) {
+    const res = await fetchImpl(SOURCE_URL, {
+      headers: { "User-Agent": USER_AGENT },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `AdGuard TP fetch failed: ${res.status} ${res.statusText}`,
+      );
+    }
+    return res.text();
+  },
+};

--- a/tools/rule-ingestion/adapters/index.mjs
+++ b/tools/rule-ingestion/adapters/index.mjs
@@ -1,0 +1,48 @@
+/**
+ * MUGA rule-ingestion adapter registry (#773).
+ *
+ * Lists the license-compatible signal sources MUGA ingests, and records the
+ * sources DELIBERATELY EXCLUDED so the exclusion is visible in code review, not
+ * just in a doc.
+ *
+ * @typedef {object} Adapter
+ * @property {string} id            Stable adapter id (used in candidate.signals).
+ * @property {string} name          Human-readable source name.
+ * @property {string} license       SPDX-ish license id of the source data.
+ * @property {string} url           Source URL.
+ * @property {(rawText: string) => Set<string>} parse  Raw → literal param names.
+ * @property {(opts?: {fetchImpl?: typeof fetch}) => Promise<string>} fetchRaw
+ */
+
+import { adguardTp } from "./adguard-tp.mjs";
+
+/**
+ * Enabled, license-compatible signal sources.
+ * - AdGuard TP: GPL-3.0 (compatible with MUGA's GPL v3) — a large, consolidated,
+ *   well-maintained list. Single source in B2.
+ *
+ * A second independent source (and cross-corroboration scoring) is deferred to
+ * #776, where the corroboration gate actually consumes it. The adapter array
+ * means adding one later is a registry edit, not a contract change.
+ * @type {Adapter[]}
+ */
+export const ENABLED_ADAPTERS = [adguardTp];
+
+/**
+ * Sources excluded ON PURPOSE — do NOT add adapters for these.
+ *
+ * DuckDuckGo (tracker-radar / tracker-blocklists) is licensed CC BY-NC-SA 4.0.
+ * The NonCommercial clause forbids use in MUGA, a commercial extension, without
+ * a separately negotiated license. Excluding it is a legal requirement, not a
+ * preference. Full ledger: tools/rule-ingestion/PROVENANCE.md (#774).
+ *
+ * @type {Array<{id: string, license: string, reason: string}>}
+ */
+export const EXCLUDED_SOURCES = [
+  {
+    id: "duckduckgo",
+    license: "CC BY-NC-SA 4.0",
+    reason:
+      "NonCommercial clause — off-limits for a commercial extension without a negotiated license.",
+  },
+];

--- a/tools/rule-ingestion/candidate.mjs
+++ b/tools/rule-ingestion/candidate.mjs
@@ -1,0 +1,85 @@
+/**
+ * MUGA: rule-ingestion candidate format — the common contract (#773).
+ *
+ * Every source adapter normalizes its upstream list into a SET of literal param
+ * names (facts, not the curated compilation — see PROVENANCE.md, #774).
+ * `mergeCandidates` folds those sets into the shared candidate shape that the
+ * EPIC C gate stack (#775-#778) consumes.
+ *
+ * SINGLE SOURCE in B2 (AdGuard TP). The contract still carries `signals[]` as an
+ * array so a second source can be added later WITHOUT a contract change — but we
+ * deliberately do NOT compute a corroboration/confidence score here. Confidence
+ * by cross-source agreement is only meaningful with ≥2 independent sources, and
+ * it is NOT the safety mechanism anyway — the EPIC C gates (affiliate-guard,
+ * canary) are. Cross-corroboration scoring lands in #776, where a second source
+ * is actually added and the score is actually consumed. Building it now would be
+ * machinery that carries no weight (and a false sense of safety).
+ *
+ * Candidate shape:
+ *   {
+ *     param:             "fbclid",        // normalized lowercase name
+ *     signals:           ["adguard-tp"],  // provenance: which adapters reported it
+ *     entropy:           null,            // derived in EPIC C (no corpus in B2)
+ *     crossSiteFrequency:null,            // derived in EPIC C (#776)
+ *     firstSeenAt:       "<iso8601>"      // when ingestion first saw it
+ *   }
+ *
+ * entropy / crossSiteFrequency are part of the contract (the issue requires the
+ * provenance fields) but stay `null`: B2 has no URL corpus to derive them
+ * honestly. They are filled by the cross-corroboration gate (#776), never
+ * fabricated at ingestion.
+ */
+
+/**
+ * Build a fresh candidate for a param first seen via `signalId`.
+ *
+ * @param {string} param Raw param name (lowercased here).
+ * @param {string} signalId Adapter id that reported it.
+ * @param {object} [opts]
+ * @param {string} [opts.now] ISO timestamp override (for deterministic tests).
+ * @returns {object} Candidate carrying one provenance signal.
+ */
+export function makeCandidate(param, signalId, { now } = {}) {
+  return {
+    param: String(param).trim().toLowerCase(),
+    signals: [signalId],
+    entropy: null,
+    crossSiteFrequency: null,
+    firstSeenAt: now || new Date().toISOString(),
+  };
+}
+
+/**
+ * Fold per-adapter param sets into the shared candidate format, accumulating
+ * provenance in `signals[]`. With a single adapter every candidate carries one
+ * signal; the array shape means adding a source later is a no-op on the contract.
+ *
+ * @param {Array<{id:string, params:Iterable<string>}>} adapterResults
+ * @param {object} [opts]
+ * @param {string} [opts.now] ISO timestamp override for deterministic tests.
+ * @returns {object[]} Candidates sorted by signal count desc, then param asc.
+ */
+export function mergeCandidates(adapterResults, { now } = {}) {
+  const byParam = new Map();
+
+  for (const { id, params } of adapterResults) {
+    for (const raw of params) {
+      const param = String(raw).trim().toLowerCase();
+      if (!param) continue;
+      const existing = byParam.get(param);
+      if (!existing) {
+        byParam.set(param, makeCandidate(param, id, { now }));
+      } else if (!existing.signals.includes(id)) {
+        existing.signals.push(id);
+      }
+    }
+  }
+
+  for (const candidate of byParam.values()) {
+    candidate.signals.sort();
+  }
+
+  return [...byParam.values()].sort(
+    (a, b) => b.signals.length - a.signals.length || a.param.localeCompare(b.param),
+  );
+}

--- a/tools/rule-ingestion/ingest.mjs
+++ b/tools/rule-ingestion/ingest.mjs
@@ -1,0 +1,88 @@
+/**
+ * MUGA: rule-ingestion entry point (#773).
+ *
+ * Runs the enabled source adapters, quarantines each raw download, and folds the
+ * normalized param sets into the common candidate format (candidate.mjs).
+ *
+ * Clean-room flow per adapter:
+ *   fetchRaw() → write raw bytes to quarantine/<id>.raw  (gitignored, ephemeral)
+ *             → parse() into literal param-name facts
+ *   mergeCandidates() → derived candidate set
+ *
+ * The candidate report is written INTO quarantine/ too: it is a working artifact
+ * for the EPIC C gates / human review to promote params into TRACKING_PARAMS —
+ * not a committed product of this stage. Raw upstream never leaves quarantine,
+ * and quarantine never reaches the repo or the bundle (verify-quarantine.mjs).
+ *
+ * Run with: node tools/rule-ingestion/ingest.mjs   (npm run ingest:rules)
+ *
+ * runIngestion() is exported with injectable fetch + dirs so it is unit-testable
+ * without the network or the real filesystem layout.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ENABLED_ADAPTERS } from "./adapters/index.mjs";
+import { mergeCandidates } from "./candidate.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const QUARANTINE_DIR = resolve(__dirname, "quarantine");
+
+/**
+ * Fetch + quarantine + normalize every adapter into a candidate set.
+ *
+ * @param {object} [opts]
+ * @param {import("./adapters/index.mjs").Adapter[]} [opts.adapters] Defaults to ENABLED_ADAPTERS.
+ * @param {typeof fetch} [opts.fetchImpl] Injectable fetch for testing.
+ * @param {string} [opts.quarantineDir] Working dir for raw downloads.
+ * @param {string} [opts.now] ISO timestamp override for deterministic output.
+ * @returns {Promise<object[]>} Candidates (see candidate.mjs).
+ */
+export async function runIngestion({
+  adapters = ENABLED_ADAPTERS,
+  fetchImpl = fetch,
+  quarantineDir = QUARANTINE_DIR,
+  now,
+} = {}) {
+  mkdirSync(quarantineDir, { recursive: true });
+
+  const results = [];
+  for (const adapter of adapters) {
+    const raw = await adapter.fetchRaw({ fetchImpl });
+    // Raw bytes land in quarantine ONLY — gitignored, never committed/bundled.
+    writeFileSync(resolve(quarantineDir, `${adapter.id}.raw`), raw, "utf8");
+    results.push({ id: adapter.id, params: adapter.parse(raw) });
+  }
+
+  return mergeCandidates(results, { now });
+}
+
+async function main() {
+  const candidates = await runIngestion();
+  const report = {
+    generatedAt: new Date().toISOString(),
+    adapters: ENABLED_ADAPTERS.map((a) => ({
+      id: a.id,
+      name: a.name,
+      license: a.license,
+      url: a.url,
+    })),
+    candidateCount: candidates.length,
+    candidates,
+  };
+  const outPath =
+    process.env.CANDIDATES_PATH || resolve(QUARANTINE_DIR, "candidates.json");
+  writeFileSync(outPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+  console.log(
+    `Ingestion: ${candidates.length} candidate(s) from ${ENABLED_ADAPTERS.length} adapter(s) → ${outPath}`,
+  );
+}
+
+if (process.argv[1]?.endsWith("ingest.mjs")) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #773. EPIC B2 of the Self-scaling ruleset (#785). Builds on the B1 scaffold (#772 / #790).

## What

Source adapters that fetch upstream lists as **signals**, quarantine the raw bytes, and normalize them into a shared **candidate format** of literal param-name facts — never the curated compilation (Feist v. Rural; clean-room re-derivation, see #774).

## Design decisions (steered with the maintainer)

- **Single source in B2 — AdGuard URL Tracking Protection (Filter 17, GPL-3.0).** A large, consolidated, reliable list.
- **No confidence/corroboration scoring.** Corroboration was never the safety mechanism — the EPIC C gates (affiliate-guard #775, canary #777) are. Building confidence machinery now would carry no weight and give a false sense of safety. A second independent source + cross-corroboration is **deferred to #776**, where it is actually consumed.
- **`signals[]` stays an array** so adding a source later is a registry edit, not a contract change.
- **`entropy` / `crossSiteFrequency` are in the contract but `null`** — B2 has no URL corpus to derive them honestly; #776 fills them, never fabricated here.

## Candidate contract

```js
{
  param: "fbclid",
  signals: ["adguard-tp"],   // provenance
  entropy: null,             // derived in EPIC C
  crossSiteFrequency: null,  // derived in #776
  firstSeenAt: "<iso8601>"
}
```

## Changes

- `tools/rule-ingestion/candidate.mjs` — contract + `mergeCandidates()`.
- `tools/rule-ingestion/adapters/adguard-tp.mjs` — AdGuard TP adapter, reuses `parseRemoveparamRules` (one parser, one place).
- `tools/rule-ingestion/adapters/index.mjs` — `ENABLED_ADAPTERS` (AdGuard only) + `EXCLUDED_SOURCES` recording **DuckDuckGo (CC BY-NC-SA, NonCommercial → off-limits)**.
- `tools/rule-ingestion/ingest.mjs` — run adapters → quarantine raw → merge. Injectable fetch/dirs. `npm run ingest:rules`.
- Tests: candidate contract + adapters + ingestion (no network, no real FS).

## Drive-by fix (separate commit)

`fix(ingestion): repoint AdGuard Filter 17 to chromium path (safari 404)` — the `safari` platform path on filters.adtidy.org was deprecated and 404s, so the existing **weekly `import-upstream` cron was failing silently**. Found while wiring the adapter against the live endpoint. The `chromium` path serves the same list.

## Verification

```
node --test tests/unit/rule-ingestion-*.test.mjs   → 20 pass / 0 fail
node --test tests/unit/import-upstream.test.mjs     → 12 pass / 0 fail
npm run ingest:rules  → 1683 candidates from AdGuard Filter 17 → quarantine/candidates.json
npm run verify:quarantine  → gate OK (raw + candidates.json stay gitignored, invisible to git)
```

No runtime/extension code touched — tooling + tests only.