### PR TITLE
ci(ingestion): scheduled self-contained auto-ingest workflow (#781 PR2)

### DIFF
--- a/.github/workflows/auto-ingest-rules.yml
+++ b/.github/workflows/auto-ingest-rules.yml
@@ -1,0 +1,230 @@
+name: Auto-ingest rule parameters
+
+# Weekly scheduled ingestion of tracking parameters.
+# Runs the full pipeline (ingest → orchestrate → promote → sign) inline,
+# gates via the same suite as ci.yml, then opens a PR and immediately
+# squash-merges it using GITHUB_TOKEN.
+#
+# Why --squash and NOT --auto:
+#   PRs opened by GITHUB_TOKEN do NOT trigger ci.yml (GitHub recursion guard).
+#   --auto blocks waiting for required status checks that will never arrive.
+#   All gates already ran inline in this job as earlier steps; the artifact in
+#   the PR is exactly what passed. Immediate --squash is correct; --auto deadlocks.
+on:
+  schedule:
+    # Sunday 04:00 UTC. Off-peak so the run completes before the maintainer's
+    # week starts, without competing with weekday CI traffic.
+    - cron: "0 4 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# One auto-ingest run at a time; never cancel in-progress — a run that reaches
+# the commit/PR stage must complete cleanly to avoid partial merges.
+concurrency:
+  group: auto-ingest-rules
+  cancel-in-progress: false
+
+jobs:
+  auto-ingest:
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── 1. Checkout ─────────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      # ── 2. Node + deps ───────────────────────────────────────────────────────
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ── 3. Write + mask signing key ──────────────────────────────────────────
+      # Key is written to RUNNER_TEMP (outside the workspace) and immediately
+      # masked so any accidental echo is redacted from logs.
+      # SECURITY: never echo $MUGA_SIGNING_KEY directly — use the file path only.
+      - name: Write signing key to temp file and mask it
+        id: write-key
+        env:
+          MUGA_SIGNING_KEY: ${{ secrets.MUGA_SIGNING_KEY }}
+        run: |
+          echo "$MUGA_SIGNING_KEY" > "$RUNNER_TEMP/key.pem"
+          echo "::add-mask::$(cat "$RUNNER_TEMP/key.pem")"
+
+      # ── 4. Run pipeline ──────────────────────────────────────────────────────
+      # pipeline.mjs runs ingest → orchestrate → promote.
+      # On completion it appends noop=<bool> to $GITHUB_OUTPUT.
+      # Non-zero exit propagates as job failure; downstream steps never run.
+      - name: Run ingestion pipeline
+        id: pipeline
+        env:
+          MUGA_SIGNING_KEY_PATH: ${{ runner.temp }}/key.pem
+        run: npm run pipeline:rules
+
+      # ── 5. No-op early exit ───────────────────────────────────────────────────
+      # If promote detected no change (params already up to date), exit cleanly.
+      # All subsequent steps are gated on noop == 'false' — they are never reached.
+      - name: Skip — no new parameters this run (noop)
+        if: steps.pipeline.outputs.noop == 'true'
+        run: |
+          echo "Pipeline reported noop=true: params are already up to date."
+          echo "Skipping gates, publish, and PR steps."
+
+      # ── 6. Gates (ALL gated on noop == 'false'; NO if:always()) ─────────────
+      # These steps mirror ci.yml exactly. A failure in any gate causes the job
+      # to fail, which prevents all downstream publish/commit/PR steps from
+      # running. This is the inline gate enforcement mechanism (R8).
+
+      - name: Compile rules artifacts
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run compile:rules
+
+      - name: Generate wrapper DNR rules
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run build:dnr
+
+      - name: Check src/rules/ is up to date
+        if: steps.pipeline.outputs.noop == 'false'
+        run: |
+          if ! git diff --exit-code -- src/rules/; then
+            echo "ERROR: src/rules/ artifacts are out of sync with their source."
+            exit 1
+          fi
+
+      - name: Bundle content script
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run build:content
+
+      - name: Check content bundle is up to date
+        if: steps.pipeline.outputs.noop == 'false'
+        run: |
+          if ! git diff --exit-code src/content/cleaner-bundle.js; then
+            echo "ERROR: cleaner-bundle.js is out of sync with its source."
+            exit 1
+          fi
+
+      - name: Verify browser-polyfill integrity
+        if: steps.pipeline.outputs.noop == 'false'
+        run: node tools/verify-polyfill-integrity.mjs
+
+      - name: Verify rule-ingestion quarantine
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run verify:quarantine
+
+      - name: Check i18n quality
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run check:i18n
+
+      - name: Run unit tests
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm test
+
+      - name: Run integration tests
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run test:integration
+
+      - name: CAPS-Contextual conformance gate
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run conformance:contextual
+
+      - name: Lint extension
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npm run lint
+
+      - name: Install Playwright browsers
+        if: steps.pipeline.outputs.noop == 'false'
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests (xvfb)
+        if: steps.pipeline.outputs.noop == 'false'
+        run: xvfb-run npx playwright test
+
+      # ── 7. Inline publish ─────────────────────────────────────────────────────
+      # sign-rules.mjs reads tools/rules-source/params.json (already mutated by
+      # promote) and writes docs/rules/v1/params.json. Identical to publish-rules.yml.
+      # Runs AFTER all gates — a gate failure never reaches this step.
+      - name: Sign and publish rules
+        if: steps.pipeline.outputs.noop == 'false'
+        env:
+          MUGA_SIGNING_KEY_PATH: ${{ runner.temp }}/key.pem
+        run: node tools/sign-rules.mjs
+
+      # ── 8. Branch + commit ────────────────────────────────────────────────────
+      # Date comes from the shell (workflow concern), NOT from pipeline.mjs
+      # (keeps pipeline deterministic and testable).
+      # Only two files are committed — clean PR diff, no transient artifacts.
+      - name: Create branch and commit updated params
+        if: steps.pipeline.outputs.noop == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="auto-ingest/$DATE"
+          git checkout -B "$BRANCH"
+          git add tools/rules-source/params.json docs/rules/v1/params.json
+          git commit -m "chore(rules): auto-ingest params ($DATE) [skip ci]"
+          git push -u origin "$BRANCH" --force-with-lease
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          echo "DATE=$DATE" >> "$GITHUB_ENV"
+
+      # ── 9. Open PR (idempotent) ──────────────────────────────────────────────
+      # If a previous run pushed the branch and created the PR but then failed
+      # before merging, a re-run (workflow_dispatch or same-day cron) would hit
+      # `gh pr create` with an already-open PR and error out.
+      # Mirror the guard from import-upstream.yml: check for an open PR on the
+      # branch first; if one exists, update it with `gh pr edit` and skip create.
+      - name: Create or update pull request
+        if: steps.pipeline.outputs.noop == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY="Automated weekly rule-parameter ingestion via auto-ingest-rules.yml.
+
+          All gates (unit, integration, e2e, lint, compile, bundle) passed inline in the
+          same job before this PR was created. Immediate squash-merge is safe.
+
+          Files changed:
+          - \`tools/rules-source/params.json\` — updated source (signed by promote step)
+          - \`docs/rules/v1/params.json\` — re-signed published artifact
+
+          Generated by workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" \
+              --title "chore(rules): auto-ingest params ($DATE)" \
+              --body "$BODY"
+            echo "Updated existing PR #$EXISTING"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(rules): auto-ingest params ($DATE)" \
+              --body "$BODY" \
+              --label "category:ops"
+          fi
+
+      # ── 10. Squash-merge PR ───────────────────────────────────────────────────
+      # Immediate --squash: gates already ran inline; no CI will run on the
+      # GITHUB_TOKEN PR; --auto would block forever waiting for checks.
+      - name: Squash-merge pull request
+        if: steps.pipeline.outputs.noop == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "$BRANCH" --squash --delete-branch
+
+      # ── 11. Key cleanup (if: always()) ───────────────────────────────────────
+      # Always runs — even if previous steps fail — so the key is never left on disk.
+      - name: Clean up signing key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/key.pem"

--- a/tests/unit/ingestion-scheduled-workflow.test.mjs
+++ b/tests/unit/ingestion-scheduled-workflow.test.mjs
@@ -1,0 +1,379 @@
+/**
+ * MUGA — Structural tests for .github/workflows/auto-ingest-rules.yml
+ *
+ * Covers spec requirements R5-A, R5-B, R5-C, R8-A:
+ *   R5-A  — cron "0 4 * * 0" + workflow_dispatch present
+ *   R5-B  — permissions contents:write + pull-requests:write + concurrency block
+ *   R5-C  — gates step appears BEFORE publish/sign step in file order
+ *   R8-A  — gates step appears BEFORE branch/commit step in file order
+ *
+ * Additional structural assertions (R4-B, R6, R7 partial):
+ *   - Key written to RUNNER_TEMP + ::add-mask:: present
+ *   - Cleanup step with `if: always()` removes key
+ *   - All `uses:` lines reference a 40-char commit SHA (belt-and-suspenders; authoritative in workflows-hardened)
+ *   - No-op skip step gated on steps.pipeline.outputs.noop == 'true'
+ *   - `gh pr merge --squash` present, `--auto` absent
+ *   - `[skip ci]` present in commit message
+ *   - Only tools/rules-source/params.json + docs/rules/v1/params.json added to git
+ *
+ * Uses string/regex assertions only (no external YAML parser — not in devDependencies).
+ * Mirrors the pattern from tests/unit/workflows-hardened.test.mjs.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = join(
+  __dirname,
+  "../../.github/workflows/auto-ingest-rules.yml"
+);
+
+// ---------------------------------------------------------------------------
+// Guard: file must exist (fails RED before the yml is created)
+// ---------------------------------------------------------------------------
+describe("auto-ingest-rules.yml existence", () => {
+  test("file exists at .github/workflows/auto-ingest-rules.yml", () => {
+    assert.ok(
+      existsSync(WORKFLOW_PATH),
+      `auto-ingest-rules.yml does not exist at expected path: ${WORKFLOW_PATH}`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: read file once (only called when existence test passes)
+// ---------------------------------------------------------------------------
+function readWorkflow() {
+  return readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// R5-A — Triggers: schedule cron + workflow_dispatch
+// ---------------------------------------------------------------------------
+describe("R5-A — triggers", () => {
+  test("has schedule trigger with cron '0 4 * * 0' (weekly Sun 04:00 UTC)", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /cron:\s*["']0 4 \* \* 0["']/.test(content),
+      "auto-ingest-rules.yml must have schedule cron '0 4 * * 0'"
+    );
+  });
+
+  test("has workflow_dispatch trigger", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /workflow_dispatch/.test(content),
+      "auto-ingest-rules.yml must have workflow_dispatch trigger"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R5-B — Top-level permissions block
+// ---------------------------------------------------------------------------
+describe("R5-B — permissions", () => {
+  test("has workflow-level permissions: contents: write", () => {
+    const content = readWorkflow();
+    // The permissions block appears before 'jobs:' at top level
+    const jobsIdx = content.indexOf("\njobs:");
+    const preJobs = jobsIdx === -1 ? content : content.slice(0, jobsIdx);
+    assert.ok(
+      /^permissions:/m.test(preJobs),
+      "auto-ingest-rules.yml must have a workflow-level 'permissions:' block before 'jobs:'"
+    );
+    assert.ok(
+      /contents:\s*write/.test(preJobs),
+      "permissions block must include 'contents: write'"
+    );
+    assert.ok(
+      /pull-requests:\s*write/.test(preJobs),
+      "permissions block must include 'pull-requests: write'"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R5-B — Concurrency block
+// ---------------------------------------------------------------------------
+describe("R5-B — concurrency", () => {
+  test("has concurrency group 'auto-ingest-rules'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /group:\s*auto-ingest-rules/.test(content),
+      "auto-ingest-rules.yml must have concurrency group 'auto-ingest-rules'"
+    );
+  });
+
+  test("concurrency cancel-in-progress: false", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /cancel-in-progress:\s*false/.test(content),
+      "auto-ingest-rules.yml must have cancel-in-progress: false"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHA pinning (belt-and-suspenders; authoritative check is in workflows-hardened)
+// ---------------------------------------------------------------------------
+describe("action SHA pinning", () => {
+  test("all 'uses:' lines reference a 40-char commit SHA", () => {
+    const content = readWorkflow();
+    const lines = content.split("\n");
+    const usesLines = lines.filter(l => /^\s+(-\s+)?uses:\s+\S/.test(l));
+
+    assert.ok(
+      usesLines.length > 0,
+      "auto-ingest-rules.yml has no 'uses:' lines — check the file is being read correctly"
+    );
+
+    for (const line of usesLines) {
+      const pinned = /uses:\s+[a-zA-Z0-9/_.-]+@[a-f0-9]{40}(\s.*)?$/.test(line.trim());
+      assert.ok(
+        pinned,
+        `auto-ingest-rules.yml has an unpinned action: "${line.trim()}"\n` +
+        "All 'uses:' references must use a 40-character commit SHA, not a tag or branch."
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Key masking and cleanup (R4)
+// ---------------------------------------------------------------------------
+describe("signing key security — write, mask, cleanup", () => {
+  test("writes signing key to RUNNER_TEMP", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /RUNNER_TEMP.*key\.pem|key\.pem.*RUNNER_TEMP/.test(content),
+      "workflow must write key to $RUNNER_TEMP/key.pem"
+    );
+  });
+
+  test("masks the key value with ::add-mask::", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /::add-mask::/.test(content),
+      "workflow must use ::add-mask:: to redact the key from logs"
+    );
+  });
+
+  test("cleanup step uses 'if: always()' to remove key.pem", () => {
+    const content = readWorkflow();
+    // The if: always() guard and the rm command must both be present
+    assert.ok(
+      /if:\s*always\(\)/.test(content),
+      "workflow must have a cleanup step with 'if: always()'"
+    );
+    assert.ok(
+      /rm\s+-f.*key\.pem/.test(content),
+      "cleanup step must remove $RUNNER_TEMP/key.pem with 'rm -f'"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-op early exit (R2)
+// ---------------------------------------------------------------------------
+describe("no-op early exit", () => {
+  test("has a step gated on steps.pipeline.outputs.noop == 'true'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /steps\.pipeline\.outputs\.noop\s*==\s*['"]true['"]/.test(content),
+      "workflow must have a step with if: steps.pipeline.outputs.noop == 'true' for early exit"
+    );
+  });
+
+  test("subsequent steps are gated on steps.pipeline.outputs.noop == 'false'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /steps\.pipeline\.outputs\.noop\s*==\s*['"]false['"]/.test(content),
+      "workflow must gate publish/commit/PR steps on steps.pipeline.outputs.noop == 'false'"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R5-C / R8-A — Gate ordering: gates BEFORE publish/sign step
+// ---------------------------------------------------------------------------
+describe("R5-C / R8-A — step ordering: gates before publish and commit", () => {
+  test("npm test step appears before sign-rules.mjs publish step", () => {
+    const content = readWorkflow();
+    const npmTestIdx = content.indexOf("npm test");
+    const signRulesIdx = content.indexOf("sign-rules.mjs");
+
+    assert.ok(npmTestIdx !== -1, "workflow must include 'npm test' gate step");
+    assert.ok(signRulesIdx !== -1, "workflow must include 'node tools/sign-rules.mjs' publish step");
+    assert.ok(
+      npmTestIdx < signRulesIdx,
+      `'npm test' gate (pos ${npmTestIdx}) must appear BEFORE 'sign-rules.mjs' publish step (pos ${signRulesIdx})`
+    );
+  });
+
+  test("npm test step appears before branch/commit step", () => {
+    const content = readWorkflow();
+    const npmTestIdx = content.indexOf("npm test");
+    // Branch step creates auto-ingest/ branch
+    const branchIdx = content.indexOf("auto-ingest/");
+
+    assert.ok(npmTestIdx !== -1, "workflow must include 'npm test' gate step");
+    assert.ok(branchIdx !== -1, "workflow must include a branch creation step with 'auto-ingest/'");
+    assert.ok(
+      npmTestIdx < branchIdx,
+      `'npm test' gate (pos ${npmTestIdx}) must appear BEFORE branch creation (pos ${branchIdx})`
+    );
+  });
+
+  test("sign-rules.mjs publish step appears before gh pr create step", () => {
+    const content = readWorkflow();
+    const signRulesIdx = content.indexOf("sign-rules.mjs");
+    const prCreateIdx = content.indexOf("gh pr create");
+
+    assert.ok(signRulesIdx !== -1, "workflow must include 'node tools/sign-rules.mjs' publish step");
+    assert.ok(prCreateIdx !== -1, "workflow must include 'gh pr create' step");
+    assert.ok(
+      signRulesIdx < prCreateIdx,
+      `publish step (pos ${signRulesIdx}) must appear BEFORE 'gh pr create' (pos ${prCreateIdx})`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR merge: --squash, no --auto (R5, design decision)
+// ---------------------------------------------------------------------------
+describe("PR merge flags", () => {
+  test("uses 'gh pr merge --squash'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /gh\s+pr\s+merge\s+.*--squash/.test(content),
+      "workflow must use 'gh pr merge --squash' (not --auto)"
+    );
+  });
+
+  test("does NOT use 'gh pr merge --auto'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      !/gh\s+pr\s+merge\s+.*--auto/.test(content),
+      "workflow must NOT use '--auto' with gh pr merge — it deadlocks with GITHUB_TOKEN PRs"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Commit message contains [skip ci]
+// ---------------------------------------------------------------------------
+describe("commit message", () => {
+  test("commit message contains [skip ci]", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /\[skip ci\]/.test(content),
+      "workflow commit message must contain '[skip ci]' to prevent CI loop"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Only two params.json files are committed (explicit add — no broad staging)
+// ---------------------------------------------------------------------------
+describe("clean PR diff — only params.json files committed", () => {
+  test("git add line explicitly names tools/rules-source/params.json", () => {
+    const content = readWorkflow();
+    // Must be a real `git add <files>` command, not just a path appearing in
+    // a comment or body string — bare-path matches are tautological.
+    assert.ok(
+      /git add\s+.*tools\/rules-source\/params\.json/.test(content),
+      "workflow must have an explicit 'git add ... tools/rules-source/params.json' command"
+    );
+  });
+
+  test("git add line explicitly names docs/rules/v1/params.json", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /git add\s+.*docs\/rules\/v1\/params\.json/.test(content),
+      "workflow must have an explicit 'git add ... docs/rules/v1/params.json' command"
+    );
+  });
+
+  test("both params.json files appear on the same git add line", () => {
+    const content = readWorkflow();
+    // Verifies the commit scope is a single targeted add, not two separate adds
+    // that could still accidentally admit a `git add -A` somewhere else.
+    const line = content
+      .split("\n")
+      .find(l => /git add\s/.test(l) && /tools\/rules-source\/params\.json/.test(l));
+    assert.ok(
+      line !== undefined,
+      "could not find a git add line containing tools/rules-source/params.json"
+    );
+    assert.ok(
+      /docs\/rules\/v1\/params\.json/.test(line),
+      `the git add line must also include docs/rules/v1/params.json. Found: "${line?.trim()}"`
+    );
+  });
+
+  test("workflow does NOT use 'git add -A' (broad staging forbidden)", () => {
+    const content = readWorkflow();
+    assert.ok(
+      !/git add\s+-A/.test(content),
+      "workflow must NOT use 'git add -A' — commit scope must be explicit"
+    );
+  });
+
+  test("workflow does NOT use 'git add .' (broad staging forbidden)", () => {
+    const content = readWorkflow();
+    assert.ok(
+      !/git add\s+\.(\s|$)/.test(content),
+      "workflow must NOT use 'git add .' — commit scope must be explicit"
+    );
+  });
+
+  test("workflow does NOT use 'git commit -am' (broad staging forbidden)", () => {
+    const content = readWorkflow();
+    assert.ok(
+      !/git commit\s+-[a-zA-Z]*a[a-zA-Z]*m|git commit\s+-[a-zA-Z]*m[a-zA-Z]*a/.test(content),
+      "workflow must NOT use 'git commit -am' or 'git commit -ma' — commit scope must be explicit"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline step uses npm run pipeline:rules script
+// ---------------------------------------------------------------------------
+describe("pipeline invocation", () => {
+  test("runs pipeline via 'npm run pipeline:rules'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /npm\s+run\s+pipeline:rules/.test(content),
+      "workflow must invoke the pipeline via 'npm run pipeline:rules'"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publish step must NOT carry if:always() — only cleanup does
+// ---------------------------------------------------------------------------
+describe("if:always() usage — only cleanup step", () => {
+  test("only one non-comment line uses if: always() — the key cleanup step", () => {
+    const content = readWorkflow();
+    // Only count lines where `if: always()` appears as actual YAML (not in # comments).
+    // A real YAML `if:` key appears on a line whose non-whitespace content starts with `if:`.
+    const lines = content.split("\n");
+    const alwaysLines = lines.filter(l => {
+      const trimmed = l.trimStart();
+      return trimmed.startsWith("if:") && /if:\s*always\(\)/.test(trimmed);
+    });
+    assert.strictEqual(
+      alwaysLines.length,
+      1,
+      `Exactly 1 YAML step field may be 'if: always()' (the cleanup step). Found ${alwaysLines.length}: ` +
+      JSON.stringify(alwaysLines) +
+      ". Publish/PR steps must NOT have if:always() — gate failures must block them."
+    );
+  });
+});

--- a/tests/unit/workflows-hardened.test.mjs
+++ b/tests/unit/workflows-hardened.test.mjs
@@ -19,7 +19,7 @@ const workflowsDir = join(__dirname, "../../.github/workflows");
 // npm test, duplicating PR CI with no additional signal. A meaningful
 // canary will be re-added when a stable fixture set is available.
 // validate-rules.yml and publish-rules.yml added in Phase 6 (T6.2, T6.3).
-const WORKFLOW_FILES = ["ci.yml", "release.yml", "validate-rules.yml", "publish-rules.yml"];
+const WORKFLOW_FILES = ["ci.yml", "release.yml", "validate-rules.yml", "publish-rules.yml", "auto-ingest-rules.yml"];
 
 function readWorkflow(name) {
   return readFileSync(join(workflowsDir, name), "utf8");


### PR DESCRIPTION
## What

PR2 of 2 for the no-user-reports engine (#781). Adds the weekly **self-contained** GitHub Actions workflow `auto-ingest-rules.yml` that drives the pipeline glue from #806. Closes #781.

## How it works (Option B — GITHUB_TOKEN, no PAT)

One job, GITHUB_TOKEN only:
- **Schedule**: `cron: '0 4 * * 0'` (Sun 04:00 UTC) + `workflow_dispatch`. `permissions: contents:write + pull-requests:write`, concurrency-guarded.
- **Key**: written to `$RUNNER_TEMP`, `::add-mask::`’d, exposed only via `MUGA_SIGNING_KEY_PATH`, cleaned up on `always()`.
- **Pipeline**: `npm run pipeline:rules`; reads `noop` from `$GITHUB_OUTPUT`. If no-op → job ends with **no publish/commit/PR** (every downstream step gated on `noop == 'false'`).
- **Inline gates**: runs the full `ci.yml` gate suite (compile/build/drift/bundle/unit/integration/conformance/lint/polyfill/e2e) **before** publish. A gate failure aborts the job (`bash -eo pipefail`, no `continue-on-error`, no `if: always()` on publish/commit/PR) — so **“CI gates block merge” holds without branch protection or a PAT**.
- **Publish**: reuses `node tools/sign-rules.mjs` (writes `docs/rules/v1/params.json`) — no logic duplication; `publish-rules.yml` stays as manual/fallback.
- **Commit**: ONLY `tools/rules-source/params.json` + `docs/rules/v1/params.json` (explicit `git add` paths — never `-A`), branch `auto-ingest/<date>`, `[skip ci]`.
- **PR**: idempotent `gh pr create` (edits an existing open PR on re-run) + `gh pr merge --squash` (NOT `--auto` — GITHUB_TOKEN PRs trigger no CI; `--auto` would hang).

## Why GITHUB_TOKEN + inline gates (not a PAT)

GITHUB_TOKEN-opened PRs don’t trigger `pull_request` CI, and GITHUB_TOKEN merges don’t trigger `publish-rules.yml`. Rather than introduce a PAT (secret + rotation), the workflow runs the gates and the publish **inline in the same job** — a failure anywhere before publish blocks everything downstream. The PR is an auditable record that auto-merges once the inline gates are green.

## Tests

`tests/unit/ingestion-scheduled-workflow.test.mjs` — 26 structural assertions (cron, permissions, concurrency, SHA-pins, no-op gating, key mask + `always()` cleanup, gates-before-publish ordering, `--squash`/no-`--auto`, and **real commit-scope checks** with negative `git add -A`/`git add .` guards). `auto-ingest-rules.yml` added to `workflows-hardened` SHA-pin coverage. Full suite **4276 pass / 0 fail**.

## Review notes

SDD verify (deep YAML reasoning, PASS-WITH-WARNINGS) + a fresh blind adversarial review (SHIP-WITH-NITS, 0 critical/major) ran before this PR. The hardest probes — the **commit-scope bug** (explicit `git add` paths, no `-A`) and **bundled/remote channel independence** (compile/build read `src/lib`; pipeline mutates the remote `params.json` — disjoint, no spurious drift) — came back clean. Fixes applied (verified, not blind):
- **PR idempotency guard** (mirror `import-upstream.yml`) so a re-run after a partial failure edits the existing PR instead of erroring.
- **Strengthened tautological commit-scope assertions** — they previously matched the path strings anywhere (incl. the PR-body text) and would have passed even with `git add -A`; now anchored to the `git add` command + negative guards.
- **Added the `verify-polyfill-integrity` gate** so the inline suite is a true `ci.yml` mirror.

## Manual-verify checklist (operational, post-merge — T-23–T-26)

- [ ] First Sunday fire completes (likely no-op if no new params).
- [ ] Inspect a live run log: no PEM/key material (mask works).
- [ ] Inject a failing test, `workflow_dispatch`: confirm no branch/PR/publish, then revert.
- [ ] After a real run: only `params.json` + `docs/rules/v1/params.json` committed; `promote-candidates.json` untracked.

> Note: the signing key secret `MUGA_SIGNING_KEY` already exists (used by `publish-rules.yml`). No new secret required.

Closes #781
