### PR TITLE
fix(dnr): gate amp_redirect & wrapper_unwrap on consent and pref toggles (#810)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -424,19 +424,67 @@ async function applyDnrState(prefs) {
   if (!hasDNR) return;
   // Gate DNR on onboardingDone too (#consent-gate). Content scripts
   // already short-circuit on `!prefs.onboardingDone`, but the DNR
-  // ruleset is declarative — it would still fire before the user
-  // accepts unless we explicitly disable it here. This makes "the
+  // rulesets are declarative — they would still fire before the user
+  // accepts unless we explicitly disable them here. This makes "the
   // extension is disabled until the user accepts the ToS" hold across
   // both the dynamic and declarative cleaning paths.
+  //
+  // Derive which rulesets are actually declared in the active manifest
+  // at runtime so we never pass IDs that don't exist in the current
+  // manifest (Firefox MV2 declares only "tracking_params"; passing
+  // "amp_redirect" or "wrapper_unwrap" there would cause the API to
+  // reject the entire call). (#810)
+  const declaredIds = (
+    chrome.runtime.getManifest()?.declarative_net_request?.rule_resources ?? []
+  ).map(r => r.id);
+
   if (prefs.enabled && prefs.dnrEnabled && prefs.onboardingDone) {
+    // Gate open: selectively enable/disable based on per-feature prefs.
+    // The manifest defaults all three to enabled:true, so rulesets whose
+    // feature pref is OFF must be explicitly disabled — otherwise they
+    // stay active from the manifest default.
+    const enableRulesetIds = [];
+    const disableRulesetIds = [];
+
+    for (const id of declaredIds) {
+      if (id === "tracking_params") {
+        enableRulesetIds.push(id);
+      } else if (id === "amp_redirect") {
+        if (prefs.ampRedirect) {
+          enableRulesetIds.push(id);
+        } else {
+          disableRulesetIds.push(id);
+        }
+      } else if (id === "wrapper_unwrap") {
+        if (prefs.unwrapRedirects) {
+          enableRulesetIds.push(id);
+        } else {
+          disableRulesetIds.push(id);
+        }
+      } else {
+        // A manifest-declared ruleset this gate doesn't know about would
+        // keep its manifest default and silently bypass any feature pref.
+        // Enable it explicitly (matching the manifest default) and warn so
+        // the gap is visible the moment a fourth ruleset is added. (#810)
+        console.warn("[MUGA] applyDnrState: unmanaged ruleset id:", id);
+        enableRulesetIds.push(id);
+      }
+    }
+
     await chrome.declarativeNetRequest.updateEnabledRulesets({
-      enableRulesetIds: ["tracking_params"],
+      enableRulesetIds,
+      disableRulesetIds,
     }).catch(err => console.warn("[MUGA] applyDnrState enable:", err));
     await syncCustomParamsDNR(prefs.customParams);
   } else {
-    await chrome.declarativeNetRequest.updateEnabledRulesets({
-      disableRulesetIds: ["tracking_params"],
-    }).catch(err => console.warn("[MUGA] applyDnrState disable:", err));
+    // Gate closed: disable ALL declared rulesets so that AMP redirects
+    // and wrapper-unwrapping cannot fire before the user has accepted
+    // the ToS or while the extension is toggled off. (#810)
+    if (declaredIds.length > 0) {
+      await chrome.declarativeNetRequest.updateEnabledRulesets({
+        disableRulesetIds: declaredIds,
+      }).catch(err => console.warn("[MUGA] applyDnrState disable:", err));
+    }
     await syncCustomParamsDNR([]);
   }
 }
@@ -590,7 +638,8 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
   // Any sync storage change (including disabledCategories, contextMenuEnabled, etc.)
   // must invalidate the prefs cache so the next getPrefsWithCache() reads fresh data.
   _invalidatePrefsCache();
-  if (changes.customParams || changes.dnrEnabled || changes.enabled) {
+  if (changes.customParams || changes.dnrEnabled || changes.enabled ||
+      changes.ampRedirect || changes.unwrapRedirects) {
     const prefs = await getPrefsWithCache();
     await applyDnrState(prefs);
   }

--- a/tests/e2e/onboarding-regression.spec.mjs
+++ b/tests/e2e/onboarding-regression.spec.mjs
@@ -237,8 +237,9 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
   });
 
   test("DNR tracking_params ruleset is disabled until onboardingDone, enabled after", async ({ context, extensionId }) => {
-    // Pre-onboarding: ruleset must be disabled. Poll so the result
-    // does not race with applyDnrState() after the beforeEach clear.
+    // Pre-onboarding: ALL three rulesets must be disabled (#810 — consent-gate
+    // must cover amp_redirect and wrapper_unwrap, not only tracking_params).
+    // Poll so the result does not race with applyDnrState() after beforeEach clear.
     await expect.poll(
       async () => {
         const r = await readEnabledRulesets(context, extensionId);
@@ -246,6 +247,22 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
       },
       { timeout: 5000 }
     ).not.toContain("tracking_params");
+
+    await expect.poll(
+      async () => {
+        const r = await readEnabledRulesets(context, extensionId);
+        return r.ruleIds || [];
+      },
+      { timeout: 5000 }
+    ).not.toContain("amp_redirect");
+
+    await expect.poll(
+      async () => {
+        const r = await readEnabledRulesets(context, extensionId);
+        return r.ruleIds || [];
+      },
+      { timeout: 5000 }
+    ).not.toContain("wrapper_unwrap");
 
     // Complete onboarding without letting the page self-close — the
     // assertion is on the SW side, but we still want a deterministic
@@ -255,8 +272,9 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
     await page.waitForFunction(() => document.body.dataset.mugaReady === "1");
     await completeOnboardingAndKeepPageOpen(page);
 
-    // After acceptance, the storage listener re-applies DNR state. The
-    // ruleset becomes enabled. Poll to absorb the listener latency.
+    // After acceptance, the storage listener re-applies DNR state.
+    // All three rulesets (with default prefs ampRedirect:true, unwrapRedirects:true)
+    // must be enabled. Poll to absorb the listener latency.
     await expect.poll(
       async () => {
         const r = await readEnabledRulesets(context, extensionId);
@@ -264,6 +282,22 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
       },
       { timeout: 5000 }
     ).toContain("tracking_params");
+
+    await expect.poll(
+      async () => {
+        const r = await readEnabledRulesets(context, extensionId);
+        return r.ruleIds || [];
+      },
+      { timeout: 5000 }
+    ).toContain("amp_redirect");
+
+    await expect.poll(
+      async () => {
+        const r = await readEnabledRulesets(context, extensionId);
+        return r.ruleIds || [];
+      },
+      { timeout: 5000 }
+    ).toContain("wrapper_unwrap");
 
     if (!page.isClosed()) await page.close();
   });

--- a/tests/unit/dnr-consent-gate.test.mjs
+++ b/tests/unit/dnr-consent-gate.test.mjs
@@ -1,0 +1,409 @@
+/**
+ * MUGA — Unit tests for applyDnrState() consent-gate fix (#810)
+ *
+ * Behavioral tests using a fake chrome.declarativeNetRequest facade.
+ * Verifies that:
+ *   1. Gate closed (onboardingDone:false) → ALL declared rulesets disabled
+ *   2. Gate closed (enabled:false) → ALL declared rulesets disabled
+ *   3. Gate open + ampRedirect:false + unwrapRedirects:true → amp_redirect disabled,
+ *      wrapper_unwrap + tracking_params enabled
+ *   4. MV2 shape (manifest with only tracking_params) → only tracking_params referenced
+ *
+ * Approach: extract applyDnrState as a pure function via dependency injection —
+ * the production function is tightly coupled to the SW module. We test the logic
+ * by replicating the algorithm here against a fake chrome facade.  This keeps
+ * tests behavioral and decoupled from source string contents per ADR-#824.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const swSource = readFileSync(
+  join(__dirname, "../../src/background/service-worker.js"),
+  "utf8"
+);
+
+// ── Pure implementation under test ───────────────────────────────────────────
+//
+// applyDnrStateLogic is a side-effect-free extraction of the consent-gate
+// algorithm.  The production service-worker.js calls the same algorithm wired
+// to chrome.declarativeNetRequest; here we pass a fake facade so we can assert
+// the exact calls made without spinning up a browser.
+//
+// @param {object} prefs - Extension preferences (enabled, dnrEnabled,
+//   onboardingDone, ampRedirect, unwrapRedirects)
+// @param {string[]} declaredIds - Ruleset IDs declared in the manifest
+//   (simulates chrome.runtime.getManifest().declarative_net_request.rule_resources)
+// @param {{ updateEnabledRulesets: Function }} dnrApi - Fake DNR API
+async function applyDnrStateLogic(prefs, declaredIds, dnrApi) {
+  const gateOpen = prefs.enabled && prefs.dnrEnabled && prefs.onboardingDone;
+
+  if (!gateOpen) {
+    // Gate closed: disable ALL declared rulesets
+    if (declaredIds.length > 0) {
+      await dnrApi.updateEnabledRulesets({
+        disableRulesetIds: declaredIds,
+      });
+    }
+    return;
+  }
+
+  // Gate open: selectively enable/disable based on per-feature prefs
+  const enableRulesetIds = [];
+  const disableRulesetIds = [];
+
+  for (const id of declaredIds) {
+    if (id === "tracking_params") {
+      enableRulesetIds.push(id);
+    } else if (id === "amp_redirect") {
+      if (prefs.ampRedirect) {
+        enableRulesetIds.push(id);
+      } else {
+        disableRulesetIds.push(id);
+      }
+    } else if (id === "wrapper_unwrap") {
+      if (prefs.unwrapRedirects) {
+        enableRulesetIds.push(id);
+      } else {
+        disableRulesetIds.push(id);
+      }
+    } else {
+      // Mirrors production: unmanaged declared rulesets keep the manifest
+      // default (enabled) and surface a warning — see service-worker.js.
+      enableRulesetIds.push(id);
+    }
+  }
+
+  await dnrApi.updateEnabledRulesets({
+    enableRulesetIds,
+    disableRulesetIds,
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeFakeDnr() {
+  const calls = [];
+  return {
+    calls,
+    updateEnabledRulesets(opts) {
+      calls.push(structuredClone(opts));
+      return Promise.resolve();
+    },
+  };
+}
+
+const MV3_IDS = ["tracking_params", "amp_redirect", "wrapper_unwrap"];
+const MV2_IDS = ["tracking_params"];
+
+const BASE_PREFS_OPEN = {
+  enabled: true,
+  dnrEnabled: true,
+  onboardingDone: true,
+  ampRedirect: true,
+  unwrapRedirects: true,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("applyDnrState — gate closed: onboardingDone:false", () => {
+  test("all MV3 declared rulesets appear in disableRulesetIds", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, onboardingDone: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    assert.strictEqual(dnr.calls.length, 1, "updateEnabledRulesets must be called once");
+    const call = dnr.calls[0];
+    assert.ok(
+      Array.isArray(call.disableRulesetIds),
+      "disableRulesetIds must be present"
+    );
+    for (const id of MV3_IDS) {
+      assert.ok(
+        call.disableRulesetIds.includes(id),
+        `${id} must be in disableRulesetIds when gate is closed (onboardingDone:false)`
+      );
+    }
+  });
+
+  test("no ruleset ends up in enableRulesetIds when gate is closed", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, onboardingDone: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+    const call = dnr.calls[0];
+    assert.ok(
+      !call.enableRulesetIds || call.enableRulesetIds.length === 0,
+      "enableRulesetIds must be absent or empty when gate is closed"
+    );
+  });
+});
+
+describe("applyDnrState — gate closed: enabled:false", () => {
+  test("all MV3 declared rulesets appear in disableRulesetIds", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, enabled: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    assert.strictEqual(dnr.calls.length, 1, "updateEnabledRulesets must be called once");
+    const call = dnr.calls[0];
+    for (const id of MV3_IDS) {
+      assert.ok(
+        call.disableRulesetIds.includes(id),
+        `${id} must be in disableRulesetIds when enabled:false`
+      );
+    }
+  });
+
+  test("amp_redirect and wrapper_unwrap must NOT stay enabled when extension is disabled", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, enabled: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+    const call = dnr.calls[0];
+    assert.ok(
+      call.disableRulesetIds.includes("amp_redirect"),
+      "amp_redirect must be explicitly disabled when extension is disabled (#810 regression)"
+    );
+    assert.ok(
+      call.disableRulesetIds.includes("wrapper_unwrap"),
+      "wrapper_unwrap must be explicitly disabled when extension is disabled (#810 regression)"
+    );
+  });
+});
+
+describe("applyDnrState — gate closed: dnrEnabled:false", () => {
+  test("all MV3 declared rulesets appear in disableRulesetIds", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, dnrEnabled: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    assert.strictEqual(dnr.calls.length, 1, "updateEnabledRulesets must be called once");
+    const call = dnr.calls[0];
+    for (const id of MV3_IDS) {
+      assert.ok(
+        call.disableRulesetIds.includes(id),
+        `${id} must be in disableRulesetIds when dnrEnabled:false`
+      );
+    }
+    assert.ok(
+      !call.enableRulesetIds || call.enableRulesetIds.length === 0,
+      "nothing may be enabled while the DNR subsystem is off"
+    );
+  });
+});
+
+describe("applyDnrState — gate open with per-feature pref toggles", () => {
+  test("all prefs ON → all three IDs in enableRulesetIds, none disabled", async () => {
+    const dnr = makeFakeDnr();
+    await applyDnrStateLogic(BASE_PREFS_OPEN, MV3_IDS, dnr);
+
+    assert.strictEqual(dnr.calls.length, 1);
+    const call = dnr.calls[0];
+    assert.ok(call.enableRulesetIds.includes("tracking_params"), "tracking_params must be enabled");
+    assert.ok(call.enableRulesetIds.includes("amp_redirect"), "amp_redirect must be enabled when ampRedirect:true");
+    assert.ok(call.enableRulesetIds.includes("wrapper_unwrap"), "wrapper_unwrap must be enabled when unwrapRedirects:true");
+    assert.strictEqual(
+      (call.disableRulesetIds || []).length,
+      0,
+      "disableRulesetIds must be empty when all prefs are on"
+    );
+  });
+
+  test("ampRedirect:false → amp_redirect disabled, others enabled", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, ampRedirect: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.ok(
+      call.disableRulesetIds.includes("amp_redirect"),
+      "amp_redirect must be in disableRulesetIds when ampRedirect:false"
+    );
+    assert.ok(
+      call.enableRulesetIds.includes("tracking_params"),
+      "tracking_params must still be enabled"
+    );
+    assert.ok(
+      call.enableRulesetIds.includes("wrapper_unwrap"),
+      "wrapper_unwrap must still be enabled when unwrapRedirects:true"
+    );
+  });
+
+  test("unwrapRedirects:false → wrapper_unwrap disabled, others enabled", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, unwrapRedirects: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.ok(
+      call.disableRulesetIds.includes("wrapper_unwrap"),
+      "wrapper_unwrap must be in disableRulesetIds when unwrapRedirects:false"
+    );
+    assert.ok(
+      call.enableRulesetIds.includes("tracking_params"),
+      "tracking_params must still be enabled"
+    );
+    assert.ok(
+      call.enableRulesetIds.includes("amp_redirect"),
+      "amp_redirect must still be enabled when ampRedirect:true"
+    );
+  });
+
+  test("ampRedirect:false + unwrapRedirects:true → amp_redirect disabled, wrapper_unwrap + tracking_params enabled", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, ampRedirect: false, unwrapRedirects: true };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.ok(
+      call.disableRulesetIds.includes("amp_redirect"),
+      "amp_redirect must be disabled"
+    );
+    assert.ok(
+      call.enableRulesetIds.includes("wrapper_unwrap"),
+      "wrapper_unwrap must be enabled"
+    );
+    assert.ok(
+      call.enableRulesetIds.includes("tracking_params"),
+      "tracking_params must be enabled"
+    );
+  });
+
+  test("ampRedirect:false + unwrapRedirects:false → both extra rulesets disabled", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, ampRedirect: false, unwrapRedirects: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.ok(call.disableRulesetIds.includes("amp_redirect"), "amp_redirect must be disabled");
+    assert.ok(call.disableRulesetIds.includes("wrapper_unwrap"), "wrapper_unwrap must be disabled");
+    assert.ok(call.enableRulesetIds.includes("tracking_params"), "tracking_params must still be enabled");
+  });
+});
+
+describe("applyDnrState — MV2 parity: only declared IDs are touched", () => {
+  test("MV2 manifest (tracking_params only): gate closed disables only tracking_params", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, onboardingDone: false };
+    await applyDnrStateLogic(prefs, MV2_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.deepEqual(
+      call.disableRulesetIds,
+      ["tracking_params"],
+      "only tracking_params must be in disableRulesetIds for MV2"
+    );
+    assert.ok(
+      !(call.disableRulesetIds || []).includes("amp_redirect"),
+      "amp_redirect must NOT appear for MV2 manifest (not declared)"
+    );
+    assert.ok(
+      !(call.disableRulesetIds || []).includes("wrapper_unwrap"),
+      "wrapper_unwrap must NOT appear for MV2 manifest (not declared)"
+    );
+  });
+
+  test("MV2 manifest (tracking_params only): gate open enables only tracking_params", async () => {
+    const dnr = makeFakeDnr();
+    await applyDnrStateLogic(BASE_PREFS_OPEN, MV2_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.deepEqual(
+      call.enableRulesetIds,
+      ["tracking_params"],
+      "only tracking_params must be enabled for MV2"
+    );
+    assert.ok(
+      !(call.enableRulesetIds || []).includes("amp_redirect"),
+      "amp_redirect must NOT appear for MV2 manifest"
+    );
+    assert.ok(
+      !(call.enableRulesetIds || []).includes("wrapper_unwrap"),
+      "wrapper_unwrap must NOT appear for MV2 manifest"
+    );
+  });
+
+  test("MV2 manifest: no unknown IDs are referenced regardless of pref values", async () => {
+    const dnr = makeFakeDnr();
+    // Even with ampRedirect:false and unwrapRedirects:false, MV2 must not
+    // reference undeclared IDs — that would cause Firefox to reject the call
+    await applyDnrStateLogic(
+      { ...BASE_PREFS_OPEN, ampRedirect: false, unwrapRedirects: false },
+      MV2_IDS,
+      dnr
+    );
+    const call = dnr.calls[0];
+    const allReferenced = [
+      ...(call.enableRulesetIds || []),
+      ...(call.disableRulesetIds || []),
+    ];
+    for (const id of allReferenced) {
+      assert.ok(
+        MV2_IDS.includes(id),
+        `ID "${id}" must not be referenced for MV2 — it is not declared in manifest.v2.json`
+      );
+    }
+  });
+});
+
+// ── Source-level guards: verify the production SW was updated ────────────────
+//
+// These are intentionally thin source guards — we verify the production code
+// calls getManifest() to derive declared IDs and touches the new prefs.
+// Full behavioral coverage is above via the algorithm extraction.
+
+describe("service-worker.js source guards — #810 fix present", () => {
+  test("applyDnrState reads declared IDs from getManifest() (not a hardcoded list)", () => {
+    assert.ok(
+      swSource.includes("getManifest()"),
+      "applyDnrState must derive declared ruleset IDs from chrome.runtime.getManifest()"
+    );
+  });
+
+  test("applyDnrState references ampRedirect pref", () => {
+    const applyFnStart = swSource.indexOf("async function applyDnrState(");
+    assert.ok(applyFnStart !== -1, "applyDnrState must exist in SW");
+    // Use 2000 chars — the function grew with comments after the #810 fix
+    const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2000);
+    assert.ok(
+      applyFnBlock.includes("ampRedirect"),
+      "applyDnrState must check prefs.ampRedirect to gate amp_redirect ruleset"
+    );
+  });
+
+  test("applyDnrState references unwrapRedirects pref", () => {
+    const applyFnStart = swSource.indexOf("async function applyDnrState(");
+    assert.ok(applyFnStart !== -1, "applyDnrState must exist in SW");
+    // Use 2000 chars — the function grew with comments after the #810 fix
+    const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2000);
+    assert.ok(
+      applyFnBlock.includes("unwrapRedirects"),
+      "applyDnrState must check prefs.unwrapRedirects to gate wrapper_unwrap ruleset"
+    );
+  });
+
+  test("storage listener re-triggers applyDnrState on ampRedirect changes", () => {
+    // Find the sync-area storage listener block and confirm it watches ampRedirect.
+    // Use 2500 chars — the condition is ~2076 chars into the listener body.
+    const storageListenerIdx = swSource.lastIndexOf("chrome.storage.onChanged.addListener");
+    assert.ok(storageListenerIdx !== -1, "storage onChanged listener must exist");
+    const listenerBlock = swSource.slice(storageListenerIdx, storageListenerIdx + 2500);
+    assert.ok(
+      listenerBlock.includes("ampRedirect"),
+      "storage listener must include ampRedirect in the condition that calls applyDnrState"
+    );
+  });
+
+  test("storage listener re-triggers applyDnrState on unwrapRedirects changes", () => {
+    const storageListenerIdx = swSource.lastIndexOf("chrome.storage.onChanged.addListener");
+    assert.ok(storageListenerIdx !== -1, "storage onChanged listener must exist");
+    const listenerBlock = swSource.slice(storageListenerIdx, storageListenerIdx + 2500);
+    assert.ok(
+      listenerBlock.includes("unwrapRedirects"),
+      "storage listener must include unwrapRedirects in the condition that calls applyDnrState"
+    );
+  });
+});


### PR DESCRIPTION
Closes #810

## Summary

- `applyDnrState()` now manages **all** rulesets declared in the active manifest, not just `tracking_params`: gate closed (`!enabled || !dnrEnabled || !onboardingDone`) disables everything; gate open enables `amp_redirect`/`wrapper_unwrap` only when their feature prefs (`ampRedirect`/`unwrapRedirects`) are on, with explicit disable otherwise (manifest default is `enabled:true`).
- Ruleset IDs are derived at runtime from `chrome.runtime.getManifest().declarative_net_request.rule_resources`, so Firefox MV2 (which declares only `tracking_params`) never receives undeclared IDs that would reject the call.
- Storage listener now re-triggers `applyDnrState` on `ampRedirect`/`unwrapRedirects` changes — previously those toggles had no effect on the DNR layer.
- Unknown future rulesets get an explicit enable + `console.warn` so a fourth ruleset cannot silently bypass its feature pref (fresh-review finding).

## Changes

| File | Change |
|------|--------|
| `src/background/service-worker.js` | `applyDnrState()` rewritten (runtime-derived IDs, per-pref gating, unmanaged-id warn); storage listener trigger set extended |
| `tests/unit/dnr-consent-gate.test.mjs` | New — 18 tests: behavioral (fake DNR facade) for gate-closed (onboardingDone/enabled/dnrEnabled), per-pref toggles, MV2 shape; plus thin source guards |
| `tests/e2e/onboarding-regression.spec.mjs` | Consent-gate spec now asserts all three ruleset IDs pre/post onboarding (not executed here — headed browser) |

## Test plan

- [x] `node --test tests/unit/dnr-consent-gate.test.mjs` → 18/18
- [x] `npm test` full unit suite → 4335 pass / 0 fail
- [x] Fresh-context adversarial review: APPROVE-WITH-NITS; both substantive nits applied (unmanaged-id `else` branch, `dnrEnabled:false` coverage)
- [ ] E2E consent-gate spec runs in CI / next local headed run

## Notes for reviewer

The new test file replicates the gate algorithm against a fake `chrome.declarativeNetRequest` facade (the production function has no import seam — extracting it is in scope for #826/#824). The 5 source-guard tests pin that production wiring matches; converting them to a true behavioral import is tracked by #824.
