### PR TITLE
ci(security): harden import-upstream + publish-rules workflows (#812)

### DIFF
--- a/.github/workflows/auto-ingest-rules.yml
+++ b/.github/workflows/auto-ingest-rules.yml
@@ -59,7 +59,7 @@ jobs:
           MUGA_SIGNING_KEY: ${{ secrets.MUGA_SIGNING_KEY }}
         run: |
           echo "$MUGA_SIGNING_KEY" > "$RUNNER_TEMP/key.pem"
-          echo "::add-mask::$(cat "$RUNNER_TEMP/key.pem")"
+          while IFS= read -r line; do echo "::add-mask::$line"; done < "$RUNNER_TEMP/key.pem"
 
       # ── 4. Run pipeline ──────────────────────────────────────────────────────
       # pipeline.mjs runs ingest → orchestrate → promote.

--- a/.github/workflows/import-upstream.yml
+++ b/.github/workflows/import-upstream.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -122,16 +122,19 @@ jobs:
           EOF
           )
 
+          # Write body to a temp file to avoid shell-injection via $BODY/$CANDIDATES.
+          printf '%s\n' "$BODY" > "$RUNNER_TEMP/pr-body.md"
+
           # Re-use existing PR if one is already open against this branch.
           EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING" ]; then
-            gh pr edit "$EXISTING" --title "[auto-import] $COUNT tracking-param candidates from AdGuard Filter 17 ($DATE)" --body "$BODY"
+            gh pr edit "$EXISTING" --title "[auto-import] $COUNT tracking-param candidates from AdGuard Filter 17 ($DATE)" --body-file "$RUNNER_TEMP/pr-body.md"
             echo "Updated existing PR #$EXISTING"
           else
             gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "[auto-import] $COUNT tracking-param candidates from AdGuard Filter 17 ($DATE)" \
-              --body "$BODY" \
+              --body-file "$RUNNER_TEMP/pr-body.md" \
               --label "needs-triage,category:ops"
           fi

--- a/.github/workflows/publish-rules.yml
+++ b/.github/workflows/publish-rules.yml
@@ -50,7 +50,7 @@ jobs:
           MUGA_SIGNING_KEY: ${{ secrets.MUGA_SIGNING_KEY }}
         run: |
           echo "$MUGA_SIGNING_KEY" > "$RUNNER_TEMP/key.pem"
-          echo "::add-mask::$(cat "$RUNNER_TEMP/key.pem")"
+          while IFS= read -r line; do echo "::add-mask::$line"; done < "$RUNNER_TEMP/key.pem"
 
       - name: Sign rules source
         env:
@@ -64,8 +64,8 @@ jobs:
 
       - name: Commit and push signed artifact
         run: |
-          git config user.name "Antonio Rodriguez"
-          git config user.email "yocreoquesi@gmail.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/rules/v1/params.json
           # Only commit if the file actually changed
           if ! git diff --cached --quiet; then

--- a/tests/unit/workflow-hardening.test.mjs
+++ b/tests/unit/workflow-hardening.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * MUGA — Workflow Hardening Guard Tests (#812)
+ *
+ * Guards for CI security patterns introduced in the #812 hardening wave:
+ *
+ *  G1 — All `uses:` in import-upstream.yml, publish-rules.yml,
+ *       auto-ingest-rules.yml, and validate-rules.yml are SHA-pinned (40-char)
+ *  G2 — import-upstream.yml uses --body-file (no `--body "$BODY"` interpolation)
+ *  G3 — auto-ingest-rules.yml and publish-rules.yml mask PEM line-by-line
+ *       (no `::add-mask::$(cat ...key.pem)`)
+ *  G4 — publish-rules.yml uses the github-actions[bot] identity (not personal email)
+ *
+ * Uses string/regex assertions only — no external YAML parser.
+ * Mirrors the pattern from tests/unit/ingestion-scheduled-workflow.test.mjs.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workflowsDir = join(__dirname, "../../.github/workflows");
+
+function readWorkflow(name) {
+  return readFileSync(join(workflowsDir, name), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// G1 — SHA pinning for all four target workflows
+// ---------------------------------------------------------------------------
+describe("G1 — SHA pinning across all hardened workflows", () => {
+  const FILES = [
+    "import-upstream.yml",
+    "publish-rules.yml",
+    "auto-ingest-rules.yml",
+    "validate-rules.yml",
+  ];
+
+  for (const file of FILES) {
+    test(`${file}: all 'uses:' lines reference a 40-char commit SHA`, () => {
+      const content = readWorkflow(file);
+      const lines = content.split("\n");
+      const usesLines = lines.filter(l => /^\s+(-\s+)?uses:\s+\S/.test(l));
+
+      assert.ok(
+        usesLines.length > 0,
+        `${file} has no 'uses:' lines — check the file is being read correctly`
+      );
+
+      for (const line of usesLines) {
+        const pinned = /uses:\s+[a-zA-Z0-9/_.-]+@[a-f0-9]{40}(\s.*)?$/.test(line.trim());
+        assert.ok(
+          pinned,
+          `${file} has an unpinned action: "${line.trim()}"\n` +
+          "All 'uses:' references must use a 40-character commit SHA, not a tag or branch."
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// G2 — import-upstream.yml must use --body-file (no shell-injection vector)
+// ---------------------------------------------------------------------------
+describe("G2 — import-upstream.yml PR body safety", () => {
+  test("does NOT contain '--body \"$BODY\"' inline interpolation", () => {
+    const content = readWorkflow("import-upstream.yml");
+    assert.ok(
+      !/--body\s+"\$BODY"/.test(content),
+      "import-upstream.yml must NOT use '--body \"$BODY\"' — this is a shell-injection vector. " +
+      "Use --body-file with printf '%s\\n' \"$BODY\" > file instead."
+    );
+  });
+
+  test("uses --body-file for both gh pr edit and gh pr create", () => {
+    const content = readWorkflow("import-upstream.yml");
+    assert.ok(
+      /--body-file/.test(content),
+      "import-upstream.yml must use --body-file for PR body (not inline --body interpolation)"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// G3 — PEM masking must be line-by-line (no collapsed newline risk)
+// ---------------------------------------------------------------------------
+describe("G3 — line-by-line PEM masking (no collapsed ::add-mask::$(cat ...))", () => {
+  const FILES_WITH_PEM = ["auto-ingest-rules.yml", "publish-rules.yml"];
+
+  for (const file of FILES_WITH_PEM) {
+    test(`${file}: does NOT use '::add-mask::$(cat' (collapsed-newline masking)`, () => {
+      const content = readWorkflow(file);
+      assert.ok(
+        !/::add-mask::\$\(cat/.test(content),
+        `${file} uses '::add-mask::$(cat ...)' which collapses newlines and leaves individual ` +
+        "PEM lines unmasked. Replace with line-by-line: " +
+        "while IFS= read -r line; do echo \"::add-mask::$line\"; done < \"$RUNNER_TEMP/key.pem\""
+      );
+    });
+
+    test(`${file}: uses line-by-line PEM masking (while IFS= read -r loop)`, () => {
+      const content = readWorkflow(file);
+      assert.ok(
+        /while\s+IFS=\s+read\s+-r\s+line/.test(content) ||
+        /while\s+IFS=\s*read\s+-r\s+line/.test(content),
+        `${file} must mask PEM line-by-line using: ` +
+        "while IFS= read -r line; do echo \"::add-mask::$line\"; done < \"$RUNNER_TEMP/key.pem\""
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// G4 — publish-rules.yml must use github-actions[bot] identity
+// ---------------------------------------------------------------------------
+describe("G4 — publish-rules.yml bot identity", () => {
+  test("does NOT contain personal email (yocreoquesi@gmail.com)", () => {
+    const content = readWorkflow("publish-rules.yml");
+    assert.ok(
+      !content.includes("yocreoquesi@gmail.com"),
+      "publish-rules.yml must NOT use a personal email address for git config. " +
+      "Use '41898282+github-actions[bot]@users.noreply.github.com' instead."
+    );
+  });
+
+  test("uses github-actions[bot] as git user.name", () => {
+    const content = readWorkflow("publish-rules.yml");
+    assert.ok(
+      /github-actions\[bot\]/.test(content),
+      "publish-rules.yml must use 'github-actions[bot]' as the git commit identity"
+    );
+  });
+
+  test("uses the canonical noreply address for github-actions[bot]", () => {
+    const content = readWorkflow("publish-rules.yml");
+    assert.ok(
+      /41898282\+github-actions\[bot\]@users\.noreply\.github\.com/.test(content),
+      "publish-rules.yml must use '41898282+github-actions[bot]@users.noreply.github.com' " +
+      "as the git commit email"
+    );
+  });
+});


### PR DESCRIPTION
Closes #812

## Summary

- `import-upstream.yml`: upstream-derived `$CANDIDATES`/`$BODY` no longer interpolated into `gh pr edit/create --body` (shell-injection surface) — both invocations now use `--body-file "$RUNNER_TEMP/pr-body.md"`, mirroring the pattern auto-ingest-rules.yml already uses; `actions/checkout@v6` / `actions/setup-node@v6` mutable tags replaced with the repo's standard 40-char SHA pins.
- `auto-ingest-rules.yml` + `publish-rules.yml`: multi-line PEM `::add-mask::$(cat ...)` only masked the newline-collapsed form, leaving individual key lines unredacted if ever logged — now masked line-by-line.
- `publish-rules.yml`: automated commits switch from the maintainer's personal identity to `github-actions[bot]`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/import-upstream.yml` | SHA pins + `--body-file` for both PR invocations |
| `.github/workflows/auto-ingest-rules.yml` | Line-by-line PEM masking |
| `.github/workflows/publish-rules.yml` | Line-by-line PEM masking + bot identity |
| `tests/unit/workflow-hardening.test.mjs` | New — 13 guards: SHA pinning across 4 rules workflows, no `--body "$BODY"`, no collapsed add-mask, no personal email |

## Test plan

- [x] TDD: guards written first (RED against old workflows), workflows fixed (GREEN)
- [x] `npm test` full suite → 4361 pass / 0 fail (post-rebase on main with #810+#811)
- [x] No other mutable `uses:` pins found in the rules workflows