### PR TITLE
fix(i18n): sync fr/it/ja toast strings + fix count-one celebration span (#819)

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -102,7 +102,11 @@
     return entry.count > 3;
   }
 
-  // Toast strings: default English, overridden by stored language preference
+  // Toast strings: default English, overridden by stored language preference.
+  // IMPORTANT: keep this table in sync with the five toast_* keys in
+  // src/lib/i18n.js — the drift guard test content-cleaner-toast-sync.test.mjs
+  // will fail red if they diverge. Do NOT edit translations here directly;
+  // update i18n.js first, then copy the values here (#819, #834).
   const STRINGS = {
     en: {
       toast_title:   "MUGA found someone else's affiliate tag",
@@ -123,18 +127,39 @@
       toast_tag_msg: "tem uma tag de afiliado que não é nossa:",
       toast_allow:   "Manter",
       toast_block:   "Remover",
-      toast_dismiss: "Dispensar",
+      toast_dismiss: "Ignorar",
     },
     de: {
       toast_title:   "MUGA hat ein fremdes Affiliate-Tag gefunden",
-      toast_tag_msg: "hat ein Affiliate-Tag, das nicht uns gehört:",
+      toast_tag_msg: "hat ein Affiliate-Tag, das nicht unseres ist:",
       toast_allow:   "Behalten",
       toast_block:   "Entfernen",
       toast_dismiss: "Schließen",
     },
+    fr: {
+      toast_title:   "MUGA a trouvé un tag d'affiliation de quelqu'un d'autre",
+      toast_tag_msg: "a un tag d'affiliation qui n'est pas le nôtre :",
+      toast_allow:   "Conserver",
+      toast_block:   "Supprimer",
+      toast_dismiss: "Ignorer",
+    },
+    it: {
+      toast_title:   "MUGA ha trovato il tag di affiliazione di qualcun altro",
+      toast_tag_msg: "ha un tag di affiliazione che non è il nostro:",
+      toast_allow:   "Mantieni",
+      toast_block:   "Rimuovi",
+      toast_dismiss: "Ignora",
+    },
+    ja: {
+      toast_title:   "MUGAは他者のアフィリエイトタグを検出しました",
+      toast_tag_msg: "には当方のものではないアフィリエイトタグがあります:",
+      toast_allow:   "保持",
+      toast_block:   "削除",
+      toast_dismiss: "閉じる",
+    },
   };
 
-  const SUPPORTED_LANGS = { en: 1, es: 1, pt: 1, de: 1 };
+  const SUPPORTED_LANGS = { en: 1, es: 1, pt: 1, de: 1, fr: 1, it: 1, ja: 1 };
   const navLang = (navigator.language || "en").slice(0, 2);
   const browserLang = navLang in SUPPORTED_LANGS ? navLang : "en";
   let s = STRINGS[browserLang];

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -392,16 +392,21 @@ function renderCountCelebration(result, url, lang) {
     // Split around {n} and rebuild via text nodes + a number span. Avoids
     // innerHTML so the i18n string can never become an injection vector,
     // and lets CSS animate just the digits.
+    // The "one" key has no {n} placeholder — render plain text only in that
+    // case so the span-build path never runs and gets clobbered (bug #819).
     el.replaceChildren();
     const [before, after] = template.split("{n}", 2);
-    if (before) el.appendChild(document.createTextNode(before));
-    const number = document.createElement("span");
-    number.className = "preview-count-number";
-    number.textContent = String(count);
-    el.appendChild(number);
-    if (after !== undefined) el.appendChild(document.createTextNode(after));
-    // The "one" key has no {n} placeholder — render plain text in that case.
-    if (after === undefined) el.textContent = template;
+    if (after === undefined) {
+      // No {n} placeholder (e.g. preview_count_one): plain text only.
+      el.textContent = template;
+    } else {
+      if (before) el.appendChild(document.createTextNode(before));
+      const number = document.createElement("span");
+      number.className = "preview-count-number";
+      number.textContent = String(count);
+      el.appendChild(number);
+      el.appendChild(document.createTextNode(after));
+    }
     el.classList.remove("is-clean");
     el.dataset.animating = "true";
     el.hidden = false;

--- a/tests/unit/content-cleaner-toast-sync.test.mjs
+++ b/tests/unit/content-cleaner-toast-sync.test.mjs
@@ -1,0 +1,183 @@
+/**
+ * MUGA — Drift guard: cleaner.js inline STRINGS table vs i18n.js (#819)
+ *
+ * Why this file exists: cleaner.js carries a self-contained copy of the
+ * five toast keys (toast_title, toast_tag_msg, toast_allow, toast_block,
+ * toast_dismiss) because content scripts cannot import from src/lib/ at
+ * runtime. When a new locale is added to i18n.js, the inline table in
+ * cleaner.js MUST be updated in sync — otherwise fr/it/ja users always
+ * see English toasts.
+ *
+ * These tests fail red until both sources are in sync and the inline
+ * locale set equals the i18n.js SUPPORTED_LANGS codes.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+
+// ── Load i18n source of truth ────────────────────────────────────────────────
+
+import { makeChromeMock } from "./helpers/chrome-stub.mjs";
+globalThis.chrome = makeChromeMock({ hasSession: false, promiseShape: true });
+
+const { TRANSLATIONS, SUPPORTED_LANGS: I18N_SUPPORTED_LANGS } = await import(
+  "../../src/lib/i18n.js"
+);
+
+// The five toast keys that must exist in both sources
+const TOAST_KEYS = [
+  "toast_title",
+  "toast_tag_msg",
+  "toast_allow",
+  "toast_block",
+  "toast_dismiss",
+];
+
+// ── Parse the inline STRINGS table from cleaner.js ──────────────────────────
+//
+// We read the source as text and eval the object literal in a sandboxed way
+// by extracting it with a regex. This avoids executing the full IIFE (which
+// requires a browser environment). The table lives between
+// "const STRINGS = {" and "};" and uses only plain string literals.
+
+const cleanerSrc = readFileSync(
+  resolve(root, "src/content/cleaner.js"),
+  "utf8"
+);
+
+// Extract inline SUPPORTED_LANGS from cleaner.js (the object literal {en:1,...})
+function parseInlineSupportedLangs(src) {
+  const match = src.match(/const SUPPORTED_LANGS\s*=\s*\{([^}]+)\}/);
+  assert.ok(match, "cleaner.js must declare const SUPPORTED_LANGS = { ... }");
+  const keys = [...match[1].matchAll(/(\w+)\s*:/g)].map((m) => m[1]);
+  return new Set(keys);
+}
+
+// Extract inline STRINGS from cleaner.js — parse each locale block
+function parseInlineStrings(src) {
+  // Find the STRINGS object block
+  const startIdx = src.indexOf("const STRINGS = {");
+  assert.ok(startIdx >= 0, "cleaner.js must contain 'const STRINGS = {'");
+
+  // Walk to find the matching closing brace at the top level of STRINGS
+  let depth = 0;
+  let objStart = src.indexOf("{", startIdx);
+  let i = objStart;
+  let objEnd = -1;
+  while (i < src.length) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        objEnd = i + 1;
+        break;
+      }
+    }
+    i++;
+  }
+  assert.ok(objEnd > 0, "cleaner.js STRINGS object must be closed with }");
+
+  const objText = src.slice(objStart, objEnd);
+
+  // Extract locale blocks: find each top-level key "xx: {" inside STRINGS
+  const result = {};
+  // Match locale-level entries: two-letter code followed by ": {"
+  const localeRe = /\b([a-z]{2})\s*:\s*\{/g;
+  let m;
+  while ((m = localeRe.exec(objText)) !== null) {
+    const locale = m[1];
+    // Find the opening brace of this locale's block
+    const blockStart = objText.indexOf("{", m.index + m[0].length - 1);
+    // Walk to find matching closing brace
+    let d = 0;
+    let j = blockStart;
+    let blockEnd = -1;
+    while (j < objText.length) {
+      if (objText[j] === "{") d++;
+      else if (objText[j] === "}") {
+        d--;
+        if (d === 0) {
+          blockEnd = j + 1;
+          break;
+        }
+      }
+      j++;
+    }
+    if (blockEnd < 0) continue;
+    const blockText = objText.slice(blockStart, blockEnd);
+
+    // Extract key-value pairs: toast_xxx: "...",
+    const kvRe = /(\w+)\s*:\s*"((?:[^"\\]|\\.)*)"/g;
+    let kv;
+    result[locale] = {};
+    while ((kv = kvRe.exec(blockText)) !== null) {
+      result[locale][kv[1]] = kv[2];
+    }
+  }
+
+  return result;
+}
+
+const inlineSupportedLangs = parseInlineSupportedLangs(cleanerSrc);
+const inlineStrings = parseInlineStrings(cleanerSrc);
+
+// The canonical locale set: all codes from i18n.js SUPPORTED_LANGS
+const i18nLocaleCodes = new Set(I18N_SUPPORTED_LANGS.map((l) => l.code));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test("cleaner.js inline SUPPORTED_LANGS matches i18n.js SUPPORTED_LANGS codes", () => {
+  // Every locale in i18n.js must be in cleaner's SUPPORTED_LANGS
+  for (const code of i18nLocaleCodes) {
+    assert.ok(
+      inlineSupportedLangs.has(code),
+      `cleaner.js SUPPORTED_LANGS is missing locale "${code}" — sync it from i18n.js`
+    );
+  }
+  // And vice versa: no extra locales in cleaner that don't exist in i18n.js
+  for (const code of inlineSupportedLangs) {
+    assert.ok(
+      i18nLocaleCodes.has(code),
+      `cleaner.js SUPPORTED_LANGS has unexpected locale "${code}" not in i18n.js`
+    );
+  }
+});
+
+test("cleaner.js STRINGS table has an entry for every i18n.js locale", () => {
+  for (const code of i18nLocaleCodes) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(inlineStrings, code),
+      `cleaner.js STRINGS is missing locale block "${code}" — add fr/it/ja entries`
+    );
+  }
+});
+
+for (const key of TOAST_KEYS) {
+  test(`cleaner.js STRINGS[locale].${key} matches i18n.js for every locale`, () => {
+    const i18nEntry = TRANSLATIONS[key];
+    assert.ok(i18nEntry, `i18n.js must have key "${key}"`);
+
+    for (const code of i18nLocaleCodes) {
+      const inlineVal = inlineStrings[code]?.[key];
+      const i18nVal = i18nEntry[code];
+
+      assert.ok(
+        typeof inlineVal === "string" && inlineVal.length > 0,
+        `cleaner.js STRINGS["${code}"]["${key}"] is missing or empty`
+      );
+      assert.strictEqual(
+        inlineVal,
+        i18nVal,
+        `cleaner.js STRINGS["${code}"]["${key}"] drifted from i18n.js:\n` +
+          `  inline: "${inlineVal}"\n` +
+          `  i18n:   "${i18nVal}"`
+      );
+    }
+  });
+}

--- a/tests/unit/popup-count-celebration.test.mjs
+++ b/tests/unit/popup-count-celebration.test.mjs
@@ -35,7 +35,7 @@ test("preview_count_one: i18n key exists with en + es non-empty, no {n} placehol
 test("preview_count_other: i18n key exists with {n} placeholder in every locale", () => {
   const k = TRANSLATIONS.preview_count_other;
   assert.ok(k, "preview_count_other must exist");
-  for (const locale of ["en", "es", "pt", "de"]) {
+  for (const locale of ["en", "es", "pt", "de", "fr", "it", "ja"]) {
     assert.ok(typeof k[locale] === "string" && k[locale].length > 0, `${locale} non-empty`);
     assert.ok(k[locale].includes("{n}"), `${locale} must contain the {n} placeholder`);
   }
@@ -108,6 +108,68 @@ test("popup.js builds the count line via DOM nodes, not innerHTML", () => {
     /createTextNode|createElement|appendChild|replaceChildren/.test(slice),
     "renderCountCelebration must build content via DOM APIs"
   );
+});
+
+test("renderCountCelebration: count=1 span-vs-textContent paths are mutually exclusive (#819)", () => {
+  // Bug: the original code unconditionally built the .preview-count-number
+  // span AND appended it to el, then — for the "one" key (after===undefined)
+  // — called `el.textContent = template` which obliterates the span and kills
+  // the CSS pulse animation for the most common case (exactly 1 tracker).
+  //
+  // Fix: the span-build path and the plain-text path must be mutually
+  // exclusive. The correct structure is:
+  //   if (after === undefined) {
+  //     el.textContent = template;           // plain text only, no span
+  //   } else {
+  //     // build text-before + span + text-after
+  //   }
+  //
+  // This test reads the function source and verifies the span is ONLY built
+  // inside the else branch (i.e. guarded by `after !== undefined`).
+
+  const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+  const fnIdx = popupSrc.indexOf("function renderCountCelebration");
+  assert.ok(fnIdx >= 0, "renderCountCelebration must exist");
+  const next = popupSrc.indexOf("\nfunction ", fnIdx + 10);
+  const fnBody = popupSrc.slice(fnIdx, next === -1 ? fnIdx + 4000 : next);
+
+  // The buggy pattern: span is created BEFORE the `after === undefined` check
+  // and `el.textContent = template` clobbers it afterward. In the fixed code,
+  // `el.textContent = template` must NOT appear AFTER `el.appendChild(number)`
+  // in an unconditional position. We detect the bug by looking for the
+  // anti-pattern: span append followed immediately (with no else-guard) by
+  // el.textContent assignment.
+  //
+  // Approach: the fixed function must NOT contain `el.textContent = template`
+  // after an unconditional `el.appendChild(number)`.  We verify this by
+  // checking that `el.textContent = template` does NOT appear after the
+  // last `el.appendChild(number)` in an unguarded path.
+  //
+  // Simpler structural invariant:  in the fixed version the `number` span and
+  // its `el.appendChild(number)` call appear ONLY inside an `else` block or
+  // ONLY when `after !== undefined`.  We assert that the span creation is
+  // never followed by `el.textContent` on the same un-branched code path.
+
+  // Collect positions of the key statements inside the fn body
+  const spanCreatePos  = fnBody.indexOf('number.className = "preview-count-number"');
+  const textContentPos = fnBody.lastIndexOf("el.textContent = template");
+
+  // If textContent still follows span creation with no intervening else/return
+  // the bug is still present.  In the fixed version either:
+  //   (a) textContent assignment is gone entirely from the count>0 branch, OR
+  //   (b) span creation appears AFTER the textContent check (inside else)
+  //
+  // Both are captured by: spanCreatePos must NOT be less than textContentPos
+  // when textContent exists inside the fn body.
+  if (textContentPos !== -1 && spanCreatePos !== -1) {
+    assert.ok(
+      spanCreatePos > textContentPos,
+      "renderCountCelebration: .preview-count-number span must be created AFTER (inside else branch of) the el.textContent plain-text path — " +
+        "otherwise el.textContent obliterates the span for count===1. " +
+        "Move the span-build path into the `else` branch guarded by `after !== undefined`."
+    );
+  }
+  // If textContent is gone from the count>0 branch entirely that's also fine.
 });
 
 test("_resetPreviewDom clears #preview-count and the animation flag", () => {


### PR DESCRIPTION
Closes #819

## Summary

- **Content toast**: the inline `STRINGS` table in `src/content/cleaner.js` only carried en/es/pt/de — French/Italian/Japanese users always saw English toasts despite full translations existing in `i18n.js`. Table synced (verbatim copies) + `SUPPORTED_LANGS` extended to all 7. New drift-guard test parses both sources and asserts key×locale parity — it also caught and fixed two pre-existing drifts (`de.toast_tag_msg`, `pt.toast_dismiss` had gone stale).
- **Popup celebration**: `renderCountCelebration` built the animated `.preview-count-number` span and then `el.textContent = template` destroyed it for the no-placeholder `count === 1` case — the pulse animation never fired for the most common outcome. Paths are now mutually exclusive.
- Locale loop in `popup-count-celebration.test.mjs` extended to all 7 locales for the `{n}` placeholder guard.
- No bundle regeneration needed: the toast table lives in the directly-loaded content script, not in cleaner-bundle.

## Test plan

- [x] TDD both parts; drift guard red against old table (and surfaced 2 real drifts)
- [x] `npm test` → green post-rebase