### PR TITLE
feat(ingestion): GATE 1 affiliate-guard (#775)

### DIFF
--- a/tests/unit/affiliate-guard.test.mjs
+++ b/tests/unit/affiliate-guard.test.mjs
@@ -1,0 +1,359 @@
+/** MUGA: test suite for GATE 1 — affiliate-guard (issue #775) */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPreserveIndex,
+  checkAffiliateGuard,
+  partitionCandidates,
+} from "../../tools/rule-ingestion/gates/affiliate-guard.mjs";
+import {
+  AFFILIATE_PATTERNS,
+  REDIRECT_NETWORK_PATTERNS,
+  TRACKING_PARAMS,
+} from "../../src/lib/affiliates.js";
+
+// ── T-02 / T-04: buildPreserveIndex — pure unit tests ───────────────────────
+
+describe("affiliate-guard", () => {
+  describe("buildPreserveIndex — pure", () => {
+    it("builds a set from synthetic AFFILIATE_PATTERNS and REDIRECT_NETWORK_PATTERNS", () => {
+      const affiliatePatterns = [{ id: "prog-a", param: "alpha" }];
+      const redirectNetworks = [{ id: "net-a", landingParams: ["beta", "gamma"] }];
+      const { set } = buildPreserveIndex(affiliatePatterns, redirectNetworks);
+      assert.equal(set.has("alpha"), true);
+      assert.equal(set.has("beta"), true);
+      assert.equal(set.has("gamma"), true);
+      assert.equal(set.size, 3);
+    });
+
+    // T-04: owner record shape + first-writer-wins + dedup
+    it("assigns source: 'affiliate' for affiliate entries", () => {
+      const { owners } = buildPreserveIndex(
+        [{ id: "prog-a", param: "alpha" }],
+        []
+      );
+      assert.equal(owners.get("alpha").source, "affiliate");
+    });
+
+    it("assigns source: 'redirect-network' for network entries", () => {
+      const { owners } = buildPreserveIndex(
+        [],
+        [{ id: "net-a", landingParams: ["beta"] }]
+      );
+      assert.equal(owners.get("beta").source, "redirect-network");
+    });
+
+    it("first-writer-wins: affiliate beats redirect-network on shared param name", () => {
+      const { owners } = buildPreserveIndex(
+        [{ id: "prog-a", param: "shared" }],
+        [{ id: "net-a", landingParams: ["shared"] }]
+      );
+      assert.equal(owners.get("shared").source, "affiliate");
+    });
+
+    it("deduplicates repeated names in landingParams", () => {
+      const { set } = buildPreserveIndex(
+        [],
+        [{ id: "net-a", landingParams: ["x", "x"] }]
+      );
+      assert.equal(set.size, 1);
+    });
+
+    it("lowercases param names from affiliatePatterns", () => {
+      const { set } = buildPreserveIndex(
+        [{ id: "prog-a", param: "UPPER" }],
+        []
+      );
+      assert.equal(set.has("upper"), true);
+      assert.equal(set.has("UPPER"), false);
+    });
+  });
+
+  // ── T-05: Live singleton derivation + count-agnostic auto-extension ────────
+
+  describe("live singletons — auto-extension", () => {
+    const { set } = buildPreserveIndex(AFFILIATE_PATTERNS, REDIRECT_NETWORK_PATTERNS);
+
+    it("every AFFILIATE_PATTERNS[].param is in the preserve set (count-agnostic)", () => {
+      for (const p of AFFILIATE_PATTERNS) {
+        assert.equal(
+          set.has(p.param.toLowerCase()),
+          true,
+          `Expected preserve set to include affiliate param '${p.param}' (id: ${p.id})`
+        );
+      }
+    });
+
+    it("every REDIRECT_NETWORK_PATTERNS[].landingParams entry is in the preserve set (count-agnostic)", () => {
+      for (const net of REDIRECT_NETWORK_PATTERNS) {
+        for (const lp of net.landingParams) {
+          assert.equal(
+            set.has(lp.toLowerCase()),
+            true,
+            `Expected preserve set to include landing param '${lp}' (network: ${net.id})`
+          );
+        }
+      }
+    });
+
+    it("preserve set has exactly 32 unique names (update comment if manifest sync changes count)", () => {
+      // update if manifest sync changes count
+      assert.equal(set.size, 32);
+    });
+  });
+
+  // ── T-06: Module shape — named exports, no default ────────────────────────
+
+  describe("module shape", () => {
+    it("checkAffiliateGuard is a function", () => {
+      assert.equal(typeof checkAffiliateGuard, "function");
+    });
+
+    it("partitionCandidates is a function", () => {
+      assert.equal(typeof partitionCandidates, "function");
+    });
+
+    it("buildPreserveIndex is a function (testability seam export)", () => {
+      assert.equal(typeof buildPreserveIndex, "function");
+    });
+
+    it("there is no default export", async () => {
+      const mod = await import("../../tools/rule-ingestion/gates/affiliate-guard.mjs");
+      assert.equal(mod.default, undefined);
+    });
+  });
+
+  // ── T-08: AFFILIATE_PATTERNS collision rejection — tag, ref, at ───────────
+
+  describe("checkAffiliateGuard — AFFILIATE_PATTERNS collisions", () => {
+    it("rejects 'tag' with id amazon-associates and source 'affiliate'", () => {
+      const result = checkAffiliateGuard({ param: "tag" });
+      assert.equal(result.rejected, true);
+      assert.equal(result.reason, "affiliate-collision");
+      assert.equal(result.collidingPrograms.length, 1);
+      assert.equal(result.collidingPrograms[0].id, "amazon-associates");
+      assert.equal(result.collidingPrograms[0].source, "affiliate");
+    });
+
+    it("rejects 'ref' with id vercel", () => {
+      const result = checkAffiliateGuard({ param: "ref" });
+      assert.equal(result.rejected, true);
+      assert.equal(result.collidingPrograms[0].id, "vercel");
+      // source uses the unified vocabulary "affiliate" (no internal/public mapping)
+      assert.equal(result.collidingPrograms[0].source, "affiliate");
+    });
+
+    it("rejects 'at' with id apple-phg", () => {
+      const result = checkAffiliateGuard({ param: "at" });
+      assert.equal(result.rejected, true);
+      assert.equal(result.collidingPrograms[0].id, "apple-phg");
+      assert.equal(result.collidingPrograms[0].source, "affiliate");
+    });
+  });
+
+  // ── T-09: Redirect-network collision — tduid, irclickid, cjevent ──────────
+
+  describe("checkAffiliateGuard — redirect-network collisions", () => {
+    it("rejects 'tduid' with id tradedoubler and source 'redirect-network'", () => {
+      const result = checkAffiliateGuard({ param: "tduid" });
+      assert.equal(result.rejected, true);
+      assert.equal(result.collidingPrograms[0].id, "tradedoubler");
+      assert.equal(result.collidingPrograms[0].source, "redirect-network");
+    });
+
+    it("rejects 'irclickid' with source 'redirect-network'", () => {
+      const result = checkAffiliateGuard({ param: "irclickid" });
+      assert.equal(result.rejected, true);
+      assert.equal(result.collidingPrograms[0].source, "redirect-network");
+    });
+
+    it("rejects 'cjevent' with reason 'affiliate-collision'", () => {
+      const result = checkAffiliateGuard({ param: "cjevent" });
+      assert.equal(result.rejected, true);
+      assert.equal(result.reason, "affiliate-collision");
+    });
+  });
+
+  // ── T-10: Standard trackers ACCEPTED — fbclid, utm_source, ir_adid ────────
+
+  describe("checkAffiliateGuard — acceptance", () => {
+    it("accepts 'fbclid'", () => {
+      const result = checkAffiliateGuard({ param: "fbclid" });
+      assert.deepEqual(result, { rejected: false });
+    });
+
+    it("accepts 'utm_source'", () => {
+      const result = checkAffiliateGuard({ param: "utm_source" });
+      assert.deepEqual(result, { rejected: false });
+    });
+
+    it("accepts 'ir_adid' (Impact Radius ad ID, not a landingParam)", () => {
+      const result = checkAffiliateGuard({ param: "ir_adid" });
+      assert.deepEqual(result, { rejected: false });
+    });
+  });
+
+  // ── T-11: eBay noise params ACCEPTED (wrong-source proof) ─────────────────
+
+  describe("checkAffiliateGuard — eBay noise accepted (GATE 1 does NOT consume AFFILIATE_PARAM_GUARD)", () => {
+    it("accepts 'mkevt'", () => {
+      assert.deepEqual(checkAffiliateGuard({ param: "mkevt" }), { rejected: false });
+    });
+
+    it("accepts 'mkcid'", () => {
+      assert.deepEqual(checkAffiliateGuard({ param: "mkcid" }), { rejected: false });
+    });
+
+    it("accepts 'mkrid'", () => {
+      assert.deepEqual(checkAffiliateGuard({ param: "mkrid" }), { rejected: false });
+    });
+
+    it("accepts 'toolid'", () => {
+      assert.deepEqual(checkAffiliateGuard({ param: "toolid" }), { rejected: false });
+    });
+
+    it("accepts 'customid'", () => {
+      assert.deepEqual(checkAffiliateGuard({ param: "customid" }), { rejected: false });
+    });
+  });
+
+  // ── T-12: Case normalization ───────────────────────────────────────────────
+
+  describe("checkAffiliateGuard — case normalization", () => {
+    it("rejects 'TAG' (uppercase) — affiliate collision", () => {
+      const result = checkAffiliateGuard({ param: "TAG" });
+      assert.equal(result.rejected, true);
+      assert.equal(result.reason, "affiliate-collision");
+    });
+
+    it("accepts 'FBCLID' (uppercase) — not a preserved param", () => {
+      const result = checkAffiliateGuard({ param: "FBCLID" });
+      assert.deepEqual(result, { rejected: false });
+    });
+  });
+
+  // ── T-13: Malformed / missing param — returns accepted ────────────────────
+
+  describe("checkAffiliateGuard — edge: malformed input", () => {
+    it("accepts null candidate", () => {
+      assert.deepEqual(checkAffiliateGuard(null), { rejected: false });
+    });
+
+    it("accepts undefined candidate", () => {
+      assert.deepEqual(checkAffiliateGuard(undefined), { rejected: false });
+    });
+
+    it("accepts candidate with no param field", () => {
+      assert.deepEqual(checkAffiliateGuard({}), { rejected: false });
+    });
+
+    it("accepts candidate with numeric param (non-string)", () => {
+      assert.deepEqual(checkAffiliateGuard({ param: 123 }), { rejected: false });
+    });
+
+    it("accepts candidate with empty string param", () => {
+      assert.deepEqual(checkAffiliateGuard({ param: "" }), { rejected: false });
+    });
+  });
+
+  // ── T-14 / T-15: partitionCandidates — mixed list, order-preserving ───────
+
+  describe("partitionCandidates", () => {
+    it("partitions a mixed list preserving order", () => {
+      const input = [
+        { param: "fbclid" },
+        { param: "tag" },
+        { param: "utm_source" },
+        { param: "awc" },
+        { param: "mkevt" },
+      ];
+      const { accepted, rejected } = partitionCandidates(input);
+
+      // accepted: fbclid, utm_source, mkevt (order preserved)
+      assert.equal(accepted.length, 3);
+      assert.deepEqual(accepted[0], { param: "fbclid" });
+      assert.deepEqual(accepted[1], { param: "utm_source" });
+      assert.deepEqual(accepted[2], { param: "mkevt" });
+
+      // rejected: tag, awc
+      assert.equal(rejected.length, 2);
+      assert.deepEqual(rejected[0].candidate, { param: "tag" });
+      assert.equal(rejected[0].reason, "affiliate-collision");
+      assert.equal(Array.isArray(rejected[0].collidingPrograms), true);
+      assert.equal(rejected[0].collidingPrograms.length > 0, true);
+      assert.equal(rejected[1].candidate.param, "awc");
+    });
+
+    // T-16: empty input, all-accepted, all-rejected
+    it("returns empty partitions for empty input", () => {
+      const { accepted, rejected } = partitionCandidates([]);
+      assert.deepEqual(accepted, []);
+      assert.deepEqual(rejected, []);
+    });
+
+    it("all-accepted list produces empty rejected partition", () => {
+      const input = [
+        { param: "fbclid" },
+        { param: "utm_source" },
+        { param: "gclid" },
+      ];
+      const { accepted, rejected } = partitionCandidates(input);
+      assert.equal(rejected.length, 0);
+      assert.equal(accepted.length, 3);
+    });
+
+    it("all-rejected list produces empty accepted partition", () => {
+      const input = [
+        { param: "tag" },
+        { param: "awc" },
+        { param: "tduid" },
+      ];
+      const { accepted, rejected } = partitionCandidates(input);
+      assert.equal(accepted.length, 0);
+      assert.equal(rejected.length, 3);
+    });
+  });
+
+  // ── T-17: Zero TRACKING_PARAMS mutation ───────────────────────────────────
+
+  describe("GATE 1 zero mutation contract", () => {
+    it("TRACKING_PARAMS length is unchanged after checkAffiliateGuard on a colliding param", () => {
+      const lengthBefore = TRACKING_PARAMS.length;
+      checkAffiliateGuard({ param: "tag" });
+      assert.equal(TRACKING_PARAMS.length, lengthBefore);
+    });
+
+    it("TRACKING_PARAMS length is unchanged after partitionCandidates call", () => {
+      const lengthBefore = TRACKING_PARAMS.length;
+      partitionCandidates([
+        { param: "tag" },
+        { param: "fbclid" },
+        { param: "awc" },
+      ]);
+      assert.equal(TRACKING_PARAMS.length, lengthBefore);
+    });
+  });
+
+  // ── T-18: Result-shape stability assertion ────────────────────────────────
+
+  describe("result shape stability", () => {
+    it("rejection result has EXACTLY keys: rejected, reason, collidingPrograms", () => {
+      const result = checkAffiliateGuard({ param: "tag" });
+      const keys = Object.keys(result).sort();
+      assert.deepEqual(keys, ["collidingPrograms", "reason", "rejected"]);
+    });
+
+    it("acceptance result has EXACTLY key: rejected (no reason, no collidingPrograms)", () => {
+      const result = checkAffiliateGuard({ param: "fbclid" });
+      const keys = Object.keys(result);
+      assert.deepEqual(keys, ["rejected"]);
+    });
+
+    it("collidingPrograms[0] has EXACTLY keys: id and source (no domains, no extras)", () => {
+      const result = checkAffiliateGuard({ param: "tag" });
+      const programKeys = Object.keys(result.collidingPrograms[0]).sort();
+      assert.deepEqual(programKeys, ["id", "source"]);
+    });
+  });
+});

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -91,6 +91,39 @@ Run locally with `npm run ingest:rules` (writes `quarantine/candidates.json`).
 clause makes it off-limits for MUGA, a commercial extension. Do NOT add a DDG
 adapter. Full ledger: `PROVENANCE.md` (#774).
 
+## GATE 1 — affiliate-guard (#775)
+
+`tools/rule-ingestion/gates/affiliate-guard.mjs`
+
+**What it does:** Rejects any ingestion candidate whose bare `param` name collides
+with a known affiliate-attribution or redirect-landing parameter. The gate NEVER
+adds to or removes from `TRACKING_PARAMS` — it is a pure read-only check.
+
+**Public exports:**
+- `checkAffiliateGuard(candidate)` — returns `{ rejected: false }` or
+  `{ rejected: true, reason: "affiliate-collision", collidingPrograms: [{ id, source }] }`.
+- `partitionCandidates(candidates)` — batch helper; splits an array into
+  `{ accepted, rejected }` in a single pass, order preserved.
+
+**Asymmetric-risk rationale:** A false-accept (letting an affiliate param through
+into `TRACKING_PARAMS`) causes unbounded revenue loss for creators whose attribution
+cookies are silently stripped. A false-reject (blocking a new tracker that shares a
+name with an affiliate param) is trivially recoverable — the candidate can be
+reviewed and re-promoted manually. GATE 1 is therefore intentionally conservative.
+
+**SURPRISING-BUT-CORRECT — `ref` and `at` are rejected globally:**
+`ref` is the Vercel referral param; `at` is the Apple PHG affiliate tag. Both are
+rejected at ingestion even though the runtime cleaner strips them per-domain via
+`getAffiliateParamSetForHost`. GATE 1 is domain-agnostic by design — it has no
+URL context at ingestion time, so global rejection is the only safe policy.
+
+**Live-derived preserve set:** The 32-name preserve set is built at module load
+from `AFFILIATE_PATTERNS[].param` (6 CAPS direct-injection programs) and
+`REDIRECT_NETWORK_PATTERNS[].landingParams` (26 redirect-network params). No
+edits to this gate are needed when a new program or network is added to those
+source arrays (today hand-maintained in `src/lib/affiliates.js` and
+`src/rules/manifest.data.js`) — the set expands automatically.
+
 ## CI gate
 
 `verify-quarantine.mjs` runs in CI ([`ci.yml`](../../.github/workflows/ci.yml))

--- a/tools/rule-ingestion/gates/affiliate-guard.mjs
+++ b/tools/rule-ingestion/gates/affiliate-guard.mjs
@@ -1,0 +1,145 @@
+/**
+ * MUGA: GATE 1 — affiliate-guard (#775)
+ *
+ * Guards against catastrophic mis-promotion of affiliate attribution parameters
+ * into the universal TRACKING_PARAMS strip list. Any ingestion candidate whose
+ * bare param name collides with a known affiliate/redirect-landing param is
+ * rejected. The gate NEVER mutates TRACKING_PARAMS or any source array.
+ *
+ * Preserve set is derived LIVE at module load from two sources in
+ * src/lib/affiliates.js so it auto-expands whenever those source arrays gain
+ * entries (today hand-maintained in src/lib/affiliates.js and
+ * src/rules/manifest.data.js) — no edits to this file required.
+ */
+
+import {
+  AFFILIATE_PATTERNS,
+  REDIRECT_NETWORK_PATTERNS,
+} from "../../../src/lib/affiliates.js";
+
+// ── Preserve-index construction ─────────────────────────────────────────────
+
+/**
+ * Builds a preserve-name Set and owner Map from the two live source arrays.
+ * Exported as a testability seam — tests can feed synthetic fixtures without
+ * touching the live singletons.
+ *
+ * @param {Array<{id: string, param: string}>} affiliatePatterns
+ * @param {Array<{id: string, landingParams: string[]}>} redirectNetworks
+ * @returns {{ set: Set<string>, owners: Map<string, {id: string, source: string}> }}
+ */
+export function buildPreserveIndex(affiliatePatterns, redirectNetworks) {
+  const set = new Set();
+  // Maps lowercased param name to its owner record; first-writer-wins so
+  // affiliate entries take precedence over redirect-network entries when
+  // (hypothetically) both contain the same name.
+  const owners = new Map();
+
+  for (const p of affiliatePatterns) {
+    const name = String(p.param).toLowerCase();
+    set.add(name);
+    if (!owners.has(name)) {
+      owners.set(name, { id: p.id, source: "affiliate" });
+    }
+  }
+
+  for (const net of redirectNetworks) {
+    for (const raw of net.landingParams) {
+      const name = String(raw).toLowerCase();
+      set.add(name);
+      if (!owners.has(name)) {
+        owners.set(name, { id: net.id, source: "redirect-network" });
+      }
+    }
+  }
+
+  return { set, owners };
+}
+
+// ── Live singleton (module-load) ─────────────────────────────────────────────
+
+// Built once at import time from the real affiliates manifest; any new CAPS
+// program or redirect network added to the source arrays is automatically
+// included — no gate edit required.
+const { set: _PRESERVE_SET, owners: _OWNER_INDEX } = buildPreserveIndex(
+  AFFILIATE_PATTERNS,
+  REDIRECT_NETWORK_PATTERNS
+);
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Checks a single ingestion candidate against the affiliate-preservation set.
+ *
+ * Returns `{ rejected: false }` when the param is safe to promote.
+ * Returns `{ rejected: true, reason, collidingPrograms }` when the param
+ * collides with a known affiliate/redirect-landing name — the candidate MUST
+ * NOT be added to TRACKING_PARAMS.
+ *
+ * The gate is intentionally conservative: `ref` (Vercel) and `at` (Apple PHG)
+ * are rejected globally even though per-domain stripping of those params is
+ * handled separately by the runtime cleaner via getAffiliateParamSetForHost.
+ * GATE 1 is domain-agnostic by design — asymmetric risk means a false-reject
+ * (a new tracker that happens to share a name) is trivially recoverable, but
+ * a false-accept (stripping an affiliate param globally) causes unbounded
+ * revenue loss for creators.
+ *
+ * @param {{ param?: string } | null | undefined} candidate
+ * @returns {{ rejected: boolean, reason?: string, collidingPrograms?: Array<{id: string, source: string}> }}
+ */
+export function checkAffiliateGuard(candidate) {
+  // Defensive extraction: treat any non-string or missing param as no-match.
+  // Pipeline already lowercases candidate.param (candidate.mjs:44), but we
+  // lowercase defensively — never trust the caller.
+  const name =
+    typeof candidate?.param === "string" ? candidate.param.toLowerCase() : "";
+
+  if (!name) {
+    return { rejected: false };
+  }
+
+  if (!_PRESERVE_SET.has(name)) {
+    return { rejected: false };
+  }
+
+  const owner = _OWNER_INDEX.get(name);
+  // owner.source is already the public contract value ("affiliate" |
+  // "redirect-network") — the builder records it directly, no mapping needed.
+  return {
+    rejected: true,
+    reason: "affiliate-collision",
+    collidingPrograms: [{ id: owner.id, source: owner.source }],
+  };
+}
+
+// ── Batch partition ──────────────────────────────────────────────────────────
+
+/**
+ * Partitions an array of ingestion candidates into accepted and rejected
+ * buckets in a single pass. Input order is preserved in both output arrays.
+ *
+ * Rejected items carry the full rejection metadata so the caller/logger
+ * doesn't need to re-run the check.
+ *
+ * @param {Array<{param?: string}>} candidates
+ * @returns {{ accepted: Array, rejected: Array<{candidate: object, reason: string, collidingPrograms: Array}> }}
+ */
+export function partitionCandidates(candidates) {
+  const accepted = [];
+  const rejected = [];
+
+  for (const candidate of candidates) {
+    const result = checkAffiliateGuard(candidate);
+    if (result.rejected) {
+      rejected.push({
+        candidate,
+        reason: result.reason,
+        collidingPrograms: result.collidingPrograms,
+      });
+    } else {
+      accepted.push(candidate);
+    }
+  }
+
+  return { accepted, rejected };
+}


### PR DESCRIPTION
## What

GATE 1 of MUGA's self-scaling ruleset (EPIC C, v2.3.0). A pure, stateless, structural name-collision check that **rejects** any ingestion candidate whose bare `param` name collides with a known affiliate-attribution or redirect-landing parameter — guarding against the catastrophic mis-promotion of an affiliate param into the universal `TRACKING_PARAMS` strip list.

Closes #775.

## How

`tools/rule-ingestion/gates/affiliate-guard.mjs` — three named exports:

- **`buildPreserveIndex(affiliatePatterns, redirectNetworks)`** — pure builder (testability seam). Builds a live 32-name preserve `Set` + an owner `Map` from `AFFILIATE_PATTERNS[].param` (6) + `REDIRECT_NETWORK_PATTERNS[].landingParams` (26 unique). First-writer-wins on hypothetical overlap.
- **`checkAffiliateGuard(candidate)`** — `O(1)` Set lookup. Returns `{ rejected: false }` or `{ rejected: true, reason: "affiliate-collision", collidingPrograms: [{ id, source }] }`. Defensive lowercase; malformed input → accepted (not GATE 1's job).
- **`partitionCandidates(candidates)`** — order-preserving batch split into `{ accepted, rejected }`, where `rejected[]` carries wrappers `{ candidate, reason, collidingPrograms }`.

### Design decisions
- **Live-derived** preserve set at module load → auto-tracks new CAPS programs/networks added to the source arrays, **zero gate edits**.
- **Does NOT** consume `AFFILIATE_PARAM_GUARD` (remote-rules.js) — that guard over-blocks eBay tracking noise (`mkevt`/`mkcid`/`mkrid`/`toolid`/`customid`) which ARE valid strip candidates. Proven by test.
- **Asymmetric risk**: a false-accept (stripping an affiliate param globally) is unbounded creator revenue loss; a false-reject is trivially recoverable. So `ref` (Vercel) and `at` (Apple PHG) are rejected **globally** even though the runtime cleaner strips them per-domain — GATE 1 is intentionally domain-agnostic.
- **Zero mutation** of `TRACKING_PARAMS` — structurally asserted.
- **Unified `source` vocabulary** (`"affiliate" | "redirect-network"`) internally and externally — no mapping step.

## Tests

42 new tests in `tests/unit/affiliate-guard.test.mjs` (pure builder layer + live layer + auto-extension + zero-mutation + shape stability). Full suite: **4169 pass / 0 fail**.

## SDD

Full SDD cycle (explore → proposal → spec → design → tasks → apply → verify) plus a coherence pass that unified the `source` vocabulary, fixed a self-contradictory partition scenario in the spec, declared `buildPreserveIndex` as the 3rd export, and removed phantom `npm run sync:manifest` references (no such script exists; manifest is hand-maintained, automation tracked in #793).