### PR TITLE
feat(ingestion): wire orchestrator output into remote-rules source — promote-rules.mjs (#780)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ src/rules/wrappers.json       text eol=lf
 src/rules/wrappers.json.sig   text eol=lf
 src/rules/worker-pubkey.txt   text eol=lf
 src/rules/wrappers.data.js    text eol=lf
+tools/rules-source/params.json text eol=lf

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "verify:quarantine": "node tools/rule-ingestion/verify-quarantine.mjs",
     "ingest:rules": "node tools/rule-ingestion/ingest.mjs",
     "orchestrate:rules": "node tools/rule-ingestion/orchestrate-cli.mjs",
+    "promote:rules": "node tools/rule-ingestion/promote-rules.mjs",
     "conformance:contextual": "node --test --test-reporter=spec tests/unit/conformance-contextual.test.mjs",
     "test:serve": "npx serve tests/browser --listen 5555 --no-clipboard",
     "brand": "npx serve tools --listen 5556 --no-clipboard",

--- a/tests/unit/ingestion-promote-rules.test.mjs
+++ b/tests/unit/ingestion-promote-rules.test.mjs
@@ -1,0 +1,1226 @@
+/**
+ * MUGA — Unit tests for tools/rule-ingestion/promote-rules.mjs
+ *
+ * Covers all requirements R1-R8 + import-smoke (T-27/T-28) +
+ * review fixes FIX-6 through FIX-9.
+ *
+ * All I/O uses TEMP files — NEVER mutates tools/rules-source/params.json
+ * or reads real domain-rules.json for mutation.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateKeyPairSync,
+  sign as cryptoSign,
+} from "node:crypto";
+import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// FIX-9: import canonicalMessage from production source so test signer and
+// production code agree on format by construction (no template-literal drift).
+import { canonicalMessage } from "../../tools/rule-ingestion/orchestrate.mjs";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Export raw 32-byte Ed25519 public key as standard base64 (DER spki slice) */
+function exportPubKeyBase64(publicKey) {
+  const der = publicKey.export({ type: "spki", format: "der" });
+  return der.slice(12).toString("base64");
+}
+
+/** Create a fresh temp directory per test invocation */
+function makeTmpDir() {
+  const d = join(
+    tmpdir(),
+    `muga-promote-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+/** Sign a canonical message with a private key, return base64url */
+function signCanonical(canonical, privateKey) {
+  return cryptoSign(null, Buffer.from(canonical, "utf8"), privateKey).toString(
+    "base64url"
+  );
+}
+
+/**
+ * Build a promote-candidates.json artifact.
+ * Uses canonicalMessage from orchestrate.mjs (FIX-9) so the test signer and
+ * production agree on format by construction — no template-literal drift.
+ *
+ * @param {object} opts
+ * @param {number}   opts.version
+ * @param {string}   opts.published
+ * @param {string[]} opts.params
+ * @param {object}   opts.privateKey - node:crypto KeyObject for signing
+ * @param {string}   [opts.sigOverride] - if provided, use this sig instead of real one
+ * @returns {object} artifact
+ */
+function buildArtifact({ version, published, params, privateKey, sigOverride }) {
+  const canonical = canonicalMessage(version, published, params);
+  const sig = sigOverride !== undefined
+    ? sigOverride
+    : signCanonical(canonical, privateKey);
+  return { version, published, params, sig };
+}
+
+/** Write artifact JSON to a temp dir */
+function writeArtifact(dir, artifact) {
+  const path = join(dir, "promote-candidates.json");
+  writeFileSync(path, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+  return path;
+}
+
+/** Write a params.json source file */
+function writeParamsJson(dir, { version, published, params }) {
+  const path = join(dir, "params.json");
+  writeFileSync(
+    path,
+    JSON.stringify({ version, published, params }, null, 2) + "\n",
+    "utf8"
+  );
+  return path;
+}
+
+/** Write a domain-rules.json fixture */
+function writeDomainRules(dir, rules) {
+  const path = join(dir, "domain-rules.json");
+  writeFileSync(path, JSON.stringify(rules, null, 2) + "\n", "utf8");
+  return path;
+}
+
+// ── Shared test keypair ────────────────────────────────────────────────────────
+const { privateKey: TEST_PRIV_KEY, publicKey: TEST_PUB_KEY } =
+  generateKeyPairSync("ed25519");
+const testPubKeyB64 = exportPubKeyBase64(TEST_PUB_KEY);
+const TEST_TRUSTED_KEYS = [testPubKeyB64];
+
+// ── Phase 1: T-01 — PromoteError class ───────────────────────────────────────
+
+describe("PromoteError — class contract", () => {
+  test("T-01: PromoteError is importable, has exitCode, extends Error", async () => {
+    const { PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+    const err = new PromoteError("test message", 2);
+    assert.strictEqual(err.exitCode, 2);
+    assert.strictEqual(err.message, "test message");
+    assert.ok(err instanceof Error, "PromoteError must extend Error");
+    assert.ok(err instanceof PromoteError, "must be instanceof PromoteError");
+  });
+});
+
+// ── Phase 1: T-03 — loadPreservedSet + computeMerge shape guard ──────────────
+
+describe("Module shape — loadPreservedSet and computeMerge exports", () => {
+  test("T-03: loadPreservedSet and computeMerge are exported functions", async () => {
+    const { loadPreservedSet, computeMerge } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+    assert.strictEqual(typeof loadPreservedSet, "function");
+    assert.strictEqual(typeof computeMerge, "function");
+  });
+});
+
+// ── Phase 2: T-05 — loadPreservedSet behavior ────────────────────────────────
+
+describe("loadPreservedSet — union of preserveParams across domains", () => {
+  test("T-05: unions all domain preserveParams, handles missing preserveParams", async () => {
+    const { loadPreservedSet } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const domainRules = [
+      { domain: "a.com", preserveParams: ["foo", "bar"] },
+      { domain: "b.com", preserveParams: ["baz", "foo"] }, // foo duplicate
+      { domain: "c.com" }, // no preserveParams — must not throw
+    ];
+
+    const result = loadPreservedSet(domainRules);
+    assert.ok(result instanceof Set, "must return a Set");
+    assert.ok(result.has("foo"), "must contain foo");
+    assert.ok(result.has("bar"), "must contain bar");
+    assert.ok(result.has("baz"), "must contain baz");
+    assert.strictEqual(result.size, 3, "must deduplicate (foo appears once)");
+  });
+});
+
+// ── Phase 2: T-07 — computeMerge behavior ────────────────────────────────────
+
+describe("computeMerge — sort, dedup, change detection", () => {
+  test("T-07a: sorted lexicographically", async () => {
+    const { computeMerge } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+    const { merged } = computeMerge(["z_param", "a_param"], ["m_param"]);
+    assert.deepStrictEqual(merged, ["a_param", "m_param", "z_param"]);
+  });
+
+  test("T-07b: deduplicates via Set", async () => {
+    const { computeMerge } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+    const { merged } = computeMerge(["existing_param"], ["existing_param"]);
+    assert.strictEqual(merged.length, 1);
+    assert.deepStrictEqual(merged, ["existing_param"]);
+  });
+
+  test("T-07c: changed:false when merged equals current (all-collide/no-op)", async () => {
+    const { computeMerge } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+    const { changed } = computeMerge(["a", "b"], []);
+    assert.strictEqual(changed, false);
+  });
+
+  test("T-07d: changed:true when new param added", async () => {
+    const { computeMerge } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+    const { changed, merged } = computeMerge(["a"], ["new_param"]);
+    assert.strictEqual(changed, true);
+    assert.ok(merged.includes("new_param"));
+  });
+});
+
+// ── Phase 3: T-09 — runPromote valid merge (A1) ───────────────────────────────
+
+describe("runPromote — valid merge (A1)", () => {
+  test("T-09: valid merge: written:true, version bumped, published=injected now, sorted params", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const nowDate = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param", "another_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, [
+      { domain: "example.com", preserveParams: ["safe_keep"] },
+    ]);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now: nowDate,
+    });
+
+    assert.strictEqual(result.verified, true);
+    assert.strictEqual(result.written, true);
+    assert.strictEqual(result.noop, false);
+    assert.strictEqual(result.version, 4);
+    assert.strictEqual(result.published, "2026-06-01T12:00:00.000Z");
+
+    // Params sorted and merged
+    assert.deepStrictEqual(result.merged, [
+      "another_param",
+      "existing_param",
+      "new_param",
+    ]);
+
+    // File bytes contain the expected JSON with trailing newline
+    const written = JSON.parse(readFileSync(sourcePath, "utf8"));
+    assert.strictEqual(written.version, 4);
+    assert.strictEqual(written.published, "2026-06-01T12:00:00.000Z");
+    assert.deepStrictEqual(written.params, [
+      "another_param",
+      "existing_param",
+      "new_param",
+    ]);
+
+    // Trailing newline
+    const raw = readFileSync(sourcePath, "utf8");
+    assert.ok(raw.endsWith("\n"), "params.json must end with \\n");
+  });
+});
+
+// ── Phase 3: T-10 — tampered sig → fail-closed (A2) ─────────────────────────
+
+describe("runPromote — tampered sig → fail-closed (A2)", () => {
+  test("T-10: mutated sig → PromoteError exitCode 2, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+      sigOverride: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now: new Date("2026-06-01T12:00:00.000Z"),
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 2);
+        return true;
+      }
+    );
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+});
+
+// ── Phase 3: T-11 — missing/null sig → fail-closed (A2b) ────────────────────
+
+describe("runPromote — missing sig → fail-closed (A2b)", () => {
+  test("T-11: sig:null → PromoteError exitCode 2, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+
+    // Build artifact without valid sig
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: ["new_param"], sig: null };
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now: new Date("2026-06-01T12:00:00.000Z"),
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 2);
+        return true;
+      }
+    );
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+});
+
+// ── Phase 3: T-12 — malformed source params.json → exitCode 1 ────────────────
+
+describe("runPromote — malformed source params.json", () => {
+  test("T-12a: non-JSON source → PromoteError exitCode 1", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+
+    // Write non-JSON to source
+    const sourcePath = join(tmpDir, "params.json");
+    writeFileSync(sourcePath, "NOT VALID JSON", "utf8");
+
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now: new Date("2026-06-01T12:00:00.000Z"),
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1);
+        return true;
+      }
+    );
+  });
+
+  test("T-12b: non-integer version in source → PromoteError exitCode 1", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+
+    // Write source with non-integer version
+    const sourcePath = join(tmpDir, "params.json");
+    writeFileSync(
+      sourcePath,
+      JSON.stringify({ version: "not-a-number", published: "2026-04-01T00:00:00.000Z", params: [] }, null, 2) + "\n",
+      "utf8"
+    );
+
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now: new Date("2026-06-01T12:00:00.000Z"),
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1);
+        return true;
+      }
+    );
+  });
+});
+
+// ── Phase 3: T-13 — missing files → exitCode 3 ───────────────────────────────
+
+describe("runPromote — missing files → exitCode 3", () => {
+  test("T-13a: missing promote artifact → PromoteError exitCode 3", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath: join(tmpDir, "does-not-exist.json"),
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now: new Date("2026-06-01T12:00:00.000Z"),
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 3);
+        return true;
+      }
+    );
+  });
+
+  test("T-13b: missing source params.json → PromoteError exitCode 3", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath: join(tmpDir, "does-not-exist-params.json"),
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now: new Date("2026-06-01T12:00:00.000Z"),
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 3);
+        return true;
+      }
+    );
+  });
+});
+
+// ── Phase 4: T-15 — stale artifact → exitCode 1 ──────────────────────────────
+
+describe("runPromote — stale artifact (STALE_DAYS=180)", () => {
+  test("T-15: artifact.published older than 180 days → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    // 181 days before now — stale
+    const staleDate = new Date(now.getTime() - 181 * 864e5);
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: staleDate.toISOString(),
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now,
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1);
+        return true;
+      }
+    );
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+});
+
+// ── Phase 4: T-16 — collision skip+log (A3) ──────────────────────────────────
+
+describe("runPromote — preserveParams collision skip (A3)", () => {
+  test("T-16: collider_param skipped, new_clean_param merges", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["collider_param", "new_clean_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, [
+      { domain: "example.com", preserveParams: ["collider_param"] },
+    ]);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+
+    // collider_param must be in skipped
+    assert.ok(
+      result.skipped.some((s) => s.param === "collider_param"),
+      "collider_param must be in skipped"
+    );
+
+    // collider_param must NOT be in merged
+    assert.ok(!result.merged.includes("collider_param"), "collider_param must not be in merged");
+
+    // new_clean_param must be in merged
+    assert.ok(result.merged.includes("new_clean_param"), "new_clean_param must be in merged");
+
+    // File written
+    assert.strictEqual(result.written, true);
+    const written = JSON.parse(readFileSync(sourcePath, "utf8"));
+    assert.ok(!written.params.includes("collider_param"));
+    assert.ok(written.params.includes("new_clean_param"));
+  });
+});
+
+// ── Phase 4: T-17 — union across two domains ─────────────────────────────────
+
+describe("runPromote — preserveParams union across multiple domains", () => {
+  test("T-17: both domain-scoped params skipped, safe_param merges", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["a_param", "b_param", "safe_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, [
+      { domain: "a.com", preserveParams: ["a_param"] },
+      { domain: "b.com", preserveParams: ["b_param"] },
+    ]);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+
+    assert.ok(result.skipped.some((s) => s.param === "a_param"), "a_param must be skipped");
+    assert.ok(result.skipped.some((s) => s.param === "b_param"), "b_param must be skipped");
+    assert.ok(!result.merged.includes("a_param"), "a_param must not be in merged");
+    assert.ok(!result.merged.includes("b_param"), "b_param must not be in merged");
+    assert.ok(result.merged.includes("safe_param"), "safe_param must be in merged");
+  });
+});
+
+// ── Phase 4: T-18 — ALL params collide → noop (R2-S3) ───────────────────────
+
+describe("runPromote — ALL promoted params collide → noop", () => {
+  test("T-18: all params in preservedSet → noop:true, written:false, bytes unchanged", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["collider_a", "collider_b"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, [
+      { domain: "a.com", preserveParams: ["collider_a", "collider_b"] },
+    ]);
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+
+    assert.strictEqual(result.noop, true);
+    assert.strictEqual(result.written, false);
+    assert.strictEqual(result.verified, true);
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+});
+
+// ── Phase 5: T-20 — idempotent no-op (A4) ────────────────────────────────────
+
+describe("runPromote — idempotent no-op (A4)", () => {
+  test("T-20: second run with same artifact → noop:true, written:false", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    // First run — should write
+    const first = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+    assert.strictEqual(first.written, true, "first run must write");
+
+    // Second run — same artifact, same source (now updated from first run)
+    // We need to re-sign with the new state's canonical to make it idempotent
+    // But the artifact is the same signed one — the params are already in source
+    // so computeMerge should return changed:false
+    const second = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+
+    assert.strictEqual(second.noop, true, "second run must be noop");
+    assert.strictEqual(second.written, false, "second run must not write");
+    assert.strictEqual(second.version, first.version, "version must not change on noop");
+  });
+});
+
+// ── Phase 5: T-21 — version monotonicity ─────────────────────────────────────
+
+describe("runPromote — version monotonicity", () => {
+  test("T-21: version = current+1; stale artifact version still proceeds", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    // artifact.version (3) <= current.version (5) — stale, but should still proceed
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["brand_new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 5,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+
+    assert.strictEqual(result.written, true);
+    // newVersion = current.version(5) + 1 = 6, NOT artifact.version+1
+    assert.strictEqual(result.version, 6, "version must be current+1=6");
+    assert.ok(Number.isInteger(result.version), "version must be integer");
+
+    const written = JSON.parse(readFileSync(sourcePath, "utf8"));
+    assert.strictEqual(written.version, 6);
+  });
+});
+
+// ── Phase 6: T-23 — exit code 0 on merge and no-op ──────────────────────────
+
+describe("runPromote — exit codes R7-S1/S2", () => {
+  test("T-23a: success merge → no throw, written:true", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["fresh_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: [],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    assert.strictEqual(result.written, true);
+    assert.strictEqual(result.noop, false);
+  });
+
+  test("T-23b: success no-op → no throw, noop:true", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    // Artifact with params already in source
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["already_there"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["already_there"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    assert.strictEqual(result.noop, true);
+    assert.strictEqual(result.written, false);
+  });
+});
+
+// ── Phase 7: T-25 — package.json promote:rules script ────────────────────────
+
+describe("package.json — promote:rules script", () => {
+  test("T-25: package.json scripts contains promote:rules key", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, resolve } = await import("node:path");
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const pkgPath = resolve(__dirname, "../../package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(pkg.scripts, "promote:rules"),
+      "package.json scripts must have promote:rules"
+    );
+    assert.ok(
+      pkg.scripts["promote:rules"].includes("promote-rules.mjs"),
+      "promote:rules must point to promote-rules.mjs"
+    );
+  });
+});
+
+// ── FIX-6: future-dated artifact (beyond CLOCK_SKEW_TOLERANCE_MS) → exit 1 ───
+
+describe("runPromote — future-dated artifact bypass (FIX-6)", () => {
+  test("FIX-6a: artifact published 2 days in the future → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    // 2 days (172 800 000 ms) > CLOCK_SKEW_TOLERANCE_MS (86 400 000 ms)
+    const futurePublished = new Date(now.getTime() + 2 * 864e5).toISOString();
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: futurePublished,
+      params: ["future_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now,
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "must be exitCode 1 (validation)");
+        return true;
+      }
+    );
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+
+  test("FIX-6b: artifact published exactly at CLOCK_SKEW_TOLERANCE_MS boundary is accepted (within tolerance)", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    // Exactly at tolerance boundary: publishedMs - now === CLOCK_SKEW_TOLERANCE_MS
+    // The check is STRICTLY GREATER THAN tolerance, so boundary itself is accepted.
+    const boundaryPublished = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString();
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: boundaryPublished,
+      params: ["boundary_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: [],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    // Must NOT throw — exactly at tolerance is still within the window
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+    assert.strictEqual(result.verified, true);
+  });
+});
+
+// ── FIX-7: domain-rules.json fail-CLOSED ─────────────────────────────────────
+
+describe("runPromote — domain-rules.json fail-CLOSED (FIX-7)", () => {
+  test("FIX-7a: missing domainRulesPath → PromoteError exitCode 3, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath: join(tmpDir, "domain-rules-does-not-exist.json"),
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now,
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 3, "missing domain-rules.json must be exitCode 3 (I/O)");
+        return true;
+      }
+    );
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+
+  test("FIX-7b: domainRulesPath contains non-array JSON → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+
+    // domain-rules.json contains a plain object — NOT an array
+    const domainRulesPath = join(tmpDir, "domain-rules.json");
+    writeFileSync(
+      domainRulesPath,
+      JSON.stringify({ notAnArray: true }, null, 2) + "\n",
+      "utf8"
+    );
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now,
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "non-array domain-rules.json must be exitCode 1 (validation)");
+        return true;
+      }
+    );
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+});
+
+// ── FIX-8: non-string params elements → exit 1, no write ─────────────────────
+
+describe("runPromote — non-string params in artifact (FIX-8)", () => {
+  test("FIX-8: artifact params contains non-string (signed with correct sig) → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    // Build canonical and sign with the ACTUAL params (including non-string),
+    // so the signature is valid for this exact params array. The schema check
+    // for non-string elements must fire BEFORE the signature check (per the
+    // artifact validation order in promote-rules.mjs step 2), meaning the
+    // test MUST result in exitCode 1 (not 2) even if the sig were valid.
+    const paramsWithNonString = ["good_param", 123, "another_good"];
+    // Manually build the canonical as orchestrate.mjs would if it received strings
+    // (the production schema check runs before sig verification, so we just need
+    // the exit code — the sig validity is irrelevant here, but we sign anyway
+    // to keep the test honest about the ordering).
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", paramsWithNonString.map(String));
+    const sig = signCanonical(canonical, TEST_PRIV_KEY);
+
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: paramsWithNonString, sig };
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () =>
+        runPromote({
+          promotePath,
+          sourcePath,
+          domainRulesPath,
+          trustedKeys: TEST_TRUSTED_KEYS,
+          subtle: globalThis.crypto.subtle,
+          now,
+        }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "non-string params must be exitCode 1 (schema validation)");
+        return true;
+      }
+    );
+
+    const bytesAfter = readFileSync(sourcePath, "utf8");
+    assert.strictEqual(bytesBefore, bytesAfter, "params.json bytes must be unchanged");
+  });
+});
+
+// ── FIX-5: idempotency vs unsorted source ─────────────────────────────────────
+
+describe("runPromote — idempotency with unsorted source params (FIX-5)", () => {
+  test("FIX-5: hand-unsorted source with same content as sorted merged → noop:true (no spurious write)", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    // Artifact promotes "already_there" — which is already in source but unsorted
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["already_there"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+
+    // Source params deliberately unsorted: ["z_param", "already_there"]
+    // The merged sorted result would be ["already_there", "z_param"] —
+    // same set, just sorted. Without FIX-5, this would report changed:true
+    // because currentParams["z_param","already_there"] !== merged["already_there","z_param"].
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["z_param", "already_there"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+
+    assert.strictEqual(result.noop, true, "must be noop — no new params added");
+    assert.strictEqual(result.written, false, "must not write — same content, just pre-sorted");
+  });
+});
+
+// ── Phase 8: T-27 — import-smoke regression test ─────────────────────────────
+
+describe("Import smoke — promote-rules.mjs under Node (D1 mitigation)", () => {
+  test("T-27: all named exports importable; end-to-end runPromote under Node", async () => {
+    const { runPromote, loadPreservedSet, computeMerge, PromoteError } =
+      await import("../../tools/rule-ingestion/promote-rules.mjs");
+
+    // All named exports present
+    assert.strictEqual(typeof runPromote, "function");
+    assert.strictEqual(typeof loadPreservedSet, "function");
+    assert.strictEqual(typeof computeMerge, "function");
+    assert.ok(PromoteError.prototype instanceof Error);
+
+    // End-to-end runPromote with real globalThis.crypto.subtle
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["smoke_test_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: [],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    const result = await runPromote({
+      promotePath,
+      sourcePath,
+      domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now,
+    });
+
+    assert.strictEqual(result.verified, true, "smoke test: verified must be true");
+  });
+});

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -285,13 +285,58 @@ validates the artifact unchanged — no new verifier.
 The sidecar is **written always** (even when `quarantine:[]`) so consumers
 never special-case absence.
 
-### #780 seam
+### #780 seam — `promote-rules.mjs`
 
-Consumer (#780 promote step) reads `tools/rule-ingestion/promote/promote-candidates.json`,
-reconstructs the canonical message, calls `verifySignature()` fail-closed
-(false → abort, no merge), and only on `true` merges `params[]` into
-`tools/rules-source/params.json` — which triggers `publish-rules.yml`.
-This is a **file contract**, not a code dependency.
+`tools/rule-ingestion/promote-rules.mjs` is the #780 consumer. It reads
+`tools/rule-ingestion/promote/promote-candidates.json`, reconstructs the
+canonical message, calls `verifySignature()` **fail-closed**
+(false → `PromoteError` exit 2, no write), and only on `true` merges
+`params[]` into `tools/rules-source/params.json` — which triggers
+`publish-rules.yml`. This is a **file contract**, not a code dependency.
+
+#### `runPromote` contract
+
+```js
+import { runPromote } from "./promote-rules.mjs";
+
+const result = await runPromote({
+  promotePath,       // path to promote-candidates.json (default: promote/promote-candidates.json)
+  sourcePath,        // path to params.json (default: tools/rules-source/params.json)
+  domainRulesPath,   // path to domain-rules.json (default: src/rules/domain-rules.json)
+  trustedKeys?,      // string[] of base64 Ed25519 public keys (default: TRUSTED_PUBLIC_KEYS)
+  subtle?,           // SubtleCrypto (default: globalThis.crypto?.subtle)
+  now?,              // Date (default: new Date()) — injectable for testing
+});
+// result: { verified, merged, skipped, written, noop, version, published, reason? }
+//   verified  — true if Ed25519 sig checked out
+//   merged    — final sorted+deduped params array written to params.json
+//   skipped   — Array<{ param, reason }> — collisions with domain preserveParams
+//   written   — true only when params.json was actually changed
+//   noop      — true when merged === current (no write, no version bump)
+//   version   — resulting params.json version (current or current+1)
+//   published — resulting params.json published (new ISO timestamp on write, current on noop)
+```
+
+Throws `PromoteError { message, exitCode }` on fail-closed or validation errors.
+
+#### Exit codes
+
+| Code | Condition |
+|------|-----------|
+| 0 | Success — params merged OR clean no-op |
+| 1 | Validation — stale artifact, malformed params.json, bad schema |
+| 2 | VERIFY\_FAILED — bad or missing Ed25519 signature (fail-closed) |
+| 3 | I/O — missing/unreadable promote artifact or source file |
+
+#### Manual run
+
+```sh
+# Run promote step (reads promote/promote-candidates.json, writes tools/rules-source/params.json)
+npm run promote:rules
+```
+
+Review the diff before committing — `publish-rules.yml` triggers automatically
+on `tools/rules-source/**` changes. Automation of this step is tracked in #781.
 
 ### Usage
 

--- a/tools/rule-ingestion/promote-rules.mjs
+++ b/tools/rule-ingestion/promote-rules.mjs
@@ -1,0 +1,388 @@
+/**
+ * MUGA — promote-rules.mjs (EPIC C, issue #780, v2.3.0)
+ *
+ * Consumes a signed promote-candidates.json artifact, verifies its Ed25519
+ * signature FAIL-CLOSED, skips params colliding with domain preserveParams,
+ * and merges surviving params into tools/rules-source/params.json.
+ *
+ * Usage (manual / CI):
+ *   node tools/rule-ingestion/promote-rules.mjs
+ *   npm run promote:rules
+ *
+ * Public API (named exports only — NO default export):
+ *   PromoteError          — class extends Error { exitCode }
+ *   loadPreservedSet      — (domainRules) → Set<string>
+ *   computeMerge          — (currentParams, cleanParams) → { merged, changed }
+ *   runPromote            — async ({ promotePath, sourcePath, domainRulesPath,
+ *                             trustedKeys?, subtle?, now? }) → result
+ *   main                  — guarded entry (mirrors ingest.mjs pattern)
+ *
+ * Exit codes:
+ *   0 — success-merged | success-noop
+ *   1 — validation (stale, malformed source, bad schema)
+ *   2 — VERIFY_FAILED (fail-closed — bad/missing signature)
+ *   3 — I/O (missing/unreadable promote or source file, malformed promote JSON)
+ */
+
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { verifySignature } from "../../src/lib/remote-rules.js";
+import { TRUSTED_PUBLIC_KEYS } from "../../src/lib/remote-rules-keys.js";
+import { canonicalMessage } from "./orchestrate.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Freshness window in days — mirror remote-rules.js STALE_DAYS */
+const STALE_DAYS = 180;
+
+/**
+ * Upper bound on how far a payload's `published` date may lead the current
+ * clock. Without it, a future-dated artifact makes (now - published) negative —
+ * never exceeding STALE_DAYS — so it would read as "fresh" forever, defeating
+ * the replay/restamp defense. Mirrors remote-rules.js CLOCK_SKEW_TOLERANCE_MS.
+ * 24 h absorbs legitimate clock skew.
+ */
+const CLOCK_SKEW_TOLERANCE_MS = 24 * 60 * 60 * 1000;
+
+// ── Production default paths ──────────────────────────────────────────────────
+
+const DEFAULT_PROMOTE_PATH = resolve(
+  __dirname,
+  "promote/promote-candidates.json"
+);
+const DEFAULT_SOURCE_PATH = resolve(
+  __dirname,
+  "../../tools/rules-source/params.json"
+);
+const DEFAULT_DOMAIN_RULES_PATH = resolve(
+  __dirname,
+  "../../src/rules/domain-rules.json"
+);
+
+// ── PromoteError ──────────────────────────────────────────────────────────────
+
+/**
+ * Structured error with an exit code for process.exitCode assignment.
+ * Mirrors orchestrate-cli.mjs CliError.
+ */
+export class PromoteError extends Error {
+  /**
+   * @param {string} message
+   * @param {number} exitCode  0|1|2|3
+   */
+  constructor(message, exitCode) {
+    super(message);
+    this.name = "PromoteError";
+    this.exitCode = exitCode;
+  }
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Builds the union of all `preserveParams` across every domain entry.
+ * Entries that omit `preserveParams` are safely skipped via `?? []`.
+ *
+ * @param {Array<{ domain: string, preserveParams?: string[] }>} domainRules
+ * @returns {Set<string>}
+ */
+export function loadPreservedSet(domainRules) {
+  return new Set(domainRules.flatMap((d) => d.preserveParams ?? []));
+}
+
+/**
+ * Merges cleanParams into currentParams: dedup via Set + sort localeCompare.
+ * Returns `changed:false` when the result is identical to currentParams.
+ *
+ * @param {string[]} currentParams
+ * @param {string[]} cleanParams    — already filtered (no preserveParams collisions)
+ * @returns {{ merged: string[], changed: boolean }}
+ */
+export function computeMerge(currentParams, cleanParams) {
+  const merged = [...new Set([...currentParams, ...cleanParams])].sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const changed =
+    merged.length !== currentParams.length ||
+    merged.some((p, i) => p !== currentParams[i]);
+  return { merged, changed };
+}
+
+// ── Core (testable) ───────────────────────────────────────────────────────────
+
+/**
+ * Verifies the signed promote artifact, resolves preserveParams collisions,
+ * and merges surviving params into the source params.json.
+ *
+ * All I/O paths and crypto dependencies are injectable for unit tests.
+ *
+ * @param {object} opts
+ * @param {string}       opts.promotePath      Path to promote-candidates.json.
+ * @param {string}       opts.sourcePath       Path to tools/rules-source/params.json.
+ * @param {string}       opts.domainRulesPath  Path to src/rules/domain-rules.json.
+ * @param {string[]}     [opts.trustedKeys]    Defaults to TRUSTED_PUBLIC_KEYS.
+ * @param {SubtleCrypto} [opts.subtle]         Defaults to globalThis.crypto?.subtle.
+ * @param {Date}         [opts.now]            Defaults to new Date().
+ *
+ * @returns {Promise<{
+ *   verified: boolean,
+ *   merged: string[],
+ *   skipped: Array<{ param: string, reason: string }>,
+ *   written: boolean,
+ *   noop: boolean,
+ *   version: number,
+ *   published: string | null,
+ *   reason?: string,
+ * }>}
+ *
+ * @throws {PromoteError} on fail-closed or validation errors.
+ */
+export async function runPromote({
+  promotePath = DEFAULT_PROMOTE_PATH,
+  sourcePath = DEFAULT_SOURCE_PATH,
+  domainRulesPath = DEFAULT_DOMAIN_RULES_PATH,
+  trustedKeys = TRUSTED_PUBLIC_KEYS,
+  subtle = globalThis.crypto?.subtle,
+  now = new Date(),
+} = {}) {
+  // ── Step 1: Read + parse source params.json ───────────────────────────────
+  let current;
+  try {
+    const raw = readFileSync(sourcePath, "utf8");
+    current = JSON.parse(raw);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new PromoteError(
+        `MALFORMED_SOURCE: params.json is not valid JSON — ${err.message}`,
+        1
+      );
+    }
+    throw new PromoteError(
+      `IO_ERROR: cannot read source params.json at ${sourcePath} — ${err.message}`,
+      3
+    );
+  }
+
+  // Validate source schema
+  if (!Number.isInteger(current.version)) {
+    throw new PromoteError(
+      `SCHEMA_ERROR: params.json.version must be an integer, got ${typeof current.version}`,
+      1
+    );
+  }
+  if (!Array.isArray(current.params)) {
+    throw new PromoteError(
+      `SCHEMA_ERROR: params.json.params must be an array`,
+      1
+    );
+  }
+
+  // ── Step 2: Read + parse promote artifact ─────────────────────────────────
+  let art;
+  try {
+    const raw = readFileSync(promotePath, "utf8");
+    art = JSON.parse(raw);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new PromoteError(
+        `IO_ERROR: promote artifact is not valid JSON — ${err.message}`,
+        3
+      );
+    }
+    throw new PromoteError(
+      `IO_ERROR: cannot read promote artifact at ${promotePath} — ${err.message}`,
+      3
+    );
+  }
+
+  // Validate artifact schema (missing required fields → exit 1)
+  if (
+    art.version === undefined ||
+    art.published === undefined ||
+    !Array.isArray(art.params)
+  ) {
+    throw new PromoteError(
+      `SCHEMA_ERROR: promote artifact is missing required fields (version, published, params)`,
+      1
+    );
+  }
+  // Validate that every element in art.params is a string (non-string elements
+  // indicate a malformed/tampered artifact — reject before signature check)
+  if (!art.params.every((p) => typeof p === "string")) {
+    throw new PromoteError(
+      `SCHEMA_ERROR: promote artifact params must be an array of strings`,
+      1
+    );
+  }
+
+  // ── Step 3: Verify Ed25519 signature FAIL-CLOSED ──────────────────────────
+  // Build canonical from artifact fields (what was signed)
+  const canonical = canonicalMessage(art.version, art.published, art.params);
+  let ok;
+  try {
+    // sig: null or missing → verifySignature returns false, but we treat it as fail-closed
+    const sigValue = art.sig ?? "";
+    ok = await verifySignature(canonical, sigValue, trustedKeys, subtle);
+  } catch {
+    ok = false;
+  }
+  if (!ok) {
+    throw new PromoteError(
+      `VERIFY_FAILED: promote artifact signature invalid or missing`,
+      2
+    );
+  }
+
+  // ── Step 4: Freshness check (STALE_DAYS=180 + future-skew guard) ────────────
+  const artPublishedMs = Date.parse(art.published);
+  if (
+    Number.isNaN(artPublishedMs) ||
+    now.getTime() - artPublishedMs > STALE_DAYS * 864e5 ||
+    artPublishedMs - now.getTime() > CLOCK_SKEW_TOLERANCE_MS
+  ) {
+    throw new PromoteError(
+      `STALE_ARTIFACT: promote artifact published ${art.published} is outside the accepted freshness window`,
+      1
+    );
+  }
+
+  // Informational log: artifact version looks stale relative to source
+  if (art.version <= current.version) {
+    console.log(
+      `[promote-rules] INFO: artifact.version (${art.version}) <= source.version (${current.version}) — artifact may be stale; proceeding on params delta`
+    );
+  }
+
+  // ── Step 5: Build preservedSet + partition art.params ─────────────────────
+  // FAIL-CLOSED: missing/unreadable domain-rules.json → exit 3 (I/O); non-array
+  // content → exit 1 (validation). No silent empty-set fallback — we cannot
+  // safely check preserveParams collisions without the safety list.
+  let domainRules;
+  try {
+    const raw = readFileSync(domainRulesPath, "utf8");
+    domainRules = JSON.parse(raw);
+  } catch (err) {
+    throw new PromoteError(
+      `IO_ERROR: cannot read domain-rules.json at ${domainRulesPath} — ${err.message}`,
+      3
+    );
+  }
+  if (!Array.isArray(domainRules)) {
+    throw new PromoteError(
+      `SCHEMA_ERROR: domain-rules.json must be an array, got ${typeof domainRules}`,
+      1
+    );
+  }
+
+  const preservedSet = loadPreservedSet(domainRules);
+  const skipped = [];
+  const cleanParams = [];
+
+  for (const param of art.params) {
+    if (preservedSet.has(param)) {
+      console.log(
+        `[promote-rules] skip: ${param} collides with preserveParams — excluded from merge`
+      );
+      skipped.push({ param, reason: "collides with preserveParams" });
+    } else {
+      cleanParams.push(param);
+    }
+  }
+
+  // ── Step 6: Compute merge ─────────────────────────────────────────────────
+  // Sort currentParams before passing so a hand-unsorted source doesn't produce
+  // a spurious change detection (FIX-5: idempotency vs unsorted source).
+  const sortedCurrentParams = [...current.params].sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const { merged, changed } = computeMerge(sortedCurrentParams, cleanParams);
+
+  // ── Step 7: No-op path ───────────────────────────────────────────────────
+  if (!changed) {
+    console.log(
+      `[promote-rules] no-op: merged params identical to current — no write, no version bump`
+    );
+    return {
+      verified: true,
+      merged,
+      skipped,
+      written: false,
+      noop: true,
+      version: current.version,
+      published: current.published,
+    };
+  }
+
+  // ── Step 8: Write — ONLY reached after verify+freshness+merge produce change
+  const newVersion = current.version + 1;
+  const newPublished = now.toISOString();
+  const payload = JSON.stringify(
+    { version: newVersion, published: newPublished, params: merged },
+    null,
+    2
+  ) + "\n";
+
+  writeFileSync(sourcePath + ".tmp", payload, "utf8");
+  renameSync(sourcePath + ".tmp", sourcePath);
+
+  console.log(
+    `[promote-rules] wrote ${sourcePath}: version ${current.version} → ${newVersion}, ` +
+      `${merged.length} params (+${merged.length - current.params.length} net), ` +
+      `${skipped.length} skipped`
+  );
+
+  return {
+    verified: true,
+    merged,
+    skipped,
+    written: true,
+    noop: false,
+    version: newVersion,
+    published: newPublished,
+  };
+}
+
+// ── Guarded main() ────────────────────────────────────────────────────────────
+
+/**
+ * CLI entry point. Resolves default paths, runs promote, prints summary JSON,
+ * sets process.exitCode.
+ *
+ * Guard mirrors ingest.mjs:83 — only runs when this file is the entry point.
+ */
+async function main() {
+  let result;
+  try {
+    result = await runPromote();
+    const { written, version, merged, skipped, noop } = result;
+    console.log(
+      JSON.stringify({
+        written,
+        version,
+        mergedCount: merged.length,
+        skippedCount: skipped.length,
+        noop,
+      })
+    );
+    process.exitCode = 0;
+  } catch (err) {
+    if (err instanceof PromoteError) {
+      console.error(`[promote-rules] ERROR (exit ${err.exitCode}): ${err.message}`);
+      process.exitCode = err.exitCode;
+    } else {
+      console.error(`[promote-rules] UNEXPECTED ERROR: ${err.message}`);
+      process.exitCode = 3;
+    }
+  }
+}
+
+if (process.argv[1]?.endsWith("promote-rules.mjs")) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(3);
+  });
+}


### PR DESCRIPTION
## What

Closes the EPIC C self-scaling loop. Adds `tools/rule-ingestion/promote-rules.mjs` — the consumer that verifies the signed promote artifact from #779 and merges surviving params into the **remote-channel** source of truth `tools/rules-source/params.json`, which `publish-rules.yml` then signs and publishes to the runtime dynamic DNR rule. The **bundled channel** (`affiliates.js` / `src/rules/`) and its byte-deterministic parity gate are untouched by design.

## Channel clarification (issue text was imprecise)

The issue acceptance said "feeds `affiliates.js` TRACKING_PARAMS". Exploration found two separate channels; the orchestrator emits the **remote-channel** artifact format (`{version, published, params, sig}` — matches `docs/rules/v1/params.json`). Feeding the bundled channel would require an **extension release per param batch**, defeating the entire point of the self-scaling ruleset. Targeting the remote channel; [documented on the issue](https://github.com/yocreoquesi/muga/issues/780#issuecomment-4594540268).

## Approach

`runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys?, subtle?, now? })` (+ `loadPreservedSet`, `computeMerge`, guarded `main()`, named exports only):
- **FAIL-CLOSED** Ed25519 verification **before any write**, reusing the existing `verifySignature` (`src/lib/remote-rules.js`) + `canonicalMessage` (`orchestrate.mjs`) — no second crypto implementation.
- **Skips + logs** any promoted param colliding with the **union of all** `domain-rules.json` `preserveParams` (stripping one globally would break site functionality). Per the user decision: skip+log, never abort the batch.
- dedup + sort (`localeCompare`), **idempotent** no-op, `version = current + 1` only on a real write, `published` = injectable now, exact `{version, published, params}` byte format preserved for the downstream signer.
- exit map: 0 ok/no-op, 1 validation, 2 verify-fail, 3 I/O.

## Tests

24 base tests → **30** after review fixes, in `tests/unit/ingestion-promote-rules.test.mjs` — covering R1–R8 + import-smoke. Temp files only; fail-closed paths assert source bytes **unchanged**. Full suite **4238 pass / 0 fail**; `git diff -- tools/rules-source/ src/rules/` empty (real sources untouched by the suite).

## Review notes — two security fixes the fresh review caught

SDD verify + a fresh **blind adversarial review** ran before this PR. Both confirmed (fixes applied, not blindly — verified against the code):

- **🔒 Future-dated-artifact replay bypass (MAJOR)**: the freshness check only tested the stale-past direction; a future `published` makes `now − published` negative → reads as fresh forever. `remote-rules.js` already fixed the identical bug with `CLOCK_SKEW_TOLERANCE_MS`. Added the same future-skew guard + test.
- **🔒 `domain-rules.json` fail-OPEN (MAJOR)**: a missing/unreadable safety list silently disabled the entire preserveParams collision guard. Now **fail-closed** (exit 3 / exit 1 on non-array) + tests.
- Plus: reject non-string params before merge; atomic write (tmp + rename); idempotent compare vs sorted source; test helper imports `canonicalMessage` (kills format drift); `params.json` pinned `eol=lf`.

## Acceptance (revised, remote channel)

- ✅ Verifies the artifact Ed25519 sig fail-closed, then merges params (sorted, deduped, idempotent) into `tools/rules-source/params.json`.
- ✅ Params colliding with any `preserveParams` are skipped + logged, never merged.
- ✅ CI parity + consistency gates unaffected (remote channel only — never writes `src/rules/`).

Manual/CLI step for v2.3.0; CI automation tracked in #781.

Closes #780
