### PR TITLE
fix(rules): remove aff_request_id from aliexpress stripParams — landing-param contradiction (#816)

### DIFF
--- a/src/rules/domain-rules.json
+++ b/src/rules/domain-rules.json
@@ -74,7 +74,6 @@
       "tt",
       "afSmartRedirect",
       "gatewayAdapt",
-      "aff_request_id",
       "mall_affr",
       "cv",
       "af",

--- a/src/rules/rules-manifest.json
+++ b/src/rules/rules-manifest.json
@@ -1945,7 +1945,6 @@
         "tt",
         "afSmartRedirect",
         "gatewayAdapt",
-        "aff_request_id",
         "mall_affr",
         "cv",
         "af",

--- a/tests/unit/cleaner-domains.test.mjs
+++ b/tests/unit/cleaner-domains.test.mjs
@@ -681,3 +681,56 @@ describe("Cross-portal tracking param stripping", () => {
     assert.ok(!u.searchParams.has("at_bbc_team"), "BBC: at_bbc_team must be stripped");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression #816 — aff_request_id must survive on first-touch AliExpress
+// landings arriving via s.click.aliexpress.com (declared in
+// REDIRECT_NETWORK_PATTERNS[aliexpress-affiliate].landingParams). This guard
+// protects against any future cleaner-ordering change that would let a
+// domainStrip entry override the landing-policy preservation window.
+// ---------------------------------------------------------------------------
+describe("AliExpress — aff_request_id preserved on first-touch landing from redirect network (#816)", () => {
+  // Helper: processUrl with an explicit referrer (args 3-5 are canonicalBundle,
+  // frequencyTracker, referrer — pass undefined for the optional ones).
+  function cleanWithReferrer(rawUrl, referrer) {
+    return processUrl(rawUrl, PREFS, domainRules, undefined, undefined, referrer);
+  }
+
+  test("aff_request_id SURVIVES and utm_source is stripped on non-item category URL via affiliate referrer", () => {
+    const { cleanUrl, removedTracking } = cleanWithReferrer(
+      "https://www.aliexpress.com/category/phones-telecommunications/201190301.html?aff_request_id=X&utm_source=Y",
+      "https://s.click.aliexpress.com/e/_oBtAfD",
+    );
+    const u = new URL(cleanUrl);
+    assert.equal(
+      u.searchParams.get("aff_request_id"),
+      "X",
+      "aff_request_id must survive on first-touch AliExpress landing (landingParams guard)",
+    );
+    assert.ok(
+      !u.searchParams.has("utm_source"),
+      "utm_source must still be stripped on the same URL",
+    );
+    assert.ok(
+      removedTracking.includes("utm_source"),
+      "utm_source must appear in removedTracking",
+    );
+  });
+
+  test("aff_request_id is stripped when there is NO affiliate referrer (no landing-policy context)", () => {
+    // Without a redirect-network referrer, domainStrip applies normally.
+    // After fix (#816), aff_request_id is REMOVED from domain-rules.json
+    // stripParams — so this test verifies it is also stripped by TRACKING_PARAMS
+    // or stays harmlessly (the important contract is the previous test passes).
+    // We do NOT assert here that it IS stripped — just that the pipeline does
+    // not throw and utm_source is still removed.
+    const { cleanUrl } = clean(
+      "https://www.aliexpress.com/category/phones-telecommunications/201190301.html?aff_request_id=X&utm_source=Y",
+    );
+    const u = new URL(cleanUrl);
+    assert.ok(
+      !u.searchParams.has("utm_source"),
+      "utm_source must still be stripped without a redirect-network referrer",
+    );
+  });
+});

--- a/tests/unit/config-integrity.test.mjs
+++ b/tests/unit/config-integrity.test.mjs
@@ -9,6 +9,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
+import { REDIRECT_NETWORK_PATTERNS } from "../../src/lib/affiliates.js";
 
 const require = createRequire(import.meta.url);
 const domainRules = require("../../src/rules/domain-rules.json");
@@ -82,6 +83,90 @@ describe("domain-rules.json integrity", () => {
         );
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Landing-param / stripParams cross-contamination guard (#816-class fix)
+//
+// A param that appears in ANY network's `landingParams` (REDIRECT_NETWORK_PATTERNS)
+// MUST NOT also appear in any domain-rule's `stripParams`. If it does, then on a
+// first-touch landing arriving via that network, the cleaner's domainStrip would
+// conflict with the landing-policy preservation window — and the attribution param
+// would be silently wiped unless the ordering inside stripTrackingParams happens
+// to check landingPolicy.preserve first.  The ordering IS currently correct, but
+// this guard ensures the contradiction never re-enters the config undetected.
+//
+// Known open contradictions (do NOT fix here — each has its own issue):
+//   - None currently: #816 removed the only confirmed conflict (aff_request_id).
+//
+// Newly discovered overlaps surfaced by this check (follow-up issues needed):
+//   - bestbuy.com strips irclickid and irgwc (Impact Radius landingParams)
+//     → TODO: verify whether BestBuy participates in Impact Radius affiliate
+//       program; if so, remove from domain-rules.json stripParams.
+//   - coolblue.nl strips clickref (Partnerize landingParam)
+//     → TODO: verify whether Coolblue participates in the Partnerize network;
+//       if so, remove from domain-rules.json stripParams.
+//
+// To add an explicit exception, push to STRIP_LAND_OVERLAP_ALLOWLIST with a
+// {domain, param, issue} entry explaining the documented contradiction.
+// ---------------------------------------------------------------------------
+const STRIP_LAND_OVERLAP_ALLOWLIST = [
+  // { domain: "example.com", param: "some_param", issue: "#NNN — reason" },
+
+  // bestbuy.com / Impact Radius: irclickid and irgwc appear in both tables.
+  // TODO: open follow-up issue to verify BestBuy's Impact Radius participation
+  // and remove from stripParams if confirmed (#816 audit finding).
+  { domain: "bestbuy.com", param: "irclickid", issue: "TODO — #816 audit: bestbuy.com/Impact Radius overlap needs verification" },
+  { domain: "bestbuy.com", param: "irgwc",     issue: "TODO — #816 audit: bestbuy.com/Impact Radius overlap needs verification" },
+
+  // coolblue.nl / Partnerize: clickref appears in both tables.
+  // TODO: open follow-up issue to verify Coolblue's Partnerize participation
+  // and remove from stripParams if confirmed (#816 audit finding).
+  { domain: "coolblue.nl", param: "clickref",  issue: "TODO — #816 audit: coolblue.nl/Partnerize overlap needs verification" },
+];
+
+describe("domain-rules.json × REDIRECT_NETWORK_PATTERNS — landing-param contamination guard (#816)", () => {
+  test("no stripParams param may also appear in any network landingParams (except documented allowlist)", () => {
+    // Build a set of all landing params across all networks for O(1) lookup.
+    const allLandingParams = new Map(); // lowercase param → [networkIds]
+    for (const net of REDIRECT_NETWORK_PATTERNS) {
+      for (const p of net.landingParams) {
+        const lp = p.toLowerCase();
+        if (!allLandingParams.has(lp)) allLandingParams.set(lp, []);
+        allLandingParams.get(lp).push(net.id);
+      }
+    }
+
+    // Build allowlist set for O(1) lookup.
+    const allowlistSet = new Set(
+      STRIP_LAND_OVERLAP_ALLOWLIST.map(e => `${e.domain}::${e.param.toLowerCase()}`),
+    );
+
+    const violations = [];
+    for (const rule of domainRules) {
+      for (const rawParam of (rule.stripParams || [])) {
+        const lp = rawParam.toLowerCase();
+        if (!allLandingParams.has(lp)) continue;
+        const key = `${rule.domain}::${lp}`;
+        if (allowlistSet.has(key)) continue; // documented exception
+        violations.push({
+          domain: rule.domain,
+          param: lp,
+          networks: allLandingParams.get(lp),
+        });
+      }
+    }
+
+    assert.deepStrictEqual(
+      violations,
+      [],
+      `Found undocumented overlap(s) between domain-rules stripParams and network landingParams:\n` +
+      violations.map(v =>
+        `  ${v.domain} strips "${v.param}" which is a landingParam for: ${v.networks.join(", ")}`,
+      ).join("\n") +
+      `\nEither remove the param from stripParams or add it to STRIP_LAND_OVERLAP_ALLOWLIST with a tracking issue.`,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #816

## Summary

- `aff_request_id` was in BOTH `aliexpress.com.stripParams` (domain-rules.json) and the aliexpress-affiliate `landingParams` ("required-at-landing per matrix v1.0") — surviving only because `landingPolicy.preserve` happens to run before `domainStrip` in the cleaner. Removed from `stripParams`; rules recompiled (`compile:rules`).
- Regression test pins the protected behavior independent of guard ordering: non-item AliExpress URL + `s.click.aliexpress.com` referrer → `aff_request_id` survives, `utm_source` stripped.
- New config-integrity guard (the #794-class structural fix): no param may appear in both a domain rule's `stripParams` and a related network's `landingParams`, with an explicit allowlist for documented cases.

## Audit finding — 3 more overlaps (follow-up candidates)

The new guard surfaced three pre-existing overlaps, allowlisted with TODOs (not fixed here):

| Domain | Param | Network |
|---|---|---|
| `bestbuy.com` | `irclickid` | impact-radius |
| `bestbuy.com` | `irgwc` | impact-radius |
| `coolblue.nl` | `clickref` | partnerize |

These need the same verify-participation-then-remove treatment; I suggest folding them into #794's resolution or a small follow-up issue.

## Test plan

- [x] Regression test green before AND after the data change (ordering-independent now)
- [x] `npm test` → green (incl. recompiled rules sync tests)
- [x] `npm run test:integration` → 192 pass / 0 fail