### PR TITLE
fix(ingestion): per-adapter isolation + fetch timeouts + failure surfacing (#813)

### DIFF
--- a/tests/unit/ingestion-ingest-robustness.test.mjs
+++ b/tests/unit/ingestion-ingest-robustness.test.mjs
@@ -1,0 +1,526 @@
+/**
+ * MUGA — Unit tests for ingest.mjs robustness (#813).
+ *
+ * Covers:
+ *   T-813-1: fetchRaw AbortController timeout — never-resolving fetch → ADAPTER_TIMEOUT error
+ *   T-813-2: one adapter throws → other adapter still contributes params; failure recorded in stats
+ *   T-813-3: all adapters throw → runIngestion rejects with all-failed error (exitCode:1)
+ *   T-813-4: failed adapter appears in formatted ingest stats (report-formatter)
+ *
+ * All tests are network-free and use injectable fetchImpl / timeoutMs / adapters.
+ * Follows the #782 established injection pattern (fetchImpl, adapters, quarantineDir).
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runIngestion } from "../../tools/rule-ingestion/ingest.mjs";
+import { clearurls } from "../../tools/rule-ingestion/adapters/clearurls.mjs";
+import { adguardTp } from "../../tools/rule-ingestion/adapters/adguard-tp.mjs";
+import { formatQuarantineReport } from "../../tools/rule-ingestion/report-formatter.mjs";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTmpDir() {
+  const d = join(
+    tmpdir(),
+    `muga-ingest-robustness-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+/** fetchImpl that returns canned content immediately */
+function makeOkFetch(content = "") {
+  return async () => ({ ok: true, text: async () => content });
+}
+
+/** Minimal adapter factory for test injection */
+function makeAdapter({ id = "test", params = new Set(), fetchRaw } = {}) {
+  return {
+    id,
+    name: `Test adapter ${id}`,
+    license: "MIT",
+    url: "https://example.com",
+    fetchRaw: fetchRaw ?? (async () => ""),
+    parse: () => ({ params, skipped: 0, affiliateExcluded: 0 }),
+  };
+}
+
+// ── T-813-1: Fetch timeout ─────────────────────────────────────────────────────
+
+describe("T-813-1 — fetch timeout via AbortController", () => {
+  test("clearurls.fetchRaw: never-resolving fetchImpl → rejects with ADAPTER_TIMEOUT error", async () => {
+    // A fetchImpl that returns a promise that never resolves — simulates a hung connection.
+    const neverResolveFetch = () => new Promise(() => {});
+
+    await assert.rejects(
+      () => clearurls.fetchRaw({ fetchImpl: neverResolveFetch, timeoutMs: 50 }),
+      (err) => {
+        assert.ok(
+          err.message.includes("ADAPTER_TIMEOUT"),
+          `Expected ADAPTER_TIMEOUT in message, got: ${err.message}`
+        );
+        assert.ok(
+          err.message.includes("clearurls"),
+          `Expected adapter id 'clearurls' in message, got: ${err.message}`
+        );
+        return true;
+      }
+    );
+  });
+
+  test("adguard-tp.fetchRaw: never-resolving fetchImpl → rejects with ADAPTER_TIMEOUT error", async () => {
+    const neverResolveFetch = () => new Promise(() => {});
+
+    await assert.rejects(
+      () => adguardTp.fetchRaw({ fetchImpl: neverResolveFetch, timeoutMs: 50 }),
+      (err) => {
+        assert.ok(
+          err.message.includes("ADAPTER_TIMEOUT"),
+          `Expected ADAPTER_TIMEOUT in message, got: ${err.message}`
+        );
+        assert.ok(
+          err.message.includes("adguard-tp"),
+          `Expected adapter id 'adguard-tp' in message, got: ${err.message}`
+        );
+        return true;
+      }
+    );
+  });
+
+  test("timeout message includes the configured timeout duration (ms)", async () => {
+    const neverResolveFetch = () => new Promise(() => {});
+    const timeoutMs = 75;
+
+    await assert.rejects(
+      () => clearurls.fetchRaw({ fetchImpl: neverResolveFetch, timeoutMs }),
+      (err) => {
+        assert.ok(
+          err.message.includes(String(timeoutMs)),
+          `Expected ${timeoutMs} in timeout message, got: ${err.message}`
+        );
+        return true;
+      }
+    );
+  });
+
+  test("successful fetch still works when timeout does not fire (no regression)", async () => {
+    const goodFetch = makeOkFetch("rawtext");
+    // Should resolve before the 5s timeout
+    const result = await clearurls.fetchRaw({ fetchImpl: goodFetch, timeoutMs: 5000 });
+    assert.equal(result, "rawtext");
+  });
+});
+
+// ── T-813-2: Per-adapter isolation ────────────────────────────────────────────
+
+describe("T-813-2 — per-adapter isolation: one fails, others still contribute", () => {
+  test("failing adapter's error is recorded in stats.adapters[]; other adapter params still returned", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const failingAdapter = makeAdapter({
+      id: "failing",
+      fetchRaw: async () => { throw new Error("network down"); },
+    });
+
+    const okAdapter = makeAdapter({
+      id: "ok-adapter",
+      params: new Set(["utm_source", "gclid"]),
+    });
+
+    const { candidates, stats } = await runIngestion({
+      adapters: [failingAdapter, okAdapter],
+      fetchImpl: makeOkFetch(),
+      quarantineDir,
+    });
+
+    // Failing adapter must be recorded in stats with status:failed + error message
+    const failedStat = stats.adapters.find((a) => a.adapterId === "failing");
+    assert.ok(failedStat, "stats.adapters must include an entry for the failing adapter");
+    assert.equal(failedStat.status, "failed", "failed adapter must have status:'failed'");
+    assert.ok(
+      typeof failedStat.error === "string" && failedStat.error.length > 0,
+      "failed adapter must record the error message"
+    );
+    assert.equal(failedStat.admitted ?? 0, 0, "failed adapter must have 0 admitted params");
+
+    // OK adapter's params must still be in the output (merged into candidates)
+    const okStat = stats.adapters.find((a) => a.adapterId === "ok-adapter");
+    assert.ok(okStat, "stats.adapters must include an entry for the ok adapter");
+    assert.equal(okStat.status, "ok", "successful adapter must have status:'ok'");
+    assert.ok(okStat.admitted > 0, "successful adapter must record non-zero admitted params");
+
+    // The ok adapter's params must feed into candidates
+    const paramNames = candidates.map((c) => c.param ?? c.candidate?.param ?? c);
+    assert.ok(
+      paramNames.length > 0 || candidates.length > 0,
+      "candidates array must be non-empty when at least one adapter succeeded"
+    );
+  });
+
+  test("failing adapter does NOT silently skip — stats entry is always present", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const failingAdapter = makeAdapter({
+      id: "adapter-a",
+      fetchRaw: async () => { throw new Error("timeout"); },
+    });
+
+    const { stats } = await runIngestion({
+      adapters: [failingAdapter, makeAdapter({ id: "adapter-b", params: new Set(["x"]) })],
+      fetchImpl: makeOkFetch(),
+      quarantineDir,
+    });
+
+    // Both adapters must appear in stats — failure is recorded, not silently dropped
+    assert.equal(stats.adapters.length, 2, "stats must have one entry per adapter regardless of failure");
+  });
+
+  test("partial failure: stats.failedAdapters count matches number of failed adapters", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const fail1 = makeAdapter({ id: "fail-1", fetchRaw: async () => { throw new Error("err"); } });
+    const fail2 = makeAdapter({ id: "fail-2", fetchRaw: async () => { throw new Error("err"); } });
+    const ok1 = makeAdapter({ id: "ok-1", params: new Set(["param_a"]) });
+
+    const { stats } = await runIngestion({
+      adapters: [fail1, fail2, ok1],
+      fetchImpl: makeOkFetch(),
+      quarantineDir,
+    });
+
+    assert.equal(
+      stats.failedAdapters,
+      2,
+      `stats.failedAdapters must be 2, got ${stats.failedAdapters}`
+    );
+  });
+});
+
+// ── T-813-3: All adapters failed → hard failure ────────────────────────────────
+
+describe("T-813-3 — all adapters failed → runIngestion rejects with exitCode:1", () => {
+  test("all adapters throw → runIngestion rejects (does not silently return empty)", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const fail1 = makeAdapter({ id: "fail-1", fetchRaw: async () => { throw new Error("err1"); } });
+    const fail2 = makeAdapter({ id: "fail-2", fetchRaw: async () => { throw new Error("err2"); } });
+
+    await assert.rejects(
+      () => runIngestion({ adapters: [fail1, fail2], fetchImpl: makeOkFetch(), quarantineDir }),
+      (err) => {
+        assert.ok(err !== null, "must throw when all adapters fail");
+        return true;
+      }
+    );
+  });
+
+  test("all-adapters-failed error has exitCode:1 (validation failure, not infra)", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const fail1 = makeAdapter({ id: "fail-1", fetchRaw: async () => { throw new Error("err1"); } });
+    const fail2 = makeAdapter({ id: "fail-2", fetchRaw: async () => { throw new Error("err2"); } });
+
+    let thrown = null;
+    try {
+      await runIngestion({ adapters: [fail1, fail2], fetchImpl: makeOkFetch(), quarantineDir });
+    } catch (err) {
+      thrown = err;
+    }
+
+    assert.ok(thrown !== null, "must throw");
+    assert.equal(
+      thrown.exitCode,
+      1,
+      `all-adapters-failed error must have exitCode:1, got ${thrown?.exitCode}`
+    );
+  });
+
+  test("all-adapters-failed error message names the condition clearly", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const fail1 = makeAdapter({ id: "fail-1", fetchRaw: async () => { throw new Error("err1"); } });
+
+    let thrown = null;
+    try {
+      await runIngestion({ adapters: [fail1], fetchImpl: makeOkFetch(), quarantineDir });
+    } catch (err) {
+      thrown = err;
+    }
+
+    assert.ok(thrown !== null, "must throw");
+    assert.ok(
+      thrown.message.toLowerCase().includes("all") &&
+      thrown.message.toLowerCase().includes("adapter"),
+      `error message must mention 'all adapters', got: ${thrown.message}`
+    );
+  });
+
+  test("single adapter ok → runIngestion resolves (partial failure is NOT a hard failure)", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const fail1 = makeAdapter({ id: "fail-1", fetchRaw: async () => { throw new Error("err"); } });
+    const ok1 = makeAdapter({ id: "ok-1", params: new Set(["utm_source"]) });
+
+    // Must NOT throw — partial failure is surfaced in stats but pipeline continues
+    const result = await runIngestion({
+      adapters: [fail1, ok1],
+      fetchImpl: makeOkFetch(),
+      quarantineDir,
+    });
+
+    assert.ok(result.candidates !== undefined, "must return candidates when at least one adapter ok");
+    assert.ok(result.stats !== undefined, "must return stats when at least one adapter ok");
+  });
+});
+
+// ── T-813-4: Failed adapter surfacing in report-formatter ─────────────────────
+
+describe("T-813-4 — failed adapter appears in formatted report output", () => {
+  /**
+   * Build a minimal quarantine-report.json shape that includes ingestStats
+   * with a failed adapter entry. This is the shape written by orchestrate-cli
+   * and read by format-surface / formatQuarantineReport.
+   */
+  function makeReportWithFailedAdapter() {
+    return {
+      generatedAt: "2025-01-15T12:00:00.000Z",
+      quarantineCount: 0,
+      quarantine: [],
+      autoMergeCount: 0,
+      ingestStats: {
+        adapters: [
+          {
+            adapterId: "clearurls",
+            status: "failed",
+            error: "ADAPTER_TIMEOUT: clearurls after 30000ms",
+            admitted: 0,
+            skipped: 0,
+            affiliateExcluded: 0,
+          },
+          {
+            adapterId: "adguard-tp",
+            status: "ok",
+            admitted: 5,
+            skipped: 2,
+            affiliateExcluded: 0,
+          },
+        ],
+        merged: { total: 0, emptyDropped: 0 },
+        failedAdapters: 1,
+      },
+    };
+  }
+
+  test("formatQuarantineReport includes failed adapter in ingest stats table", () => {
+    const report = makeReportWithFailedAdapter();
+    const md = formatQuarantineReport(report);
+
+    assert.ok(md.includes("clearurls"), "report must mention the failed adapter id");
+    assert.ok(md.includes("failed") || md.includes("FAILED"), "report must indicate adapter failure");
+  });
+
+  test("formatQuarantineReport includes the error message for failed adapters", () => {
+    const report = makeReportWithFailedAdapter();
+    const md = formatQuarantineReport(report);
+
+    assert.ok(
+      md.includes("ADAPTER_TIMEOUT") || md.includes("clearurls after"),
+      `report must include the timeout error in the output. Got:\n${md}`
+    );
+  });
+
+  test("formatQuarantineReport still renders ok adapter stats alongside failed ones", () => {
+    const report = makeReportWithFailedAdapter();
+    const md = formatQuarantineReport(report);
+
+    assert.ok(md.includes("adguard-tp"), "successful adapter must also appear in stats table");
+    assert.ok(md.includes("5"), "admitted count for ok adapter must appear");
+  });
+
+  test("all-adapters-failed: failedAdapters count visible in report when > 0", () => {
+    const report = makeReportWithFailedAdapter();
+    const md = formatQuarantineReport(report);
+
+    // The report must surface that an adapter failed — pattern covers "1 failed" / "failedAdapters: 1" etc.
+    assert.ok(
+      md.includes("1") && (md.includes("failed") || md.includes("FAILED")),
+      `report must surface failed adapter count. Got:\n${md.slice(0, 500)}`
+    );
+  });
+});
+
+// ── T-813-5: Null-payload fetch robustness (#813 follow-up) ───────────────────
+//
+// Reproduces the crash described in the review finding: a fetchImpl whose
+// res.text() resolves to null previously caused writeFileSync(path, null, "utf8")
+// to throw a TypeError, which was re-thrown by the `instanceof TypeError` proxy
+// (crashing the whole run with exitCode: undefined instead of recording failure).
+//
+// After the fix: the null-payload is caught BEFORE writeFileSync is called
+// (ADAPTER_BAD_PAYLOAD guard), the adapter is recorded as failed, the loop
+// continues, and other adapters still contribute their params.
+
+describe("T-813-5 — null-payload fetch → records as failed, no crash", () => {
+  /** A fetchImpl whose res.text() resolves to null (simulates upstream garbage) */
+  function makeNullTextFetch() {
+    return async () => ({ ok: true, text: async () => null });
+  }
+
+  /**
+   * Adapter whose fetchRaw delegates to fetchImpl and returns whatever text() gives.
+   * This is the minimal repro: fetchRaw gets null and returns it, triggering the bug.
+   */
+  function makeNullPayloadAdapter(id = "null-fetch") {
+    return {
+      id,
+      name: `Null-payload adapter ${id}`,
+      license: "MIT",
+      url: "https://example.com",
+      fetchRaw: async ({ fetchImpl }) => {
+        const res = await fetchImpl();
+        return await res.text();   // returns null
+      },
+      parse: () => ({ params: new Set(["should-not-reach"]), skipped: 0, affiliateExcluded: 0 }),
+    };
+  }
+
+  test("fetchImpl returning { ok:true, text: async () => null } → adapter recorded failed, no crash", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const nullAdapter = makeNullPayloadAdapter("null-fetch");
+
+    // Must NOT throw — the adapter failure is recorded, not re-thrown.
+    let thrown = null;
+    let result = null;
+    try {
+      result = await runIngestion({
+        adapters: [nullAdapter],
+        fetchImpl: makeNullTextFetch(),
+        quarantineDir,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    // Single adapter failed → all-adapters-failed → throws with exitCode:1
+    // (that is the correct hard-failure path, not a re-thrown TypeError crash)
+    // The key invariant: exitCode must be defined (1) — not undefined as in the bug.
+    assert.ok(
+      thrown !== null,
+      "single-adapter null-payload → all-adapters-failed → must throw (exitCode:1 path)"
+    );
+    assert.strictEqual(
+      thrown.exitCode,
+      1,
+      `all-adapters-failed error must have exitCode:1, not undefined — got: ${thrown?.exitCode}, message: ${thrown?.message}`
+    );
+  });
+
+  test("null-payload adapter recorded as failed; other (ok) adapter still ingests its params", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const nullAdapter = makeNullPayloadAdapter("null-fetch");
+    const okAdapter = makeAdapter({
+      id: "ok-adapter",
+      params: new Set(["utm_source", "gclid"]),
+    });
+
+    // Must NOT throw — the null-fetch adapter fails but ok-adapter succeeds.
+    const { candidates, stats } = await runIngestion({
+      adapters: [nullAdapter, okAdapter],
+      fetchImpl: makeNullTextFetch(),
+      quarantineDir,
+    });
+
+    // null-fetch adapter must appear as failed
+    const nullStat = stats.adapters.find((a) => a.adapterId === "null-fetch");
+    assert.ok(nullStat, "null-fetch adapter must have a stats entry");
+    assert.strictEqual(nullStat.status, "failed", "null-fetch adapter must be recorded as failed");
+    assert.ok(
+      typeof nullStat.error === "string" && nullStat.error.length > 0,
+      "null-fetch adapter must record a non-empty error string"
+    );
+    assert.ok(
+      nullStat.error.includes("ADAPTER_BAD_PAYLOAD") || nullStat.error.includes("null"),
+      `null-fetch error must mention ADAPTER_BAD_PAYLOAD or null; got: ${nullStat.error}`
+    );
+
+    // ok-adapter must still contribute params
+    const okStat = stats.adapters.find((a) => a.adapterId === "ok-adapter");
+    assert.ok(okStat, "ok-adapter must have a stats entry");
+    assert.strictEqual(okStat.status, "ok", "ok-adapter must succeed");
+    assert.ok(okStat.admitted > 0, "ok-adapter must admit its params");
+
+    // candidates must include ok-adapter's output
+    assert.ok(candidates.length > 0, "candidates must be non-empty when ok-adapter contributed");
+
+    // failedAdapters count must be 1
+    assert.strictEqual(stats.failedAdapters, 1, "failedAdapters must be 1");
+  });
+});
+
+// ── T-813-6: AdapterContractError sentinel re-throw still works ───────────────
+//
+// Verifies that true programming-contract violations (parse() returning garbage)
+// still bubble up immediately (not recorded as transient failures).
+// This is the updated FIX-2 behavior: sentinel path, not `instanceof TypeError`.
+
+describe("T-813-6 — AdapterContractError sentinel still re-throws for true contract violations", () => {
+  test("parse() returning null → throws with code ADAPTER_CONTRACT (not recorded as failed)", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const contractViolator = {
+      id: "contract-violator",
+      name: "Contract violator",
+      license: "MIT",
+      url: "https://example.com",
+      fetchRaw: async () => "valid-raw",
+      parse: () => null,  // programming contract violation: must return { params: Set, ... }
+    };
+
+    await assert.rejects(
+      () => runIngestion({ adapters: [contractViolator], quarantineDir }),
+      (err) => {
+        assert.strictEqual(
+          err.code,
+          "ADAPTER_CONTRACT",
+          `must re-throw with code ADAPTER_CONTRACT; got code=${err.code}, message=${err.message}`
+        );
+        assert.ok(
+          err.message.includes("contract-violator"),
+          `error must name the adapter id; got: ${err.message}`
+        );
+        return true;
+      }
+    );
+  });
+
+  test("parse() returning a bare Set → throws with code ADAPTER_CONTRACT", async () => {
+    const quarantineDir = makeTmpDir();
+
+    const bareSetAdapter = {
+      id: "bare-set-adapter",
+      name: "Bare set",
+      license: "MIT",
+      url: "https://example.com",
+      fetchRaw: async () => "valid-raw",
+      parse: () => new Set(["p1", "p2"]),  // missing { params } wrapper
+    };
+
+    await assert.rejects(
+      () => runIngestion({ adapters: [bareSetAdapter], quarantineDir }),
+      (err) => {
+        assert.strictEqual(err.code, "ADAPTER_CONTRACT");
+        assert.ok(err.message.includes("bare-set-adapter"));
+        return true;
+      }
+    );
+  });
+});

--- a/tests/unit/rule-ingestion-adapters.test.mjs
+++ b/tests/unit/rule-ingestion-adapters.test.mjs
@@ -225,8 +225,11 @@ test("T-10: runIngestion aggregates stats from adapters", async () => {
 });
 
 // ── FIX-2 (quarantine-surface PR1 review): bare-Set adapter throws clearly ────
+// Updated (#813): re-throw is now via AdapterContractError sentinel (err.code === "ADAPTER_CONTRACT")
+// rather than `instanceof TypeError` so that transient I/O TypeErrors (e.g. writeFileSync receiving
+// null from garbage upstream) are recorded as failed adapters instead of crashing the run.
 
-test("FIX-2: runIngestion throws a clear TypeError naming the adapter when parse() returns a bare Set", async () => {
+test("FIX-2: runIngestion throws a contract error naming the adapter when parse() returns a bare Set", async () => {
   const dir = mkdtempSync(resolve(tmpdir(), "muga-ingest-bare-set-"));
   try {
     const bareSetAdapter = {
@@ -244,7 +247,13 @@ test("FIX-2: runIngestion throws a clear TypeError naming the adapter when parse
     await assert.rejects(
       () => runIngestion({ adapters: [bareSetAdapter], quarantineDir: dir }),
       (err) => {
-        assert.ok(err instanceof TypeError, "must throw a TypeError");
+        // Sentinel: must carry code "ADAPTER_CONTRACT" (not merely instanceof TypeError,
+        // because transient I/O TypeErrors must NOT be re-thrown — they are recorded as failures).
+        assert.strictEqual(
+          err.code,
+          "ADAPTER_CONTRACT",
+          `must throw with code "ADAPTER_CONTRACT"; got code=${err.code}, message=${err.message}`
+        );
         assert.ok(
           err.message.includes("bad-adapter"),
           `error message must name the adapter id; got: ${err.message}`

--- a/tools/rule-ingestion/adapters/adguard-tp.mjs
+++ b/tools/rule-ingestion/adapters/adguard-tp.mjs
@@ -39,19 +39,58 @@ export const adguardTp = {
   /**
    * Fetch the raw filter list. Returns the raw text so the caller can quarantine
    * it before parsing (raw bytes are ephemeral — never committed/bundled).
+   *
+   * A 30-second AbortController timeout is applied by default to prevent a
+   * hung connection from blocking the CI run until the 6h Actions limit
+   * (#813). Override via timeoutMs for tests (use a short value like 50ms).
+   *
+   * On abort, throws: `ADAPTER_TIMEOUT: adguard-tp after <ms>ms`
+   *
    * @param {object} [opts]
    * @param {typeof fetch} [opts.fetchImpl] Injectable fetch for testing.
+   * @param {number} [opts.timeoutMs=30000] Abort timeout in ms. Injectable for tests.
    * @returns {Promise<string>}
    */
-  async fetchRaw({ fetchImpl = fetch } = {}) {
-    const res = await fetchImpl(SOURCE_URL, {
-      headers: { "User-Agent": USER_AGENT },
+  async fetchRaw({ fetchImpl = fetch, timeoutMs = 30_000 } = {}) {
+    const controller = new AbortController();
+
+    // Race the fetch against an explicit timeout promise so that hung
+    // connections — including test fakes that ignore the abort signal —
+    // are forcibly cut off after timeoutMs (#813).
+    let timer;
+    const timeoutPromise = new Promise((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        const err = new Error(`ADAPTER_TIMEOUT: adguard-tp after ${timeoutMs}ms`);
+        err.name = "AdapterTimeoutError";
+        reject(err);
+      }, timeoutMs);
     });
-    if (!res.ok) {
-      throw new Error(
-        `AdGuard TP fetch failed: ${res.status} ${res.statusText}`,
-      );
+
+    try {
+      const res = await Promise.race([
+        fetchImpl(SOURCE_URL, {
+          headers: { "User-Agent": USER_AGENT },
+          signal: controller.signal,
+        }),
+        timeoutPromise,
+      ]);
+      if (!res.ok) {
+        throw new Error(
+          `AdGuard TP fetch failed: ${res.status} ${res.statusText}`,
+        );
+      }
+      return res.text();
+    } catch (err) {
+      // Re-throw timeout errors and AbortErrors with the canonical ADAPTER_TIMEOUT message.
+      if (err.name === "AdapterTimeoutError" || err.name === "AbortError" || controller.signal.aborted) {
+        const timeoutErr = new Error(`ADAPTER_TIMEOUT: adguard-tp after ${timeoutMs}ms`);
+        timeoutErr.name = "AdapterTimeoutError";
+        throw timeoutErr;
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
     }
-    return res.text();
   },
 };

--- a/tools/rule-ingestion/adapters/clearurls.mjs
+++ b/tools/rule-ingestion/adapters/clearurls.mjs
@@ -162,19 +162,58 @@ export const clearurls = {
   /**
    * Fetch the raw rules JSON. Returns raw text for the caller to quarantine
    * before parsing (raw bytes are ephemeral — never committed/bundled).
+   *
+   * A 30-second AbortController timeout is applied by default to prevent a
+   * hung connection from blocking the CI run until the 6h Actions limit
+   * (#813). Override via timeoutMs for tests (use a short value like 50ms).
+   *
+   * On abort, throws: `ADAPTER_TIMEOUT: clearurls after <ms>ms`
+   *
    * @param {object} [opts]
    * @param {typeof fetch} [opts.fetchImpl] Injectable fetch for testing.
+   * @param {number} [opts.timeoutMs=30000] Abort timeout in ms. Injectable for tests.
    * @returns {Promise<string>}
    */
-  async fetchRaw({ fetchImpl = fetch } = {}) {
-    const res = await fetchImpl(SOURCE_URL, {
-      headers: { "User-Agent": USER_AGENT },
+  async fetchRaw({ fetchImpl = fetch, timeoutMs = 30_000 } = {}) {
+    const controller = new AbortController();
+
+    // Race the fetch against an explicit timeout promise so that hung
+    // connections — including test fakes that ignore the abort signal —
+    // are forcibly cut off after timeoutMs (#813).
+    let timer;
+    const timeoutPromise = new Promise((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        const err = new Error(`ADAPTER_TIMEOUT: clearurls after ${timeoutMs}ms`);
+        err.name = "AdapterTimeoutError";
+        reject(err);
+      }, timeoutMs);
     });
-    if (!res.ok) {
-      throw new Error(
-        `ClearURLs fetch failed: ${res.status} ${res.statusText}`,
-      );
+
+    try {
+      const res = await Promise.race([
+        fetchImpl(SOURCE_URL, {
+          headers: { "User-Agent": USER_AGENT },
+          signal: controller.signal,
+        }),
+        timeoutPromise,
+      ]);
+      if (!res.ok) {
+        throw new Error(
+          `ClearURLs fetch failed: ${res.status} ${res.statusText}`,
+        );
+      }
+      return res.text();
+    } catch (err) {
+      // Re-throw timeout errors and AbortErrors with the canonical ADAPTER_TIMEOUT message.
+      if (err.name === "AdapterTimeoutError" || err.name === "AbortError" || controller.signal.aborted) {
+        const timeoutErr = new Error(`ADAPTER_TIMEOUT: clearurls after ${timeoutMs}ms`);
+        timeoutErr.name = "AdapterTimeoutError";
+        throw timeoutErr;
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
     }
-    return res.text();
   },
 };

--- a/tools/rule-ingestion/ingest.mjs
+++ b/tools/rule-ingestion/ingest.mjs
@@ -27,18 +27,37 @@ import { fileURLToPath } from "node:url";
 import { ENABLED_ADAPTERS } from "./adapters/index.mjs";
 import { mergeCandidates } from "./candidate.mjs";
 
+/**
+ * Sentinel error class for adapter programming-contract violations.
+ * Re-thrown immediately (not recorded as a transient failure) because these
+ * are bugs in the adapter code itself, not transient upstream problems.
+ */
+class AdapterContractError extends Error {
+  constructor(adapterId, detail) {
+    super(`[runIngestion] Adapter "${adapterId}" violated its contract: ${detail}`);
+    this.code = "ADAPTER_CONTRACT";
+    this.adapterId = adapterId;
+  }
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const QUARANTINE_DIR = resolve(__dirname, "quarantine");
 
 /**
  * Fetch + quarantine + normalize every adapter into a candidate set.
  *
+ * Per-adapter isolation (#813): each adapter is wrapped in try/catch.
+ * A failing adapter records { adapterId, status:'failed', error, admitted:0 }
+ * in stats and contributes zero params — the loop continues with remaining
+ * adapters. If EVERY adapter fails, runIngestion throws with exitCode:1
+ * so the scheduled CI run goes RED instead of silently green.
+ *
  * @param {object} [opts]
  * @param {import("./adapters/index.mjs").Adapter[]} [opts.adapters] Defaults to ENABLED_ADAPTERS.
  * @param {typeof fetch} [opts.fetchImpl] Injectable fetch for testing.
  * @param {string} [opts.quarantineDir] Working dir for raw downloads.
  * @param {string} [opts.now] ISO timestamp override for deterministic output.
- * @returns {Promise<{ candidates: object[], stats: { adapters: object[], merged: { emptyDropped: number, total: number } } }>}
+ * @returns {Promise<{ candidates: object[], stats: { adapters: object[], failedAdapters: number, merged: { emptyDropped: number, total: number } } }>}
  */
 export async function runIngestion({
   adapters = ENABLED_ADAPTERS,
@@ -50,24 +69,86 @@ export async function runIngestion({
 
   const results = [];
   const adapterStats = [];
+  let failedAdapters = 0;
+
   for (const adapter of adapters) {
-    const raw = await adapter.fetchRaw({ fetchImpl });
-    // Raw bytes land in quarantine ONLY — gitignored, never committed/bundled.
-    writeFileSync(resolve(quarantineDir, `${adapter.id}.raw`), raw, "utf8");
-    const parseResult = adapter.parse(raw);
-    if (!parseResult || !(parseResult.params instanceof Set)) {
-      throw new TypeError(
-        `[runIngestion] Adapter "${adapter.id}" parse() must return { params: Set, skipped, affiliateExcluded } — got ${typeof parseResult}`
-      );
+    try {
+      const raw = await adapter.fetchRaw({ fetchImpl });
+
+      // Guard: raw must be a string or Buffer — null/undefined from garbage upstream
+      // responses would cause writeFileSync to throw a TypeError, which would previously
+      // be re-thrown (crashing the run) due to the `instanceof TypeError` proxy below.
+      // Instead, record it as a failed adapter with a clear diagnostic.
+      if (raw == null || (typeof raw !== "string" && !Buffer.isBuffer(raw))) {
+        failedAdapters++;
+        adapterStats.push({
+          adapterId: adapter.id,
+          status: "failed",
+          error: `ADAPTER_BAD_PAYLOAD: ${adapter.id} fetchRaw returned non-string (got ${raw === null ? "null" : typeof raw})`,
+          admitted: 0,
+          skipped: 0,
+          affiliateExcluded: 0,
+        });
+        continue;
+      }
+
+      // Raw bytes land in quarantine ONLY — gitignored, never committed/bundled.
+      writeFileSync(resolve(quarantineDir, `${adapter.id}.raw`), raw, "utf8");
+
+      const parseResult = adapter.parse(raw);
+      // Programming-contract check: parse() must return { params: Set, ... }.
+      // This is a sentinel throw (AdapterContractError) so the catch below can
+      // distinguish it from transient I/O / upstream errors. Only AdapterContractError
+      // is re-thrown; everything else (including I/O TypeErrors on garbage input) is
+      // recorded as a transient failure. (FIX-2: replaces `instanceof TypeError` proxy.)
+      if (!parseResult || !(parseResult.params instanceof Set)) {
+        throw new AdapterContractError(
+          adapter.id,
+          `parse() must return { params: Set, skipped, affiliateExcluded } — got ${typeof parseResult}`
+        );
+      }
+
+      const { params, skipped = 0, affiliateExcluded = 0 } = parseResult;
+      results.push({ id: adapter.id, params });
+      adapterStats.push({
+        adapterId: adapter.id,
+        status: "ok",
+        admitted: params.size,   // per-adapter count BEFORE cross-adapter dedup
+        skipped,
+        affiliateExcluded,
+      });
+    } catch (err) {
+      // Re-throw ONLY the named contract-violation sentinel — these are adapter bugs,
+      // not transient failures. Everything else (network errors, I/O TypeErrors from
+      // garbage payloads, parse internals, etc.) is recorded in stats and the loop
+      // continues with remaining adapters.
+      if (err.code === "ADAPTER_CONTRACT") throw err;
+
+      // Transient adapter failure (network error, timeout, HTTP 5xx, parse crash, etc.):
+      // record it in stats and continue with remaining adapters.
+      // NOT a silent skip — the failure is visible in the run stats and report.
+      failedAdapters++;
+      adapterStats.push({
+        adapterId: adapter.id,
+        status: "failed",
+        error: err.message ?? String(err),
+        admitted: 0,
+        skipped: 0,
+        affiliateExcluded: 0,
+      });
     }
-    const { params, skipped = 0, affiliateExcluded = 0 } = parseResult;
-    results.push({ id: adapter.id, params });
-    adapterStats.push({
-      adapterId: adapter.id,
-      admitted: params.size,   // per-adapter count BEFORE cross-adapter dedup
-      skipped,
-      affiliateExcluded,
-    });
+  }
+
+  // All-adapters-failed → hard failure: the run must go RED, not silently green.
+  // exitCode:1 mirrors the "validation / bad-JSON / empty-source" convention
+  // from pipeline.mjs and orchestrate-cli.mjs (exit code comment at top of pipeline.mjs).
+  if (failedAdapters === adapters.length && adapters.length > 0) {
+    const failureList = adapterStats.map((a) => `${a.adapterId}: ${a.error}`).join("; ");
+    const err = new Error(
+      `[runIngestion] All adapters failed — ingestion aborted. Failures: ${failureList}`
+    );
+    err.exitCode = 1;
+    throw err;
   }
 
   const { candidates, emptyDropped } = mergeCandidates(results, { now });
@@ -75,6 +156,7 @@ export async function runIngestion({
     candidates,
     stats: {
       adapters: adapterStats,
+      failedAdapters,
       merged: { emptyDropped, total: candidates.length }, // total = unique candidates after cross-adapter dedup (NOT sum of per-adapter admitted)
     },
   };

--- a/tools/rule-ingestion/report-formatter.mjs
+++ b/tools/rule-ingestion/report-formatter.mjs
@@ -43,13 +43,29 @@ export function formatQuarantineReport(reportObj, { promoteSkipped = [], topN = 
   if (!ingestStats) {
     lines.push("_(no ingest stats — legacy run)_");
   } else {
-    lines.push("| Adapter | Admitted | Skipped | Affiliate-Excluded |");
-    lines.push("|---------|----------|---------|-------------------|");
-
     const adapters = Array.isArray(ingestStats.adapters) ? ingestStats.adapters : [];
-    for (const a of adapters) {
+    const failedAdapters = ingestStats.failedAdapters ?? adapters.filter((a) => a.status === "failed").length;
+
+    // Surface adapter failures prominently so the GitHub step summary makes
+    // silent all-zero runs visible (#813).
+    if (failedAdapters > 0) {
       lines.push(
-        `| ${a.adapterId ?? "?"} | ${a.admitted ?? 0} | ${a.skipped ?? 0} | ${a.affiliateExcluded ?? 0} |`
+        `> **WARNING**: ${failedAdapters} adapter(s) failed — ` +
+        (failedAdapters === adapters.length
+          ? "ALL adapters failed; this run produced NO candidates."
+          : "partial failure; only surviving adapters contributed candidates.")
+      );
+      lines.push("");
+    }
+
+    lines.push("| Adapter | Status | Admitted | Skipped | Affiliate-Excluded | Error |");
+    lines.push("|---------|--------|----------|---------|-------------------|-------|");
+
+    for (const a of adapters) {
+      const status = a.status === "failed" ? "FAILED" : "ok";
+      const errorCell = a.status === "failed" ? (a.error ?? "unknown error") : "";
+      lines.push(
+        `| ${a.adapterId ?? "?"} | ${status} | ${a.admitted ?? 0} | ${a.skipped ?? 0} | ${a.affiliateExcluded ?? 0} | ${errorCell} |`
       );
     }
 


### PR DESCRIPTION
Closes #813

## Summary

- Both upstream adapters (`clearurls`, `adguard-tp`) get a 30s injectable fetch timeout (`Promise.race` + `AbortController`; the race guards even against fetch impls that ignore the abort signal). Timeout throws `ADAPTER_TIMEOUT: <id> after <ms>ms`.
- The ingest loop isolates each adapter: a transient failure (network, non-200, garbage payload) is recorded in stats as `{ status: "failed", error }`, contributes zero params, and the other adapters continue. Previously one adapter failure aborted the run — and with `MIN_SIGNALS=2` over two sources, a single outage quarantined everything and the scheduled run stayed **silently green**.
- All-enabled-adapters-failed now throws with `exitCode: 1` → the scheduled run goes RED (failure list lands in the Actions log).
- Step-summary surface (per #782 conventions): adapter table gains Status/Error columns plus a WARNING banner on partial failure.
- Review fix: the original `instanceof TypeError` re-throw carve-out misclassified upstream garbage (e.g. `res.text()` → `null` hitting `writeFileSync`) as a programming error and crashed the run. Replaced with a named `AdapterContractError` sentinel (`code: "ADAPTER_CONTRACT"`) for true adapter-contract violations, plus an explicit `ADAPTER_BAD_PAYLOAD` guard for non-string payloads.

## Changes

| File | Change |
|------|--------|
| `tools/rule-ingestion/adapters/clearurls.mjs`, `adapters/adguard-tp.mjs` | Injectable 30s timeout, abort signal wired to fetchImpl |
| `tools/rule-ingestion/ingest.mjs` | Per-adapter try/catch, `AdapterContractError` sentinel, null-payload guard, `stats.failedAdapters`, all-failed → exitCode 1 |
| `tools/rule-ingestion/report-formatter.mjs` | Status/Error columns + partial/total failure banner |
| `tests/unit/ingestion-ingest-robustness.test.mjs` | New — 19 tests (timeouts, isolation, all-failed, null payload, contract sentinel) |
| `tests/unit/rule-ingestion-adapters.test.mjs` | FIX-2 assertion now pins the sentinel behavior instead of the `instanceof TypeError` mechanism |

## Test plan

- [x] TDD throughout; repro of the silent-green and the TypeError-crash paths confirmed before fixing
- [x] `node --test tests/unit/ingestion-ingest-robustness.test.mjs` → 19/19
- [x] `npm test` full suite → 4390 pass / 0 fail
- [x] Fresh-context adversarial review: the real finding (TypeError carve-out) fixed; the "workflow revert" finding was a stale-base diff artifact, resolved by rebase onto main