### PR TITLE
test(affiliates): redirect-URL pass-through invariant + STRIP coherence guards (#815)

### DIFF
--- a/tests/integration/affiliate-harness.test.mjs
+++ b/tests/integration/affiliate-harness.test.mjs
@@ -127,6 +127,32 @@ describe("affiliate-harness — G1: redirect-host pass-through (HARD)", () => {
             `redirect URL host must remain on an AFFILIATE_REDIRECT_NETWORKS entry`,
           );
         });
+
+        // G1 sub-test (#815): The redirect URL is the attribution event.
+        // processUrl MUST return the URL byte-identical (action="untouched",
+        // cleanUrl===input). Any param stripped here destroys a creator's
+        // commission on the click itself — before the merchant even reads it.
+        test(`sample redirect URL ${sampleUrl} passes through processUrl byte-identical (click IS the attribution event)`, pending ? { skip: pending } : {}, () => {
+          const { action, cleanUrl } = processUrl(
+            sampleUrl,
+            PREFS,
+            [],
+            undefined,
+            undefined,
+          );
+          assert.equal(
+            action,
+            "untouched",
+            `processUrl must not touch a redirect-network URL — returned action="${action}" for ${sampleUrl}. ` +
+            `The click-through URL IS the attribution event; any mutation destroys the creator's commission.`,
+          );
+          assert.equal(
+            cleanUrl,
+            sampleUrl,
+            `processUrl must return the redirect URL byte-identical — got cleanUrl=${cleanUrl} for input ${sampleUrl}. ` +
+            `Params on redirect-network hosts carry attribution state for the network, not tracking noise.`,
+          );
+        });
       }
     });
   }

--- a/tests/unit/strip-table-parity.test.mjs
+++ b/tests/unit/strip-table-parity.test.mjs
@@ -22,6 +22,8 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 
+import { TRACKING_PARAMS, REDIRECT_NETWORK_PATTERNS } from "../../src/lib/affiliates.js";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const FILES = [
@@ -69,5 +71,117 @@ test("all four content-script STRIP tables are byte-identical (#723)", () => {
           `cleaners diverge silently.`,
       );
     }
+  }
+});
+
+// ── STRIP ↔ TRACKING_PARAMS / landingParams coherence (#815) ────────────────
+//
+// The STRIP table is a hot-path subset hand-copied into four content scripts.
+// Each STRIP param must appear in one of two places:
+//   (A) TRACKING_PARAMS — universally stripped by the cleaner on every site, OR
+//   (B) REDIRECT_NETWORK_PATTERNS[*].landingParams — required-at-landing by an
+//       affiliate-redirect network. These params are intentionally NOT in
+//       TRACKING_PARAMS because stripping them universally destroys creator
+//       attribution. The cleaner's getLandingPolicy() preserves them on first-
+//       touch landings; STRIP keeps them out of window.name/history leaks.
+//
+// Verified divergence set (as of #815, matrix v1.0):
+//   - irclickid  → REDIRECT_NETWORK_PATTERNS["impact-radius"].landingParams
+//   - cjevent    → REDIRECT_NETWORK_PATTERNS["cj-affiliate"].landingParams
+//   - awc        → REDIRECT_NETWORK_PATTERNS["awin"].landingParams
+//
+// If the real divergence set grows, this test will fail with the actual
+// params missing from both lists — update the divergence set comment AND
+// ensure the new params are correctly placed in REDIRECT_NETWORK_PATTERNS
+// (NOT in TRACKING_PARAMS).
+
+/**
+ * Extracts the keys from a STRIP object literal body (brace-matched).
+ * Parses `key: value` pairs where key is an identifier or quoted string.
+ */
+function extractStripKeys(stripBody) {
+  // Match identifier keys (unquoted) or quoted keys, followed by ": <value>"
+  const keyRe = /(?:^|,)\s*([a-zA-Z_$][a-zA-Z0-9_$]*|"[^"]+"|'[^']+')\s*:/gm;
+  const keys = [];
+  let m;
+  while ((m = keyRe.exec(stripBody)) !== null) {
+    let key = m[1];
+    if ((key.startsWith('"') && key.endsWith('"')) ||
+        (key.startsWith("'") && key.endsWith("'"))) {
+      key = key.slice(1, -1);
+    }
+    keys.push(key);
+  }
+  return keys;
+}
+
+test("every STRIP param is in TRACKING_PARAMS or in a REDIRECT_NETWORK_PATTERNS.landingParams (#815)", () => {
+  // Use the first file as canonical (byte-identity already verified above).
+  const stripBody = extractStripTable(FILES[0]);
+  const stripKeys = extractStripKeys(stripBody);
+
+  assert.ok(stripKeys.length > 0, "STRIP table must not be empty");
+
+  const trackingSet = new Set(TRACKING_PARAMS.map((p) => p.toLowerCase()));
+
+  // Build the union of all landingParams across all redirect-network entries.
+  const allLandingParams = new Set();
+  for (const network of REDIRECT_NETWORK_PATTERNS) {
+    for (const p of network.landingParams) {
+      allLandingParams.add(p.toLowerCase());
+    }
+  }
+
+  const unmapped = [];
+  for (const key of stripKeys) {
+    const lower = key.toLowerCase();
+    if (!trackingSet.has(lower) && !allLandingParams.has(lower)) {
+      unmapped.push(key);
+    }
+  }
+
+  assert.deepEqual(
+    unmapped,
+    [],
+    `The following STRIP params are not in TRACKING_PARAMS and not in any ` +
+    `REDIRECT_NETWORK_PATTERNS.landingParams:\n  ${unmapped.join(", ")}\n\n` +
+    `Each STRIP param must be rooted in one of the two source-of-truth ` +
+    `lists. If this param is a new click-ID that affiliate networks read ` +
+    `at landing, add it to the appropriate REDIRECT_NETWORK_PATTERNS entry ` +
+    `— NOT to TRACKING_PARAMS (doing so would strip it universally and ` +
+    `break creator attribution). If it is generic tracking noise with no ` +
+    `attribution semantics, add it to TRACKING_PARAMS instead.`,
+  );
+});
+
+test("irclickid, cjevent, awc are NOT in TRACKING_PARAMS — inverse attribution guard (#815)", () => {
+  // These three params are in STRIP (content scripts keep them out of
+  // window.name/history leaks) but intentionally absent from TRACKING_PARAMS
+  // because they are the click IDs that affiliate redirect networks (Impact
+  // Radius, CJ Affiliate, Awin) write into the landing URL. Adding them to
+  // TRACKING_PARAMS would cause the cleaner to strip them universally —
+  // destroying creator commission on every first-touch landing.
+  //
+  // Verified against REDIRECT_NETWORK_PATTERNS (#815):
+  //   irclickid → impact-radius.landingParams
+  //   cjevent   → cj-affiliate.landingParams
+  //   awc       → awin.landingParams
+  //
+  // If this test is RED, a contributor has added one of these params to
+  // TRACKING_PARAMS. Revert that change and instead verify the param is
+  // correctly declared in REDIRECT_NETWORK_PATTERNS.landingParams so
+  // getLandingPolicy() preserves it on first-touch landings.
+  const trackingSet = new Set(TRACKING_PARAMS.map((p) => p.toLowerCase()));
+
+  const PROTECTED_CLICK_IDS = ["irclickid", "cjevent", "awc"];
+  for (const param of PROTECTED_CLICK_IDS) {
+    assert.equal(
+      trackingSet.has(param.toLowerCase()),
+      false,
+      `"${param}" MUST NOT be in TRACKING_PARAMS. It is a redirect-network ` +
+      `click ID required at landing for creator attribution. Adding it to ` +
+      `TRACKING_PARAMS strips it universally and kills affiliate commission. ` +
+      `It belongs in REDIRECT_NETWORK_PATTERNS.landingParams only.`,
+    );
   }
 });


### PR DESCRIPTION
Closes #815

## Summary

Test-only PR pinning the product's core invariant (creator commission preservation):

- **G1 redirect pass-through**: every `redirect_url_samples` entry in all 10 affiliate-harness fixtures now runs through the full `processUrl` and must emerge byte-identical (`action === "untouched"`, `cleanUrl === input`). This is the click that IS the attribution event — previously no test exercised it end-to-end. Sensitivity proven: injecting `gclid` into a redirect URL flips the test red. **Result: no real bug — all 20 samples across A8.net, Admitad, AliExpress, Awin, CJ, Impact Radius, Partnerize, Rakuten, Tradedoubler, TradeTracker pass untouched.**
- **STRIP coherence** (follow-up to #723): every content-script STRIP param must exist in `TRACKING_PARAMS` OR in some `REDIRECT_NETWORK_PATTERNS[].landingParams`; plus an inverse guard pinning that `irclickid`/`cjevent`/`awc` (the verified 3-param intentional divergence) are NOT in `TRACKING_PARAMS` — with an assertion message explaining why "fixing the gap" would destroy creator attribution.

## Test plan

- [x] `npm test` → 4392 pass / 0 fail (+2)
- [x] `npm run test:integration` → 190 pass / 0 fail (+20)
- [x] Each new test proven able to fail (mutation check)