### PR TITLE
feat(ingestion): count every ingest-layer exclusion — stats contracts (#782 PR1)

### DIFF
--- a/tests/unit/clearurls-adapter.test.mjs
+++ b/tests/unit/clearurls-adapter.test.mjs
@@ -222,10 +222,63 @@ describe("clearurls.parse — malformed JSON", () => {
 // ── T-16: Missing providers ───────────────────────────────────────────────────
 
 describe("clearurls.parse — missing providers", () => {
-  test("parse('{}') returns empty Set (no throw)", () => {
+  test("parse('{}') returns { params, skipped, affiliateExcluded } with empty params (no throw)", () => {
     const result = clearurls.parse("{}");
-    assert.ok(result instanceof Set);
-    assert.equal(result.size, 0);
+    // After T-02: parse() returns { params, skipped, affiliateExcluded }
+    assert.ok(result.params instanceof Set);
+    assert.equal(result.params.size, 0);
+    assert.equal(result.affiliateExcluded, 0);
+  });
+});
+
+// ── T-01 (quarantine-surface #782): affiliateExcluded count ──────────────────
+
+describe("extractClearurlsLiterals — affiliateExcluded (T-01)", () => {
+  // Fixture: 3 literal rules, 2 non-literal (skipped), 1 referralMarketing (affiliateExcluded)
+  const FIXTURE_AFFILIATE = JSON.stringify({
+    providers: {
+      main: {
+        rules: ["utm_source", "gclid", "(regex-only)", ".*complex.*", "fbclid", "tag"],
+        referralMarketing: ["tag"],
+      },
+    },
+  });
+
+  test("affiliateExcluded counts referralMarketing hits (T-01)", () => {
+    const { params, skipped, affiliateExcluded } = extractClearurlsLiterals(FIXTURE_AFFILIATE);
+    assert.equal(params.size, 3, `expected 3 admitted params, got ${params.size}`);
+    assert.ok(skipped >= 2, `expected skipped >= 2 (regex patterns), got ${skipped}`);
+    assert.equal(affiliateExcluded, 1, `expected affiliateExcluded === 1, got ${affiliateExcluded}`);
+  });
+
+  test("affiliateExcluded param is absent from params Set (T-01)", () => {
+    const { params } = extractClearurlsLiterals(FIXTURE_AFFILIATE);
+    assert.ok(!params.has("tag"), "'tag' is referralMarketing — must not be in params");
+    assert.ok(params.has("utm_source"), "utm_source must be admitted");
+    assert.ok(params.has("gclid"), "gclid must be admitted");
+    assert.ok(params.has("fbclid"), "fbclid must be admitted");
+  });
+});
+
+describe("clearurls.parse — returns { params, skipped, affiliateExcluded } (T-01)", () => {
+  const FIXTURE_MIXED = JSON.stringify({
+    providers: {
+      p: {
+        rules: ["utm_source", "(skip-me)", "aff_tag"],
+        referralMarketing: ["aff_tag"],
+      },
+    },
+  });
+
+  test("parse() returns object with params Set, skipped number, affiliateExcluded number", () => {
+    const result = clearurls.parse(FIXTURE_MIXED);
+    assert.ok(result.params instanceof Set, "params must be a Set");
+    assert.equal(typeof result.skipped, "number", "skipped must be a number");
+    assert.equal(typeof result.affiliateExcluded, "number", "affiliateExcluded must be a number");
+    assert.ok(result.params.has("utm_source"), "utm_source must be admitted");
+    assert.ok(!result.params.has("aff_tag"), "aff_tag is referralMarketing — excluded");
+    assert.equal(result.affiliateExcluded, 1, "affiliateExcluded must be 1");
+    assert.ok(result.skipped >= 1, "skipped must be >= 1 (regex pattern)");
   });
 });
 

--- a/tests/unit/import-upstream.test.mjs
+++ b/tests/unit/import-upstream.test.mjs
@@ -11,6 +11,7 @@
  *   - Comments (!) and section headers ([) are ignored
  *   - Param names are lowercased and validated
  *   - Empty input returns an empty set
+ *   - (#782) returns { params, skipped } object (not a bare Set)
  */
 
 import { test, describe } from "node:test";
@@ -20,55 +21,57 @@ import { parseRemoveparamRules } from "../../tools/import-upstream.mjs";
 describe("parseRemoveparamRules", () => {
   test("extracts a simple removeparam rule", () => {
     const text = "*$removeparam=fbclid";
-    const result = parseRemoveparamRules(text);
-    assert.deepEqual([...result], ["fbclid"]);
+    const { params } = parseRemoveparamRules(text);
+    assert.deepEqual([...params], ["fbclid"]);
   });
 
   test("splits pipe-separated multi-param rules", () => {
     const text = "*$removeparam=fbclid|gclid|msclkid";
-    const result = parseRemoveparamRules(text);
-    assert.deepEqual([...result].sort(), ["fbclid", "gclid", "msclkid"]);
+    const { params } = parseRemoveparamRules(text);
+    assert.deepEqual([...params].sort(), ["fbclid", "gclid", "msclkid"]);
   });
 
   test("handles host-scoped rules (||example.com^)", () => {
     const text = "||example.com^$removeparam=utm_source";
-    const result = parseRemoveparamRules(text);
-    assert.deepEqual([...result], ["utm_source"]);
+    const { params } = parseRemoveparamRules(text);
+    assert.deepEqual([...params], ["utm_source"]);
   });
 
   test("skips regex specs that start with /", () => {
     const text = "*$removeparam=/^utm_/";
-    const result = parseRemoveparamRules(text);
-    assert.equal(result.size, 0);
+    const { params, skipped } = parseRemoveparamRules(text);
+    assert.equal(params.size, 0);
+    assert.ok(skipped >= 1, "regex spec must be counted as skipped");
   });
 
   test("skips negation specs that start with ~", () => {
     const text = "*$removeparam=~tag";
-    const result = parseRemoveparamRules(text);
-    assert.equal(result.size, 0);
+    const { params, skipped } = parseRemoveparamRules(text);
+    assert.equal(params.size, 0);
+    assert.ok(skipped >= 1, "negation spec must be counted as skipped");
   });
 
   test("ignores comment lines starting with !", () => {
     const text = "! this is a comment\n*$removeparam=fbclid";
-    const result = parseRemoveparamRules(text);
-    assert.deepEqual([...result], ["fbclid"]);
+    const { params } = parseRemoveparamRules(text);
+    assert.deepEqual([...params], ["fbclid"]);
   });
 
   test("ignores section header lines starting with [", () => {
     const text = "[Adblock Plus 2.0]\n*$removeparam=fbclid";
-    const result = parseRemoveparamRules(text);
-    assert.deepEqual([...result], ["fbclid"]);
+    const { params } = parseRemoveparamRules(text);
+    assert.deepEqual([...params], ["fbclid"]);
   });
 
   test("lowercases all param names", () => {
     const text = "*$removeparam=FBclid|GCLID";
-    const result = parseRemoveparamRules(text);
-    assert.deepEqual([...result].sort(), ["fbclid", "gclid"]);
+    const { params } = parseRemoveparamRules(text);
+    assert.deepEqual([...params].sort(), ["fbclid", "gclid"]);
   });
 
   test("returns an empty set for empty input", () => {
-    assert.equal(parseRemoveparamRules("").size, 0);
-    assert.equal(parseRemoveparamRules("\n\n").size, 0);
+    assert.equal(parseRemoveparamRules("").params.size, 0);
+    assert.equal(parseRemoveparamRules("\n\n").params.size, 0);
   });
 
   test("handles realistic AdGuard Filter 17 sample correctly", () => {
@@ -82,23 +85,23 @@ describe("parseRemoveparamRules", () => {
 ! comment
 *$removeparam=/^_branch_/
 *$removeparam=~important_tag`;
-    const result = parseRemoveparamRules(text);
+    const { params } = parseRemoveparamRules(text);
     assert.deepEqual(
-      [...result].sort(),
+      [...params].sort(),
       ["dclid", "fbclid", "gclid", "gclsrc", "utm_medium", "utm_source"]
     );
   });
 
   test("rejects malformed param names containing illegal characters", () => {
     const text = "*$removeparam=foo bar|baz<script>";
-    const result = parseRemoveparamRules(text);
+    const { params } = parseRemoveparamRules(text);
     // Neither matches the conservative validator regex; both are rejected.
-    assert.equal(result.size, 0);
+    assert.equal(params.size, 0);
   });
 
   test("ignores lines with no $removeparam modifier", () => {
     const text = "||tracker.example.com^\n*$third-party";
-    const result = parseRemoveparamRules(text);
-    assert.equal(result.size, 0);
+    const { params } = parseRemoveparamRules(text);
+    assert.equal(params.size, 0);
   });
 });

--- a/tests/unit/ingestion-orchestrator-cli.test.mjs
+++ b/tests/unit/ingestion-orchestrator-cli.test.mjs
@@ -43,14 +43,19 @@ function makeTmpDir() {
   return d;
 }
 
-/** Write a minimal candidates.json fixture to a temp dir and return its path */
-function writeCandidatesFixture(dir, candidates) {
+/** Write a minimal candidates.json fixture to a temp dir and return its path.
+ * Optional stats param adds a stats field to the report (for T-12 null-safe tests).
+ */
+function writeCandidatesFixture(dir, candidates, stats = undefined) {
   const path = join(dir, "candidates.json");
   const report = {
     generatedAt: "2024-01-01T00:00:00.000Z",
     candidateCount: candidates.length,
     candidates,
   };
+  if (stats !== undefined) {
+    report.stats = stats;
+  }
   writeFileSync(path, JSON.stringify(report, null, 2) + "\n", "utf8");
   return path;
 }
@@ -529,6 +534,69 @@ describe("R4 — MUGA_RULES_VERSION env override", () => {
 
     assert.ok(thrown !== null, "non-integer MUGA_RULES_VERSION must throw");
     assert.strictEqual(thrown.exitCode, 1, "MUGA_RULES_VERSION validation error must have exitCode:1");
+  });
+});
+
+// ── T-12 (quarantine-surface #782): ingestStats null-safe copy ────────────────
+
+describe("T-12 — ingestStats null-safe (quarantine-surface #782)", () => {
+  const SAMPLE_STATS = {
+    adapters: [
+      { adapterId: "adguard-tp", admitted: 3, skipped: 1, affiliateExcluded: 0 },
+      { adapterId: "clearurls", admitted: 2, skipped: 0, affiliateExcluded: 1 },
+    ],
+    merged: { emptyDropped: 0, total: 4 },
+  };
+
+  test("T-12a: candidates WITH stats → report.ingestStats deep-equals stats", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")], SAMPLE_STATS);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.ok("ingestStats" in report, "quarantine-report.json must have ingestStats field");
+    assert.deepStrictEqual(report.ingestStats, SAMPLE_STATS, "ingestStats must deep-equal the stats from candidates.json");
+  });
+
+  test("T-12b: candidates WITHOUT stats → report.ingestStats === null (null-safe)", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    // No stats passed → old-format candidates.json
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.ok("ingestStats" in report, "quarantine-report.json must have ingestStats field even when candidates.json has no stats");
+    assert.strictEqual(report.ingestStats, null, "ingestStats must be null when candidates.json has no stats field");
   });
 });
 

--- a/tests/unit/ingestion-pipeline.test.mjs
+++ b/tests/unit/ingestion-pipeline.test.mjs
@@ -132,7 +132,7 @@ describe("R1 — Pipeline chain + exit propagation", () => {
       license: "MIT",
       url: "https://example.com",
       fetchRaw: async () => { throw ingestError; },
-      parse: () => new Set(),
+      parse: () => ({ params: new Set(), skipped: 0, affiliateExcluded: 0 }),
     };
 
     let thrown = null;
@@ -179,7 +179,7 @@ describe("R1 — Pipeline chain + exit propagation", () => {
       license: "MIT",
       url: "https://example.com",
       fetchRaw: async () => "",
-      parse: () => new Set(),
+      parse: () => ({ params: new Set(), skipped: 0, affiliateExcluded: 0 }),
     };
 
     let thrown = null;
@@ -227,7 +227,7 @@ describe("R1 — Pipeline chain + exit propagation", () => {
       license: "MIT",
       url: "https://example.com",
       fetchRaw: async () => "",
-      parse: () => new Set(),
+      parse: () => ({ params: new Set(), skipped: 0, affiliateExcluded: 0 }),
     };
 
     // Pass a WRONG trustedKeys so promote's verify fails → PromoteError(2)
@@ -287,7 +287,7 @@ describe("R2 — No-op detection + return shape", () => {
       license: "GPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
 
     let result;
@@ -331,7 +331,7 @@ describe("R2 — No-op detection + return shape", () => {
       license: "GPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
     // Second adapter also producing "utm_source" → two signals → passes corroboration
     const passAdapter2 = {
@@ -340,7 +340,7 @@ describe("R2 — No-op detection + return shape", () => {
       license: "LGPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
 
     let result;
@@ -386,7 +386,7 @@ describe("R3 — Happy-path return shape", () => {
       license: "GPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
     const passAdapter2 = {
       id: "clearurls",
@@ -394,7 +394,7 @@ describe("R3 — Happy-path return shape", () => {
       license: "LGPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
 
     const result = await runPipeline({
@@ -440,7 +440,7 @@ describe("R4 — Signing-key fail-closed", () => {
       license: "GPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
     const passAdapter2 = {
       id: "clearurls",
@@ -448,7 +448,7 @@ describe("R4 — Signing-key fail-closed", () => {
       license: "LGPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
 
     // Explicitly remove the env fallback so pipeline can't sneak a key from env
@@ -551,7 +551,7 @@ describe("Critical trap — candidates.json wrapper shape", () => {
       license: "GPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
     const passAdapter2 = {
       id: "clearurls",
@@ -559,7 +559,7 @@ describe("Critical trap — candidates.json wrapper shape", () => {
       license: "LGPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
 
     // Run pipeline (may succeed or fail — we only care the file was written with correct shape)
@@ -589,6 +589,8 @@ describe("Critical trap — candidates.json wrapper shape", () => {
     assert.ok(Array.isArray(written.adapters), "wrapper must have adapters array");
     assert.ok(typeof written.candidateCount === "number", "wrapper must have candidateCount number");
     assert.ok(Array.isArray(written.candidates), "wrapper must have candidates array (not a bare array)");
+    assert.ok(typeof written.stats === "object" && written.stats !== null, "wrapper must carry stats object");
+    assert.ok(Array.isArray(written.stats.adapters), "wrapper stats must have adapters array");
   });
 });
 
@@ -613,7 +615,7 @@ describe("R5 — GITHUB_OUTPUT dual-emit", () => {
       license: "GPL-3.0",
       url: "https://example.com",
       fetchRaw: async () => "utm_source",
-      parse: (raw) => new Set(raw.trim().split("\n").filter(Boolean)),
+      parse: (raw) => ({ params: new Set(raw.trim().split("\n").filter(Boolean)), skipped: 0, affiliateExcluded: 0 }),
     };
 
     // Temp file for $GITHUB_OUTPUT; does not exist yet — appendFileSync will create it.

--- a/tests/unit/rule-ingestion-adapters.test.mjs
+++ b/tests/unit/rule-ingestion-adapters.test.mjs
@@ -19,6 +19,7 @@ import {
   EXCLUDED_SOURCES,
 } from "../../tools/rule-ingestion/adapters/index.mjs";
 import { runIngestion } from "../../tools/rule-ingestion/ingest.mjs";
+import { parseRemoveparamRules } from "../../tools/import-upstream.mjs";
 
 const SAMPLE_ADGUARD = [
   "! Title: AdGuard URL Tracking filter",
@@ -36,7 +37,9 @@ test("adguardTp adapter has the expected identity + license", () => {
 });
 
 test("adguardTp.parse extracts literal params and skips regex specs", () => {
-  const params = adguardTp.parse(SAMPLE_ADGUARD);
+  // After T-06: adguardTp.parse returns { params, skipped, affiliateExcluded }
+  const result = adguardTp.parse(SAMPLE_ADGUARD);
+  const params = result.params;
   assert.ok(params instanceof Set);
   assert.ok(params.has("utm_source"));
   assert.ok(params.has("fbclid"));
@@ -44,6 +47,32 @@ test("adguardTp.parse extracts literal params and skips regex specs", () => {
   assert.ok(params.has("msclkid"));
   // The /^utm_/ regex spec must NOT leak in as a literal.
   assert.ok(!params.has("/^utm_/"));
+});
+
+// ── T-03 (quarantine-surface #782): adguard parse shape ─────────────────────
+
+test("T-03: adguardTp.parse returns { params, skipped, affiliateExcluded: 0 } shape", () => {
+  const result = adguardTp.parse(SAMPLE_ADGUARD);
+  // Must be an object with params Set
+  assert.ok(result.params instanceof Set, "params must be a Set");
+  // SAMPLE_ADGUARD has one regex spec ($removeparam=/^utm_/) → skipped >= 1
+  assert.ok(typeof result.skipped === "number", "skipped must be a number");
+  assert.ok(result.skipped >= 1, `expected skipped >= 1 (regex spec), got ${result.skipped}`);
+  // adguard has no affiliate concept → affiliateExcluded === 0
+  assert.equal(result.affiliateExcluded, 0, "affiliateExcluded must be 0 for adguard-tp");
+});
+
+// ── T-04 (quarantine-surface #782): parseRemoveparamRules shape ─────────────
+
+test("T-04: parseRemoveparamRules returns { params, skipped } not a bare Set", () => {
+  const result = parseRemoveparamRules(SAMPLE_ADGUARD);
+  // Must be { params: Set, skipped: number } — NOT a bare Set
+  assert.ok(!(result instanceof Set), "parseRemoveparamRules must return an object, not a bare Set");
+  assert.ok(result.params instanceof Set, "result.params must be a Set");
+  assert.ok(typeof result.skipped === "number", "result.skipped must be a number");
+  assert.ok(result.params.has("utm_source"), "utm_source must be in params");
+  assert.ok(result.params.has("fbclid"), "fbclid must be in params");
+  assert.ok(result.skipped >= 1, `expected skipped >= 1 (regex spec), got ${result.skipped}`);
 });
 
 test("registry enables AdGuard TP and ClearURLs (two independent signal sources for GATE 2, #776)", () => {
@@ -73,7 +102,8 @@ test("runIngestion quarantines raw bytes and returns merged candidates", async (
       },
     };
 
-    const candidates = await runIngestion({
+    // After T-11: runIngestion returns { candidates, stats }
+    const result = await runIngestion({
       adapters: [fakeAdapter],
       quarantineDir: dir,
       now: "2026-05-31T00:00:00.000Z",
@@ -85,6 +115,7 @@ test("runIngestion quarantines raw bytes and returns merged candidates", async (
     assert.equal(readFileSync(rawPath, "utf8"), SAMPLE_ADGUARD);
 
     // Candidates carry adguard-tp provenance.
+    const candidates = result.candidates;
     const names = candidates.map((c) => c.param);
     assert.ok(names.includes("fbclid"));
     assert.ok(names.includes("utm_source"));
@@ -114,7 +145,8 @@ test("runIngestion injects fetch into fetchRaw (no real network)", async () => {
       fetchRaw: adguardTp.fetchRaw,
     };
 
-    const candidates = await runIngestion({
+    // After T-11: runIngestion returns { candidates, stats }
+    const result = await runIngestion({
       adapters: [netAdapter],
       fetchImpl: fakeFetch,
       quarantineDir: dir,
@@ -122,7 +154,105 @@ test("runIngestion injects fetch into fetchRaw (no real network)", async () => {
     });
 
     assert.ok(sawInjectedFetch, "fetchRaw must use the injected fetch");
-    assert.ok(candidates.length > 0);
+    assert.ok(result.candidates.length > 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── T-10 (quarantine-surface #782): runIngestion stats aggregation ────────────
+
+test("T-10: runIngestion aggregates stats from adapters", async () => {
+  const dir = mkdtempSync(resolve(tmpdir(), "muga-ingest-stats-"));
+  try {
+    // Two fake adapters with known return shapes
+    const fakeAdapterA = {
+      id: "adapter-a",
+      name: "Fake A",
+      license: "test",
+      url: "https://example.test/a",
+      parse() {
+        return { params: new Set(["p1", "p2", "p3"]), skipped: 1, affiliateExcluded: 0 };
+      },
+      async fetchRaw() { return "raw-a"; },
+    };
+    const fakeAdapterB = {
+      id: "adapter-b",
+      name: "Fake B",
+      license: "test",
+      url: "https://example.test/b",
+      parse() {
+        return { params: new Set(["p4", "p5"]), skipped: 0, affiliateExcluded: 1 };
+      },
+      async fetchRaw() { return "raw-b"; },
+    };
+
+    const result = await runIngestion({
+      adapters: [fakeAdapterA, fakeAdapterB],
+      quarantineDir: dir,
+      now: "2026-05-31T00:00:00.000Z",
+    });
+
+    // result must have candidates array
+    assert.ok(Array.isArray(result.candidates), "result.candidates must be an array");
+
+    // result must have stats object
+    assert.ok(result.stats, "result.stats must exist");
+    assert.ok(Array.isArray(result.stats.adapters), "result.stats.adapters must be an array");
+    assert.equal(result.stats.adapters.length, 2, "stats.adapters must have 2 entries");
+
+    // adapter-a stats
+    const statsA = result.stats.adapters.find((s) => s.adapterId === "adapter-a");
+    assert.ok(statsA, "stats for adapter-a must exist");
+    assert.equal(statsA.admitted, 3, "adapter-a admitted must be 3 (params.size)");
+    assert.equal(statsA.skipped, 1, "adapter-a skipped must be 1");
+    assert.equal(statsA.affiliateExcluded, 0, "adapter-a affiliateExcluded must be 0");
+
+    // adapter-b stats
+    const statsB = result.stats.adapters.find((s) => s.adapterId === "adapter-b");
+    assert.ok(statsB, "stats for adapter-b must exist");
+    assert.equal(statsB.admitted, 2, "adapter-b admitted must be 2 (params.size)");
+    assert.equal(statsB.skipped, 0, "adapter-b skipped must be 0");
+    assert.equal(statsB.affiliateExcluded, 1, "adapter-b affiliateExcluded must be 1");
+
+    // merged stats
+    assert.ok(result.stats.merged, "result.stats.merged must exist");
+    assert.equal(typeof result.stats.merged.emptyDropped, "number", "merged.emptyDropped must be a number");
+    assert.equal(result.stats.merged.total, result.candidates.length, "merged.total must equal candidates.length");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── FIX-2 (quarantine-surface PR1 review): bare-Set adapter throws clearly ────
+
+test("FIX-2: runIngestion throws a clear TypeError naming the adapter when parse() returns a bare Set", async () => {
+  const dir = mkdtempSync(resolve(tmpdir(), "muga-ingest-bare-set-"));
+  try {
+    const bareSetAdapter = {
+      id: "bad-adapter",
+      name: "Bad",
+      license: "test",
+      url: "https://example.test/bad",
+      parse() {
+        // Intentionally wrong: returns a bare Set instead of { params: Set, ... }
+        return new Set(["p1", "p2"]);
+      },
+      async fetchRaw() { return "raw-bad"; },
+    };
+
+    await assert.rejects(
+      () => runIngestion({ adapters: [bareSetAdapter], quarantineDir: dir }),
+      (err) => {
+        assert.ok(err instanceof TypeError, "must throw a TypeError");
+        assert.ok(
+          err.message.includes("bad-adapter"),
+          `error message must name the adapter id; got: ${err.message}`
+        );
+        return true;
+      },
+      "runIngestion must throw a clear contract error when parse() returns a bare Set"
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/unit/rule-ingestion-candidate.test.mjs
+++ b/tests/unit/rule-ingestion-candidate.test.mjs
@@ -27,7 +27,8 @@ test("makeCandidate lowercases the param and carries one signal", () => {
 });
 
 test("mergeCandidates dedupes params and lowercases", () => {
-  const out = mergeCandidates(
+  // After T-09: mergeCandidates returns { candidates, emptyDropped }
+  const { candidates: out } = mergeCandidates(
     [{ id: "adguard-tp", params: ["fbclid", "FBCLID", "gclid"] }],
     { now: NOW },
   );
@@ -39,7 +40,7 @@ test("mergeCandidates dedupes params and lowercases", () => {
 });
 
 test("mergeCandidates accumulates provenance across adapters without dup signals", () => {
-  const out = mergeCandidates(
+  const { candidates: out } = mergeCandidates(
     [
       { id: "adguard-tp", params: ["fbclid"] },
       { id: "other", params: ["fbclid"] },
@@ -52,7 +53,7 @@ test("mergeCandidates accumulates provenance across adapters without dup signals
 });
 
 test("single-source candidates survive (corroboration is not a hard gate)", () => {
-  const out = mergeCandidates(
+  const { candidates: out } = mergeCandidates(
     [{ id: "adguard-tp", params: ["only_here"] }],
     { now: NOW },
   );
@@ -61,7 +62,7 @@ test("single-source candidates survive (corroboration is not a hard gate)", () =
 });
 
 test("entropy and crossSiteFrequency stay null at B2 (no corpus)", () => {
-  const out = mergeCandidates(
+  const { candidates: out } = mergeCandidates(
     [{ id: "adguard-tp", params: ["x"] }],
     { now: NOW },
   );
@@ -70,7 +71,7 @@ test("entropy and crossSiteFrequency stay null at B2 (no corpus)", () => {
 });
 
 test("merge sorts by signal count desc, then param asc", () => {
-  const out = mergeCandidates(
+  const { candidates: out } = mergeCandidates(
     [
       { id: "a", params: ["zeta", "shared"] },
       { id: "b", params: ["shared", "alpha"] },
@@ -85,7 +86,8 @@ test("merge sorts by signal count desc, then param asc", () => {
 });
 
 test("empty/whitespace params are dropped", () => {
-  const out = mergeCandidates(
+  // After T-09: mergeCandidates returns { candidates, emptyDropped }
+  const { candidates: out } = mergeCandidates(
     [{ id: "a", params: ["", "  ", "real"] }],
     { now: NOW },
   );
@@ -93,4 +95,19 @@ test("empty/whitespace params are dropped", () => {
     out.map((c) => c.param),
     ["real"],
   );
+});
+
+// ── T-08 (quarantine-surface #782): mergeCandidates emptyDropped ──────────────
+
+test("T-08: mergeCandidates returns { candidates, emptyDropped }", () => {
+  const result = mergeCandidates(
+    [{ id: "x", params: new Set(["", "  ", "a"]) }],
+    { now: NOW },
+  );
+  // Must return an object { candidates, emptyDropped }
+  assert.ok(!Array.isArray(result), "mergeCandidates must return an object, not a bare array");
+  assert.ok(Array.isArray(result.candidates), "result.candidates must be an array");
+  assert.equal(result.candidates.length, 1, "candidates must contain 1 entry (only 'a')");
+  assert.equal(result.candidates[0].param, "a");
+  assert.equal(result.emptyDropped, 2, `emptyDropped must be 2 ('' and '  '), got ${result.emptyDropped}`);
 });

--- a/tools/import-upstream.mjs
+++ b/tools/import-upstream.mjs
@@ -42,10 +42,11 @@ const ADGUARD_FILTER_17_URL =
  * handling than a flat name list.
  *
  * @param {string} text The raw filter list contents.
- * @returns {Set<string>} Lowercased parameter names found in $removeparam rules.
+ * @returns {{ params: Set<string>, skipped: number }} Lowercased parameter names + skip count.
  */
 export function parseRemoveparamRules(text) {
   const params = new Set();
+  let skipped = 0;
   for (const rawLine of text.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line) continue;
@@ -58,20 +59,22 @@ export function parseRemoveparamRules(text) {
     if (!match) continue;
 
     const spec = match[1].trim();
-    if (!spec) continue;
+    if (!spec) { skipped++; continue; }
 
     // Skip regex specs and negations: those need rule-by-rule handling.
-    if (spec.startsWith("/") || spec.startsWith("~")) continue;
+    // NIT: skip granularity is per-spec (one whole $removeparam= value), NOT per-piece
+    // for pipe-separated multi-regex specs — a spec like "/regex1/|/regex2/" counts as 1 skip.
+    if (spec.startsWith("/") || spec.startsWith("~")) { skipped++; continue; }
 
     for (const piece of spec.split("|")) {
       const name = piece.trim().toLowerCase();
-      if (!name) continue;
+      if (!name) { skipped++; continue; }
       // Conservative param-name validation: alphanumeric + _ - . only.
-      if (!/^[a-z0-9_\-.]{1,64}$/.test(name)) continue;
+      if (!/^[a-z0-9_\-.]{1,64}$/.test(name)) { skipped++; continue; }
       params.add(name);
     }
   }
-  return params;
+  return { params, skipped };
 }
 
 async function main() {
@@ -83,7 +86,7 @@ async function main() {
   }
   const text = await response.text();
 
-  const upstreamParams = parseRemoveparamRules(text);
+  const { params: upstreamParams, skipped } = parseRemoveparamRules(text);
   const existing = new Set(TRACKING_PARAMS.map((p) => p.toLowerCase()));
 
   const candidates = [...upstreamParams].filter((p) => !existing.has(p));
@@ -97,10 +100,12 @@ async function main() {
     total_in_muga: existing.size,
     new_candidates_count: candidates.length,
     new_candidates: candidates,
+    skipped,
   };
 
   const outPath = process.env.IMPORT_REPORT_PATH || "/tmp/import-report.json";
   writeFileSync(outPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+  console.log(`[import-upstream] parseRemoveparamRules: skipped ${skipped} non-literal removeparam spec(s)`);
   console.log(`AdGuard Filter 17: ${upstreamParams.size} params parsed`);
   console.log(`MUGA TRACKING_PARAMS: ${existing.size} entries`);
   console.log(`New candidates: ${candidates.length}`);

--- a/tools/rule-ingestion/adapters/adguard-tp.mjs
+++ b/tools/rule-ingestion/adapters/adguard-tp.mjs
@@ -29,10 +29,11 @@ export const adguardTp = {
   /**
    * Extract literal tracking param names from an AdGuard filter list.
    * @param {string} rawText Raw filter-list contents.
-   * @returns {Set<string>} Lowercased param names.
+   * @returns {{ params: Set<string>, skipped: number, affiliateExcluded: number }}
    */
   parse(rawText) {
-    return parseRemoveparamRules(rawText);
+    const { params, skipped } = parseRemoveparamRules(rawText);
+    return { params, skipped, affiliateExcluded: 0 };
   },
 
   /**

--- a/tools/rule-ingestion/adapters/clearurls.mjs
+++ b/tools/rule-ingestion/adapters/clearurls.mjs
@@ -14,7 +14,7 @@
  * any provider's referralMarketing is excluded from every provider's output.
  *
  * Public API (named exports only — no default):
- *   extractClearurlsLiterals(rawText) → { params: Set<string>, skipped: number }
+ *   extractClearurlsLiterals(rawText) → { params: Set<string>, skipped: number, affiliateExcluded: number }
  *   clearurls                         → Adapter (id, name, license, url, parse, fetchRaw)
  */
 
@@ -70,7 +70,7 @@ function normalizeName(raw) {
  * Does NOT read: top-level globalRules / rawGlobalRules (locked out-of-scope).
  *
  * @param {string} rawText Raw ClearURLs rules JSON string.
- * @returns {{ params: Set<string>, skipped: number }}
+ * @returns {{ params: Set<string>, skipped: number, affiliateExcluded: number }}
  */
 export function extractClearurlsLiterals(rawText) {
   let data;
@@ -103,6 +103,7 @@ export function extractClearurlsLiterals(rawText) {
   // PASS 2: Extract safe literals from providers[*].rules[], subtract global referral union.
   const params = new Set();
   let skipped = 0;
+  let affiliateExcluded = 0;
 
   for (const provider of providerList) {
     const rules = Array.isArray(provider?.rules) ? provider.rules : [];
@@ -125,15 +126,14 @@ export function extractClearurlsLiterals(rawText) {
       }
 
       // SAFETY-CRITICAL: affiliate preserve check using global union.
-      // Excluded entries are intentional — NOT counted as skip (parse success,
-      // deliberate exclusion).
-      if (globalReferral.has(name)) continue;
+      // Counted as affiliateExcluded (deliberate exclusion, not a parse skip).
+      if (globalReferral.has(name)) { affiliateExcluded++; continue; }
 
       params.add(name);
     }
   }
 
-  return { params, skipped };
+  return { params, skipped, affiliateExcluded };
 }
 
 // ── Adapter object ────────────────────────────────────────────────────────────
@@ -150,13 +150,13 @@ export const clearurls = {
 
   /**
    * Extract literal tracking param names from a ClearURLs rules JSON string.
-   * Delegates to extractClearurlsLiterals and returns the params Set directly
-   * to honor the Adapter typedef contract (parse → Set<string>).
+   * Delegates to extractClearurlsLiterals and returns the full stats object.
    * @param {string} rawText Raw rules JSON.
-   * @returns {Set<string>} Lowercased param names (referralMarketing excluded).
+   * @returns {{ params: Set<string>, skipped: number, affiliateExcluded: number }}
    */
   parse(rawText) {
-    return extractClearurlsLiterals(rawText).params;
+    const { params, skipped, affiliateExcluded } = extractClearurlsLiterals(rawText);
+    return { params, skipped, affiliateExcluded };
   },
 
   /**

--- a/tools/rule-ingestion/adapters/index.mjs
+++ b/tools/rule-ingestion/adapters/index.mjs
@@ -10,7 +10,7 @@
  * @property {string} name          Human-readable source name.
  * @property {string} license       SPDX-ish license id of the source data.
  * @property {string} url           Source URL.
- * @property {(rawText: string) => Set<string>} parse  Raw → literal param names.
+ * @property {(rawText: string) => { params: Set<string>, skipped?: number, affiliateExcluded?: number }} parse  Raw → literal param names with exclusion counts.
  * @property {(opts?: {fetchImpl?: typeof fetch}) => Promise<string>} fetchRaw
  */
 

--- a/tools/rule-ingestion/candidate.mjs
+++ b/tools/rule-ingestion/candidate.mjs
@@ -57,15 +57,16 @@ export function makeCandidate(param, signalId, { now } = {}) {
  * @param {Array<{id:string, params:Iterable<string>}>} adapterResults
  * @param {object} [opts]
  * @param {string} [opts.now] ISO timestamp override for deterministic tests.
- * @returns {object[]} Candidates sorted by signal count desc, then param asc.
+ * @returns {{ candidates: object[], emptyDropped: number }} Candidates + empty-drop count.
  */
 export function mergeCandidates(adapterResults, { now } = {}) {
   const byParam = new Map();
+  let emptyDropped = 0;
 
   for (const { id, params } of adapterResults) {
     for (const raw of params) {
       const param = String(raw).trim().toLowerCase();
-      if (!param) continue;
+      if (!param) { emptyDropped++; continue; }
       const existing = byParam.get(param);
       if (!existing) {
         byParam.set(param, makeCandidate(param, id, { now }));
@@ -79,7 +80,9 @@ export function mergeCandidates(adapterResults, { now } = {}) {
     candidate.signals.sort();
   }
 
-  return [...byParam.values()].sort(
+  const candidates = [...byParam.values()].sort(
     (a, b) => b.signals.length - a.signals.length || a.param.localeCompare(b.param),
   );
+
+  return { candidates, emptyDropped };
 }

--- a/tools/rule-ingestion/ingest.mjs
+++ b/tools/rule-ingestion/ingest.mjs
@@ -38,7 +38,7 @@ const QUARANTINE_DIR = resolve(__dirname, "quarantine");
  * @param {typeof fetch} [opts.fetchImpl] Injectable fetch for testing.
  * @param {string} [opts.quarantineDir] Working dir for raw downloads.
  * @param {string} [opts.now] ISO timestamp override for deterministic output.
- * @returns {Promise<object[]>} Candidates (see candidate.mjs).
+ * @returns {Promise<{ candidates: object[], stats: { adapters: object[], merged: { emptyDropped: number, total: number } } }>}
  */
 export async function runIngestion({
   adapters = ENABLED_ADAPTERS,
@@ -49,18 +49,39 @@ export async function runIngestion({
   mkdirSync(quarantineDir, { recursive: true });
 
   const results = [];
+  const adapterStats = [];
   for (const adapter of adapters) {
     const raw = await adapter.fetchRaw({ fetchImpl });
     // Raw bytes land in quarantine ONLY — gitignored, never committed/bundled.
     writeFileSync(resolve(quarantineDir, `${adapter.id}.raw`), raw, "utf8");
-    results.push({ id: adapter.id, params: adapter.parse(raw) });
+    const parseResult = adapter.parse(raw);
+    if (!parseResult || !(parseResult.params instanceof Set)) {
+      throw new TypeError(
+        `[runIngestion] Adapter "${adapter.id}" parse() must return { params: Set, skipped, affiliateExcluded } — got ${typeof parseResult}`
+      );
+    }
+    const { params, skipped = 0, affiliateExcluded = 0 } = parseResult;
+    results.push({ id: adapter.id, params });
+    adapterStats.push({
+      adapterId: adapter.id,
+      admitted: params.size,   // per-adapter count BEFORE cross-adapter dedup
+      skipped,
+      affiliateExcluded,
+    });
   }
 
-  return mergeCandidates(results, { now });
+  const { candidates, emptyDropped } = mergeCandidates(results, { now });
+  return {
+    candidates,
+    stats: {
+      adapters: adapterStats,
+      merged: { emptyDropped, total: candidates.length }, // total = unique candidates after cross-adapter dedup (NOT sum of per-adapter admitted)
+    },
+  };
 }
 
 async function main() {
-  const candidates = await runIngestion();
+  const { candidates, stats } = await runIngestion();
   const report = {
     generatedAt: new Date().toISOString(),
     adapters: ENABLED_ADAPTERS.map((a) => ({
@@ -71,6 +92,7 @@ async function main() {
     })),
     candidateCount: candidates.length,
     candidates,
+    stats,
   };
   const outPath =
     process.env.CANDIDATES_PATH || resolve(QUARANTINE_DIR, "candidates.json");

--- a/tools/rule-ingestion/orchestrate-cli.mjs
+++ b/tools/rule-ingestion/orchestrate-cli.mjs
@@ -254,6 +254,7 @@ export async function runOrchestrateCli({
     generatedAt: published,
     autoMergeCount: autoMerge.length,
     quarantineCount: quarantine.length,
+    ingestStats: candidateReport.stats ?? null,  // null-safe: tolerates stats-less old candidates.json (#782)
     quarantine, // full QuarantineEntry[] with candidate + rejections
   };
 

--- a/tools/rule-ingestion/pipeline.mjs
+++ b/tools/rule-ingestion/pipeline.mjs
@@ -114,8 +114,8 @@ export async function runPipeline({
     now instanceof Date ? now : now !== undefined ? new Date(now) : undefined;
 
   // ── Step 1: Ingest ─────────────────────────────────────────────────────────
-  // runIngestion returns a BARE candidate array.
-  const candidates = await runIngestion({
+  // runIngestion returns { candidates, stats } (#782 quarantine-surface).
+  const { candidates, stats } = await runIngestion({
     adapters,
     fetchImpl,
     quarantineDir: dirname(candidatesPath),
@@ -125,7 +125,7 @@ export async function runPipeline({
   // ── CRITICAL: Write report wrapper (NOT bare array) ───────────────────────
   // orchestrate-cli reads `candidateReport.candidates` — bare array breaks it.
   // Mirror exact wrapper shape from ingest.mjs main():
-  //   { generatedAt, adapters, candidateCount, candidates }
+  //   { generatedAt, adapters, candidateCount, candidates, stats }
   const candidateReport = {
     generatedAt: (nowDate ?? new Date()).toISOString(),
     adapters: adapters.map((a) => ({
@@ -136,6 +136,7 @@ export async function runPipeline({
     })),
     candidateCount: candidates.length,
     candidates,
+    stats,
   };
   mkdirSync(dirname(candidatesPath), { recursive: true });
   writeFileSync(


### PR DESCRIPTION
## What

PR1 of 2 for the quarantine review surface + no-silent-caps logging (#782). Closes the **silent-drop gaps in the ingest layer** by making every exclusion a counted, propagated statistic. The human-readable review surface + workflow integration land in **PR2**.

## Contract changes (additive — every call site updated)

- **Adapter `parse(raw)` → `{ params: Set, skipped, affiliateExcluded }`** (was a bare `Set`). ClearURLs now surfaces the non-literal skip count it previously **discarded**, and counts `referralMarketing`/affiliate exclusions (was a silent `continue`). AdGuard-TP returns its regex-spec skip count.
- **`parseRemoveparamRules` (import-upstream.mjs) → `{ params, skipped }`**; caller updated, and `main()` now **logs** the skip count (previously discarded).
- **`mergeCandidates` → `{ candidates, emptyDropped }`** (empty-param drops were silent).
- **`runIngestion` → `{ candidates, stats: { adapters[], merged } }`** aggregating per-adapter `admitted`/`skipped`/`affiliateExcluded` + merged `emptyDropped`/`total`.
- **`orchestrate-cli`** copies `candidateReport.stats → quarantine-report.json.ingestStats` (null-safe — tolerates a stats-less `candidates.json`).

## No-silent-caps enforced at the boundary

An adapter returning a bare `Set` now **throws a clear `TypeError` naming the adapter** — no silent-zero fallback. `params` Set semantics are unchanged, so all gate/orchestrate behavior is identical (no gate regressions).

## Tests

+10 unit tests (adapter stats, `mergeCandidates` emptyDropped, `runIngestion` aggregation, null-safe `ingestStats`, bare-Set fail-loud guard). Full suite **4286 pass / 0 fail**; integration **172 / 0**.

## Review notes — a silent-cap caught and removed

SDD verify + a fresh blind adversarial review ran before this PR. Both probed the contract-change blast radius (every `runIngestion`/`mergeCandidates`/`parse` caller updated — confirmed) and remaining silent drops. The key catch:
- The first implementation added an `instanceof Set` **backward-compat shim** that silently zeroed `skipped`/`affiliateExcluded` for bare-Set adapters — the **exact anti-pattern #782 exists to fix**, and it meant the pipeline tests exercised a legacy contract. **Removed the shim**, updated all 13 bare-Set test adapters to the real contract, and added a fail-loud shape guard + test.
- Plus: documented that `stats.merged.total` is post-dedup-unique (not the sum of per-adapter `admitted`); surfaced the import-upstream skip count; stripped stale `(RED until T-N)` test names.

## Scope boundary

OUT (PR2, T-14–T-22): `report-formatter.mjs` (pure markdown), pipeline `surface-input.json` (two-phase, incl. promote skips), and the `auto-ingest-rules.yml` step-summary + PR-body surface.

Refs #782
