### PR TITLE
feat(ingestion): GATE 3 canary-gate (#777)

### DIFF
--- a/tests/unit/canary-gate.test.mjs
+++ b/tests/unit/canary-gate.test.mjs
@@ -1,0 +1,282 @@
+/**
+ * MUGA — Unit tests for GATE 3: canary-gate (#777).
+ *
+ * PURE layer: synthetic canaries + fake processUrlFn via the seam opts.
+ *   Exercises rejection, collect-all, malformed input, processUrlFn throws,
+ *   partitionCandidates order-preservation, zero TRACKING_PARAMS mutation,
+ *   and module shape.
+ *
+ * LIVE layer: real PRESERVE_CANARIES + real processUrl (no opts override).
+ *   Proves realistic params are ACCEPTED and documents GATE-1 complementarity.
+ *   WHY a live break is unconstructable: every mustSurvive key (tag, campid, …)
+ *   is affiliate-protected at cleaner.js:303 and immune to remoteParams stripping.
+ *   Rejection-path tests must therefore use the PURE layer (synthetic + fake fn).
+ *
+ * RED first: canary-gate.mjs does not exist at write time → all 21 cases fail on import.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { checkCanaryGate, partitionCandidates } from "../../tools/rule-ingestion/gates/canary-gate.mjs";
+import { TRACKING_PARAMS } from "../../src/lib/affiliates.js";
+
+// ---------------------------------------------------------------------------
+// Shared synthetic fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal preserve-style canary used across all PURE-layer tests.
+ * mustSurvive: { keepme: "v1" } — the fake processUrlFn strips any param
+ * that appears in prefs.remoteParams, so { param: "keepme" } will break it.
+ */
+const syntheticCanary = {
+  name: "synthetic-A",
+  url: "https://example.com/p?keepme=v1",
+  prefs: {},
+  mustSurvive: { keepme: "v1" },
+  mustStrip: [],
+};
+
+/**
+ * Fake processUrlFn: strips any param listed in prefs.remoteParams and returns
+ * the remaining URL. Mimics the cleaner's remoteParams path without live deps.
+ *
+ * @param {string} url
+ * @param {{ remoteParams?: string[] }} prefs
+ * @returns {{ cleanUrl: string }}
+ */
+const fakeFn = (url, prefs) => {
+  const u = new URL(url);
+  for (const rp of (prefs.remoteParams || [])) {
+    u.searchParams.delete(rp);
+  }
+  return { cleanUrl: u.toString() };
+};
+
+// ---------------------------------------------------------------------------
+// PURE layer — synthetic canaries + fake processUrlFn
+// ---------------------------------------------------------------------------
+
+describe("checkCanaryGate — PURE layer: safe param accepted", () => {
+  test("unrelated param returns { rejected: false }", () => {
+    const result = checkCanaryGate(
+      { param: "unrelated" },
+      { canaries: [syntheticCanary], processUrlFn: fakeFn }
+    );
+    assert.deepEqual(result, { rejected: false });
+  });
+});
+
+describe("checkCanaryGate — PURE layer: breaking param rejected", () => {
+  test("{ param: 'keepme' } with synthetic canary returns rejected:true, reason:'canary-break'", () => {
+    const result = checkCanaryGate(
+      { param: "keepme" },
+      { canaries: [syntheticCanary], processUrlFn: fakeFn }
+    );
+    assert.equal(result.rejected, true);
+    assert.equal(result.reason, "canary-break");
+    assert.ok(Array.isArray(result.brokenCanaries), "brokenCanaries must be an array");
+    assert.equal(result.brokenCanaries.length, 1);
+    const [f] = result.brokenCanaries;
+    assert.equal(f.name, "synthetic-A");
+    assert.equal(f.kind, "preserve");
+    // reason format: `${param} expected "${value}", got "${got}"`
+    assert.match(f.reason, /keepme expected/);
+  });
+});
+
+describe("checkCanaryGate — PURE layer: collect-all (two canaries broken)", () => {
+  test("two synthetic canaries both mustSurvive keepme → brokenCanaries.length === 2", () => {
+    const canaryB = { ...syntheticCanary, name: "synthetic-B" };
+    const result = checkCanaryGate(
+      { param: "keepme" },
+      { canaries: [syntheticCanary, canaryB], processUrlFn: fakeFn }
+    );
+    assert.equal(result.rejected, true);
+    assert.equal(result.brokenCanaries.length, 2, "must collect ALL broken canaries, no short-circuit");
+  });
+});
+
+describe("checkCanaryGate — PURE layer: malformed input returns { rejected: false }", () => {
+  test("null → { rejected: false }", () => {
+    const result = checkCanaryGate(null, { canaries: [syntheticCanary], processUrlFn: fakeFn });
+    assert.deepEqual(result, { rejected: false });
+  });
+
+  test("undefined → { rejected: false }", () => {
+    const result = checkCanaryGate(undefined, { canaries: [syntheticCanary], processUrlFn: fakeFn });
+    assert.deepEqual(result, { rejected: false });
+  });
+
+  test("{} → { rejected: false }", () => {
+    const result = checkCanaryGate({}, { canaries: [syntheticCanary], processUrlFn: fakeFn });
+    assert.deepEqual(result, { rejected: false });
+  });
+
+  test("{ param: 42 } → { rejected: false }", () => {
+    const result = checkCanaryGate({ param: 42 }, { canaries: [syntheticCanary], processUrlFn: fakeFn });
+    assert.deepEqual(result, { rejected: false });
+  });
+
+  test("{ param: '' } → { rejected: false }", () => {
+    const result = checkCanaryGate({ param: "" }, { canaries: [syntheticCanary], processUrlFn: fakeFn });
+    assert.deepEqual(result, { rejected: false });
+  });
+});
+
+describe("checkCanaryGate — PURE layer: processUrlFn throws", () => {
+  test("throwing processUrlFn is recorded as broken canary, gate does not crash", () => {
+    const throwingFn = () => { throw new Error("boom"); };
+    const result = checkCanaryGate(
+      { param: "k" },
+      { canaries: [syntheticCanary], processUrlFn: throwingFn }
+    );
+    assert.equal(result.rejected, true);
+    assert.ok(Array.isArray(result.brokenCanaries));
+    assert.equal(result.brokenCanaries.length, 1);
+    const [f] = result.brokenCanaries;
+    assert.equal(f.kind, "preserve");
+    assert.match(f.reason, /processUrl threw/);
+  });
+});
+
+describe("partitionCandidates — PURE layer: mixed list partitioned, order preserved", () => {
+  test("accepted and rejected preserve input order", () => {
+    const candidates = [
+      { param: "unrelated" },
+      { param: "keepme" },
+      { param: "also-safe" },
+    ];
+    const { accepted, rejected } = partitionCandidates(candidates, {
+      canaries: [syntheticCanary],
+      processUrlFn: fakeFn,
+    });
+    assert.deepEqual(accepted, [{ param: "unrelated" }, { param: "also-safe" }]);
+    assert.equal(rejected.length, 1);
+    assert.deepEqual(rejected[0].candidate, { param: "keepme" });
+    assert.equal(rejected[0].reason, "canary-break");
+    assert.ok(Array.isArray(rejected[0].brokenCanaries));
+  });
+});
+
+describe("partitionCandidates — PURE layer: empty input", () => {
+  test("returns { accepted: [], rejected: [] }", () => {
+    const result = partitionCandidates([], { canaries: [syntheticCanary], processUrlFn: fakeFn });
+    assert.deepEqual(result, { accepted: [], rejected: [] });
+  });
+});
+
+describe("partitionCandidates — PURE layer: all accepted", () => {
+  test("rejected is [] when no candidate breaks any canary", () => {
+    const candidates = [{ param: "utm_source" }, { param: "gclid" }];
+    const { accepted, rejected } = partitionCandidates(candidates, {
+      canaries: [syntheticCanary],
+      processUrlFn: fakeFn,
+    });
+    assert.equal(rejected.length, 0);
+    assert.equal(accepted.length, 2);
+  });
+});
+
+describe("partitionCandidates — PURE layer: all rejected", () => {
+  test("accepted is [] when every candidate breaks at least one synthetic canary", () => {
+    // Both params are in syntheticCanary.mustSurvive... actually synthetic has only "keepme".
+    // Use two separate canaries so both params cause breaks.
+    const canaryB = {
+      name: "synthetic-B",
+      url: "https://example.com/q?other=v2",
+      prefs: {},
+      mustSurvive: { other: "v2" },
+      mustStrip: [],
+    };
+    const { accepted, rejected } = partitionCandidates(
+      [{ param: "keepme" }, { param: "other" }],
+      { canaries: [syntheticCanary, canaryB], processUrlFn: fakeFn }
+    );
+    assert.equal(accepted.length, 0);
+    assert.equal(rejected.length, 2);
+  });
+});
+
+describe("checkCanaryGate — PURE layer: seam honored", () => {
+  test("only synthetic canary is iterated and fakeFn is called when seam opts supplied", () => {
+    let fnCallCount = 0;
+    const countingFn = (url, prefs) => {
+      fnCallCount++;
+      return fakeFn(url, prefs);
+    };
+    checkCanaryGate(
+      { param: "unrelated" },
+      { canaries: [syntheticCanary], processUrlFn: countingFn }
+    );
+    // exactly 1 canary in seam → fn must be called exactly once
+    assert.equal(fnCallCount, 1, "countingFn must be called once per canary in the seam");
+  });
+});
+
+describe("checkCanaryGate — PURE layer: zero-mutation of TRACKING_PARAMS", () => {
+  test("TRACKING_PARAMS.length is unchanged after checkCanaryGate", () => {
+    const before = TRACKING_PARAMS.length;
+    checkCanaryGate({ param: "keepme" }, { canaries: [syntheticCanary], processUrlFn: fakeFn });
+    assert.equal(TRACKING_PARAMS.length, before, "TRACKING_PARAMS must never be mutated");
+  });
+});
+
+describe("partitionCandidates — PURE layer: zero-mutation of TRACKING_PARAMS", () => {
+  test("TRACKING_PARAMS.length is unchanged after partitionCandidates", () => {
+    const before = TRACKING_PARAMS.length;
+    partitionCandidates(
+      [{ param: "keepme" }, { param: "unrelated" }],
+      { canaries: [syntheticCanary], processUrlFn: fakeFn }
+    );
+    assert.equal(TRACKING_PARAMS.length, before, "TRACKING_PARAMS must never be mutated");
+  });
+});
+
+describe("canary-gate — module shape", () => {
+  test("checkCanaryGate and partitionCandidates are exported functions", async () => {
+    // Re-import to inspect namespace without relying on top-level bindings
+    const mod = await import("../../tools/rule-ingestion/gates/canary-gate.mjs");
+    assert.equal(typeof mod.checkCanaryGate, "function");
+    assert.equal(typeof mod.partitionCandidates, "function");
+  });
+
+  test("no default export", async () => {
+    const mod = await import("../../tools/rule-ingestion/gates/canary-gate.mjs");
+    assert.ok(!("default" in mod), "canary-gate must not have a default export");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LIVE layer — real PRESERVE_CANARIES + real processUrl (no opts override)
+// ---------------------------------------------------------------------------
+// WHY: a live break is unconstructable because every mustSurvive key (tag,
+// campid, cjevent, awc, …) is affiliate-protected at cleaner.js:303 and
+// therefore immune to remoteParams stripping. LIVE tests prove realistic
+// params are ACCEPTED and document the GATE-1 complementarity relationship.
+
+describe("checkCanaryGate — LIVE layer: fbclid accepted", () => {
+  test("{ param: 'fbclid' } returns { rejected: false } with real processUrl", () => {
+    const result = checkCanaryGate({ param: "fbclid" });
+    assert.deepEqual(result, { rejected: false });
+  });
+});
+
+describe("checkCanaryGate — LIVE layer: tag accepted (GATE-1 complementarity proof)", () => {
+  test("{ param: 'tag' } returns { rejected: false } with real processUrl", () => {
+    // WHY: cleaner.js:303 `if (affiliateParamSet.has(lower)) continue;` fires BEFORE
+    // isTrackingParam during processUrl — affiliate-protected params like Amazon `tag`
+    // survive even when injected via remoteParams. GATE 3 alone returns { rejected: false }.
+    // GATE 1 separately rejects { param: "tag" } for structural reasons (affiliate-collision).
+    // These gates are COMPLEMENTARY (GATE 1 = structural; GATE 3 = behavioral), not redundant.
+    const result = checkCanaryGate({ param: "tag" });
+    assert.deepEqual(result, { rejected: false });
+  });
+});
+
+describe("checkCanaryGate — LIVE layer: campid accepted", () => {
+  test("{ param: 'campid' } returns { rejected: false } with real processUrl", () => {
+    const result = checkCanaryGate({ param: "campid" });
+    assert.deepEqual(result, { rejected: false });
+  });
+});

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -124,6 +124,61 @@ edits to this gate are needed when a new program or network is added to those
 source arrays (today hand-maintained in `src/lib/affiliates.js` and
 `src/rules/manifest.data.js`) — the set expands automatically.
 
+## GATE 3 — canary-gate (#777)
+
+`tools/rule-ingestion/gates/canary-gate.mjs`
+
+**What it does:** Replays the ingestion candidate via `remoteParams` against
+all 16 `PRESERVE_CANARIES` (the affiliate-survival moat). For each canary it
+calls the real `processUrl` with `{ remoteParams: [candidate.param] }` and
+checks that every `mustSurvive` attribute still holds. Any canary break causes
+REJECTION. The gate is pure — it never mutates `TRACKING_PARAMS`,
+`TRACKING_PARAMS_SET`, or any module-level singleton.
+
+**Public exports:**
+- `checkCanaryGate(candidate, opts?)` — returns `{ rejected: false }` when the
+  candidate param does not break any canary, or
+  `{ rejected: true, reason: "canary-break", brokenCanaries: CanaryFailure[] }`
+  when at least one canary breaks. `CanaryFailure = { name, kind: "preserve", reason }`.
+  `brokenCanaries` is PARAM-LEVEL and collect-all (no short-circuit).
+- `partitionCandidates(candidates, opts?)` — batch helper; returns
+  `{ accepted: Candidate[], rejected: Array<{ candidate, reason, brokenCanaries }> }`,
+  input order preserved in both arrays. `opts` is forwarded to each individual
+  `checkCanaryGate` call (testability seam works at batch level too).
+
+**Asymmetric-risk rationale:** A false-accept (failing to catch a param that
+strips an affiliate attribution cookie at runtime) causes unbounded revenue loss
+for creators. A false-reject (blocking a tracker whose name happens to match an
+inert URL param in a canary) is recoverable by manual review. GATE 3 is
+therefore intentionally conservative — it only promotes a candidate once it has
+proved that injecting that param as a runtime strip rule leaves every canary
+intact.
+
+**GATE-1 complementarity (`tag` example):** GATE 1 rejects `{ param: "tag" }`
+structurally (the name collides with the Amazon Associates tag param). GATE 3
+returns `{ rejected: false }` for the same candidate — because `cleaner.js:303`
+runs `if (affiliateParamSet.has(lower)) continue;` before `isTrackingParam`,
+making affiliate-protected params like `tag` and `campid` immune to
+`remoteParams` stripping at runtime. The two gates are COMPLEMENTARY (GATE 1 =
+structural; GATE 3 = behavioral), not redundant. A candidate rejected by GATE 1
+never reaches GATE 3.
+
+**LANDING_CANARIES excluded — WHY:** `LANDING_CANARIES` exercise
+`getLandingPolicy()`, an orthogonal code-path driven by referrer heuristics
+rather than `remoteParams` stripping. Including them in GATE 3 would simulate a
+wrong behavior. GATE 3 imports `PRESERVE_CANARIES` only.
+
+**Affiliate-safety domain:** The canaries and the shared break-evaluator now
+live in `tools/affiliate-safety/`:
+- `canaries.mjs` — exports `PRESERVE_CANARIES` and `LANDING_CANARIES`
+  (relocated from `tests/fixtures/` in #777, EPIC C).
+- `evaluate.mjs` — exports `evaluateCanary(canary, processUrlFn, extraRemoteParams?)`
+  — the shared break-evaluator used by BOTH the A4 runner
+  (`tools/affiliate-safety/runner.mjs`) AND GATE 3. Single source of truth;
+  zero drift.
+- `runner.mjs` — exports `runAffiliateCanaries()` (relocated from
+  `tests/fixtures/`; PRESERVE loop now delegates to `evaluateCanary`).
+
 ## CI gate
 
 `verify-quarantine.mjs` runs in CI ([`ci.yml`](../../.github/workflows/ci.yml))

--- a/tools/rule-ingestion/gates/canary-gate.mjs
+++ b/tools/rule-ingestion/gates/canary-gate.mjs
@@ -1,0 +1,117 @@
+/**
+ * MUGA: GATE 3 — canary-gate (#777)
+ *
+ * Guards against the behavioral failure of auto-promoting a param that, at
+ * runtime, would STRIP an affiliate attribution param. The gate simulates
+ * adding `candidate.param` to the runtime strip list via `remoteParams` and
+ * runs EVERY PRESERVE canary through the live cleaner. Any canary break means
+ * REJECTION.
+ *
+ * GATE 3 is COMPLEMENTARY to GATE 1 (affiliate-guard): GATE 1 = structural
+ * (is this param a known affiliate NAME?); GATE 3 = behavioral (does adding
+ * this param BREAK any affiliate canary?). Additive and independent.
+ *
+ * The gate NEVER mutates TRACKING_PARAMS, TRACKING_PARAMS_SET, or any
+ * module-level singleton. It passes `candidate.param` as a per-call
+ * `remoteParams` pref to processUrlFn — pure simulation, zero side-effects.
+ *
+ * Public API (named exports only — no default):
+ *   checkCanaryGate(candidate, opts?) → { rejected }
+ *   partitionCandidates(candidates, opts?) → { accepted, rejected }
+ */
+
+import { processUrl } from "../../../src/lib/cleaner.js";
+import { PRESERVE_CANARIES } from "../../affiliate-safety/canaries.mjs";
+import { evaluateCanary } from "../../affiliate-safety/evaluate.mjs";
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Checks a single ingestion candidate against the PRESERVE canary set.
+ *
+ * Returns `{ rejected: false }` when the candidate param does not break any
+ * canary. Returns `{ rejected: true, reason: "canary-break", brokenCanaries }`
+ * when at least one canary breaks — `brokenCanaries` is PARAM-LEVEL and
+ * collect-all (no short-circuit), matching the runner's existing granularity.
+ *
+ * WHY — LANDING_CANARIES are excluded: they exercise getLandingPolicy(), an
+ * orthogonal code-path driven by referrer heuristics rather than remoteParams
+ * stripping. Including them here would be a false behavioral simulation.
+ *
+ * WHY — zero TRACKING_PARAMS mutation: `candidate.param` is passed ONLY as a
+ * transient `remoteParams` override in the prefs given to processUrlFn. The
+ * module-level singleton is never touched.
+ *
+ * WHY — seam via opts: the testability seam (`canaries` / `processUrlFn`) lets
+ * tests inject synthetic fixtures and a fake processUrlFn for the rejection
+ * path. A live break is unconstructable with the real PRESERVE_CANARIES because
+ * every mustSurvive key is affiliate-protected at cleaner.js:303 and immune to
+ * remoteParams stripping.
+ *
+ * @param {{ param?: string } | null | undefined} candidate
+ * @param {{ canaries?: object[], processUrlFn?: Function }} [opts]
+ * @returns {{ rejected: boolean, reason?: string, brokenCanaries?: object[] }}
+ */
+export function checkCanaryGate(
+  candidate,
+  { canaries = PRESERVE_CANARIES, processUrlFn = processUrl } = {}
+) {
+  // Defensive extraction: treat any non-string or missing/empty param as no-op.
+  // Schema validation is an upstream gate's job (mirrors GATE 1 defensive style).
+  const param =
+    typeof candidate?.param === "string" ? candidate.param.toLowerCase() : "";
+
+  if (!param) {
+    return { rejected: false };
+  }
+
+  // Loop ALL canaries — collect-all, no short-circuit.
+  // evaluateCanary wraps processUrlFn in try/catch so a throwing canary
+  // becomes a recorded failure rather than an uncaught exception.
+  const brokenCanaries = [];
+  for (const c of canaries) {
+    brokenCanaries.push(...evaluateCanary(c, processUrlFn, [param]));
+  }
+
+  if (brokenCanaries.length > 0) {
+    return { rejected: true, reason: "canary-break", brokenCanaries };
+  }
+
+  return { rejected: false };
+}
+
+// ── Batch partition ────────────────────────────────────────────────────────────
+
+/**
+ * Partitions an array of ingestion candidates into accepted and rejected
+ * buckets in a single pass. Input order is preserved in both output arrays.
+ *
+ * Forwards `opts` to each `checkCanaryGate` call so the testability seam
+ * (synthetic canaries + fake processUrlFn) works at batch level too.
+ *
+ * Rejected items carry the full rejection metadata so the caller/logger
+ * doesn't need to re-run the check.
+ *
+ * @param {Array<{ param?: string }>} candidates
+ * @param {{ canaries?: object[], processUrlFn?: Function }} [opts]
+ * @returns {{ accepted: Array, rejected: Array<{ candidate: object, reason: string, brokenCanaries: object[] }> }}
+ */
+export function partitionCandidates(candidates, opts = {}) {
+  const accepted = [];
+  const rejected = [];
+
+  for (const candidate of candidates) {
+    const result = checkCanaryGate(candidate, opts);
+    if (result.rejected) {
+      rejected.push({
+        candidate,
+        reason: result.reason,
+        brokenCanaries: result.brokenCanaries,
+      });
+    } else {
+      accepted.push(candidate);
+    }
+  }
+
+  return { accepted, rejected };
+}


### PR DESCRIPTION
## What

**PR 2 of 2** for #777 (stacked on the merged `tools/affiliate-safety/` domain from #796). GATE 3 of MUGA's self-scaling ruleset — the **behavioral** safety net complementing GATE 1's structural check.

For every ingestion candidate, GATE 3 simulates adding its `param` to the strip list (via `processUrl` + `remoteParams` injection) against all 16 PRESERVE_CANARIES and **rejects** the candidate if any affiliate canary breaks. This is the automated replacement for human affiliate-safety review.

Closes #777.

## How

`tools/rule-ingestion/gates/canary-gate.mjs`:
- **`checkCanaryGate(candidate, opts?)`** → `{ rejected: false }` or `{ rejected: true, reason: "canary-break", brokenCanaries: [{ name, kind: "preserve", reason }] }`. Collect-all, param-level diagnostics. Defensive (malformed param → accepted; schema validation is an upstream gate's job).
- **`partitionCandidates(candidates, opts?)`** → order-preserving `{ accepted, rejected }`.
- **Consumes the shared `evaluateCanary`** from `tools/affiliate-safety/evaluate.mjs` — **zero duplicated break-detection**; the gate and the A4 runner now share one evaluator (no drift).
- Testability seam: injectable `{ canaries, processUrlFn }`.

### Design decisions
- **LANDING_CANARIES excluded** — driven by `getLandingPolicy`, orthogonal to TRACKING_PARAMS additions; including them gives false confidence.
- **Complementary to GATE 1, not redundant**: GATE 1 = structural (is the param a known affiliate *name*?); GATE 3 = behavioral (does adding it *break* a canary?). `tag` is **accepted by GATE 3 alone** (affiliate-protected at `cleaner.js:303`) but **rejected by GATE 1** — each catches what the other cannot. Proven by a live test.
- **Zero mutation** of `TRACKING_PARAMS` — simulation is per-call `remoteParams` only.

### Testing insight
The live 16 PRESERVE_CANARIES cannot exercise the rejection path (every `mustSurvive` key is affiliate-protected and immune to `remoteParams` stripping). Rejection is proven deterministically in the PURE layer via synthetic canaries + a fake `processUrlFn`; the LIVE layer proves realistic params are accepted + the GATE-1 complementarity.

## Tests

21 new tests (PURE synthetic layer + LIVE complementarity proofs). Full suite **4197 pass / 0 fail**.