### PR TITLE
feat(ingestion): orchestrator CLI — sign auto-merge bucket + emit promote artifact (#779 PR2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:i18n": "node tools/check-i18n-fixme.mjs",
     "verify:quarantine": "node tools/rule-ingestion/verify-quarantine.mjs",
     "ingest:rules": "node tools/rule-ingestion/ingest.mjs",
+    "orchestrate:rules": "node tools/rule-ingestion/orchestrate-cli.mjs",
     "conformance:contextual": "node --test --test-reporter=spec tests/unit/conformance-contextual.test.mjs",
     "test:serve": "npx serve tests/browser --listen 5555 --no-clipboard",
     "brand": "npx serve tools --listen 5556 --no-clipboard",

--- a/tests/unit/ingestion-orchestrator-cli.test.mjs
+++ b/tests/unit/ingestion-orchestrator-cli.test.mjs
@@ -1,0 +1,569 @@
+/**
+ * MUGA — Unit tests for tools/rule-ingestion/orchestrate-cli.mjs
+ *
+ * Covers:
+ *   - Signed artifact shape {version, published, params, sig} (R5-S1, R5-S2, R9-S1)
+ *   - Params sorted + deduped; sig non-empty base64url; verifiable with test pubkey (R6-S1)
+ *   - Empty auto-merge produces valid artifact with params:[] (R5-S2)
+ *   - Audit sidecar write-always (R8-S1, R8-S2)
+ *   - Missing signing key → throws / exit 2, no file written (R7-S1)
+ *   - Valid run exits cleanly (R7-S2)
+ *
+ * All I/O is injected: candidatesPath, promotePath, reportPath, keyPath, now.
+ * Tests NEVER touch the real promote/ dir.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateKeyPairSync,
+  createPrivateKey,
+  createPublicKey,
+} from "node:crypto";
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { verifySignature } from "../../src/lib/remote-rules.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Export raw 32-byte Ed25519 public key as standard base64 (DER spki slice) */
+function exportPubKeyBase64(publicKey) {
+  const der = publicKey.export({ type: "spki", format: "der" });
+  return der.slice(12).toString("base64");
+}
+
+/** Create a fresh temp directory per test group invocation */
+function makeTmpDir() {
+  const d = join(tmpdir(), `muga-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+/** Write a minimal candidates.json fixture to a temp dir and return its path */
+function writeCandidatesFixture(dir, candidates) {
+  const path = join(dir, "candidates.json");
+  const report = {
+    generatedAt: "2024-01-01T00:00:00.000Z",
+    candidateCount: candidates.length,
+    candidates,
+  };
+  writeFileSync(path, JSON.stringify(report, null, 2) + "\n", "utf8");
+  return path;
+}
+
+/** Write an Ed25519 PEM private key to disk and return the path */
+function writeTmpPrivKey(dir, privateKey) {
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" });
+  const path = join(dir, "test-key.pem");
+  writeFileSync(path, pem, "utf8");
+  return path;
+}
+
+/**
+ * Minimal valid candidate that passes all real gates.
+ * Carries ≥2 signals because the real checkCorroborationGate default is minSignals: 2.
+ */
+function passCandidate(param) {
+  return {
+    param,
+    signals: ["adguard-tp", "other-source"],
+    entropy: null,
+    crossSiteFrequency: null,
+    firstSeenAt: "2024-01-01T00:00:00.000Z",
+  };
+}
+
+/** Candidate that will be quarantined (signals:null → GATE2 rejects) */
+function failCandidate(param) {
+  return {
+    param,
+    signals: null,
+    entropy: null,
+    crossSiteFrequency: null,
+    firstSeenAt: "2024-01-01T00:00:00.000Z",
+  };
+}
+
+// ── Shared test keypair ────────────────────────────────────────────────────────
+const { privateKey: TEST_PRIV_KEY, publicKey: TEST_PUB_KEY } =
+  generateKeyPairSync("ed25519");
+const testPubKeyB64 = exportPubKeyBase64(TEST_PUB_KEY);
+const trustedKeys = [testPubKeyB64];
+
+// ── T-15: CLI writes signed artifact shape ────────────────────────────────────
+
+describe("R5/R9 — Signed artifact shape + verify", () => {
+  test("R5-S1: signed artifact has exactly {version, published, params, sig} and sig verifies", async () => {
+    // Lazy import to avoid import-time failures before module is created
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [
+      passCandidate("utm_source"),
+      passCandidate("fbclid"),
+    ]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    assert.ok(existsSync(promotePath), "promote file must be written");
+    const artifact = JSON.parse(readFileSync(promotePath, "utf8"));
+
+    // Exactly 4 keys
+    const keys = Object.keys(artifact);
+    assert.deepStrictEqual(keys.sort(), ["params", "published", "sig", "version"]);
+
+    // params is sorted
+    assert.deepStrictEqual(artifact.params, ["fbclid", "utm_source"]);
+
+    // sig is non-empty base64url
+    assert.ok(typeof artifact.sig === "string" && artifact.sig.length > 0, "sig must be non-empty string");
+    assert.ok(!/[+/=]/.test(artifact.sig), "sig must be base64url (no +, /, = chars)");
+
+    // published is injected now
+    assert.strictEqual(artifact.published, "2024-01-01T00:00:00.000Z");
+
+    // version
+    assert.strictEqual(artifact.version, 1);
+
+    // sig verifies with test pubkey using the REAL verifySignature
+    const canonical = `${artifact.version}|${artifact.published}|${artifact.params.join(",")}`;
+    const verified = await verifySignature(
+      canonical,
+      artifact.sig,
+      trustedKeys,
+      globalThis.crypto.subtle
+    );
+    assert.strictEqual(verified, true, "verifySignature must return true for correctly signed artifact");
+  });
+
+  test("R5-S2: empty auto-merge (all quarantined) → params:[] with valid sig", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [
+      failCandidate("bad-param"),
+    ]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 2,
+      now: new Date("2024-06-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    assert.ok(existsSync(promotePath), "promote file must be written even when all quarantined");
+    const artifact = JSON.parse(readFileSync(promotePath, "utf8"));
+
+    assert.deepStrictEqual(artifact.params, [], "empty autoMerge → params:[]");
+    assert.ok(typeof artifact.sig === "string" && artifact.sig.length > 0, "sig must be present even for empty params");
+
+    // Verify the empty-params signature
+    const canonical = `${artifact.version}|${artifact.published}|${artifact.params.join(",")}`;
+    const verified = await verifySignature(
+      canonical,
+      artifact.sig,
+      trustedKeys,
+      globalThis.crypto.subtle
+    );
+    assert.strictEqual(verified, true, "empty-params sig must verify");
+  });
+});
+
+// ── T-16: Sidecar write-always ─────────────────────────────────────────────────
+
+describe("R8 — Audit sidecar write-always", () => {
+  test("R8-S1: mixed run → sidecar has full quarantine entries; promote has no rejectedBy", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [
+      passCandidate("utm_source"),
+      failCandidate("bad-param"),
+    ]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    // Sidecar must exist
+    assert.ok(existsSync(reportPath), "quarantine report must be written");
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+
+    assert.ok("quarantine" in report, "sidecar must have quarantine key");
+    assert.strictEqual(report.quarantine.length, 1, "sidecar must have 1 quarantined entry");
+    assert.ok(report.quarantine[0].rejections, "quarantine entry must have rejections array");
+
+    // Promote must NOT have rejectedBy or raw candidate fields
+    const promote = JSON.parse(readFileSync(promotePath, "utf8"));
+    assert.ok(!("rejectedBy" in promote), "promote must not contain rejectedBy");
+    assert.ok(!("candidates" in promote), "promote must not contain candidates field");
+    assert.ok(!("quarantine" in promote), "promote must not contain quarantine field");
+  });
+
+  test("R8-S2: all-pass run → sidecar written with quarantine:[]", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [
+      passCandidate("utm_source"),
+    ]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    assert.ok(existsSync(reportPath), "sidecar must exist even with no quarantine entries");
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.deepStrictEqual(report.quarantine, [], "sidecar quarantine must be [] when all pass");
+  });
+});
+
+// ── T-17: CLI exit codes + key guard ─────────────────────────────────────────
+
+describe("R7 — CLI exit codes + key guard", () => {
+  test("R7-S1: missing keyPath → throws with exit code 2, no promote file written", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    // Env isolation: remove MUGA_SIGNING_KEY_PATH so the CLI cannot fall back to it.
+    const savedEnvKey = process.env.MUGA_SIGNING_KEY_PATH;
+    delete process.env.MUGA_SIGNING_KEY_PATH;
+
+    let thrown = null;
+    try {
+      await runOrchestrateCli({
+        candidatesPath,
+        promotePath,
+        reportPath,
+        version: 1,
+        now: new Date(),
+        keyPath: undefined, // no key
+      });
+    } catch (err) {
+      thrown = err;
+    } finally {
+      // Restore regardless of outcome.
+      if (savedEnvKey !== undefined) {
+        process.env.MUGA_SIGNING_KEY_PATH = savedEnvKey;
+      }
+    }
+
+    assert.ok(thrown !== null, "runOrchestrateCli must throw when keyPath is missing");
+    assert.strictEqual(thrown.exitCode, 2, "thrown error must have exitCode:2");
+    assert.ok(!existsSync(promotePath), "promote file must NOT be written when key is missing");
+  });
+
+  test("R7-S1b: non-existent key file → throws with exit code 2", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    // Env isolation: remove MUGA_SIGNING_KEY_PATH so the CLI cannot fall back to it.
+    const savedEnvKey = process.env.MUGA_SIGNING_KEY_PATH;
+    delete process.env.MUGA_SIGNING_KEY_PATH;
+
+    let thrown = null;
+    try {
+      await runOrchestrateCli({
+        candidatesPath,
+        promotePath,
+        reportPath,
+        version: 1,
+        now: new Date(),
+        keyPath: join(tmpDir, "does-not-exist.pem"),
+      });
+    } catch (err) {
+      thrown = err;
+    } finally {
+      if (savedEnvKey !== undefined) {
+        process.env.MUGA_SIGNING_KEY_PATH = savedEnvKey;
+      }
+    }
+
+    assert.ok(thrown !== null, "runOrchestrateCli must throw when key file is missing");
+    assert.strictEqual(thrown.exitCode, 2, "thrown error must have exitCode:2");
+    assert.ok(!existsSync(promotePath), "promote file must NOT be written when key is missing");
+  });
+
+  test("R7-S2: valid run returns cleanly (no throw)", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    let thrown = null;
+    try {
+      await runOrchestrateCli({
+        candidatesPath,
+        promotePath,
+        reportPath,
+        version: 1,
+        now: new Date("2024-01-01T00:00:00.000Z"),
+        keyPath,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    assert.strictEqual(thrown, null, "valid run must not throw");
+    assert.ok(existsSync(promotePath), "promote file must be written on success");
+  });
+});
+
+// ── M2: Tamper-resistance — verifySignature must return false for tampered artifact ──
+
+describe("R5/R6 — Tamper resistance (negative)", () => {
+  test("tampered params → verifySignature returns false", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [
+      passCandidate("utm_source"),
+      passCandidate("fbclid"),
+    ]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    const artifact = JSON.parse(readFileSync(promotePath, "utf8"));
+
+    // Tamper: inject an extra param that was not part of the signed payload.
+    const tamperedParams = [...artifact.params, "injected"];
+    const tamperedCanonical = `${artifact.version}|${artifact.published}|${tamperedParams.join(",")}`;
+
+    const result = await verifySignature(
+      tamperedCanonical,
+      artifact.sig,
+      trustedKeys,
+      globalThis.crypto.subtle
+    );
+
+    assert.strictEqual(result, false, "verifySignature must return false for tampered params");
+  });
+});
+
+// ── n4: Malformed PEM → key-error exit code + no artifact written ─────────────
+
+describe("R7 — Malformed PEM key guard", () => {
+  test("n4: garbage PEM file → throws exitCode:2, no artifact written", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    // Write garbage content — not a valid PEM.
+    const garbageKeyPath = join(tmpDir, "garbage-key.pem");
+    writeFileSync(garbageKeyPath, "this is not a valid pem file\ngarbage content\n", "utf8");
+
+    // Env isolation.
+    const savedEnvKey = process.env.MUGA_SIGNING_KEY_PATH;
+    delete process.env.MUGA_SIGNING_KEY_PATH;
+
+    let thrown = null;
+    try {
+      await runOrchestrateCli({
+        candidatesPath,
+        promotePath,
+        reportPath,
+        version: 1,
+        now: new Date(),
+        keyPath: garbageKeyPath,
+      });
+    } catch (err) {
+      thrown = err;
+    } finally {
+      if (savedEnvKey !== undefined) {
+        process.env.MUGA_SIGNING_KEY_PATH = savedEnvKey;
+      }
+    }
+
+    assert.ok(thrown !== null, "must throw for malformed PEM");
+    assert.strictEqual(thrown.exitCode, 2, "malformed PEM must throw with exitCode:2");
+    assert.ok(!existsSync(promotePath), "promote file must NOT be written for malformed PEM");
+  });
+});
+
+// ── n2: MUGA_RULES_VERSION env path ───────────────────────────────────────────
+
+describe("R4 — MUGA_RULES_VERSION env override", () => {
+  test("n2a: MUGA_RULES_VERSION sets artifact version (no version param)", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    const savedVersion = process.env.MUGA_RULES_VERSION;
+    process.env.MUGA_RULES_VERSION = "42";
+    try {
+      await runOrchestrateCli({
+        candidatesPath,
+        promotePath,
+        reportPath,
+        // no version param — must come from env
+        now: new Date("2024-01-01T00:00:00.000Z"),
+        keyPath,
+      });
+    } finally {
+      if (savedVersion !== undefined) {
+        process.env.MUGA_RULES_VERSION = savedVersion;
+      } else {
+        delete process.env.MUGA_RULES_VERSION;
+      }
+    }
+
+    const artifact = JSON.parse(readFileSync(promotePath, "utf8"));
+    assert.strictEqual(artifact.version, 42, "artifact.version must come from MUGA_RULES_VERSION env var");
+  });
+
+  test("n2b: MUGA_RULES_VERSION non-integer → throws exitCode:1", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    const savedVersion = process.env.MUGA_RULES_VERSION;
+    process.env.MUGA_RULES_VERSION = "not-a-number";
+
+    let thrown = null;
+    try {
+      await runOrchestrateCli({
+        candidatesPath,
+        promotePath,
+        reportPath,
+        now: new Date(),
+        keyPath,
+      });
+    } catch (err) {
+      thrown = err;
+    } finally {
+      if (savedVersion !== undefined) {
+        process.env.MUGA_RULES_VERSION = savedVersion;
+      } else {
+        delete process.env.MUGA_RULES_VERSION;
+      }
+    }
+
+    assert.ok(thrown !== null, "non-integer MUGA_RULES_VERSION must throw");
+    assert.strictEqual(thrown.exitCode, 1, "MUGA_RULES_VERSION validation error must have exitCode:1");
+  });
+});
+
+// ── n3: Dedup at CLI boundary ─────────────────────────────────────────────────
+
+describe("R4 — Dedup at CLI boundary", () => {
+  test("n3: two passing candidates with same param → artifact.params contains it exactly once", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    // Both candidates carry the same param — dedup must collapse them to one entry.
+    const candidatesPath = writeCandidatesFixture(tmpDir, [
+      passCandidate("utm_source"),
+      passCandidate("utm_source"),
+    ]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    const artifact = JSON.parse(readFileSync(promotePath, "utf8"));
+    assert.deepStrictEqual(
+      artifact.params,
+      ["utm_source"],
+      "duplicate params must be deduped to a single entry"
+    );
+  });
+});

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -227,6 +227,91 @@ behavioral signals.
   `{ accepted: Candidate[], rejected: Array<{ candidate, reason, detail }> }`,
   input order preserved. `opts` forwarded to each `checkFunctionalBiasGate` call.
 
+## Orchestrator — binary-bucket pipeline + signed artifact (EPIC C, #779)
+
+`tools/rule-ingestion/orchestrate.mjs` (pure) + `tools/rule-ingestion/orchestrate-cli.mjs` (CLI)
+
+### Contract
+
+After ingestion produces `quarantine/candidates.json`, the orchestrator wires all
+four EPIC C gates into a **deterministic binary-bucket pipeline**:
+
+```
+candidates[] → GATE1 → GATE2 → GATE3 → GATE4 → autoMerge[] + quarantine[]
+```
+
+Every candidate lands in **exactly one** bucket — mutually exclusive and
+collectively exhaustive:
+
+- `autoMerge` — passes ALL four gates in fixed order. Input order preserved.
+- `quarantine` — any gate rejects. Collect-all: ALL rejections recorded (no
+  short-circuit), in gate evaluation order.
+
+### Gate ordering invariant
+
+Gates are evaluated in a fixed `[affiliate-guard, corroboration-gate,
+canary-gate, functional-bias-gate]` order for every candidate, every run.
+This order is guaranteed by the `DEFAULT_GATES` array literal in
+`orchestrate.mjs` — never by Set or object-key iteration.
+
+### GATE 2 malformed-candidate posture (fail-closed)
+
+Candidates missing `signals` (null, absent, or non-array) are rejected by
+`corroboration-gate` with `signalCount = 0`. They **never appear in
+`autoMerge` or `promote-candidates.json`**. The quarantine sidecar captures
+the full `evidence.detail = { signalCount, minSignals }` for audit.
+
+### Signing format + verification path
+
+`orchestrate-cli.mjs` signs the `autoMerge` params with an Ed25519 private
+key (path via `MUGA_SIGNING_KEY_PATH` — never a CLI arg):
+
+```
+canonical = `${version}|${published}|${params.join(",")}`
+sig       = cryptoSign(null, Buffer.from(canonical), privateKey) → base64url
+```
+
+The format is **identical** to `docs/rules/v1/params.json` produced by
+`sign-rules.mjs`. The existing `verifySignature()` in `src/lib/remote-rules.js`
+validates the artifact unchanged — no new verifier.
+
+### Promote artifact vs. quarantine sidecar
+
+| File | Path | Purpose | Committed? |
+|------|------|---------|------------|
+| Signed promote artifact | `tools/rule-ingestion/promote/promote-candidates.json` | `{version, published, params, sig}` — #780 seam input | YES |
+| Unsigned audit sidecar  | `quarantine/quarantine-report.json` | Full `QuarantineEntry[]` with all rejection reasons + signals | No (gitignored) |
+
+The sidecar is **written always** (even when `quarantine:[]`) so consumers
+never special-case absence.
+
+### #780 seam
+
+Consumer (#780 promote step) reads `tools/rule-ingestion/promote/promote-candidates.json`,
+reconstructs the canonical message, calls `verifySignature()` fail-closed
+(false → abort, no merge), and only on `true` merges `params[]` into
+`tools/rules-source/params.json` — which triggers `publish-rules.yml`.
+This is a **file contract**, not a code dependency.
+
+### Usage
+
+```sh
+# Inject the signing key path and run
+MUGA_SIGNING_KEY_PATH=/path/to/key.pem npm run orchestrate:rules
+
+# Override version
+MUGA_SIGNING_KEY_PATH=/path/to/key.pem MUGA_RULES_VERSION=4 npm run orchestrate:rules
+```
+
+Version resolution precedence (CLI):
+1. `MUGA_RULES_VERSION` env var
+2. `--version <n>` CLI flag
+3. Fallback: read `tools/rules-source/params.json`.version
+
+Exit codes: `0` success, `1` validation/bad-JSON, `2` key setup, `3` I/O.
+
+---
+
 ## CI gate
 
 `verify-quarantine.mjs` runs in CI ([`ci.yml`](../../.github/workflows/ci.yml))

--- a/tools/rule-ingestion/orchestrate-cli.mjs
+++ b/tools/rule-ingestion/orchestrate-cli.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+/**
+ * MUGA — orchestrate-cli.mjs (EPIC C, issue #779, v2.3.0)
+ *
+ * Thin CLI: read candidates → orchestrate → sign → write artifacts.
+ * Pure decision logic lives in orchestrate.mjs (zero I/O, zero crypto).
+ *
+ * Usage:
+ *   node tools/rule-ingestion/orchestrate-cli.mjs
+ *   npm run orchestrate:rules
+ *
+ * Environment variables:
+ *   MUGA_SIGNING_KEY_PATH  (required)  Path to Ed25519 private key PEM file.
+ *                                      Do NOT pass key material via CLI args.
+ *   MUGA_RULES_VERSION     (optional)  Override target version integer.
+ *   CANDIDATES_PATH        (optional)  Override candidates.json path.
+ *
+ * CLI flags:
+ *   --version <n>  Target source version (overridden by MUGA_RULES_VERSION env).
+ *
+ * Exit codes (mirrors sign-rules.mjs):
+ *   0 — success
+ *   1 — validation / bad-JSON / empty-source
+ *   2 — signing setup (missing/unreadable key)
+ *   3 — I/O error
+ *
+ * Security rules:
+ *   - Private key only via MUGA_SIGNING_KEY_PATH — never CLI args (shell history).
+ *   - Key material never on stdout.
+ *   - No npm dependencies — node:crypto and node:fs only.
+ */
+
+import { sign as cryptoSign, createPrivateKey, createHash } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  runOrchestration,
+  canonicalMessage,
+} from "./orchestrate.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Paths (production defaults) ───────────────────────────────────────────────
+
+const DEFAULT_CANDIDATES_PATH = resolve(
+  __dirname,
+  "quarantine/candidates.json"
+);
+const DEFAULT_PROMOTE_PATH = resolve(
+  __dirname,
+  "promote/promote-candidates.json"
+);
+const DEFAULT_REPORT_PATH = resolve(
+  __dirname,
+  "quarantine/quarantine-report.json"
+);
+const PARAMS_JSON_PATH = resolve(
+  __dirname,
+  "../../tools/rules-source/params.json"
+);
+
+// ── CLI exit error helper ─────────────────────────────────────────────────────
+
+class CliError extends Error {
+  constructor(message, exitCode) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+// ── Core (testable) ───────────────────────────────────────────────────────────
+
+/**
+ * Orchestrate candidates, sign, and write artifacts.
+ *
+ * Injectable for unit tests — all I/O paths and key material can be overridden.
+ *
+ * @param {object} opts
+ * @param {string} [opts.candidatesPath]  Path to candidates.json (default: quarantine/candidates.json)
+ * @param {string} [opts.promotePath]     Path to write promote-candidates.json (default: promote/...)
+ * @param {string} [opts.reportPath]      Path to write quarantine-report.json (default: quarantine/...)
+ * @param {number} [opts.version]         Target rules version (overrides env/file fallback when set)
+ * @param {Date}   [opts.now]             Injectable clock for deterministic published timestamp
+ * @param {string} [opts.keyPath]         Path to Ed25519 PEM private key (overrides MUGA_SIGNING_KEY_PATH)
+ * @returns {Promise<void>}
+ * @throws {CliError} with .exitCode 2 on key errors, 1 on validation, 3 on I/O
+ */
+export async function runOrchestrateCli({
+  candidatesPath,
+  promotePath,
+  reportPath,
+  version: versionOpt,
+  now,
+  keyPath,
+} = {}) {
+  // ── 1. Resolve paths ────────────────────────────────────────────────────────
+  const resolvedCandidatesPath =
+    candidatesPath ||
+    process.env.CANDIDATES_PATH ||
+    DEFAULT_CANDIDATES_PATH;
+
+  const resolvedPromotePath = promotePath || DEFAULT_PROMOTE_PATH;
+  const resolvedReportPath = reportPath || DEFAULT_REPORT_PATH;
+
+  // ── 2. Load signing key (exit 2 if missing/unreadable) ─────────────────────
+  const resolvedKeyPath =
+    keyPath || process.env.MUGA_SIGNING_KEY_PATH;
+
+  if (!resolvedKeyPath) {
+    throw new CliError(
+      "[orchestrate-cli] ERROR: MUGA_SIGNING_KEY_PATH env var is not set.\n" +
+        "  Set it to the path of the Ed25519 private key PEM file.",
+      2
+    );
+  }
+
+  let privateKey;
+  try {
+    const keyPem = readFileSync(resolvedKeyPath, "utf8");
+    privateKey = createPrivateKey({ key: keyPem, format: "pem" });
+  } catch (err) {
+    throw new CliError(
+      `[orchestrate-cli] ERROR: Cannot read private key from "${resolvedKeyPath}": ${err.message}`,
+      2
+    );
+  }
+
+  // ── 3. Read candidates ──────────────────────────────────────────────────────
+  let rawCandidates;
+  try {
+    rawCandidates = readFileSync(resolvedCandidatesPath, "utf8");
+  } catch (err) {
+    throw new CliError(
+      `[orchestrate-cli] ERROR: Cannot read candidates file "${resolvedCandidatesPath}": ${err.message}`,
+      3
+    );
+  }
+
+  let candidateReport;
+  try {
+    candidateReport = JSON.parse(rawCandidates);
+  } catch (err) {
+    throw new CliError(
+      `[orchestrate-cli] ERROR: candidates.json is not valid JSON: ${err.message}`,
+      1
+    );
+  }
+
+  const candidates = candidateReport.candidates;
+  if (!Array.isArray(candidates)) {
+    throw new CliError(
+      "[orchestrate-cli] ERROR: candidates.json must have a .candidates array",
+      1
+    );
+  }
+
+  // ── 4. Resolve version ──────────────────────────────────────────────────────
+  // Precedence: MUGA_RULES_VERSION env → versionOpt (injectable / --version arg) → params.json fallback
+  let version = versionOpt;
+
+  if (process.env.MUGA_RULES_VERSION !== undefined) {
+    const parsed = parseInt(process.env.MUGA_RULES_VERSION, 10);
+    if (!Number.isInteger(parsed)) {
+      throw new CliError(
+        `[orchestrate-cli] ERROR: MUGA_RULES_VERSION must be an integer, got "${process.env.MUGA_RULES_VERSION}"`,
+        1
+      );
+    }
+    version = parsed;
+  }
+
+  if (version === undefined) {
+    // Last-resort fallback: read tools/rules-source/params.json
+    try {
+      const paramsJson = JSON.parse(readFileSync(PARAMS_JSON_PATH, "utf8"));
+      version = paramsJson.version;
+    } catch (err) {
+      throw new CliError(
+        `[orchestrate-cli] ERROR: Cannot resolve version — MUGA_RULES_VERSION unset, no --version arg, and cannot read params.json: ${err.message}`,
+        1
+      );
+    }
+  }
+
+  if (!Number.isInteger(version)) {
+    throw new CliError(
+      `[orchestrate-cli] ERROR: Resolved version is not an integer: ${version}`,
+      1
+    );
+  }
+
+  // ── 5. Resolve published ────────────────────────────────────────────────────
+  // CLI boundary: Date lives here, never in the pure module.
+  const published = (now instanceof Date ? now : new Date()).toISOString();
+
+  // ── 6. Run orchestration ────────────────────────────────────────────────────
+  const { autoMerge, quarantine, artifactBody } = runOrchestration({
+    candidates,
+    version,
+    published,
+  });
+
+  // ── 7. Sign the canonical message ───────────────────────────────────────────
+  // Inline sign block — mirrors sign-rules.mjs:211-215 verbatim (ADR: no shared helper)
+  const canonical = canonicalMessage(
+    artifactBody.version,
+    artifactBody.published,
+    artifactBody.params
+  );
+
+  let sigBuf;
+  try {
+    sigBuf = cryptoSign(null, Buffer.from(canonical, "utf8"), privateKey);
+  } catch (err) {
+    throw new CliError(
+      `[orchestrate-cli] ERROR: Signing failed: ${err.message}`,
+      2
+    );
+  }
+
+  // base64url encode (URL-safe, no padding) — sign-rules.mjs:211-215
+  const sig = sigBuf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+  // ── 8. Write signed promote artifact ────────────────────────────────────────
+  // Canonical JSON (literal key order matches docs/rules/v1/params.json contract)
+  const promoteOut = {
+    version: artifactBody.version,
+    published: artifactBody.published,
+    params: artifactBody.params,
+    sig,
+  };
+
+  // One shared variable for both write and hash — they can never drift.
+  const promoteFileContent = JSON.stringify(promoteOut, null, 2) + "\n";
+
+  try {
+    mkdirSync(dirname(resolvedPromotePath), { recursive: true });
+    writeFileSync(resolvedPromotePath, promoteFileContent, "utf8");
+  } catch (err) {
+    throw new CliError(
+      `[orchestrate-cli] ERROR: Cannot write promote artifact to "${resolvedPromotePath}": ${err.message}`,
+      3
+    );
+  }
+
+  // ── 9. Write unsigned audit sidecar (write-always, R8-S2) ──────────────────
+  const reportOut = {
+    generatedAt: published,
+    autoMergeCount: autoMerge.length,
+    quarantineCount: quarantine.length,
+    quarantine, // full QuarantineEntry[] with candidate + rejections
+  };
+
+  try {
+    mkdirSync(dirname(resolvedReportPath), { recursive: true });
+    writeFileSync(
+      resolvedReportPath,
+      JSON.stringify(reportOut, null, 2) + "\n",
+      "utf8"
+    );
+  } catch (err) {
+    throw new CliError(
+      `[orchestrate-cli] ERROR: Cannot write quarantine report to "${resolvedReportPath}": ${err.message}`,
+      3
+    );
+  }
+
+  // ── 10. One-line JSON stdout summary (no key material) ──────────────────────
+  // Hash is computed over the EXACT bytes written to disk (same string, same encoding).
+  const sha256 = createHash("sha256")
+    .update(promoteFileContent, "utf8")
+    .digest("hex");
+
+  console.log(
+    JSON.stringify({
+      promote: resolvedPromotePath,
+      report: resolvedReportPath,
+      version: artifactBody.version,
+      autoMergeCount: autoMerge.length,
+      quarantineCount: quarantine.length,
+      sha256,
+    })
+  );
+}
+
+// ── main() entry ─────────────────────────────────────────────────────────────
+
+async function main() {
+  // Parse --version flag from argv
+  const args = process.argv.slice(2);
+  let versionArg;
+  const vIdx = args.indexOf("--version");
+  if (vIdx !== -1 && args[vIdx + 1] !== undefined) {
+    versionArg = parseInt(args[vIdx + 1], 10);
+    if (!Number.isInteger(versionArg)) {
+      console.error(
+        `[orchestrate-cli] ERROR: --version must be an integer, got "${args[vIdx + 1]}"`
+      );
+      process.exit(1);
+    }
+  }
+
+  try {
+    await runOrchestrateCli({ version: versionArg });
+    process.exit(0);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(err.exitCode ?? 3);
+  }
+}
+
+if (process.argv[1]?.endsWith("orchestrate-cli.mjs")) {
+  main().catch((err) => {
+    console.error(err.message ?? err);
+    process.exit(err.exitCode ?? 3);
+  });
+}


### PR DESCRIPTION
## What

PR2 of 2 for the EPIC C ingestion orchestrator (#779) — the thin **CLI layer** over the pure decision module merged in #803. This is the piece that actually signs the auto-merge bucket and emits the promote artifact for #780 to consume.

## Approach

`tools/rule-ingestion/orchestrate-cli.mjs`:
- `runOrchestrateCli(opts)` testable core + guarded `main()` (mirrors `ingest.mjs`).
- Reads ingestion candidates, runs the merged `runOrchestration()`, signs **only** the sorted+deduped auto-merge `params[]` with node:crypto Ed25519 (`sign(null, …)`, base64url) over the canonical `${version}|${published}|${params.join(",")}` — byte-identical to `sign-rules.mjs`.
- **Key handling (fail-closed)**: private key loaded ONLY from `MUGA_SIGNING_KEY_PATH` (never CLI args); validated **before** any file is written; never logged, never emitted into an artifact or error.
- **version precedence**: `MUGA_RULES_VERSION` env → `--version` arg → fallback `tools/rules-source/params.json`.
- `published` injected at the CLI boundary so tests are deterministic; JSON output is stable-key-order + pretty + newline (diff-friendly).
- Writes signed `tools/rule-ingestion/promote/promote-candidates.json` `{version, published, params, sig}` (committed path; empty bucket → `params: []` still signed) + a **separate unsigned audit sidecar** with rich quarantine reasons (write-always, even `quarantine: []`).
- The produced `sig` verifies fail-closed with the existing `verifySignature()` (`src/lib/remote-rules.js`).

Plus: `orchestrate:rules` npm script, README orchestrator section, `promote/.gitkeep`.

## Tests

CLI tests in `tests/unit/ingestion-orchestrator-cli.test.mjs` — R5/R9 (artifact shape + verify round-trip), R7 (exit codes + key guard), R8 (sidecar separation). Temp dirs + throw-away keypairs only; never touches the real `promote/` dir or a real key. Full suite: **4208 pass / 0 fail**.

## Review notes

SDD verify (PASS-WITH-WARNINGS, security CLEAN) + a fresh blind adversarial review (SHIP-WITH-NITS, 0 critical/major) ran before this PR. Both flagged the same two **test-side** gaps, now fixed (not blindly — confirmed against the code):
- **Env-isolated the missing-key tests** — they passed `keyPath: undefined`, which falls back to `process.env.MUGA_SIGNING_KEY_PATH`; if that var was set in the shell the fail-closed contract went unverified. Now save/delete/restore.
- **Added a tamper-resistance test** — asserts a mutated artifact verifies `false`, so a regression that broke `verifySignature` to always-true would now fail.
- Also: malformed-PEM, `MUGA_RULES_VERSION`-env, and dedup tests; fixed the stdout `sha256` to hash the exact bytes written (it hashed compact JSON while writing pretty); gave `main()` the sibling `.catch()` handler.

## Acceptance mapping (#779) — now complete across PR1+PR2

- ✅ Auto-merge / quarantine buckets produced deterministically (#803)
- ✅ Output artifact signed; signature verified fail-closed downstream (this PR — real-verifier round-trip + tamper test)

## #780 seam

`tools/rule-ingestion/promote/promote-candidates.json` is a pure **file contract**: #780 reads it, rebuilds the canonical string, calls the existing `verifySignature()` fail-closed, and only on `true` merges `params[]` into `tools/rules-source/params.json` (which triggers the existing `publish-rules.yml`). No code dependency.

Closes #779
