### PR TITLE
fix(security): nonce-validate muga:history-gate events across worlds (#811)

### DIFF
--- a/src/content/bounce-state-cleaner.js
+++ b/src/content/bounce-state-cleaner.js
@@ -226,6 +226,21 @@
   // each gate-open event until the first time the cleaner acts on an
   // intermediary URL (result.cleaned === true), which performs the clear
   // regardless of how many keys were present. After that we latch off.
+  //
+  // Nonce handshake (#811): capture the shared secret from the one-shot
+  // `muga:history-gate:nonce` event fired at document_start by the
+  // dispatcher. Gate events without the matching nonce are rejected.
+  let _capturedNonce = null;
+  (function () {
+    function _onNonce(e) {
+      if (e && e.detail && typeof e.detail.nonce === "string") {
+        _capturedNonce = e.detail.nonce;
+      }
+      document.removeEventListener("muga:history-gate:nonce", _onNonce);
+    }
+    document.addEventListener("muga:history-gate:nonce", _onNonce);
+  })();
+
   let _haveCleaned = false;
 
   function attemptCleanup() {
@@ -238,8 +253,16 @@
     }
   }
 
+  let _warnedOrder = false;
   document.addEventListener("muga:history-gate", (e) => {
-    const enabled = !!(e && e.detail && e.detail.enabled);
+    if (!e || !e.detail || e.detail.nonce !== _capturedNonce) {
+      if (!_warnedOrder && e && e.detail && typeof e.detail.nonce === "string" && _capturedNonce === null) {
+        _warnedOrder = true;
+        console.warn("[MUGA] gate event before nonce capture — check manifest script order");
+      }
+      return;
+    }
+    const enabled = !!(e.detail.enabled);
     if (enabled) attemptCleanup();
   });
 })();

--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -150,6 +150,21 @@
   // ── Disabled-state gate ───────────────────────────────────────────────
   // Reuse the same `muga:history-gate` event the History Defuser
   // publishes — no extra prefs round-trip, no second gate.
+  //
+  // Nonce handshake (#811): capture the shared secret from the one-shot
+  // `muga:history-gate:nonce` event fired at document_start by the
+  // dispatcher. Gate events without the matching nonce are rejected.
+  let _capturedNonce = null;
+  (function () {
+    function _onNonce(e) {
+      if (e && e.detail && typeof e.detail.nonce === "string") {
+        _capturedNonce = e.detail.nonce;
+      }
+      document.removeEventListener("muga:history-gate:nonce", _onNonce);
+    }
+    document.addEventListener("muga:history-gate:nonce", _onNonce);
+  })();
+
   let _installed = false;
   const CAPTURE_OPTS = { capture: true };
 
@@ -174,8 +189,16 @@
     _installed = false;
   }
 
+  let _warnedOrder = false;
   document.addEventListener("muga:history-gate", (e) => {
-    const enabled = !!(e && e.detail && e.detail.enabled);
+    if (!e || !e.detail || e.detail.nonce !== _capturedNonce) {
+      if (!_warnedOrder && e && e.detail && typeof e.detail.nonce === "string" && _capturedNonce === null) {
+        _warnedOrder = true;
+        console.warn("[MUGA] gate event before nonce capture — check manifest script order");
+      }
+      return;
+    }
+    const enabled = !!(e.detail.enabled);
     if (enabled) install();
     else uninstall();
   });

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -213,6 +213,21 @@
   // publishes from `content/history-defuser.js`. A separate gate event
   // would mean two prefs round-trips on every page; sharing keeps
   // disabled-state behavior coherent and cheap.
+  //
+  // Nonce handshake (#811): capture the shared secret from the one-shot
+  // `muga:history-gate:nonce` event fired at document_start by the
+  // dispatcher. Gate events without the matching nonce are rejected.
+  let _capturedNonce = null;
+  (function () {
+    function _onNonce(e) {
+      if (e && e.detail && typeof e.detail.nonce === "string") {
+        _capturedNonce = e.detail.nonce;
+      }
+      document.removeEventListener("muga:history-gate:nonce", _onNonce);
+    }
+    document.addEventListener("muga:history-gate:nonce", _onNonce);
+  })();
+
   let _observer = null;
 
   function observerCallback(records) {
@@ -253,8 +268,16 @@
     _observer = null;
   }
 
+  let _warnedOrder = false;
   document.addEventListener("muga:history-gate", (e) => {
-    const enabled = !!(e && e.detail && e.detail.enabled);
+    if (!e || !e.detail || e.detail.nonce !== _capturedNonce) {
+      if (!_warnedOrder && e && e.detail && typeof e.detail.nonce === "string" && _capturedNonce === null) {
+        _warnedOrder = true;
+        console.warn("[MUGA] gate event before nonce capture — check manifest script order");
+      }
+      return;
+    }
+    const enabled = !!(e.detail.enabled);
     if (enabled) startObserver();
     else stopObserver();
   });

--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -98,13 +98,39 @@
   // dispatched on `document`: events DO cross the isolated/main world
   // boundary even though `window` properties don't. The companion
   // isolated-world script (content/history-defuser.js) reads prefs and
-  // dispatches `muga:history-gate` with `detail: { enabled: bool }`.
+  // dispatches `muga:history-gate` with `detail: { enabled: bool, nonce }`.
   // Until the first event arrives the gate stays CLOSED (fail-closed):
   // the wrap is installed but pass-through, matching the
   // disabled-state guard contract in AGENTS.md.
+  //
+  // Nonce handshake (#811): the dispatcher fires a one-shot
+  // `muga:history-gate:nonce` event at document_start before any page
+  // script executes. We capture the nonce here, then remove the listener
+  // so no persistent listener can be observed. All subsequent gate events
+  // must carry the matching nonce or they are silently ignored — this
+  // prevents hostile page scripts from spoofing the gate event.
+  let _capturedNonce = null;
+  function _onNonce(e) {
+    if (e && e.detail && typeof e.detail.nonce === "string") {
+      _capturedNonce = e.detail.nonce;
+    }
+    document.removeEventListener("muga:history-gate:nonce", _onNonce);
+  }
+  document.addEventListener("muga:history-gate:nonce", _onNonce);
+
   let _gateOpen = false;
+  let _warnedOrder = false;
   document.addEventListener("muga:history-gate", (e) => {
-    _gateOpen = !!(e && e.detail && e.detail.enabled);
+    // Reject events that do not carry the handshake nonce. A missing or
+    // mismatched nonce indicates a spoofed dispatch from page-script code.
+    if (!e || !e.detail || e.detail.nonce !== _capturedNonce) {
+      if (!_warnedOrder && e && e.detail && typeof e.detail.nonce === "string" && _capturedNonce === null) {
+        _warnedOrder = true;
+        console.warn("[MUGA] gate event before nonce capture — check manifest script order");
+      }
+      return;
+    }
+    _gateOpen = !!(e.detail.enabled);
   });
 
   function gateOpen() {

--- a/src/content/history-defuser.js
+++ b/src/content/history-defuser.js
@@ -27,6 +27,48 @@
   if (window.__mugaHistoryDefuserGate) return;
   window.__mugaHistoryDefuserGate = true;
 
+  // ── Nonce handshake (#811) ────────────────────────────────────────────
+  //
+  // The `muga:history-gate` CustomEvent crosses the isolated/main-world
+  // boundary and is therefore also dispatchable by hostile page scripts.
+  // A page can call `document.dispatchEvent(new CustomEvent("muga:history-gate",
+  // { detail: { enabled: false } }))` to silently disable the active-defense
+  // layer or force-open it pre-consent.
+  //
+  // Fix: generate a random nonce here (isolated world, first script in the
+  // injection order), share it via a one-shot `muga:history-gate:nonce` event
+  // that fires at document_start BEFORE any page script can run, and require
+  // every subsequent gate event to carry the correct nonce in its detail.
+  //
+  // Injection-order contract (PINNED — do not reorder without updating both
+  // manifests AND tests/unit/gate-nonce.test.mjs):
+  //
+  //   The handshake fires ONCE, synchronously, at document_start. Every
+  //   listener script MUST be ordered BEFORE this file in BOTH manifests
+  //   (src/manifest.json and src/manifest.v2.json). A listener that
+  //   registers AFTER this dispatch never captures the nonce and stays
+  //   fail-closed — it will reject every subsequent gate event silently.
+  //   Ordering is pinned by tests/unit/gate-nonce.test.mjs.
+  //
+  //   MV3 Chrome — MAIN-world scripts (history-defuser-mainworld.js,
+  //     window-name-defuser-mainworld.js) run in a separate group that
+  //     executes before the ISOLATED group; they register their nonce
+  //     listeners before this file fires. Within the ISOLATED group, all
+  //     gate-aware siblings (window-name-defuser.js, dom-link-rewriter.js,
+  //     dom-link-rewriter-click.js, bounce-state-cleaner.js) are listed
+  //     before this file in the manifest so they register first.
+  //   Firefox MV2 — no world:MAIN group; the window-name-defuser-mainworld
+  //     page copy is injected as a synchronous <script> by
+  //     window-name-defuser.js (which runs before this file). All isolated-
+  //     world siblings are likewise listed before this file in the manifest.
+  //
+  // No global property stores the nonce after handshake — it lives only
+  // inside each listener's closure to prevent page scripts from reading it
+  // back via window inspection.
+  const _nonceBytes = new Uint8Array(16);
+  crypto.getRandomValues(_nonceBytes);
+  const _nonce = Array.from(_nonceBytes, (b) => b.toString(16).padStart(2, "0")).join("");
+
   // ── Firefox MV2 page-world bootstrap (#509 / B12) ────────────────────
   //
   // Chrome MV3 registers `history-defuser-mainworld.js` as a `world: "MAIN"`
@@ -59,10 +101,19 @@
     }
   } catch { /* manifest unavailable / DOM not ready — leave the page-world wrap absent */ }
 
+  // Broadcast the nonce once at document_start so all listeners (both worlds)
+  // can capture it before any page script executes. This event is fired once
+  // and never again; listeners remove themselves after capturing the nonce.
+  try {
+    document.dispatchEvent(new CustomEvent("muga:history-gate:nonce", {
+      detail: { nonce: _nonce },
+    }));
+  } catch { /* document detached — silent */ }
+
   function dispatchGate(enabled) {
     try {
       document.dispatchEvent(new CustomEvent("muga:history-gate", {
-        detail: { enabled: !!enabled },
+        detail: { enabled: !!enabled, nonce: _nonce },
       }));
     } catch { /* document detached or CustomEvent unavailable — silent */ }
   }

--- a/src/content/window-name-defuser-mainworld.js
+++ b/src/content/window-name-defuser-mainworld.js
@@ -122,9 +122,32 @@
   // dispatcher → both main-world wraps. Until the first event arrives
   // the gate stays CLOSED (fail-closed): the wrap is installed but
   // pass-through, matching the disabled-state guard contract.
+  //
+  // Nonce handshake (#811): same pattern as history-defuser-mainworld.js.
+  // The one-shot `muga:history-gate:nonce` event broadcasts the shared
+  // secret before page scripts run; we capture it here and validate it
+  // on every subsequent gate event to reject hostile page-script spoofing.
+  let _capturedNonce = null;
+  function _onNonce(e) {
+    if (e && e.detail && typeof e.detail.nonce === "string") {
+      _capturedNonce = e.detail.nonce;
+    }
+    document.removeEventListener("muga:history-gate:nonce", _onNonce);
+  }
+  document.addEventListener("muga:history-gate:nonce", _onNonce);
+
   let _gateOpen = false;
+  let _warnedOrder = false;
   document.addEventListener("muga:history-gate", (e) => {
-    _gateOpen = !!(e && e.detail && e.detail.enabled);
+    // Reject events that do not carry the handshake nonce.
+    if (!e || !e.detail || e.detail.nonce !== _capturedNonce) {
+      if (!_warnedOrder && e && e.detail && typeof e.detail.nonce === "string" && _capturedNonce === null) {
+        _warnedOrder = true;
+        console.warn("[MUGA] gate event before nonce capture — check manifest script order");
+      }
+      return;
+    }
+    _gateOpen = !!(e.detail.enabled);
   });
 
   // Capture whatever value `window.name` held before we replaced the

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,7 +44,7 @@
     },
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/bounce-state-cleaner.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/bounce-state-cleaner.js", "content/history-defuser.js", "content/cleaner.js"],
       "run_at": "document_start"
     }
   ],

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -33,7 +33,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/history-defuser.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/bounce-state-cleaner.js", "content/cleaner.js"],
+      "js": ["lib/browser-polyfill.min.js", "content/cleaner-bundle.js", "content/window-name-defuser.js", "content/dom-link-rewriter.js", "content/dom-link-rewriter-click.js", "content/bounce-state-cleaner.js", "content/history-defuser.js", "content/cleaner.js"],
       "run_at": "document_start"
     },
     {

--- a/tests/e2e/history-defuser.spec.mjs
+++ b/tests/e2e/history-defuser.spec.mjs
@@ -72,6 +72,44 @@ test.describe("History Defuser (#444)", () => {
     await completeOnboarding(context, extensionId);
   });
 
+  /**
+   * Security regression for #811: a hostile page script that dispatches
+   * `muga:history-gate` with `enabled: false` but WITHOUT the correct
+   * nonce must not be able to disarm the defuser.
+   *
+   * NOTE: This spec is NOT run as part of `npm test` (unit suite). It
+   * requires a headed Playwright browser with the extension loaded. Run
+   * via `npm run test:e2e` or equivalent when validating the fix live.
+   */
+  test("hostile page dispatch without nonce cannot disarm the defuser (#811)", async ({ context }) => {
+    const page = await context.newPage();
+    await stubPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaHistoryDefused === true, { timeout: 10000 });
+
+    // Simulate a hostile page script dispatching the gate event without the
+    // correct nonce. The detail carries enabled: false but no nonce — the
+    // listener must reject it and keep the gate in its current state.
+    await page.evaluate(() => {
+      document.dispatchEvent(new CustomEvent("muga:history-gate", {
+        detail: { enabled: false },
+      }));
+    });
+
+    // Now perform a pushState with tracking params. If the defuser was
+    // wrongly disarmed, the URL would retain the tracking params.
+    await page.locator("#muga-push-btn").click();
+    await page.waitForFunction(() => typeof window.__mugaTestSearch === "string");
+
+    const search = await page.evaluate(() => window.__mugaTestSearch);
+    expect(search).not.toContain("utm_source");
+    expect(search).not.toContain("utm_medium");
+    expect(search).toContain("id=42");
+
+    await page.close();
+  });
+
   test("pushState with tracking params lands a cleaned URL in window.location", async ({ context }) => {
     const page = await context.newPage();
     await stubPage(page);

--- a/tests/unit/gate-nonce.test.mjs
+++ b/tests/unit/gate-nonce.test.mjs
@@ -1,0 +1,246 @@
+/**
+ * MUGA — Gate-nonce security tests (#811)
+ *
+ * Verifies that the `muga:history-gate` event cannot be spoofed by a
+ * hostile page. The handshake mechanism works as follows:
+ *
+ *   1. At document_start, `history-defuser.js` (isolated world) generates
+ *      a random nonce and fires a one-shot `muga:history-gate:nonce` event.
+ *   2. All listeners — in both worlds — capture the nonce from this event
+ *      and store it in a closure-local variable, then remove the nonce
+ *      listener. No global property is written.
+ *   3. Every subsequent `muga:history-gate` dispatch by the isolated-world
+ *      gatekeeper includes the nonce in `detail.nonce`.
+ *   4. Listeners silently ignore any gate event whose `detail.nonce` does
+ *      not match the captured value.
+ *
+ * These tests are source-analysis tests (no DOM, no jsdom). They verify
+ * the structural contracts that make the handshake sound.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { readdirSync } from "node:fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const src = {
+  dispatcher:      readFileSync(join(__dirname, "../../src/content/history-defuser.js"), "utf8"),
+  histMainworld:   readFileSync(join(__dirname, "../../src/content/history-defuser-mainworld.js"), "utf8"),
+  winNameMainworld:readFileSync(join(__dirname, "../../src/content/window-name-defuser-mainworld.js"), "utf8"),
+  domRewriter:     readFileSync(join(__dirname, "../../src/content/dom-link-rewriter.js"), "utf8"),
+  domRewriterClick:readFileSync(join(__dirname, "../../src/content/dom-link-rewriter-click.js"), "utf8"),
+  bounceStateCleaner: readFileSync(join(__dirname, "../../src/content/bounce-state-cleaner.js"), "utf8"),
+};
+
+// ── Dispatcher contracts ────────────────────────────────────────────────────
+
+describe("gate-nonce — dispatcher (history-defuser.js)", () => {
+  test("dispatcher generates a random nonce using crypto.getRandomValues", () => {
+    assert.ok(
+      /crypto\.getRandomValues/.test(src.dispatcher),
+      "dispatcher must generate nonce via crypto.getRandomValues",
+    );
+  });
+
+  test("dispatcher fires the one-shot muga:history-gate:nonce handshake event", () => {
+    assert.ok(
+      /muga:history-gate:nonce/.test(src.dispatcher),
+      "dispatcher must fire muga:history-gate:nonce to share the nonce with listeners",
+    );
+  });
+
+  test("dispatcher includes nonce in muga:history-gate detail", () => {
+    // The dispatchGate function must spread or include the nonce in detail.
+    assert.ok(
+      /dispatchEvent[^]*CustomEvent[^]*muga:history-gate[^;]{0,400}nonce/s.test(src.dispatcher) ||
+      /nonce[^]*muga:history-gate/s.test(src.dispatcher),
+      "dispatcher must include nonce in every muga:history-gate event detail",
+    );
+  });
+
+  test("dispatcher does not leave a global nonce property after handshake", () => {
+    // No persistent window.__muga* assignment that stores the nonce.
+    // The nonce must live only inside the IIFE closure.
+    const stripped = src.dispatcher
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+    // window.__mugaNonce or similar globals are forbidden
+    assert.ok(
+      !/window\.__mugaNonce/.test(stripped) &&
+      !/window\.__mugaGateNonce/.test(stripped) &&
+      !/window\.__mugaHandshake/.test(stripped),
+      "dispatcher must not write the nonce to any window.__ property",
+    );
+  });
+});
+
+// ── Listener contracts (common) ─────────────────────────────────────────────
+
+const listenerFiles = [
+  ["history-defuser-mainworld.js", src.histMainworld],
+  ["window-name-defuser-mainworld.js", src.winNameMainworld],
+  ["dom-link-rewriter.js", src.domRewriter],
+  ["dom-link-rewriter-click.js", src.domRewriterClick],
+  ["bounce-state-cleaner.js", src.bounceStateCleaner],
+];
+
+describe("gate-nonce — all listeners capture the nonce", () => {
+  for (const [filename, fileSource] of listenerFiles) {
+    test(`${filename} listens for muga:history-gate:nonce to capture the nonce`, () => {
+      assert.ok(
+        /muga:history-gate:nonce/.test(fileSource),
+        `${filename} must subscribe to the muga:history-gate:nonce handshake event`,
+      );
+    });
+
+    test(`${filename} validates nonce on muga:history-gate before acting`, () => {
+      // The listener must check that e.detail.nonce matches its captured value.
+      assert.ok(
+        /detail\.nonce/.test(fileSource),
+        `${filename} must check detail.nonce when processing muga:history-gate`,
+      );
+    });
+
+    test(`${filename} does not expose the nonce as a global window property`, () => {
+      const stripped = fileSource
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/.*$/gm, "");
+      assert.ok(
+        !/window\.__mugaNonce/.test(stripped) &&
+        !/window\.__mugaGateNonce/.test(stripped) &&
+        !/window\.__mugaHandshake/.test(stripped),
+        `${filename} must not leak the nonce via any window.__ property`,
+      );
+    });
+  }
+});
+
+// ── No-global-trace contract ─────────────────────────────────────────────────
+
+describe("gate-nonce — handshake leaves no readable global behind", () => {
+  test("no content script assigns the nonce to a window property readable after handshake", () => {
+    const allSources = Object.values(src);
+    for (const fileSource of allSources) {
+      const stripped = fileSource
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/.*$/gm, "");
+      assert.ok(
+        !/window\.__mugaNonce\s*=/.test(stripped) &&
+        !/window\.__mugaGateNonce\s*=/.test(stripped),
+        "no content script may assign the nonce to a global window property",
+      );
+    }
+  });
+
+  test("handshake event name muga:history-gate:nonce is distinct from the gate event", () => {
+    // Sanity: the nonce handshake must use a different event name than the
+    // operational gate, so the nonce-bearing handshake event is one-shot
+    // and the gate event is the recurring signal.
+    assert.notEqual(
+      "muga:history-gate:nonce",
+      "muga:history-gate",
+      "handshake event name must differ from gate event name",
+    );
+    // Verify dispatcher fires both event names.
+    assert.ok(/muga:history-gate:nonce/.test(src.dispatcher), "dispatcher fires handshake event");
+    assert.ok(/muga:history-gate[^:]/.test(src.dispatcher), "dispatcher fires gate event");
+  });
+});
+
+// ── Manifest ordering invariant ───────────────────────────────────────────────
+//
+// history-defuser.js (the dispatcher) MUST appear AFTER every other script
+// that contains "muga:history-gate:nonce" (i.e., every listener). If a new
+// listener is added without moving the dispatcher to the end, this test fails.
+// Invariant is checked dynamically so adding a new listener without reordering
+// manifests will automatically break this test.
+
+describe("gate-nonce — manifest ordering: dispatcher runs last", () => {
+  const contentDir = join(__dirname, "../../src/content");
+  const DISPATCHER = "content/history-defuser.js";
+  const NONCE_PATTERN = /muga:history-gate:nonce/;
+
+  /**
+   * Discover all content scripts that subscribe to the nonce event by
+   * reading each file referenced in the manifest content_scripts list.
+   * Returns the set of manifest-relative paths (e.g. "content/foo.js")
+   * whose source contains the pattern.
+   */
+  function findNonceRegistrants(manifestScripts) {
+    const srcRoot = join(__dirname, "../../src");
+    const registrants = [];
+    for (const scriptPath of manifestScripts) {
+      if (scriptPath === DISPATCHER) continue; // skip dispatcher itself
+      let source;
+      try {
+        source = readFileSync(join(srcRoot, scriptPath), "utf8");
+      } catch {
+        continue; // lib or missing file — not a content script we own
+      }
+      if (NONCE_PATTERN.test(source)) {
+        registrants.push(scriptPath);
+      }
+    }
+    return registrants;
+  }
+
+  function extractIsolatedScripts(manifestPath) {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    // Find the content_scripts group that is NOT world:MAIN and runs at
+    // document_start — that is the isolated group containing the dispatcher.
+    const groups = manifest.content_scripts || [];
+    for (const group of groups) {
+      const world = group.world || "ISOLATED";
+      const runAt = group.run_at || "document_idle";
+      if (world !== "MAIN" && runAt === "document_start" && Array.isArray(group.js)) {
+        if (group.js.includes(DISPATCHER)) {
+          return group.js;
+        }
+      }
+    }
+    return [];
+  }
+
+  const manifests = [
+    ["src/manifest.json (MV3)", join(__dirname, "../../src/manifest.json")],
+    ["src/manifest.v2.json (Firefox MV2)", join(__dirname, "../../src/manifest.v2.json")],
+  ];
+
+  for (const [label, manifestPath] of manifests) {
+    test(`${label}: history-defuser.js appears after all nonce-registrant scripts`, () => {
+      const scripts = extractIsolatedScripts(manifestPath);
+      assert.ok(
+        scripts.length > 0,
+        `${label}: could not locate the isolated document_start group containing ${DISPATCHER}`,
+      );
+
+      const dispatcherIdx = scripts.indexOf(DISPATCHER);
+      assert.ok(
+        dispatcherIdx !== -1,
+        `${label}: ${DISPATCHER} not found in the isolated document_start group`,
+      );
+
+      const registrants = findNonceRegistrants(scripts);
+      assert.ok(
+        registrants.length > 0,
+        `${label}: no nonce registrant scripts found — at least one listener must exist`,
+      );
+
+      for (const registrant of registrants) {
+        const registrantIdx = scripts.indexOf(registrant);
+        assert.ok(
+          registrantIdx !== -1,
+          `${label}: registrant ${registrant} is not in the isolated group`,
+        );
+        assert.ok(
+          registrantIdx < dispatcherIdx,
+          `${label}: ${registrant} (index ${registrantIdx}) must come BEFORE ${DISPATCHER} (index ${dispatcherIdx}) — nonce registrants must register before the dispatcher fires`,
+        );
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #811

## Summary

- `muga:history-gate` CustomEvents (which arm/disarm the history/window.name defusers, DOM link rewriters and bounce-state cleaner) were spoofable by page scripts — a hostile page could silently disarm MUGA's active-defense layer or force it open pre-consent.
- Fix: 16-byte nonce handshake at `document_start`. The isolated-world dispatcher (`history-defuser.js`) generates the nonce and fires a one-shot `muga:history-gate:nonce` event **before any page script can run**; all six listeners capture it into a closure, remove the handshake listener, and reject any gate event whose `detail.nonce` mismatches. No global trace remains afterwards.
- `e.isTrusted` was NOT an option: the legitimate dispatch also comes from `document.dispatchEvent` (isolated world), which is equally untrusted.
- **Ordering is the security guarantee**: the nonce may only travel in the pre-page-script window, so a late re-fire/request mechanism was explicitly rejected (it would leak the nonce to page scripts). Both manifests now order the dispatcher LAST among gate-aware scripts, and a unit test pins that invariant by reading the manifests and discovering registrants dynamically.

## Review history

Fresh adversarial review caught a BLOCKING execution-order bug in the first iteration (one-shot handshake fired before sibling isolated-world scripts registered → permanently disarmed; proven by `dom-link-rewriter.spec.mjs` failing). Fixed by the dispatcher-last reorder; the previously failing spec now passes.

## Changes

| File | Change |
|------|--------|
| `src/content/history-defuser.js` | Nonce generation + one-shot handshake before gate dispatches; contract comment |
| `src/content/history-defuser-mainworld.js`, `window-name-defuser-mainworld.js`, `dom-link-rewriter.js`, `dom-link-rewriter-click.js`, `bounce-state-cleaner.js` | Capture nonce in closure; validate `detail.nonce`; one-shot order-warning when a gate event precedes capture (fail-closed) |
| `src/manifest.json`, `src/manifest.v2.json` | Dispatcher moved after all gate registrants (MV3 isolated group / MV2 group) |
| `tests/unit/gate-nonce.test.mjs` | New — nonce-flow source invariants + manifest-ordering invariant (dynamic registrant discovery) |
| `tests/e2e/history-defuser.spec.mjs` | New hostile-dispatch spec: page-forged gate event → defuser stays armed |

## Test plan

- [x] `npm test` → 4358 pass / 0 fail
- [x] E2E (headed Chromium, local): `history-defuser.spec.mjs` + `dom-link-rewriter.spec.mjs` + `dom-link-rewriter-click.spec.mjs` → 4/4 pass (includes the spec that failed pre-reorder)
- [x] Fresh-context adversarial review: REQUEST-CHANGES → blocking issue fixed → ordering invariant pinned by test