### PR TITLE
refactor: extract affiliate-safety domain (canaries + evaluateCanary + runner)

### DIFF
--- a/tests/unit/affiliate-canaries.test.mjs
+++ b/tests/unit/affiliate-canaries.test.mjs
@@ -14,8 +14,8 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { processUrl, getLandingPolicy } from "../../src/lib/cleaner.js";
 import { REDIRECT_NETWORK_PATTERNS } from "../../src/lib/affiliates.js";
-import { PRESERVE_CANARIES, LANDING_CANARIES } from "../fixtures/affiliate-canaries.mjs";
-import { runAffiliateCanaries } from "../fixtures/canary-runner.mjs";
+import { PRESERVE_CANARIES, LANDING_CANARIES } from "../../tools/affiliate-safety/canaries.mjs";
+import { runAffiliateCanaries } from "../../tools/affiliate-safety/runner.mjs";
 
 describe("affiliate canaries — preserve (processUrl)", () => {
   for (const canary of PRESERVE_CANARIES) {

--- a/tests/unit/affiliate-safety.test.mjs
+++ b/tests/unit/affiliate-safety.test.mjs
@@ -1,0 +1,149 @@
+/**
+ * MUGA — Unit tests for evaluateCanary (tools/affiliate-safety/evaluate.mjs).
+ *
+ * Pure break-evaluation tests using synthetic canaries and a fake processUrlFn.
+ * No live deps — fully deterministic. Covers the shared semantics that both the
+ * affiliate-canary runner and GATE 3 (#777) depend on.
+ *
+ * RED first: evaluate.mjs does not exist at write time → all 7 cases fail on import.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { evaluateCanary } from "../../tools/affiliate-safety/evaluate.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** A minimal preserve-style canary fixture used across most tests. */
+const makeCanary = (overrides = {}) => ({
+  name: "synthetic-test",
+  url: "https://example.com/p?k=v",
+  prefs: {},
+  mustSurvive: { k: "v" },
+  mustStrip: [],
+  ...overrides,
+});
+
+/**
+ * A fake processUrlFn that returns the URL unchanged (every param preserved).
+ * Used to prove "no failures when nothing breaks."
+ */
+const identityFn = (url, _prefs) => ({ cleanUrl: url });
+
+/**
+ * A fake processUrlFn that strips ALL query params from the URL.
+ * Used to simulate a stripping cleaner.
+ */
+const stripAllFn = (_url, _prefs) => ({ cleanUrl: "https://example.com/p" });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("evaluateCanary — held (no breaks)", () => {
+  test("returns empty array when mustSurvive param is intact", () => {
+    const canary = makeCanary();
+    const result = evaluateCanary(canary, identityFn);
+    assert.deepEqual(result, []);
+  });
+});
+
+describe("evaluateCanary — one mustSurvive break", () => {
+  test("returns exactly 1 failure with correct shape when processUrlFn strips the param", () => {
+    const canary = makeCanary({ mustSurvive: { k: "v" } });
+    const result = evaluateCanary(canary, stripAllFn);
+    assert.equal(result.length, 1);
+    const [f] = result;
+    assert.equal(f.name, "synthetic-test");
+    assert.equal(f.kind, "preserve");
+    // reason format: `${param} expected "${value}", got "${got}"`
+    assert.ok(f.reason.includes("k expected"), `reason must mention the param: got "${f.reason}"`);
+  });
+});
+
+describe("evaluateCanary — two mustSurvive breaks (collect-all)", () => {
+  test("returns 2 failures when processUrlFn strips both params (no short-circuit)", () => {
+    const canary = makeCanary({
+      url: "https://example.com/p?a=1&b=2",
+      mustSurvive: { a: "1", b: "2" },
+    });
+    const result = evaluateCanary(canary, stripAllFn);
+    assert.equal(result.length, 2, "must collect ALL param failures, not short-circuit on first");
+  });
+});
+
+describe("evaluateCanary — mustStrip violation", () => {
+  test("returns failure when mustStrip param is still present after cleaning", () => {
+    // identityFn preserves everything, so mustStrip params will remain → violation
+    const canary = makeCanary({
+      url: "https://example.com/p?k=v&noise=1",
+      mustSurvive: {},
+      mustStrip: ["noise"],
+    });
+    const result = evaluateCanary(canary, identityFn);
+    assert.equal(result.length, 1);
+    const [f] = result;
+    assert.equal(f.kind, "preserve");
+    assert.ok(
+      f.reason.includes("should have been stripped"),
+      `reason must say "should have been stripped", got: "${f.reason}"`
+    );
+  });
+});
+
+describe("evaluateCanary — processUrlFn throws", () => {
+  test("returns single failure with kind:preserve and reason matching /processUrl threw:/", () => {
+    const throwingFn = () => { throw new Error("boom"); };
+    const canary = makeCanary();
+    const result = evaluateCanary(canary, throwingFn);
+    assert.equal(result.length, 1, "a throw must yield exactly one failure, not crash");
+    const [f] = result;
+    assert.equal(f.kind, "preserve");
+    assert.match(f.reason, /processUrl threw:/);
+  });
+});
+
+describe("evaluateCanary — extraRemoteParams injected", () => {
+  test("processUrlFn receives merged remoteParams containing the extra param", () => {
+    let capturedPrefs = null;
+    const capturingFn = (url, prefs) => {
+      capturedPrefs = prefs;
+      return { cleanUrl: url };
+    };
+    const canary = makeCanary();
+    evaluateCanary(canary, capturingFn, ["extra-param"]);
+    assert.ok(capturedPrefs !== null, "processUrlFn must be called");
+    assert.ok(
+      Array.isArray(capturedPrefs.remoteParams),
+      "prefs.remoteParams must be an array"
+    );
+    assert.ok(
+      capturedPrefs.remoteParams.includes("extra-param"),
+      `extra-param must appear in remoteParams; got: ${JSON.stringify(capturedPrefs.remoteParams)}`
+    );
+  });
+});
+
+describe("evaluateCanary — canary prefs.remoteParams merged with extraRemoteParams", () => {
+  test("both existing and extra remoteParams are present in the merged array", () => {
+    let capturedPrefs = null;
+    const capturingFn = (url, prefs) => {
+      capturedPrefs = prefs;
+      return { cleanUrl: url };
+    };
+    const canary = makeCanary({
+      prefs: { remoteParams: ["existing"] },
+    });
+    evaluateCanary(canary, capturingFn, ["extra"]);
+    assert.ok(
+      capturedPrefs.remoteParams.includes("existing"),
+      "original canary remoteParams must be preserved in merge"
+    );
+    assert.ok(
+      capturedPrefs.remoteParams.includes("extra"),
+      "extra remoteParams must be merged in"
+    );
+  });
+});

--- a/tests/unit/cleaner.test.mjs
+++ b/tests/unit/cleaner.test.mjs
@@ -570,7 +570,7 @@ describe("Amazon affiliate tags — real tag injection per marketplace", () => {
       assert.equal(new URL(cleanUrl).searchParams.get("tag"), tag);
     });
 
-    // (foreign-tag-survives canary moved to tests/fixtures/affiliate-canaries.mjs, #769)
+    // (foreign-tag-survives canary moved to tools/affiliate-safety/canaries.mjs, #769 / #777)
     test(`amazon.${name}: own tag is not flagged as foreign`, () => {
       const { action } = processUrl(
         `https://${domain}/dp/B08N5WRWNW?tag=${tag}`,
@@ -606,7 +606,7 @@ describe("eBay affiliate tags — real tag injection per marketplace", () => {
       assert.equal(new URL(cleanUrl).searchParams.get("campid"), "5339147108");
     });
 
-    // (foreign-campid-survives canary moved to tests/fixtures/affiliate-canaries.mjs, #769)
+    // (foreign-campid-survives canary moved to tools/affiliate-safety/canaries.mjs, #769 / #777)
     test(`ebay.${name}: own campid is not flagged as foreign`, () => {
       const { action } = processUrl(
         `https://${domain}/itm/123456789?campid=5339147108`,
@@ -1442,7 +1442,7 @@ describe("whitelist priority over stripAllAffiliates", () => {
 describe("affiliate param / tracking param collision", () => {
 
   // (pccomponentes ref + eBay campid collisions moved to the shared canary
-  //  fixtures — tests/fixtures/affiliate-canaries.mjs, #769)
+  //  fixtures — tools/affiliate-safety/canaries.mjs, #769 / #777)
   test("ref= is NOT stripped on a non-affiliate host (e.g., example.com) — ref removed from global TRACKING_PARAMS (#160)", () => {
     // 'ref' was removed from TRACKING_PARAMS because it is the affiliate param for
     // PcComponentes and MediaMarkt. Applying it globally stripped it before the

--- a/tests/unit/get-landing-policy.test.mjs
+++ b/tests/unit/get-landing-policy.test.mjs
@@ -11,7 +11,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { getLandingPolicy, processUrl } from "../../src/lib/cleaner.js";
-import { LANDING_CANARIES } from "../fixtures/affiliate-canaries.mjs";
+import { LANDING_CANARIES } from "../../tools/affiliate-safety/canaries.mjs";
 
 const PREFS = Object.freeze({
   enabled: true,

--- a/tools/affiliate-safety/canaries.mjs
+++ b/tools/affiliate-safety/canaries.mjs
@@ -4,8 +4,8 @@
  * The canary safety net: a curated set of real affiliate URLs whose attribution
  * MUST survive MUGA's cleaning. This module is PURE DATA — no imports, no logic —
  * so it can be consumed by:
- *   - the test runner (tests/unit/affiliate-canaries.test.mjs), and
- *   - the future programmatic canary runner / pipeline GATE 3 (#771, #777).
+ *   - the test suite (tests/unit/affiliate-canaries.test.mjs), and
+ *   - the rule-ingestion pipeline GATE 3 (#771, #777).
  *
  * Two kinds:
  *   PRESERVE_CANARIES — run processUrl(url, prefs). Every key in `mustSurvive`
@@ -17,6 +17,9 @@
  *
  * Extracted verbatim from the assertions previously scattered across
  * cleaner.test.mjs and get-landing-policy.test.mjs (deduped by #769).
+ * Relocated from tests/fixtures/affiliate-canaries.mjs to
+ * tools/affiliate-safety/canaries.mjs (#777, EPIC C) — direction is now
+ * tests/→tools/ (correct); tools/ production code can safely import this.
  *
  * NOTE: amzn.to is intentionally absent — it sits in opaque-networks'
  * PENDING_VERDICT bucket awaiting #665. The Tradedoubler `tduid` canary is added

--- a/tools/affiliate-safety/evaluate.mjs
+++ b/tools/affiliate-safety/evaluate.mjs
@@ -1,0 +1,52 @@
+/**
+ * MUGA: pure break-evaluation for ONE preserve-style affiliate canary.
+ *
+ * Extracted from the inline loop in canary-runner.mjs (#777, EPIC C) to enable
+ * independent unit-testing and sharing between the runner and GATE 3 (#777).
+ * Behavior is identical to the original inline logic: param-level, collect-all
+ * (no short-circuit), throw→single failure.
+ */
+
+/**
+ * @typedef {{ name: string, kind: "preserve", reason: string }} CanaryFailure
+ */
+
+/**
+ * Evaluates a single preserve-style canary against a given processUrlFn.
+ *
+ * Merges `canary.prefs.remoteParams` (if any) with `extraRemoteParams` so the
+ * cleaner considers the candidate param as a remote-injected tracking param.
+ * Collects ALL param-level failures (no short-circuit) — a canary with 2 broken
+ * mustSurvive entries yields 2 CanaryFailure entries.
+ *
+ * @param {{ name: string, url: string, prefs?: object, mustSurvive: Record<string,string>, mustStrip: string[] }} canary
+ * @param {(url: string, prefs: object) => { cleanUrl: string }} processUrlFn
+ * @param {string[]} extraRemoteParams — additional params to inject via remoteParams (defaults to [])
+ * @returns {CanaryFailure[]} empty array means the canary held; non-empty means it broke
+ */
+export function evaluateCanary(canary, processUrlFn, extraRemoteParams = []) {
+  const failures = [];
+  // WHY: merge canary's own remoteParams (if any) with the extra ones supplied by
+  // the caller (e.g. GATE 3 passes [candidate.param] here).
+  const remoteParams = [...(canary.prefs?.remoteParams ?? []), ...extraRemoteParams];
+  let params;
+  try {
+    params = new URL(processUrlFn(canary.url, { ...canary.prefs, remoteParams }).cleanUrl).searchParams;
+  } catch (err) {
+    // WHY: a throwing cleaner must not crash the gate/runner — record it and
+    // return early so the caller sees a concrete failure rather than an exception.
+    return [{ name: canary.name, kind: "preserve", reason: `processUrl threw: ${err.message}` }];
+  }
+  for (const [param, value] of Object.entries(canary.mustSurvive)) {
+    const got = params.get(param);
+    if (got !== value) {
+      failures.push({ name: canary.name, kind: "preserve", reason: `${param} expected "${value}", got "${got}"` });
+    }
+  }
+  for (const param of canary.mustStrip) {
+    if (params.has(param)) {
+      failures.push({ name: canary.name, kind: "preserve", reason: `${param} should have been stripped` });
+    }
+  }
+  return failures;
+}

--- a/tools/affiliate-safety/runner.mjs
+++ b/tools/affiliate-safety/runner.mjs
@@ -6,12 +6,19 @@
  * pipeline's GATE 3 (#777) calls: after a candidate strip rule is applied, it
  * runs this and rejects the candidate if any affiliate canary broke.
  *
- * Pure: imports only the cleaner + the fixtures. Safe to call from CLI, tests,
- * or the pipeline.
+ * Relocated from tests/fixtures/canary-runner.mjs to
+ * tools/affiliate-safety/runner.mjs (#777, EPIC C). The PRESERVE loop now
+ * delegates to evaluateCanary (shared with GATE 3) — behavior-preserving:
+ * evaluateCanary with extraRemoteParams=[] reconstructs the same semantics as
+ * the original inline loop (param-level, collect-all, throw→single failure).
+ *
+ * Pure: imports only the cleaner + the domain modules. Safe to call from CLI,
+ * tests, or the pipeline.
  */
 
 import { processUrl, getLandingPolicy } from "../../src/lib/cleaner.js";
-import { PRESERVE_CANARIES, LANDING_CANARIES } from "./affiliate-canaries.mjs";
+import { PRESERVE_CANARIES, LANDING_CANARIES } from "./canaries.mjs";
+import { evaluateCanary } from "./evaluate.mjs";
 
 /**
  * @typedef {{ name: string, kind: "preserve"|"landing", reason: string }} CanaryFailure
@@ -23,27 +30,12 @@ import { PRESERVE_CANARIES, LANDING_CANARIES } from "./affiliate-canaries.mjs";
 export function runAffiliateCanaries() {
   const failures = [];
 
-  for (const c of PRESERVE_CANARIES) {
-    let params;
-    try {
-      params = new URL(processUrl(c.url, c.prefs).cleanUrl).searchParams;
-    } catch (err) {
-      failures.push({ name: c.name, kind: "preserve", reason: `processUrl threw: ${err.message}` });
-      continue;
-    }
-    for (const [param, value] of Object.entries(c.mustSurvive)) {
-      const got = params.get(param);
-      if (got !== value) {
-        failures.push({ name: c.name, kind: "preserve", reason: `${param} expected "${value}", got "${got}"` });
-      }
-    }
-    for (const param of c.mustStrip) {
-      if (params.has(param)) {
-        failures.push({ name: c.name, kind: "preserve", reason: `${param} should have been stripped` });
-      }
-    }
-  }
+  // WHY: evaluateCanary with no extraRemoteParams is behavior-identical to the
+  // original inline loop (canary-runner.mjs:26-45) — param-level, collect-all.
+  for (const c of PRESERVE_CANARIES) failures.push(...evaluateCanary(c, processUrl));
 
+  // LANDING loop unchanged — getLandingPolicy has a different shape and is NOT
+  // part of GATE 3's scope.
   for (const c of LANDING_CANARIES) {
     const policy = getLandingPolicy(c.landingHost, c.referrer);
     for (const param of c.mustPreserve) {


### PR DESCRIPTION
## What

**PR 1 of 2** for GATE 3 / #777 (stacked-to-main). Behavior-preserving refactor that promotes the affiliate-safety canaries from test scaffolding to a first-class shared domain.

The canary fixtures are the **affiliate-safety contract** (the moat) — consumed by the A4 runner, three test suites, and the upcoming GATE 3 (#777, production code under `tools/`). Keeping them under `tests/fixtures/` would force a `tools/ → tests/` dependency (wrong directionality).

## How

New domain `tools/affiliate-safety/`:
- **`canaries.mjs`** — `PRESERVE_CANARIES` + `LANDING_CANARIES` (moved verbatim, `Object.freeze` + helpers preserved).
- **`evaluate.mjs`** — `evaluateCanary(canary, processUrlFn, extraRemoteParams = []) → CanaryFailure[]`, **extracted** from the runner's previously-inline break-detection. The single shared break-evaluator (param-level, collect-all, `processUrl`-throw → one failure).
- **`runner.mjs`** — `runAffiliateCanaries()` relocated; its PRESERVE loop now delegates to `evaluateCanary` (byte-identical output); LANDING loop unchanged.

Deleted `tests/fixtures/affiliate-canaries.mjs` and `tests/fixtures/canary-runner.mjs` (no re-export shims); repointed 3 test importers.

## Why it matters

- Dependency direction is now **`tests/ → tools/`** (correct).
- Break-detection is **shared**, not duplicated — GATE 3 (PR 2) consumes the same `evaluateCanary`, eliminating drift between the runner and the gate.
- `evaluateCanary` is now **independently unit-tested** (+7 pure tests).

## Tests

Behavior-preserving — full suite **4176 pass / 0 fail** (4169 baseline + 7 new `evaluateCanary` tests). The runner's `{ ok, total, failures }` output is unchanged.

Part of #777 (GATE 3). PR 2 will add the gate itself on top of this.