### PR TITLE
fix(parity): declare wrapper_unwrap DNR ruleset in Firefox MV2 manifest (#820)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -387,7 +387,9 @@ async function maybeFetchRemoteRules(deps) {
 }
 
 // --- DNR sync helpers ---
-// Firefox MV2 does not support declarativeNetRequest; guard all DNR calls.
+// Guard all DNR calls with a feature-detect. Firefox MV2 (≥113) DOES support
+// declarativeNetRequest for static rulesets and regexSubstitution redirects;
+// the guard covers Firefox Android and any environment where the API is absent.
 const hasDNR = typeof chrome.declarativeNetRequest !== "undefined";
 
 async function syncCustomParamsDNR(customParams) {

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -87,6 +87,11 @@
         "id": "tracking_params",
         "enabled": true,
         "path": "rules/tracking-params.json"
+      },
+      {
+        "id": "wrapper_unwrap",
+        "enabled": true,
+        "path": "rules/wrapper-dnr-rules.json"
       }
     ]
   },

--- a/tests/unit/firefox-mv2.test.mjs
+++ b/tests/unit/firefox-mv2.test.mjs
@@ -36,6 +36,7 @@ const BACKGROUND_HTML = readFileSync(
   join(__dirname, "../../src/background/background.html"), "utf8"
 );
 const MANIFEST_V2 = require("../../src/manifest.v2.json");
+const MANIFEST_V3 = require("../../src/manifest.json");
 
 // ---------------------------------------------------------------------------
 // Firefox MV2 compatibility -- guards that must never be removed
@@ -276,5 +277,88 @@ describe("Firefox MV2 manifest structure", () => {
     const pkg = require("../../package.json");
     assert.equal(MANIFEST_V2.version, pkg.version,
       "manifest.v2.json version must match package.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DNR ruleset parity — MV2 must declare all MV3 rulesets except documented ones
+// ---------------------------------------------------------------------------
+//
+// Documented exceptions (rulesets intentionally absent from MV2):
+//
+//   amp_redirect — the content script content/amp-redirect.js (run_at:
+//   document_end) is the documented Firefox fallback for AMP unwrapping.
+//   Whether amp-redirect.json's regexSubstitution rules also work on Firefox
+//   MV2 is unverified; tracked separately. Do not remove it from this list
+//   without a confirmed live Firefox run.
+//
+// All other rulesets must be declared in both manifests. If a new ruleset is
+// added to manifest.json (MV3) without a decision for Firefox, this test will
+// fail loudly so the gap is never silent. (#820)
+//
+describe("DNR ruleset MV2 parity (#820)", () => {
+  const DOCUMENTED_MV2_EXCEPTIONS = new Set([
+    "amp_redirect",
+  ]);
+
+  const mv3Ids = new Set(
+    (MANIFEST_V3.declarative_net_request?.rule_resources ?? []).map(r => r.id)
+  );
+  const mv2Ids = new Set(
+    (MANIFEST_V2.declarative_net_request?.rule_resources ?? []).map(r => r.id)
+  );
+
+  test("every MV3 ruleset is either declared in MV2 or listed in DOCUMENTED_MV2_EXCEPTIONS", () => {
+    const missing = [];
+    for (const id of mv3Ids) {
+      if (!mv2Ids.has(id) && !DOCUMENTED_MV2_EXCEPTIONS.has(id)) {
+        missing.push(id);
+      }
+    }
+    assert.deepEqual(
+      missing,
+      [],
+      "The following MV3 DNR ruleset IDs are absent from manifest.v2.json and not in the " +
+      "documented-exceptions list — add them to manifest.v2.json (if compatible) or add " +
+      "them to DOCUMENTED_MV2_EXCEPTIONS with a comment explaining why:\n  " +
+      missing.join("\n  ")
+    );
+  });
+
+  test("no ruleset in DOCUMENTED_MV2_EXCEPTIONS is silently added to MV2", () => {
+    const conflicts = [];
+    for (const id of DOCUMENTED_MV2_EXCEPTIONS) {
+      if (mv2Ids.has(id)) {
+        conflicts.push(id);
+      }
+    }
+    assert.deepEqual(
+      conflicts,
+      [],
+      "The following ruleset IDs are in both DOCUMENTED_MV2_EXCEPTIONS and manifest.v2.json — " +
+      "remove them from DOCUMENTED_MV2_EXCEPTIONS (the exception is resolved):\n  " +
+      conflicts.join("\n  ")
+    );
+  });
+
+  test("wrapper_unwrap is declared in MV2 manifest (#820)", () => {
+    assert.ok(
+      mv2Ids.has("wrapper_unwrap"),
+      "manifest.v2.json must declare the wrapper_unwrap ruleset — Firefox users would get no " +
+      "pre-navigation wrapper unwrapping (l.facebook.com, Skimlinks, ShareASale) without it"
+    );
+  });
+
+  test("amp_redirect is documented as a MV2 exception (content-script fallback in place)", () => {
+    assert.ok(
+      DOCUMENTED_MV2_EXCEPTIONS.has("amp_redirect"),
+      "amp_redirect must remain in DOCUMENTED_MV2_EXCEPTIONS until a confirmed Firefox MV2 " +
+      "live test validates its regexSubstitution rules — the content-script fallback covers it"
+    );
+    assert.ok(
+      !mv2Ids.has("amp_redirect"),
+      "amp_redirect must NOT be declared in manifest.v2.json until Firefox MV2 compatibility " +
+      "is confirmed with a live test"
+    );
   });
 });


### PR DESCRIPTION
Closes #820

## Summary

- Firefox MV2 now declares the `wrapper_unwrap` DNR ruleset — Firefox users get the same pre-navigation wrapper unwrapping (l.facebook.com, Skimlinks, ShareASale...) Chrome users already had, instead of sending the wrapper server a request first.
- Compatibility verdict backed by evidence: the rules use `action.type: "redirect"` + `regexSubstitution` — identical shape to rules Firefox already runs; MDN BCD lists `regexSubstitution` support since Firefox 113 (manifest pins `strict_min_version: 129.0`).
- Zero gate changes needed: #810's `applyDnrState` derives ruleset IDs from the active manifest, so Firefox manages the new ruleset automatically via `prefs.unwrapRedirects`.
- New MV2-parity test suite: every MV3 ruleset must be declared in MV2 or listed in `DOCUMENTED_MV2_EXCEPTIONS`. `amp_redirect` stays excepted (its `content/amp-redirect.js` fallback is the documented MV2 path) — promoting it to DNR on Firefox is a separate decision, noted for follow-up.
- Corrected a stale comment claiming "Firefox MV2 does not support declarativeNetRequest" (the `hasDNR` guard exists for Firefox Android / absent-API environments).

## Test plan

- [x] `npm run lint` (web-ext, Firefox manifest) → 0 errors; 2 pre-existing i18n warnings unchanged
- [x] `npm test` → green post-rebase (4 new parity tests)