### PR TITLE
feat(ingestion): GATE 2 cross-corroboration + ClearURLs adapter (#776)

### DIFF
--- a/tests/unit/clearurls-adapter.test.mjs
+++ b/tests/unit/clearurls-adapter.test.mjs
@@ -1,0 +1,248 @@
+/**
+ * MUGA — ClearURLs adapter tests (#776).
+ *
+ * Tests the clearurls adapter shape, literal extraction, referralMarketing
+ * safety exclusion (SAFETY-CRITICAL: affiliate tokens must NEVER reach the
+ * output Set), lowercasing, dedup, malformed-input handling, and fetchRaw
+ * with injectable fetchImpl (no real network).
+ *
+ * All ClearURLs JSON is supplied as synthetic fixture STRINGS — no network.
+ *
+ * CRITICAL correctness: T-13 covers the GLOBAL referralMarketing exclusion
+ * algorithm: a param in rules[] of provider A but referralMarketing[] of
+ * provider B MUST be excluded. The two-pass global-union algorithm ensures this.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  clearurls,
+  extractClearurlsLiterals,
+} from "../../tools/rule-ingestion/adapters/clearurls.mjs";
+
+// ── Synthetic ClearURLs JSON fixtures ─────────────────────────────────────────
+
+/**
+ * Standard fixture: two providers covering the common extraction scenarios.
+ * - Provider A: mix of literals, patterns, UPPERCASE (for lowercasing test),
+ *   empty string; referralMarketing contains known affiliate tokens.
+ * - Provider B: literal overlap (utm_source dedup test), cross-provider
+ *   referralMarketing token (cjevent).
+ */
+const FIXTURE_STANDARD = JSON.stringify({
+  providers: {
+    providerA: {
+      rules: ["utm_source", "^gclid$", "(ref)", ".*sess.*", "FBCLID", ""],
+      referralMarketing: ["tag", "awc"],
+    },
+    providerB: {
+      rules: ["utm_source", "mc_eid"],
+      referralMarketing: ["cjevent"],
+    },
+  },
+});
+
+/**
+ * Cross-provider exclusion fixture (T-13 LOCKED DECISION):
+ * param "ref" is in rules[] of provider A but referralMarketing[] of provider B.
+ * The global-union algorithm must exclude it regardless of which provider
+ * it appears in — per-provider-scoped exclusion would incorrectly admit it.
+ */
+const FIXTURE_CROSS_PROVIDER = JSON.stringify({
+  providers: {
+    providerA: {
+      rules: ["ref"],
+      referralMarketing: [],
+    },
+    providerB: {
+      rules: [],
+      referralMarketing: ["ref"],
+    },
+  },
+});
+
+// ── T-09: Adapter shape ───────────────────────────────────────────────────────
+
+describe("clearurls adapter shape", () => {
+  test("id is 'clearurls'", () => {
+    assert.equal(clearurls.id, "clearurls");
+  });
+
+  test("license is 'LGPL-3.0'", () => {
+    assert.equal(clearurls.license, "LGPL-3.0");
+  });
+
+  test("parse is a function", () => {
+    assert.equal(typeof clearurls.parse, "function");
+  });
+
+  test("fetchRaw is a function", () => {
+    assert.equal(typeof clearurls.fetchRaw, "function");
+  });
+
+  test("no default export", async () => {
+    const mod = await import(
+      "../../tools/rule-ingestion/adapters/clearurls.mjs"
+    );
+    assert.equal(mod.default, undefined);
+  });
+});
+
+// ── T-10: Literal extraction from standard fixture ───────────────────────────
+
+describe("extractClearurlsLiterals — standard fixture", () => {
+  test("Set contains utm_source", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(params.has("utm_source"), "utm_source must be in params");
+  });
+
+  test("Set contains gclid (stripped from ^gclid$)", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(params.has("gclid"), "gclid must be in params after anchor stripping");
+  });
+
+  test("Set contains fbclid (lowercased from FBCLID)", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(params.has("fbclid"), "fbclid must be in params (lowercased)");
+  });
+
+  test("Set contains mc_eid", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(params.has("mc_eid"), "mc_eid must be in params");
+  });
+
+  test("Set does NOT contain (ref) pattern", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(!params.has("(ref)"), "(ref) is a regex pattern — must be skipped");
+  });
+
+  test("Set does NOT contain .*sess.* pattern", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(!params.has(".*sess.*"), ".*sess.* is a regex pattern — must be skipped");
+  });
+
+  test("skipped count is >= 2 (at least (ref) and .*sess.* are skipped)", () => {
+    const { skipped } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(skipped >= 2, `expected skipped >= 2, got ${skipped}`);
+  });
+});
+
+// ── T-11: Lowercasing ────────────────────────────────────────────────────────
+
+describe("extractClearurlsLiterals — lowercasing", () => {
+  test("FBCLID in rules → fbclid in Set (not FBCLID)", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(params.has("fbclid"));
+    assert.ok(!params.has("FBCLID"));
+  });
+});
+
+// ── T-12: referralMarketing exclusion (per-provider) ────────────────────────
+
+describe("extractClearurlsLiterals — referralMarketing exclusion", () => {
+  test("'tag' (affiliate token) is NOT in params", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(!params.has("tag"), "affiliate token 'tag' must not be in params");
+  });
+
+  test("'awc' (affiliate token) is NOT in params", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(!params.has("awc"), "affiliate token 'awc' must not be in params");
+  });
+
+  test("'cjevent' (cross-provider affiliate token) is NOT in params", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    assert.ok(!params.has("cjevent"), "affiliate token 'cjevent' must not be in params");
+  });
+});
+
+// ── T-13: CROSS-PROVIDER exclusion (GLOBAL union algorithm — LOCKED DECISION) ─
+
+describe("extractClearurlsLiterals — global referralMarketing union", () => {
+  test("'ref' in rules[A] but referralMarketing[B] → NOT in params (global exclusion)", () => {
+    // WHY this test is LOCKED: a per-provider exclusion would admit 'ref' from
+    // provider A (because A.referralMarketing is empty). The global-union
+    // algorithm first collects ALL referralMarketing names across ALL providers,
+    // then subtracts the entire union — so 'ref' is excluded from the output Set
+    // regardless of which provider's rules[] listed it.
+    const { params } = extractClearurlsLiterals(FIXTURE_CROSS_PROVIDER);
+    assert.ok(
+      !params.has("ref"),
+      "'ref' must not be in params: it is referralMarketing in provider B and therefore globally excluded"
+    );
+  });
+
+  test("anchored referralMarketing entry ('^tag$') still excludes a bare 'tag' rule (normalization symmetry)", () => {
+    // Hardening regression: referralMarketing names are normalized IDENTICALLY
+    // to rules[] (anchor-strip + lowercase). An anchored affiliate entry must
+    // not slip past the exclusion due to normalization drift.
+    const fixture = JSON.stringify({
+      providers: {
+        anchored: {
+          rules: ["tag", "utm_term"],
+          referralMarketing: ["^tag$"],
+        },
+      },
+    });
+    const { params } = extractClearurlsLiterals(fixture);
+    assert.ok(
+      !params.has("tag"),
+      "'tag' must be excluded: '^tag$' in referralMarketing normalizes to 'tag'"
+    );
+    assert.ok(params.has("utm_term"), "non-affiliate literal still extracted");
+  });
+});
+
+// ── T-14: Dedup across providers ─────────────────────────────────────────────
+
+describe("extractClearurlsLiterals — dedup", () => {
+  test("utm_source appears in both providers → Set has exactly one entry for it", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_STANDARD);
+    // Set membership is inherently deduped; verify it is present exactly once
+    // by checking the Set size difference when removing it.
+    const sizeBefore = params.size;
+    params.delete("utm_source");
+    const sizeAfter = params.size;
+    assert.equal(sizeBefore - sizeAfter, 1, "utm_source should contribute exactly 1 slot in the Set");
+  });
+});
+
+// ── T-15: Malformed JSON ──────────────────────────────────────────────────────
+
+describe("clearurls.parse — malformed JSON", () => {
+  test("parse('{bad json}') throws", () => {
+    assert.throws(
+      () => clearurls.parse("{bad json}"),
+      /ClearURLs parse failed/,
+    );
+  });
+});
+
+// ── T-16: Missing providers ───────────────────────────────────────────────────
+
+describe("clearurls.parse — missing providers", () => {
+  test("parse('{}') returns empty Set (no throw)", () => {
+    const result = clearurls.parse("{}");
+    assert.ok(result instanceof Set);
+    assert.equal(result.size, 0);
+  });
+});
+
+// ── T-17: fetchRaw injectable seam ───────────────────────────────────────────
+
+describe("clearurls.fetchRaw — injectable fetchImpl", () => {
+  test("fetchImpl returning ok:false throws with 'ClearURLs fetch failed'", async () => {
+    const badFetch = async () => ({ ok: false, status: 500, statusText: "Internal Server Error" });
+    await assert.rejects(
+      () => clearurls.fetchRaw({ fetchImpl: badFetch }),
+      /ClearURLs fetch failed/,
+    );
+  });
+
+  test("fetchImpl returning ok:true returns raw text", async () => {
+    const goodFetch = async () => ({ ok: true, text: async () => "rawtext" });
+    const result = await clearurls.fetchRaw({ fetchImpl: goodFetch });
+    assert.equal(result, "rawtext");
+  });
+});

--- a/tests/unit/corroboration-gate.test.mjs
+++ b/tests/unit/corroboration-gate.test.mjs
@@ -1,0 +1,225 @@
+/**
+ * MUGA: GATE 2 — corroboration-gate tests (#776).
+ *
+ * Verifies the corroboration predicate: a candidate is accepted only when
+ * ≥ MIN_SIGNALS independent upstream sources reported it. Signal count is the
+ * SOLE predicate — entropy/CSF arms are NOT evaluated (deferred to #798).
+ *
+ * Tests cover: module shape, threshold boundaries, opts override, malformed
+ * candidate handling (REJECTS — inverse of GATE 1/3's accept-malformed posture),
+ * no-mutation purity, and partitionCandidates batch behavior.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MIN_SIGNALS,
+  checkCorroborationGate,
+  partitionCandidates,
+} from "../../tools/rule-ingestion/gates/corroboration-gate.mjs";
+
+// ── T-01: Module shape ────────────────────────────────────────────────────────
+
+describe("corroboration-gate module shape", () => {
+  test("MIN_SIGNALS is 2", () => {
+    assert.equal(MIN_SIGNALS, 2);
+  });
+
+  test("checkCorroborationGate is a function", () => {
+    assert.equal(typeof checkCorroborationGate, "function");
+  });
+
+  test("partitionCandidates is a function", () => {
+    assert.equal(typeof partitionCandidates, "function");
+  });
+
+  test("no default export", async () => {
+    const mod = await import(
+      "../../tools/rule-ingestion/gates/corroboration-gate.mjs"
+    );
+    assert.equal(mod.default, undefined);
+  });
+});
+
+// ── T-02: Accept at/above threshold ──────────────────────────────────────────
+
+describe("checkCorroborationGate — accept", () => {
+  test("exactly two signals → accepted", () => {
+    const candidate = { param: "utm_source", signals: ["adguard-tp", "clearurls"] };
+    assert.deepEqual(checkCorroborationGate(candidate), { rejected: false });
+  });
+
+  test("three signals → accepted", () => {
+    const candidate = { signals: ["adguard-tp", "clearurls", "brave"] };
+    assert.deepEqual(checkCorroborationGate(candidate), { rejected: false });
+  });
+});
+
+// ── T-03: Reject below threshold ─────────────────────────────────────────────
+
+describe("checkCorroborationGate — reject below threshold", () => {
+  test("one signal → rejected with signalCount 1", () => {
+    const candidate = { param: "fbclid", signals: ["adguard-tp"] };
+    assert.deepEqual(checkCorroborationGate(candidate), {
+      rejected: true,
+      reason: "corroboration-below-threshold",
+      detail: { signalCount: 1, minSignals: 2 },
+    });
+  });
+
+  test("zero signals → rejected with signalCount 0", () => {
+    const candidate = { param: "ref", signals: [] };
+    assert.deepEqual(checkCorroborationGate(candidate), {
+      rejected: true,
+      reason: "corroboration-below-threshold",
+      detail: { signalCount: 0, minSignals: 2 },
+    });
+  });
+});
+
+// ── T-04: Opts override ───────────────────────────────────────────────────────
+
+describe("checkCorroborationGate — opts override", () => {
+  test("minSignals:1 accepts single-source candidate", () => {
+    const candidate = { signals: ["adguard-tp"] };
+    assert.deepEqual(
+      checkCorroborationGate(candidate, { minSignals: 1 }),
+      { rejected: false }
+    );
+  });
+
+  test("minSignals:3 rejects two-source candidate with correct detail", () => {
+    const candidate = { signals: ["adguard-tp", "clearurls"] };
+    assert.deepEqual(
+      checkCorroborationGate(candidate, { minSignals: 3 }),
+      {
+        rejected: true,
+        reason: "corroboration-below-threshold",
+        detail: { signalCount: 2, minSignals: 3 },
+      }
+    );
+  });
+});
+
+// ── T-05: Malformed candidate — REJECTS (inverse of GATE 1/3 accept-malformed) ─
+
+describe("checkCorroborationGate — malformed → rejected", () => {
+  // WHY: GATE 2 rejects = "not yet corroborated". A candidate with no provable
+  // signals IS the failure mode the gate exists to catch. Accept-malformed would
+  // defeat the gate's entire purpose.
+
+  test("null candidate → rejected with signalCount 0", () => {
+    assert.deepEqual(checkCorroborationGate(null), {
+      rejected: true,
+      reason: "corroboration-below-threshold",
+      detail: { signalCount: 0, minSignals: 2 },
+    });
+  });
+
+  test("undefined candidate → rejected with signalCount 0", () => {
+    assert.deepEqual(checkCorroborationGate(undefined), {
+      rejected: true,
+      reason: "corroboration-below-threshold",
+      detail: { signalCount: 0, minSignals: 2 },
+    });
+  });
+
+  test("empty object (no signals field) → rejected with signalCount 0", () => {
+    assert.deepEqual(checkCorroborationGate({}), {
+      rejected: true,
+      reason: "corroboration-below-threshold",
+      detail: { signalCount: 0, minSignals: 2 },
+    });
+  });
+
+  test("signals: null → rejected with signalCount 0", () => {
+    assert.deepEqual(checkCorroborationGate({ signals: null }), {
+      rejected: true,
+      reason: "corroboration-below-threshold",
+      detail: { signalCount: 0, minSignals: 2 },
+    });
+  });
+
+  test("signals is a string (not array) → rejected with signalCount 0", () => {
+    assert.deepEqual(checkCorroborationGate({ signals: "adguard-tp" }), {
+      rejected: true,
+      reason: "corroboration-below-threshold",
+      detail: { signalCount: 0, minSignals: 2 },
+    });
+  });
+});
+
+// ── T-06: Entropy does not rescue single-source candidate ─────────────────────
+
+describe("checkCorroborationGate — entropy ignored", () => {
+  test("non-null entropy on single-source candidate still rejected", () => {
+    // WHY: entropy/CSF evaluation is deferred to #798 — these fields are
+    // HARDCODED null at ingestion time. Including an entropy arm here = dead code.
+    const candidate = { param: "track", signals: ["adguard-tp"], entropy: 4.5, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+  });
+});
+
+// ── T-07: Pure function — no mutation ────────────────────────────────────────
+
+describe("checkCorroborationGate — purity", () => {
+  test("call does not mutate input candidate", () => {
+    const signals = ["adguard-tp"];
+    const c = { param: "foo", signals };
+    checkCorroborationGate(c);
+    // signals array reference and contents must be identical after the call
+    assert.strictEqual(c.signals, signals);
+    assert.deepEqual(c.signals, ["adguard-tp"]);
+  });
+});
+
+// ── T-08: partitionCandidates ─────────────────────────────────────────────────
+
+describe("partitionCandidates", () => {
+  test("mixed candidates → correct buckets, order preserved", () => {
+    const A = { param: "utm_source", signals: ["adguard-tp", "clearurls"] };
+    const B = { param: "some_tracker", signals: ["adguard-tp"] };
+    const C = { param: "gclid", signals: ["adguard-tp", "clearurls", "brave"] };
+
+    const { accepted, rejected } = partitionCandidates([A, B, C]);
+
+    assert.deepEqual(accepted, [A, C]);
+    assert.equal(rejected.length, 1);
+    assert.strictEqual(rejected[0].candidate, B);
+    assert.equal(rejected[0].reason, "corroboration-below-threshold");
+    assert.deepEqual(rejected[0].detail, { signalCount: 1, minSignals: 2 });
+  });
+
+  test("empty input → {accepted:[], rejected:[]}", () => {
+    assert.deepEqual(partitionCandidates([]), { accepted: [], rejected: [] });
+  });
+
+  test("all accepted", () => {
+    const candidates = [
+      { signals: ["a", "b"] },
+      { signals: ["c", "d"] },
+    ];
+    const { accepted, rejected } = partitionCandidates(candidates);
+    assert.equal(accepted.length, 2);
+    assert.equal(rejected.length, 0);
+  });
+
+  test("all rejected", () => {
+    const candidates = [
+      { signals: ["a"] },
+      { signals: [] },
+    ];
+    const { accepted, rejected } = partitionCandidates(candidates);
+    assert.equal(accepted.length, 0);
+    assert.equal(rejected.length, 2);
+  });
+
+  test("opts forwarded — minSignals:1 makes single-source accepted", () => {
+    const candidates = [{ signals: ["adguard-tp"] }];
+    const { accepted, rejected } = partitionCandidates(candidates, { minSignals: 1 });
+    assert.equal(accepted.length, 1);
+    assert.equal(rejected.length, 0);
+  });
+});

--- a/tests/unit/rule-ingestion-adapters.test.mjs
+++ b/tests/unit/rule-ingestion-adapters.test.mjs
@@ -46,10 +46,10 @@ test("adguardTp.parse extracts literal params and skips regex specs", () => {
   assert.ok(!params.has("/^utm_/"));
 });
 
-test("registry enables only AdGuard TP in B2", () => {
+test("registry enables AdGuard TP and ClearURLs (two independent signal sources for GATE 2, #776)", () => {
   assert.deepEqual(
     ENABLED_ADAPTERS.map((a) => a.id),
-    ["adguard-tp"],
+    ["adguard-tp", "clearurls"],
   );
 });
 

--- a/tools/rule-ingestion/PROVENANCE.md
+++ b/tools/rule-ingestion/PROVENANCE.md
@@ -58,7 +58,7 @@ Verified against each project's actual `LICENSE` file. Status reflects use as a
 | Source | Data license | Status | Notes |
 |---|---|---|---|
 | **AdGuard URL Tracking Protection (Filter 17)** | GPL-3.0 | ✅ **Enabled** (B2) | Strong copyleft, compatible with MUGA's GPL v3. Large, consolidated, actively maintained. Sole source in B2. |
-| **ClearURLs Rules** | LGPL-3.0 | ⏸️ Candidate (#776) | Library copyleft — ships alongside MUGA without relicensing the extension. Per-provider JSON; `rules` (tracking) only, **never** `referralMarketing` (affiliate — MUGA's preserve set). Re-added when cross-corroboration lands. |
+| **ClearURLs Rules** | LGPL-3.0 | ✅ **Enabled** (#776) | Library copyleft — ships alongside MUGA without relicensing the extension. Per-provider JSON; `rules` (tracking) only, **never** `referralMarketing` (affiliate — MUGA's preserve set). Second independent source enabling cross-source corroboration via GATE 2. |
 | **Brave adblock-lists** (`clean-urls.json`, `debounce.json`) | MPL-2.0 | ⏸️ Candidate | File-level copyleft, friendliest for commercial use. Not yet wired. |
 | **uBlock Origin / uAssets** | GPL-3.0 | ⏸️ Candidate | Strong copyleft, compatible. Overlaps heavily with AdGuard. |
 | **Neat URL** | GPL-2.0-or-later | ⏸️ Candidate | Compatible. Small list. |

--- a/tools/rule-ingestion/adapters/clearurls.mjs
+++ b/tools/rule-ingestion/adapters/clearurls.mjs
@@ -1,0 +1,180 @@
+/**
+ * MUGA rule-ingestion adapter: ClearURLs Rules (#776).
+ *
+ * License: LGPL-3.0 (library copyleft — ships alongside MUGA without
+ * relicensing the extension). Used as a SIGNAL only: we extract individual
+ * literal param-name facts from providers[*].rules[] and independently
+ * re-derive each through MUGA's EPIC C gates. See PROVENANCE.md (#774).
+ *
+ * SAFETY-CRITICAL: providers[*].referralMarketing[] entries MUST NEVER reach
+ * the output Set. These are affiliate attribution parameters that belong to
+ * MUGA's preserve set. Ingesting them as strip candidates would cause
+ * catastrophic revenue loss for creators. Exclusion uses a TWO-PASS GLOBAL
+ * union algorithm (see extractClearurlsLiterals) so a param that appears in
+ * any provider's referralMarketing is excluded from every provider's output.
+ *
+ * Public API (named exports only — no default):
+ *   extractClearurlsLiterals(rawText) → { params: Set<string>, skipped: number }
+ *   clearurls                         → Adapter (id, name, license, url, parse, fetchRaw)
+ */
+
+/** @type {import("./index.mjs").Adapter} */
+
+// Canonical raw URL for the ClearURLs rules database (data.min.json is the
+// minified production file published on the master branch of ClearURLs/Rules).
+// Verified at apply time: https://raw.githubusercontent.com/ClearURLs/Rules/master/data.min.json
+const SOURCE_URL =
+  "https://raw.githubusercontent.com/ClearURLs/Rules/master/data.min.json";
+
+const USER_AGENT =
+  "muga-rule-ingestion/1.0 (+https://github.com/yocreoquesi/muga)";
+
+// Locked contract: safe literal param name — alphanumeric, underscore, hyphen.
+// NO dot (conservative; dotted param names are rare in tracking lists and the
+// skip-direction is safe). Mirrors adguard-tp precedent but stricter per design.
+const LITERAL = /^[a-z0-9_-]+$/;
+
+/**
+ * Normalize a ClearURLs entry to a comparable bare name: strip trivial regex
+ * anchors (leading `^`, trailing `$`), trim, lowercase.
+ *
+ * WHY shared: rules[] and referralMarketing[] MUST be normalized identically so
+ * the affiliate-exclusion comparison can never miss due to normalization drift
+ * (e.g. a `^tag$` referralMarketing entry must still exclude a bare `tag` rule).
+ *
+ * @param {unknown} raw
+ * @returns {string}
+ */
+function normalizeName(raw) {
+  return String(raw).replace(/^\^/, "").replace(/\$$/, "").trim().toLowerCase();
+}
+
+// ── Core extraction (testable seam) ──────────────────────────────────────────
+
+/**
+ * Extracts safe literal tracking param names from a ClearURLs rules JSON string.
+ *
+ * WHY two-pass global algorithm: a param that is in rules[] of provider A
+ * but referralMarketing[] of provider B must still be excluded. A per-provider
+ * exclusion would incorrectly admit it from A. The global union collects ALL
+ * referralMarketing names across ALL providers first, then subtracts that entire
+ * union during extraction — making referralMarketing exclusion provider-agnostic.
+ *
+ * Extraction rules (providers[*].rules[] only):
+ * 1. Strip trivial regex anchors: leading `^` and trailing `$`.
+ * 2. Lowercase.
+ * 3. Keep only entries matching /^[a-z0-9_-]+$/ (LITERAL). Others → skipped++.
+ * 4. Subtract global referralMarketing union (affiliate preserve — SAFETY).
+ * 5. Add to output Set (Set deduplicates across providers automatically).
+ *
+ * Does NOT read: top-level globalRules / rawGlobalRules (locked out-of-scope).
+ *
+ * @param {string} rawText Raw ClearURLs rules JSON string.
+ * @returns {{ params: Set<string>, skipped: number }}
+ */
+export function extractClearurlsLiterals(rawText) {
+  let data;
+  try {
+    data = JSON.parse(rawText);
+  } catch {
+    throw new Error("ClearURLs parse failed: invalid JSON");
+  }
+
+  // Guard: providers must be a non-null object; otherwise treat as empty.
+  const providers =
+    data?.providers && typeof data.providers === "object"
+      ? data.providers
+      : {};
+
+  const providerList = Object.values(providers);
+
+  // PASS 1: Build a global Set of ALL referralMarketing names across ALL providers.
+  // WHY first: ensures cross-provider exclusion — see docblock above.
+  const globalReferral = new Set();
+  for (const provider of providerList) {
+    if (!Array.isArray(provider?.referralMarketing)) continue;
+    for (const raw of provider.referralMarketing) {
+      // Normalize IDENTICALLY to rules[] (PASS 2) — anchor-strip included — so
+      // an anchored affiliate entry can never slip past the exclusion check.
+      globalReferral.add(normalizeName(raw));
+    }
+  }
+
+  // PASS 2: Extract safe literals from providers[*].rules[], subtract global referral union.
+  const params = new Set();
+  let skipped = 0;
+
+  for (const provider of providerList) {
+    const rules = Array.isArray(provider?.rules) ? provider.rules : [];
+    for (const raw of rules) {
+      // Strip trivial anchors before literal check (^gclid$ → gclid).
+      // Same normalization as the referralMarketing union (PASS 1).
+      const name = normalizeName(raw);
+
+      if (!name) {
+        // Empty or whitespace-only rule — skip+count (parse failure, not affiliate).
+        skipped++;
+        continue;
+      }
+
+      if (!LITERAL.test(name)) {
+        // Regex metacharacters or other non-literal patterns — skip+count.
+        // No silent truncation: skipped count surfaces via return value.
+        skipped++;
+        continue;
+      }
+
+      // SAFETY-CRITICAL: affiliate preserve check using global union.
+      // Excluded entries are intentional — NOT counted as skip (parse success,
+      // deliberate exclusion).
+      if (globalReferral.has(name)) continue;
+
+      params.add(name);
+    }
+  }
+
+  return { params, skipped };
+}
+
+// ── Adapter object ────────────────────────────────────────────────────────────
+
+/**
+ * ClearURLs adapter. Mirrors adguard-tp.mjs shape exactly.
+ * @type {import("./index.mjs").Adapter}
+ */
+export const clearurls = {
+  id: "clearurls",
+  name: "ClearURLs Rules",
+  license: "LGPL-3.0",
+  url: SOURCE_URL,
+
+  /**
+   * Extract literal tracking param names from a ClearURLs rules JSON string.
+   * Delegates to extractClearurlsLiterals and returns the params Set directly
+   * to honor the Adapter typedef contract (parse → Set<string>).
+   * @param {string} rawText Raw rules JSON.
+   * @returns {Set<string>} Lowercased param names (referralMarketing excluded).
+   */
+  parse(rawText) {
+    return extractClearurlsLiterals(rawText).params;
+  },
+
+  /**
+   * Fetch the raw rules JSON. Returns raw text for the caller to quarantine
+   * before parsing (raw bytes are ephemeral — never committed/bundled).
+   * @param {object} [opts]
+   * @param {typeof fetch} [opts.fetchImpl] Injectable fetch for testing.
+   * @returns {Promise<string>}
+   */
+  async fetchRaw({ fetchImpl = fetch } = {}) {
+    const res = await fetchImpl(SOURCE_URL, {
+      headers: { "User-Agent": USER_AGENT },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `ClearURLs fetch failed: ${res.status} ${res.statusText}`,
+      );
+    }
+    return res.text();
+  },
+};

--- a/tools/rule-ingestion/adapters/index.mjs
+++ b/tools/rule-ingestion/adapters/index.mjs
@@ -1,5 +1,5 @@
 /**
- * MUGA rule-ingestion adapter registry (#773).
+ * MUGA rule-ingestion adapter registry (#773, #776).
  *
  * Lists the license-compatible signal sources MUGA ingests, and records the
  * sources DELIBERATELY EXCLUDED so the exclusion is visible in code review, not
@@ -15,18 +15,21 @@
  */
 
 import { adguardTp } from "./adguard-tp.mjs";
+import { clearurls } from "./clearurls.mjs";
 
 /**
  * Enabled, license-compatible signal sources.
  * - AdGuard TP: GPL-3.0 (compatible with MUGA's GPL v3) — a large, consolidated,
- *   well-maintained list. Single source in B2.
- *
- * A second independent source (and cross-corroboration scoring) is deferred to
- * #776, where the corroboration gate actually consumes it. The adapter array
- * means adding one later is a registry edit, not a contract change.
+ *   well-maintained list. First signal source.
+ * - ClearURLs: LGPL-3.0 (library copyleft — ships alongside MUGA without
+ *   relicensing the extension) — second independent source that makes
+ *   cross-source corroboration real. A param appearing in BOTH AdGuard TP AND
+ *   ClearURLs accumulates signals.length === 2, passing GATE 2 (corroboration-
+ *   gate, #776). Single-source params remain at signals.length === 1 and are
+ *   quarantined (recoverable false-positive guard).
  * @type {Adapter[]}
  */
-export const ENABLED_ADAPTERS = [adguardTp];
+export const ENABLED_ADAPTERS = [adguardTp, clearurls];
 
 /**
  * Sources excluded ON PURPOSE — do NOT add adapters for these.

--- a/tools/rule-ingestion/gates/corroboration-gate.mjs
+++ b/tools/rule-ingestion/gates/corroboration-gate.mjs
@@ -1,0 +1,95 @@
+/**
+ * MUGA: GATE 2 — corroboration-gate (#776)
+ *
+ * Reduces false positives by requiring INDEPENDENT CORROBORATION: a candidate
+ * is accepted only when ≥ MIN_SIGNALS independent upstream signal sources
+ * reported it. Signal count is the SOLE predicate.
+ *
+ * WHY signal-count-only: entropy and cross-site-frequency fields are HARDCODED
+ * null at ingestion time (candidate.mjs:46-47). Adding entropy/CSF arms here
+ * would be dead code — deferred to #798 where real heuristics are planned.
+ *
+ * WHY malformed → REJECT (inverse of GATE 1/3 accept-malformed posture):
+ * - GATE 1/3 reject = "this param is dangerous to strip" → accept-malformed
+ *   is the safe direction (don't block a param that didn't prove danger).
+ * - GATE 2 reject = "this param is NOT YET corroborated" → accept-malformed
+ *   would defeat the gate entirely. A candidate with no provable signals IS
+ *   the failure mode GATE 2 exists to catch (signalCount 0 < MIN_SIGNALS).
+ *
+ * Public API (named exports only — no default):
+ *   MIN_SIGNALS              → number (default threshold = 2)
+ *   checkCorroborationGate   → (candidate, opts?) → { rejected }
+ *   partitionCandidates      → (candidates, opts?) → { accepted, rejected }
+ */
+
+// ── Threshold constant ────────────────────────────────────────────────────────
+
+/**
+ * Minimum number of independent upstream signal sources required for a
+ * candidate to pass GATE 2. Configurable at call-site via opts.minSignals.
+ * @type {number}
+ */
+export const MIN_SIGNALS = 2;
+
+// ── Predicate ─────────────────────────────────────────────────────────────────
+
+/**
+ * Checks a single ingestion candidate against the corroboration threshold.
+ *
+ * Returns `{ rejected: false }` when `candidate.signals.length >= minSignals`.
+ * Returns `{ rejected: true, reason, detail }` when under-corroborated,
+ * including when the candidate is null / missing `signals` / signals is
+ * not an array — all treated as signalCount = 0 (under-corroborated by
+ * definition).
+ *
+ * PURE: no file writes, no network calls, no singleton mutations.
+ *
+ * @param {{ signals?: string[] } | null | undefined} candidate
+ * @param {{ minSignals?: number }} [opts]
+ * @returns {{ rejected: boolean, reason?: string, detail?: { signalCount: number, minSignals: number } }}
+ */
+export function checkCorroborationGate(candidate, { minSignals = MIN_SIGNALS } = {}) {
+  // Array.isArray is the correct guard — strings, null, undefined all yield 0.
+  const signalCount = Array.isArray(candidate?.signals)
+    ? candidate.signals.length
+    : 0;
+
+  if (signalCount >= minSignals) {
+    return { rejected: false };
+  }
+
+  return {
+    rejected: true,
+    reason: "corroboration-below-threshold",
+    detail: { signalCount, minSignals },
+  };
+}
+
+// ── Batch partition ───────────────────────────────────────────────────────────
+
+/**
+ * Partitions an array of ingestion candidates into accepted and rejected
+ * buckets in a single pass. Input order is preserved in both output arrays.
+ *
+ * Forwards `opts` to each `checkCorroborationGate` call so callers can
+ * override the threshold at batch level (mirrors GATE 3's partition signature).
+ *
+ * @param {Array<{ signals?: string[] }>} candidates
+ * @param {{ minSignals?: number }} [opts]
+ * @returns {{ accepted: Array, rejected: Array<{ candidate: object, reason: string, detail: { signalCount: number, minSignals: number } }> }}
+ */
+export function partitionCandidates(candidates, opts = {}) {
+  const accepted = [];
+  const rejected = [];
+
+  for (const candidate of candidates) {
+    const result = checkCorroborationGate(candidate, opts);
+    if (result.rejected) {
+      rejected.push({ candidate, reason: result.reason, detail: result.detail });
+    } else {
+      accepted.push(candidate);
+    }
+  }
+
+  return { accepted, rejected };
+}


### PR DESCRIPTION
## What

GATE 2 of MUGA's self-scaling ruleset — the **confidence/corroboration** axis, complementing GATE 1 (structural affiliate safety) and GATE 3 (behavioral affiliate safety). It reduces **false positives**: a candidate is promoted only if confirmed by **2+ independent source lists**, not a single source's idiosyncratic entry.

Ships the **ClearURLs adapter** (the second independent source) in the same PR — without it, `MIN_SIGNALS=2` would quarantine every candidate (single source today). The gate and adapter are one correctness unit.

Closes #776.

## How

**Gate** `tools/rule-ingestion/gates/corroboration-gate.mjs`:
- `checkCorroborationGate(candidate, opts?)` → `{ rejected: false }` or `{ rejected: true, reason: "corroboration-below-threshold", detail: { signalCount, minSignals } }`. Pure predicate on `signals.length`. `MIN_SIGNALS = 2`, opts-injectable.
- `partitionCandidates(candidates, opts?)` → order-preserving `{ accepted, rejected }`.
- **Malformed → REJECT** (signalCount 0). This deliberately *inverts* GATE 1/3's accept-malformed posture: an under-corroborated candidate is exactly what GATE 2 filters out.

**Adapter** `tools/rule-ingestion/adapters/clearurls.mjs` (LGPL-3.0, mirrors `adguard-tp.mjs`):
- `extractClearurlsLiterals(rawText) → { params, skipped }`; `parse` delegates. Extracts safe literal param names from `providers[*].rules[]` (anchor-strip + `^[a-z0-9_-]+$`), **skips + counts** regex patterns (no silent truncation).
- **SAFETY-CRITICAL — global referralMarketing exclusion**: a two-pass algorithm builds a union of *all* `providers[*].referralMarketing[]` (affiliate tokens = MUGA's preserve set) across every provider, then subtracts it globally — so a param that is `rules` in provider A but `referralMarketing` in provider B is still excluded. `rules` and `referralMarketing` are normalized **identically** (shared `normalizeName`, anchor-strip included) so an anchored affiliate entry (`^tag$`) cannot slip past the bare-`tag` exclusion.
- Wired into `ENABLED_ADAPTERS`; PROVENANCE row flipped ⏸️→✅.

### Deferred
The issue's **entropy** and **cross-site-frequency** corroboration arms are deferred to **#798** — those candidate fields are always `null` at ingestion and the `src/lib/` heuristic modules are runtime-only (need a URL corpus / chrome.storage). Shipping skip-on-null arms would be dead code. #798 builds the data infrastructure first. GATE 2 here is pure multi-signal corroboration.

## Tests

45 new tests (gate: 22; adapter: 23, incl. the global cross-provider exclusion + the anchored-affiliate regression). Full suite **4242 pass / 0 fail**.

Part of EPIC C (#785). Next: GATE 4 (#778), then the orchestrator (#779) wires all four gates.