### PR TITLE
feat(ingestion): GATE 4 functional-bias-gate (#778)

### DIFF
--- a/tests/unit/functional-bias-gate.test.mjs
+++ b/tests/unit/functional-bias-gate.test.mjs
@@ -1,0 +1,338 @@
+/**
+ * MUGA — Unit tests for GATE 4: functional-bias-gate (#778).
+ *
+ * Exercises the full behavioral contract of checkFunctionalBiasGate and
+ * partitionCandidates: rejection of functional roster members, acceptance
+ * of real trackers, case normalization, fail-safe acceptance of malformed
+ * inputs, disjointness invariant against live TRACKING_PARAMS, opts
+ * injection seam, batch partition, zero side-effects (pure), and module
+ * shape.
+ *
+ * RED first: functional-bias-gate.mjs does not exist at write time →
+ * all test cases fail on import. Pre-existing suite remains unaffected.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FUNCTIONAL_PARAM_NAMES,
+  checkFunctionalBiasGate,
+  partitionCandidates,
+} from "../../tools/rule-ingestion/gates/functional-bias-gate.mjs";
+
+import { TRACKING_PARAMS } from "../../src/lib/affiliates.js";
+
+// ---------------------------------------------------------------------------
+// T-01 — module shape
+// ---------------------------------------------------------------------------
+
+describe("functional-bias-gate — module shape", () => {
+  test("FUNCTIONAL_PARAM_NAMES is a Set", () => {
+    assert.ok(
+      FUNCTIONAL_PARAM_NAMES instanceof Set,
+      "FUNCTIONAL_PARAM_NAMES must be a Set"
+    );
+  });
+
+  test("checkFunctionalBiasGate is a function", () => {
+    assert.equal(typeof checkFunctionalBiasGate, "function");
+  });
+
+  test("partitionCandidates is a function", () => {
+    assert.equal(typeof partitionCandidates, "function");
+  });
+
+  test("no default export", async () => {
+    // Dynamic import to inspect the raw namespace object.
+    const mod = await import(
+      "../../tools/rule-ingestion/gates/functional-bias-gate.mjs"
+    );
+    assert.equal(
+      mod.default,
+      undefined,
+      "functional-bias-gate must NOT have a default export"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-02 — functional-param rejection — one member from each roster family
+// ---------------------------------------------------------------------------
+
+describe("checkFunctionalBiasGate — functional-param rejection — roster members", () => {
+  test("{ param: 'q' } → rejected, reason functional-param, detail.param='q'", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "q" }), {
+      rejected: true,
+      reason: "functional-param",
+      detail: { param: "q" },
+    });
+  });
+
+  test("{ param: 'page' } → rejected, detail.param='page'", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "page" }), {
+      rejected: true,
+      reason: "functional-param",
+      detail: { param: "page" },
+    });
+  });
+
+  test("{ param: 'lang' } → rejected, detail.param='lang'", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "lang" }), {
+      rejected: true,
+      reason: "functional-param",
+      detail: { param: "lang" },
+    });
+  });
+
+  test("{ param: 'id' } → rejected, detail.param='id'", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "id" }), {
+      rejected: true,
+      reason: "functional-param",
+      detail: { param: "id" },
+    });
+  });
+
+  test("{ param: 's' } → rejected, detail.param='s'", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "s" }), {
+      rejected: true,
+      reason: "functional-param",
+      detail: { param: "s" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-03 — non-functional acceptance — real trackers confirmed NOT in roster
+// ---------------------------------------------------------------------------
+
+describe("checkFunctionalBiasGate — non-functional acceptance — real trackers", () => {
+  test("{ param: 'fbclid' } → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "fbclid" }), {
+      rejected: false,
+    });
+  });
+
+  test("{ param: 'utm_source' } → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "utm_source" }), {
+      rejected: false,
+    });
+  });
+
+  test("{ param: 'gclid' } → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "gclid" }), {
+      rejected: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-04 — case normalization — uppercase/mixed-case param names
+// ---------------------------------------------------------------------------
+
+describe("checkFunctionalBiasGate — case normalization", () => {
+  test("{ param: 'Q' } → rejected, detail.param is lowercased 'q'", () => {
+    const result = checkFunctionalBiasGate({ param: "Q" });
+    assert.equal(result.rejected, true);
+    assert.equal(result.reason, "functional-param");
+    assert.deepStrictEqual(result.detail, { param: "q" });
+  });
+
+  test("{ param: 'PAGE' } → rejected, detail.param is lowercased 'page'", () => {
+    const result = checkFunctionalBiasGate({ param: "PAGE" });
+    assert.equal(result.rejected, true);
+    assert.equal(result.reason, "functional-param");
+    assert.deepStrictEqual(result.detail, { param: "page" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-05 — malformed input — fail-safe acceptance (5 cases)
+// ---------------------------------------------------------------------------
+
+describe("checkFunctionalBiasGate — malformed input — fail-safe acceptance", () => {
+  test("null → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate(null), { rejected: false });
+  });
+
+  test("undefined → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate(undefined), {
+      rejected: false,
+    });
+  });
+
+  test("{} (missing param) → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({}), { rejected: false });
+  });
+
+  test("{ param: 42 } (non-string) → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: 42 }), {
+      rejected: false,
+    });
+  });
+
+  test("{ param: '' } (empty string) → { rejected: false }", () => {
+    assert.deepStrictEqual(checkFunctionalBiasGate({ param: "" }), {
+      rejected: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-06 — DISJOINTNESS INVARIANT — TRACKING_PARAMS (load-bearing drift guard)
+// ---------------------------------------------------------------------------
+// WHY: no GATE 4 roster member may ever appear in the global TRACKING_PARAMS
+// strip list. If it did, that param would be silently stripped at runtime —
+// catastrophically breaking search/pagination/i18n across the web. This test
+// imports the LIVE TRACKING_PARAMS (not a snapshot) so any future drift that
+// introduces an overlap immediately breaks the build (fail-closed).
+
+describe("DISJOINTNESS INVARIANT — FUNCTIONAL_PARAM_NAMES vs TRACKING_PARAMS", () => {
+  test("zero overlap between FUNCTIONAL_PARAM_NAMES and TRACKING_PARAMS (fail-closed)", () => {
+    const trackingSet = new Set(TRACKING_PARAMS);
+    const overlapping = [...FUNCTIONAL_PARAM_NAMES].filter((n) =>
+      trackingSet.has(n)
+    );
+    assert.deepStrictEqual(
+      overlapping,
+      [],
+      `DISJOINTNESS VIOLATED — these names appear in both FUNCTIONAL_PARAM_NAMES and TRACKING_PARAMS: ${overlapping.join(", ")}. ` +
+        `Fix by removing them from one list. Any overlap means a functional param would be silently stripped at runtime.`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-07 — opts injection seam
+// ---------------------------------------------------------------------------
+
+describe("checkFunctionalBiasGate — opts injection seam", () => {
+  test("custom functionalNames set → 'custom' rejected", () => {
+    assert.deepStrictEqual(
+      checkFunctionalBiasGate(
+        { param: "custom" },
+        { functionalNames: new Set(["custom"]) }
+      ),
+      {
+        rejected: true,
+        reason: "functional-param",
+        detail: { param: "custom" },
+      }
+    );
+  });
+
+  test("custom functionalNames set → production roster member 'q' accepted (roster bypassed)", () => {
+    assert.deepStrictEqual(
+      checkFunctionalBiasGate(
+        { param: "q" },
+        { functionalNames: new Set(["custom"]) }
+      ),
+      { rejected: false }
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-08 — partitionCandidates — batch processing
+// ---------------------------------------------------------------------------
+
+describe("partitionCandidates — mixed batch — order preserved", () => {
+  test("fbclid/q/gclid/page → accepted=[fbclid,gclid], rejected=[q,page] in input order", () => {
+    const candidates = [
+      { param: "fbclid" },
+      { param: "q" },
+      { param: "gclid" },
+      { param: "page" },
+    ];
+    const { accepted, rejected } = partitionCandidates(candidates);
+
+    assert.deepStrictEqual(accepted, [
+      { param: "fbclid" },
+      { param: "gclid" },
+    ]);
+
+    assert.equal(rejected.length, 2);
+    assert.deepStrictEqual(rejected[0].candidate, { param: "q" });
+    assert.equal(rejected[0].reason, "functional-param");
+    assert.deepStrictEqual(rejected[0].detail, { param: "q" });
+    assert.deepStrictEqual(rejected[1].candidate, { param: "page" });
+    assert.equal(rejected[1].reason, "functional-param");
+    assert.deepStrictEqual(rejected[1].detail, { param: "page" });
+  });
+});
+
+describe("partitionCandidates — empty input", () => {
+  test("[] → { accepted: [], rejected: [] }", () => {
+    assert.deepStrictEqual(partitionCandidates([]), {
+      accepted: [],
+      rejected: [],
+    });
+  });
+});
+
+describe("partitionCandidates — all accepted", () => {
+  test("[fbclid, utm_source] → rejected.length === 0", () => {
+    const { accepted, rejected } = partitionCandidates([
+      { param: "fbclid" },
+      { param: "utm_source" },
+    ]);
+    assert.equal(rejected.length, 0);
+    assert.equal(accepted.length, 2);
+  });
+});
+
+describe("partitionCandidates — all rejected", () => {
+  test("[q, page] → accepted.length === 0", () => {
+    const { accepted, rejected } = partitionCandidates([
+      { param: "q" },
+      { param: "page" },
+    ]);
+    assert.equal(accepted.length, 0);
+    assert.equal(rejected.length, 2);
+  });
+});
+
+describe("partitionCandidates — opts forwarded to inner check", () => {
+  test("custom set: 'q' accepted, 'custom' rejected", () => {
+    const opts = { functionalNames: new Set(["custom"]) };
+    const { accepted, rejected } = partitionCandidates(
+      [{ param: "custom" }, { param: "q" }],
+      opts
+    );
+    assert.deepStrictEqual(accepted, [{ param: "q" }]);
+    assert.equal(rejected.length, 1);
+    assert.deepStrictEqual(rejected[0].candidate, { param: "custom" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-09 — zero side-effects (pure) + FUNCTIONAL_PARAM_NAMES.size === 43
+// ---------------------------------------------------------------------------
+
+describe("checkFunctionalBiasGate — zero side-effects (pure)", () => {
+  test("input candidate object is NOT mutated by checkFunctionalBiasGate", () => {
+    const candidate = { param: "q", extra: "data" };
+    checkFunctionalBiasGate(candidate);
+    assert.deepStrictEqual(candidate, { param: "q", extra: "data" });
+  });
+
+  test("FUNCTIONAL_PARAM_NAMES.size is unchanged after calls to gate and partition", () => {
+    const sizeBefore = FUNCTIONAL_PARAM_NAMES.size;
+    checkFunctionalBiasGate({ param: "q" });
+    checkFunctionalBiasGate({ param: "fbclid" });
+    partitionCandidates([{ param: "q" }, { param: "gclid" }, { param: "page" }]);
+    assert.equal(
+      FUNCTIONAL_PARAM_NAMES.size,
+      sizeBefore,
+      "FUNCTIONAL_PARAM_NAMES must not be mutated by gate calls"
+    );
+  });
+
+  test("FUNCTIONAL_PARAM_NAMES.size === 43 (authoritative roster)", () => {
+    assert.equal(
+      FUNCTIONAL_PARAM_NAMES.size,
+      43,
+      `Expected exactly 43 functional param names, got ${FUNCTIONAL_PARAM_NAMES.size}`
+    );
+  });
+});

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -179,6 +179,54 @@ live in `tools/affiliate-safety/`:
 - `runner.mjs` — exports `runAffiliateCanaries()` (relocated from
   `tests/fixtures/`; PRESERVE loop now delegates to `evaluateCanary`).
 
+## GATE 4 — functional-bias (#778)
+
+`tools/rule-ingestion/gates/functional-bias-gate.mjs`
+
+**What it does:** Quarantines ingestion candidates whose bare `param` name is a
+member of the universally-functional roster (search/query, pagination,
+identity/product, locale/i18n, sort/filter/view). Such a param in
+`TRACKING_PARAMS` would silently break search, pagination, and i18n across every
+site MUGA touches — catastrophically and irreversibly. The gate NEVER auto-strips;
+it routes to human review. Policy: **FAIL-SAFE TOWARD PRESERVATION** — no name =
+no match possible → accepted.
+
+**Global-denylist vs. domain-scoped rationale:** Functional params are
+domain-scoped in MUGA's data model. For example, `s` is a tracker on some
+affiliate networks; `k` is an affiliate alias in `domain-rules.json`. GATE 4
+guards the GLOBAL `TRACKING_PARAMS` strip list, so the roster must be a
+hardcoded global curated set — NOT derived from `domain-rules.json`. Deriving it
+would incorrectly apply domain-local aliases universally. Domain-specific
+functional-param protection belongs in `domain-rules.json` (per-host
+`preserveParams`), NOT here.
+
+**TRACKING_PARAMS-disjointness invariant:** No GATE 4 roster member may appear
+in `TRACKING_PARAMS`. Enforced by a fail-closed test in
+`tests/unit/functional-bias-gate.test.mjs` that imports the LIVE
+`TRACKING_PARAMS` (not a frozen snapshot) — any drift that introduces an overlap
+immediately breaks the build. When editing the roster, manually cross-check
+against `domain-rules.json` preserveParams entries as well (the disjointness
+test guards only the TRACKING_PARAMS axis).
+
+**GATE 1/2/3/4 complementarity:**
+- GATE 1 (`affiliate-guard`) — does this NAME collide with a known affiliate/redirect-landing attribution param?
+- GATE 2 (`corroboration-gate`) — does this candidate have enough independent upstream signal?
+- GATE 3 (`canary-gate`) — does injecting this param as a runtime strip rule break any affiliate-survival canary?
+- GATE 4 (`functional-bias-gate`) — is this NAME universally load-bearing for search, pagination, or UX?
+
+A candidate rejected by GATE 1 never reaches GATE 3. GATE 4 is orthogonal to
+GATE 1/3 — it operates purely on the param NAME shape, not on attribution or
+behavioral signals.
+
+**Public exports:**
+- `FUNCTIONAL_PARAM_NAMES` — frozen `Set<string>`, 43 members, exact-name match only (no regex).
+- `checkFunctionalBiasGate(candidate, opts?)` — returns `{ rejected: false }` or
+  `{ rejected: true, reason: "functional-param", detail: { param } }` (param is lowercased).
+  `opts.functionalNames` replaces the production roster (testability seam).
+- `partitionCandidates(candidates, opts?)` — batch helper; returns
+  `{ accepted: Candidate[], rejected: Array<{ candidate, reason, detail }> }`,
+  input order preserved. `opts` forwarded to each `checkFunctionalBiasGate` call.
+
 ## CI gate
 
 `verify-quarantine.mjs` runs in CI ([`ci.yml`](../../.github/workflows/ci.yml))

--- a/tools/rule-ingestion/gates/functional-bias-gate.mjs
+++ b/tools/rule-ingestion/gates/functional-bias-gate.mjs
@@ -1,0 +1,123 @@
+/**
+ * MUGA: GATE 4 — functional-bias-gate (#778)
+ *
+ * Guards the rule-ingestion pipeline against auto-promoting universally-
+ * functional URL parameters into the global TRACKING_PARAMS strip list.
+ * A functional param (search, pagination, identity, locale, sort/filter/view)
+ * in that list would silently break search, pagination, and i18n across the
+ * web — catastrophically and silently. Policy: FAIL-SAFE TOWARD PRESERVATION.
+ *
+ * When a candidate's param name matches the functional roster the gate REJECTS
+ * it (routing to human review); it never auto-strips. When the param is absent,
+ * non-string, or empty the gate ACCEPTS (fail-safe: no name = no match possible).
+ *
+ * The roster is a hardcoded global exact-name denylist — NOT derived from
+ * domain-rules.json — because functional params are domain-scoped in MUGA's
+ * data model (e.g. `s` is a tracker elsewhere; `k` is an affiliate alias in
+ * domain-rules.json) while this gate guards the GLOBAL strip list. Domain-
+ * specific protection stays in domain-rules.json.
+ *
+ * COMPLEMENTARITY with other gates:
+ *   GATE 1 (affiliate-guard)      — guards by attribution param NAME collision
+ *   GATE 2 (corroboration-gate)   — guards by minimum corroboration signal count
+ *   GATE 3 (canary-gate)          — guards by behavioral canary break
+ *   GATE 4 (functional-bias-gate) — guards by "is this NAME universally functional?"
+ *
+ * PURE — no I/O, no mutations, no quarantine writes. Orchestrator wiring: #779.
+ */
+
+// AUTHORITATIVE — 43 names. asin excluded (domain-scoped, Amazon-specific).
+// Disjointness with TRACKING_PARAMS enforced by test (fail-closed drift guard).
+// WHY conservative breadth: ambiguous short names included per fail-safe-toward-
+// preservation mandate — a false-reject is recoverable; a false-strip is not.
+
+/** @type {Set<string>} */
+export const FUNCTIONAL_PARAM_NAMES = new Set([
+  // search / query (10)
+  "q", "query", "search", "s", "keyword", "keywords", "kw", "k", "term", "text",
+
+  // pagination (10)
+  "page", "p", "offset", "limit", "start", "per_page", "pagesize", "size", "num", "count",
+
+  // identity / product (7)
+  "id", "pid", "uid", "item", "sku", "product_id", "item_id",
+
+  // locale / i18n (7)
+  "lang", "language", "locale", "hl", "lr", "gl", "region",
+
+  // sort / filter / view (9)
+  "sort", "order", "filter", "view", "tab", "type", "category", "cat", "section",
+]);
+
+/**
+ * Checks a single ingestion candidate against the functional param roster.
+ *
+ * Returns `{ rejected: false }` when the param is safe to consider for
+ * promotion (it is not a universally-functional name).
+ * Returns `{ rejected: true, reason: "functional-param", detail: { param } }`
+ * when the param name is on the roster — the candidate MUST NOT be added to
+ * TRACKING_PARAMS without human review.
+ *
+ * Fail-safe posture: null/undefined/missing/non-string/empty param → accept.
+ * WHY: the predicate is "does this NAME match a functional shape?" — no name
+ * means the gate cannot fire; failing safe means we do not quarantine what we
+ * cannot evaluate. Mirrors GATE 1/3 accept-malformed posture.
+ *
+ * @param {{ param?: string } | null | undefined} candidate
+ * @param {{ functionalNames?: Set<string> }} [opts]
+ * @returns {{ rejected: boolean, reason?: string, detail?: { param: string } }}
+ */
+export function checkFunctionalBiasGate(
+  candidate,
+  { functionalNames = FUNCTIONAL_PARAM_NAMES } = {}
+) {
+  // Defensive extraction: treat any non-string or missing param as no-match.
+  // Pipeline already lowercases candidate.param (candidate.mjs:43-48), but we
+  // lowercase defensively — never trust the caller. Mirrors affiliate-guard.mjs:94.
+  const param =
+    typeof candidate?.param === "string" ? candidate.param.toLowerCase() : "";
+
+  // Empty string means no name to evaluate — fail safe toward acceptance.
+  if (!param) {
+    return { rejected: false };
+  }
+
+  if (functionalNames.has(param)) {
+    return { rejected: true, reason: "functional-param", detail: { param } };
+  }
+
+  return { rejected: false };
+}
+
+/**
+ * Partitions an array of ingestion candidates into accepted and rejected
+ * buckets in a single pass. Input order is preserved in both output arrays.
+ *
+ * Rejected items carry the full rejection metadata so the caller/logger does
+ * not need to re-run the check. `opts` is forwarded to each individual
+ * `checkFunctionalBiasGate` call (injectable `functionalNames` seam works at
+ * batch level too — mirrors GATE 3 opts-forwarding pattern).
+ *
+ * @param {Array<{param?: string}>} candidates
+ * @param {{ functionalNames?: Set<string> }} [opts]
+ * @returns {{ accepted: Array, rejected: Array<{candidate: object, reason: string, detail: {param: string}}> }}
+ */
+export function partitionCandidates(candidates, opts = {}) {
+  const accepted = [];
+  const rejected = [];
+
+  for (const candidate of candidates) {
+    const result = checkFunctionalBiasGate(candidate, opts);
+    if (result.rejected) {
+      rejected.push({
+        candidate,
+        reason: result.reason,
+        detail: result.detail,
+      });
+    } else {
+      accepted.push(candidate);
+    }
+  }
+
+  return { accepted, rejected };
+}


### PR DESCRIPTION
## What

GATE 4 of MUGA's self-scaling ruleset — the **"is this load-bearing for the site?"** axis. It guards against auto-promoting a universally-functional URL param (search, pagination, identity, locale, sort/filter) into the global `TRACKING_PARAMS` strip list, which would silently break search, pagination, and i18n across the web.

**Fail-safe toward preservation**: candidates matching a functional shape are **quarantined** (rejected), never auto-stripped.

Closes #778.

## How

`tools/rule-ingestion/gates/functional-bias-gate.mjs`:
- **`FUNCTIONAL_PARAM_NAMES`** — a 43-name global exact-match denylist (search/query, pagination, identity, locale/i18n, sort/filter/view). Exact-name match only — no regex (a `*_id` pattern would wrongly catch real trackers like `click_id`/`ad_id`).
- **`checkFunctionalBiasGate(candidate, opts?)`** → `{ rejected: false }` or `{ rejected: true, reason: "functional-param", detail: { param } }`. Accept-malformed (mirrors GATE 1/3 — can't evaluate a missing name, so fail-safe toward preservation).
- **`partitionCandidates(candidates, opts?)`** → order-preserving `{ accepted, rejected }`. opts seam for testability.

### Design decisions
- **Global denylist, NOT derived from `domain-rules.json`**: functional params are *domain-scoped* in MUGA's data model (`s` is a tracker on some sites but Amazon's search-sort on amazon.*). GATE 4 captures only *universally*-functional shapes; per-domain protection remains domain-rules.json's job. Domain-specific IDs like `asin` are deliberately excluded.
- **Conservative breadth** (per the issue's fail-safe mandate): ambiguous short names (`id`, `s`, `k`, `type`) are included — over-quarantining is recoverable via human review; auto-stripping a functional param is not.
- **DISJOINTNESS invariant (fail-closed drift guard)**: a test asserts `FUNCTIONAL_PARAM_NAMES` shares no member with the **live** `TRACKING_PARAMS` import. A name cannot be both a confirmed tracker and functional — if the two lists ever overlap, the build breaks. (`cid`/`source` are in TRACKING_PARAMS → correctly absent from the roster.)

## Tests

30 new tests (rejection, acceptance, case-norm, malformed ×5, the live disjointness guard, opts seam, partition, purity, module shape). Full suite **4272 pass / 0 fail**.

## EPIC C status

✅ GATE 1 (#775) · ✅ GATE 2 (#776) · ✅ GATE 3 (#777) · ✅ GATE 4 (#778). All four gates exist — the orchestrator (#779) can now wire them.