### PR TITLE
fix(storage): batch incrementShortenerStat via pending+flush — lost-update race (#817)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1108,8 +1108,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         // Native resolution — sole path as of ADR-0004 phase 5.
         const result = await resolveShortener(rawUrl);
-        // ADR-0004 phase 4: per-shortener pass/fail counter (local-only, never transmitted).
-        incrementShortenerStat(hostname, result.ok ? "pass" : "fail").catch(() => {});
+        // ADR-0004 phase 4: per-shortener pass/fail counter (local-only, never
+        // transmitted). Synchronous accumulate-and-flush since #817 — no .catch.
+        incrementShortenerStat(hostname, result.ok ? "pass" : "fail");
 
         try { sendResponse(result); } catch { /* channel closed */ }
       } catch (err) {

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -414,6 +414,9 @@ if (typeof chrome !== "undefined" && chrome.runtime?.onSuspend) {
     if (Object.keys(_pendingDomainStats).length > 0) {
       _flushDomainStats();
     }
+    if (Object.keys(_pendingShortenerStats).length > 0) {
+      _flushShortenerStats();
+    }
   });
 }
 
@@ -681,27 +684,32 @@ export async function getShortenerStats() {
   }
 }
 
-/**
- * Increments the pass or fail counter for a specific shortener host.
- * Silently ignores unknown hosts.
- *
- * @param {string} host   - Hostname of the shortener (e.g. "bit.ly").
- * @param {"pass"|"fail"} outcome - Which counter to increment.
- * @returns {Promise<void>}
- */
-export async function incrementShortenerStat(host, outcome) {
-  if (outcome !== "pass" && outcome !== "fail") return;
-  // Defense-in-depth: never accumulate arbitrary hostnames in local storage.
-  // The privacy contract is "only the eight GENERIC_SHORTENERS are tracked";
-  // this guard enforces it at the source, independent of any callsite.
-  if (!isGenericShortener(host)) return;
+// ── Per-shortener pending+flush (mirrors incrementStat / incrementDomainStat) ──
+//
+// Two concurrent RESOLVE_SHORTENER handlers both called the old implementation
+// before either write completed → the second write silently overwrote the first,
+// losing one increment (#817). The pending+flush pattern eliminates the race:
+// all in-flight calls accumulate synchronously into the pending map; a single
+// coalesced flush does one read + one write per 50ms window.
+
+let _pendingShortenerStats = {};
+let _shortenerStatsFlushTimer = null;
+
+async function _flushShortenerStats() {
+  _shortenerStatsFlushTimer = null;
+  if (Object.keys(_pendingShortenerStats).length === 0) return;
+  const toFlush = _pendingShortenerStats;
+  _pendingShortenerStats = {};
+
   try {
     const current = await getShortenerStats();
-    const entry = current[host] || { pass: 0, fail: 0 };
-    current[host] = {
-      pass: entry.pass + (outcome === "pass" ? 1 : 0),
-      fail: entry.fail + (outcome === "fail" ? 1 : 0),
-    };
+    for (const [host, delta] of Object.entries(toFlush)) {
+      const entry = current[host] || { pass: 0, fail: 0 };
+      current[host] = {
+        pass: entry.pass + (delta.pass || 0),
+        fail: entry.fail + (delta.fail || 0),
+      };
+    }
     await new Promise((resolve, reject) => {
       chrome.storage.local.set({ shortenerStats: current }, () => {
         if (chrome.runtime.lastError) {
@@ -712,7 +720,50 @@ export async function incrementShortenerStat(host, outcome) {
       });
     });
   } catch (err) {
-    console.error("[MUGA] incrementShortenerStat failed:", err);
+    console.error("[MUGA] _flushShortenerStats failed:", err);
+    // Restore pending deltas so they are not lost on write failure
+    for (const [host, delta] of Object.entries(toFlush)) {
+      if (!_pendingShortenerStats[host]) _pendingShortenerStats[host] = { pass: 0, fail: 0 };
+      _pendingShortenerStats[host].pass += delta.pass || 0;
+      _pendingShortenerStats[host].fail += delta.fail || 0;
+    }
+  }
+}
+
+/**
+ * Flushes pending shortener stats immediately (bypasses the 50ms timer).
+ * Exported for test harnesses; production code should not call this directly.
+ *
+ * @returns {Promise<void>}
+ */
+export async function flushShortenerStats() {
+  clearTimeout(_shortenerStatsFlushTimer);
+  await _flushShortenerStats();
+}
+
+/**
+ * Increments the pass or fail counter for a specific shortener host.
+ * Silently ignores unknown hosts and invalid outcomes.
+ *
+ * Uses a pending+flush pattern (same as incrementStat / incrementDomainStat)
+ * to eliminate the lost-update race: multiple concurrent calls accumulate
+ * synchronously into an in-memory map; a single coalesced flush does one
+ * chrome.storage.local read + write per 50ms window.
+ *
+ * @param {string} host   - Hostname of the shortener (e.g. "bit.ly").
+ * @param {"pass"|"fail"} outcome - Which counter to increment.
+ */
+export function incrementShortenerStat(host, outcome) {
+  if (outcome !== "pass" && outcome !== "fail") return;
+  // Defense-in-depth: never accumulate arbitrary hostnames in local storage.
+  // The privacy contract is "only the eight GENERIC_SHORTENERS are tracked";
+  // this guard enforces it at the source, independent of any callsite.
+  if (!isGenericShortener(host)) return;
+  if (!_pendingShortenerStats[host]) _pendingShortenerStats[host] = { pass: 0, fail: 0 };
+  if (outcome === "pass") _pendingShortenerStats[host].pass += 1;
+  else _pendingShortenerStats[host].fail += 1;
+  if (!_shortenerStatsFlushTimer) {
+    _shortenerStatsFlushTimer = setTimeout(_flushShortenerStats, 50);
   }
 }
 

--- a/tests/unit/shortener-stats-race.test.mjs
+++ b/tests/unit/shortener-stats-race.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * MUGA — Regression tests for the incrementShortenerStat race condition (#817)
+ *
+ * Covers the lost-update bug where two concurrent RESOLVE_SHORTENER handlers
+ * both called the old read-modify-write implementation before either write
+ * completed, causing one increment to be silently dropped.
+ *
+ * The fix converts incrementShortenerStat to the same pending+flush batching
+ * pattern used by incrementStat and incrementDomainStat, eliminating the race.
+ *
+ * Test approach:
+ *   - Uses the chrome.storage.local stub from shortener-stats.test.mjs.
+ *   - Calls flushShortenerStats (test hook exported by storage.js) to force
+ *     immediate flush without waiting for the 50ms timer.
+ *   - All three new tests MUST fail against the old implementation
+ *     (concurrent calls race → one count is lost).
+ */
+
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Minimal chrome.storage.local stub ────────────────────────────────────────
+
+let _localStore = {};
+let _writeCount = 0; // counts chrome.storage.local.set calls
+
+const chromeMock = {
+  storage: {
+    local: {
+      get(defaults, cb) {
+        const result = {};
+        for (const [k, defaultVal] of Object.entries(
+          typeof defaults === "string" ? { [defaults]: undefined } : defaults
+        )) {
+          result[k] = _localStore[k] !== undefined ? _localStore[k] : defaultVal;
+        }
+        cb(result);
+      },
+      set(items, cb) {
+        _writeCount++;
+        Object.assign(_localStore, items);
+        cb && cb();
+      },
+    },
+  },
+  runtime: { lastError: null },
+};
+
+// Install mock BEFORE first import (storage.js reads `chrome` at module level)
+global.chrome = chromeMock;
+
+const storageModule = await import("../../src/lib/storage.js");
+const { getShortenerStats, incrementShortenerStat, flushShortenerStats } = storageModule;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetStore() {
+  _localStore = {};
+  _writeCount = 0;
+}
+
+// ── Race-condition regression tests ──────────────────────────────────────────
+
+describe("incrementShortenerStat — race condition (#817)", () => {
+  beforeEach(resetStore);
+
+  test("two concurrent increments for the same host both land after flush — lost-update repro", async () => {
+    // Both calls fire synchronously (before either flush runs).
+    // Old implementation: both awaited getShortenerStats() before either write
+    // completed → second write overwrote first → only one increment persisted.
+    // New implementation: both accumulate into _pendingShortenerStats synchronously
+    // → a single flush reads once, applies both deltas, writes once → both counted.
+    incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("bit.ly", "pass");
+
+    await flushShortenerStats();
+
+    const stats = await getShortenerStats();
+    assert.equal(
+      stats["bit.ly"]?.pass,
+      2,
+      "both concurrent pass increments must survive — old read-modify-write dropped one"
+    );
+  });
+
+  test("increments for different hosts coalesce into one storage write per flush", async () => {
+    incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("tinyurl.com", "fail");
+    incrementShortenerStat("t.co", "pass");
+
+    const writesBeforeFlush = _writeCount;
+    await flushShortenerStats();
+    const writesAfterFlush = _writeCount;
+
+    const stats = await getShortenerStats();
+    assert.equal(stats["bit.ly"]?.pass, 1, "bit.ly pass must be 1");
+    assert.equal(stats["tinyurl.com"]?.fail, 1, "tinyurl.com fail must be 1");
+    assert.equal(stats["t.co"]?.pass, 1, "t.co pass must be 1");
+
+    assert.equal(
+      writesAfterFlush - writesBeforeFlush,
+      1,
+      "all three host increments must coalesce into exactly one chrome.storage.local.set call"
+    );
+  });
+
+  test("pass and fail outcomes accumulate correctly across concurrent calls", async () => {
+    incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("bit.ly", "fail");
+    incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("t.co", "fail");
+    incrementShortenerStat("t.co", "fail");
+
+    await flushShortenerStats();
+
+    const stats = await getShortenerStats();
+    assert.equal(stats["bit.ly"]?.pass, 2, "bit.ly pass must accumulate to 2");
+    assert.equal(stats["bit.ly"]?.fail, 1, "bit.ly fail must accumulate to 1");
+    assert.equal(stats["t.co"]?.pass, 0, "t.co pass must be 0");
+    assert.equal(stats["t.co"]?.fail, 2, "t.co fail must accumulate to 2");
+  });
+});
+
+// ── Caller-contract guard ─────────────────────────────────────────────────────
+//
+// incrementShortenerStat / incrementStat / incrementDomainStat are SYNCHRONOUS
+// accumulate-and-flush counters (return undefined). Chaining `.catch(...)` on
+// any of them throws TypeError at runtime — and the service worker has no
+// behavioral unit harness, so only this structural guard catches it. Found the
+// hard way in #817 review: `incrementShortenerStat(...).catch(() => {})`.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+describe("sync counters — no promise chaining in service-worker callers", () => {
+  const swSource = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../src/background/service-worker.js"),
+    "utf8"
+  );
+
+  for (const fn of ["incrementShortenerStat", "incrementStat", "incrementDomainStat"]) {
+    test(`${fn}(...) is never chained with .then/.catch/await`, () => {
+      const re = new RegExp(
+        "(?:await\\s+" + fn + "\\s*\\(|" + fn + "\\s*\\([^;]*\\)\\s*\\.(?:then|catch)\\b)"
+      );
+      const match = swSource.match(re);
+      assert.equal(
+        match,
+        null,
+        `${fn} is synchronous (returns undefined) — found promise-style usage: ${match?.[0] ?? ""}`
+      );
+    });
+  }
+});

--- a/tests/unit/shortener-stats.test.mjs
+++ b/tests/unit/shortener-stats.test.mjs
@@ -48,13 +48,17 @@ const chromeMock = {
 // storage.js reads `chrome` at import time for the shim probe; we must install
 // the mock BEFORE the first import. Use a dynamic import inside the tests.
 
-let getShortenerStats, incrementShortenerStat;
+let getShortenerStats, incrementShortenerStat, flushShortenerStats;
 
 // Install mock globally before dynamic import
 global.chrome = chromeMock;
 const storageModule = await import("../../src/lib/storage.js");
 getShortenerStats = storageModule.getShortenerStats;
 incrementShortenerStat = storageModule.incrementShortenerStat;
+// Test hook: forces the pending+flush write without waiting for the 50ms timer.
+// Required because incrementShortenerStat is now synchronous (accumulates into
+// a pending map) — persistence is deferred to the coalesced flush (#817).
+flushShortenerStats = storageModule.flushShortenerStats;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -91,7 +95,8 @@ describe("incrementShortenerStat — pass increments", () => {
   beforeEach(resetStore);
 
   test("increments pass for a known shortener", async () => {
-    await incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("bit.ly", "pass");
+    await flushShortenerStats();
     const stats = await getShortenerStats();
     assert.ok(stats["bit.ly"], "bit.ly entry must exist");
     assert.equal(stats["bit.ly"].pass, 1);
@@ -99,7 +104,8 @@ describe("incrementShortenerStat — pass increments", () => {
   });
 
   test("increments fail for a known shortener", async () => {
-    await incrementShortenerStat("t.co", "fail");
+    incrementShortenerStat("t.co", "fail");
+    await flushShortenerStats();
     const stats = await getShortenerStats();
     assert.ok(stats["t.co"], "t.co entry must exist");
     assert.equal(stats["t.co"].fail, 1);
@@ -107,18 +113,20 @@ describe("incrementShortenerStat — pass increments", () => {
   });
 
   test("accumulates multiple increments", async () => {
-    await incrementShortenerStat("bit.ly", "pass");
-    await incrementShortenerStat("bit.ly", "pass");
-    await incrementShortenerStat("bit.ly", "fail");
+    incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("bit.ly", "fail");
+    await flushShortenerStats();
     const stats = await getShortenerStats();
     assert.equal(stats["bit.ly"].pass, 2);
     assert.equal(stats["bit.ly"].fail, 1);
   });
 
   test("tracks multiple shorteners independently", async () => {
-    await incrementShortenerStat("bit.ly", "pass");
-    await incrementShortenerStat("tinyurl.com", "fail");
-    await incrementShortenerStat("tinyurl.com", "fail");
+    incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("tinyurl.com", "fail");
+    incrementShortenerStat("tinyurl.com", "fail");
+    await flushShortenerStats();
     const stats = await getShortenerStats();
     assert.equal(stats["bit.ly"].pass, 1);
     assert.equal(stats["bit.ly"].fail, 0);
@@ -129,7 +137,8 @@ describe("incrementShortenerStat — pass increments", () => {
   test("each shortener entry has both pass and fail keys", async () => {
     for (const host of GENERIC_SHORTENERS) {
       resetStore();
-      await incrementShortenerStat(host, "pass");
+      incrementShortenerStat(host, "pass");
+      await flushShortenerStats();
       const stats = await getShortenerStats();
       assert.ok(typeof stats[host].pass === "number", `${host} must have pass`);
       assert.ok(typeof stats[host].fail === "number", `${host} must have fail`);
@@ -138,7 +147,9 @@ describe("incrementShortenerStat — pass increments", () => {
 
   test("ignores unknown hosts silently — does not throw AND does not record them", async () => {
     resetStore();
-    await assert.doesNotReject(() => incrementShortenerStat("unknown.example.com", "pass"));
+    // incrementShortenerStat is now synchronous — wrap in a resolved promise for doesNotReject
+    await assert.doesNotReject(async () => { incrementShortenerStat("unknown.example.com", "pass"); });
+    await flushShortenerStats();
     const stats = await getShortenerStats();
     assert.equal(
       stats["unknown.example.com"],
@@ -151,7 +162,8 @@ describe("incrementShortenerStat — pass increments", () => {
 describe("shortener stats storage key", () => {
   test("getShortenerStats and incrementShortenerStat use 'shortenerStats' key", async () => {
     resetStore();
-    await incrementShortenerStat("bit.ly", "pass");
+    incrementShortenerStat("bit.ly", "pass");
+    await flushShortenerStats();
     assert.ok(
       "shortenerStats" in _localStore,
       "incrementShortenerStat must write to chrome.storage.local under 'shortenerStats' key"


### PR DESCRIPTION
Closes #817

## Summary

- `incrementShortenerStat` was the only counter in storage.js doing an unprotected read-modify-write (two concurrent RESOLVE_SHORTENER handlers → one increment lost) with a full-map read+write per call. It now uses the exact `_pending* + setTimeout(flush, 50)` coalescing pattern of `incrementStat`/`incrementDomainStat`: one read + one write per flush window, all concurrent deltas accumulated. `flushShortenerStats` exported as test hook; flush wired into `onSuspend` for MV2 parity.
- **Review catch (orchestrator)**: the function became synchronous, but the SW caller did `incrementShortenerStat(...).catch(() => {})` → would throw `TypeError` on every shortener resolution at runtime, invisible to unit tests (the SW handler has no behavioral harness). Caller fixed to the bare call style of its sibling counters, plus a structural guard test asserting none of the three sync counters is ever chained with `.then/.catch/await` in service-worker.js.

## Changes

| File | Change |
|------|--------|
| `src/lib/storage.js` | Pending+flush batching for shortener stats (pattern-identical to siblings) |
| `src/background/service-worker.js` | Caller updated: no `.catch` on a sync counter |
| `tests/unit/shortener-stats-race.test.mjs` | New — lost-update repro (red against old impl), coalescing, accumulation, sync-caller contract guards |
| `tests/unit/shortener-stats.test.mjs` | Existing tests adapted to flush explicitly |

## Test plan

- [x] Race repro failed against the old implementation, passes now
- [x] `npm test` → 4407 pass / 0 fail (post-rebase on main with #815)