### PR TITLE
chore(ingestion): boundary hardening — atomic writes, promote validation, markdown escaping, no-shell exec (#821)

### DIFF
--- a/tests/unit/ingestion-orchestrator-cli.test.mjs
+++ b/tests/unit/ingestion-orchestrator-cli.test.mjs
@@ -600,6 +600,39 @@ describe("T-12 — ingestStats null-safe (quarantine-surface #782)", () => {
   });
 });
 
+// ── #821-I1: Atomic write for promote-candidates.json ─────────────────────────
+
+describe("#821-I1 — Atomic write: no .tmp sibling left after successful write", () => {
+  test("promote artifact is written atomically (no .tmp file remains after success)", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+    });
+
+    // Final file must exist
+    assert.ok(existsSync(promotePath), "promote file must exist after write");
+    // No .tmp sibling must remain (atomic: write to .tmp then rename)
+    assert.ok(
+      !existsSync(promotePath + ".tmp"),
+      ".tmp sibling must NOT exist after atomic write completes"
+    );
+  });
+});
+
 // ── n3: Dedup at CLI boundary ─────────────────────────────────────────────────
 
 describe("R4 — Dedup at CLI boundary", () => {

--- a/tests/unit/ingestion-promote-rules.test.mjs
+++ b/tests/unit/ingestion-promote-rules.test.mjs
@@ -1182,6 +1182,245 @@ describe("runPromote — idempotency with unsorted source params (FIX-5)", () =>
   });
 });
 
+// ── #821-I2: Param format validation at promote boundary ──────────────────────
+
+describe("#821-I2 — Param format validation at promote boundary", () => {
+  test("I2-a: param failing PARAM_FORMAT_RE (contains space) → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    // "bad param" has a space — fails PARAM_FORMAT_RE /^[a-zA-Z0-9_.\-]+$/
+    const badParams = ["bad param", "good_param"];
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", badParams);
+    const sig = cryptoSign(null, Buffer.from(canonical, "utf8"), TEST_PRIV_KEY).toString("base64url");
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: badParams, sig };
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: ["existing_param"],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "bad format param → exitCode 1");
+        return true;
+      }
+    );
+    assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
+  });
+
+  test("I2-b: param exceeding MAX_PARAM_LEN (>64 chars) → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const overLongParam = "a".repeat(65); // 65 chars > MAX_PARAM_LEN (64)
+    const badParams = [overLongParam];
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", badParams);
+    const sig = cryptoSign(null, Buffer.from(canonical, "utf8"), TEST_PRIV_KEY).toString("base64url");
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: badParams, sig };
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+
+    const sourcePath = writeParamsJson(tmpDir, { version: 3, published: "2026-04-01T00:00:00.000Z", params: [] });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "over-long param → exitCode 1");
+        return true;
+      }
+    );
+    assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
+  });
+
+  test("I2-c: param in REMOTE_PARAM_DENYLIST → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    // "q" is in REMOTE_PARAM_DENYLIST
+    const badParams = ["q"];
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", badParams);
+    const sig = cryptoSign(null, Buffer.from(canonical, "utf8"), TEST_PRIV_KEY).toString("base64url");
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: badParams, sig };
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+
+    const sourcePath = writeParamsJson(tmpDir, { version: 3, published: "2026-04-01T00:00:00.000Z", params: [] });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "denylist param → exitCode 1");
+        return true;
+      }
+    );
+    assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
+  });
+
+  test("I2-d: param in AFFILIATE_PARAM_GUARD → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    // "tag" is in AFFILIATE_PARAM_GUARD (Amazon)
+    const badParams = ["tag"];
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", badParams);
+    const sig = cryptoSign(null, Buffer.from(canonical, "utf8"), TEST_PRIV_KEY).toString("base64url");
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: badParams, sig };
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+
+    const sourcePath = writeParamsJson(tmpDir, { version: 3, published: "2026-04-01T00:00:00.000Z", params: [] });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "affiliate guard param → exitCode 1");
+        return true;
+      }
+    );
+    assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
+  });
+});
+
+// ── #821-I3: Validate `published` in promote source schema ────────────────────
+
+describe("#821-I3 — Validate `published` in source params.json schema", () => {
+  test("I3-a: source params.json missing `published` field → PromoteError exitCode 1, bytes unchanged", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+
+    // Source without `published` field
+    const sourcePath = join(tmpDir, "params.json");
+    writeFileSync(
+      sourcePath,
+      JSON.stringify({ version: 3, params: ["existing_param"] }, null, 2) + "\n",
+      "utf8"
+    );
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+    const bytesBefore = readFileSync(sourcePath, "utf8");
+
+    await assert.rejects(
+      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "missing published in source → exitCode 1 (SCHEMA_ERROR)");
+        return true;
+      }
+    );
+    assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
+  });
+
+  test("I3-b: source params.json with non-string `published` → PromoteError exitCode 1", async () => {
+    const { runPromote, PromoteError } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+
+    // Source with published as a number (not string)
+    const sourcePath = join(tmpDir, "params.json");
+    writeFileSync(
+      sourcePath,
+      JSON.stringify({ version: 3, published: 12345, params: ["existing_param"] }, null, 2) + "\n",
+      "utf8"
+    );
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    await assert.rejects(
+      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
+      (err) => {
+        assert.ok(err instanceof PromoteError, "must be PromoteError");
+        assert.strictEqual(err.exitCode, 1, "non-string published in source → exitCode 1");
+        return true;
+      }
+    );
+  });
+
+  test("I3-c: valid source with string `published` proceeds normally", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    const artifact = buildArtifact({
+      version: 3,
+      published: "2026-05-01T00:00:00.000Z",
+      params: ["new_param"],
+      privateKey: TEST_PRIV_KEY,
+    });
+    const promotePath = writeArtifact(tmpDir, artifact);
+    const sourcePath = writeParamsJson(tmpDir, {
+      version: 3,
+      published: "2026-04-01T00:00:00.000Z",
+      params: [],
+    });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    // Must not throw — valid published field
+    const result = await runPromote({
+      promotePath, sourcePath, domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now,
+    });
+    assert.strictEqual(result.verified, true, "valid source must proceed to verify");
+    assert.strictEqual(result.written, true, "valid source must write result");
+  });
+});
+
 // ── Phase 8: T-27 — import-smoke regression test ─────────────────────────────
 
 describe("Import smoke — promote-rules.mjs under Node (D1 mitigation)", () => {

--- a/tests/unit/rule-ingestion-quarantine.test.mjs
+++ b/tests/unit/rule-ingestion-quarantine.test.mjs
@@ -61,3 +61,38 @@ test("the real .gitignore lists the quarantine path", () => {
 test("no raw upstream is git-tracked under the quarantine dir", () => {
   assert.deepEqual(listTrackedQuarantineFiles(), []);
 });
+
+// ── #821-I5: execFileSync (no shell) ─────────────────────────────────────────
+// Doc-level test: listTrackedQuarantineFiles must use execFileSync, not execSync.
+// We verify the exported function works correctly (observable behavior) AND
+// check source code for the no-shell pattern as a documentation guard.
+
+import { readFileSync as readFs } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirnameTest = dirname(fileURLToPath(import.meta.url));
+const verifySrc = readFs(resolve(__dirnameTest, "../../tools/rule-ingestion/verify-quarantine.mjs"), "utf8");
+
+test("#821-I5: verify-quarantine.mjs uses execFileSync not execSync (no shell)", () => {
+  assert.ok(
+    verifySrc.includes("execFileSync"),
+    "verify-quarantine.mjs must use execFileSync (no-shell pattern)"
+  );
+  assert.ok(
+    !verifySrc.includes("execSync("),
+    "verify-quarantine.mjs must NOT use execSync (shell=true variant)"
+  );
+});
+
+test("#821-I5: execFileSync invocation splits args correctly — git + ls-files + -- + path", () => {
+  // Verify the call pattern is present in source code
+  assert.ok(
+    verifySrc.includes('"git"'),
+    'execFileSync call must pass "git" as first argument'
+  );
+  assert.ok(
+    verifySrc.includes('"ls-files"'),
+    'execFileSync args must include "ls-files"'
+  );
+});

--- a/tests/unit/rule-ingestion-report-formatter.test.mjs
+++ b/tests/unit/rule-ingestion-report-formatter.test.mjs
@@ -279,6 +279,95 @@ describe("F8 — empty/noop input: valid minimal markdown, no crash", () => {
   });
 });
 
+// ── #821-I4: Escape backticks and pipe chars in upstream-derived strings ──────
+
+describe("#821-I4 — Backtick and pipe escaping in markdown output", () => {
+  test("I4-a: param containing backtick → backtick escaped in quarantine listing", async () => {
+    const { formatQuarantineReport } = await import("../../tools/rule-ingestion/report-formatter.mjs");
+
+    // A param with a backtick — would break markdown code-span if unescaped
+    const paramWithBacktick = "bad`param";
+    const report = makeReport({
+      quarantine: [makeQuarantineEntry(paramWithBacktick)],
+      quarantineCount: 1,
+    });
+    const md = formatQuarantineReport(report);
+
+    // The raw backtick must not appear unescaped inside the code-span
+    // i.e., we must not see `` `bad`param` `` — the inner backtick must be escaped
+    assert.ok(!md.includes("`bad`param`"), "unescaped backtick in param must not appear in output");
+    // The param content should still appear in some form
+    assert.ok(md.includes("bad"), "param content must still appear in output");
+  });
+
+  test("I4-b: param containing pipe → pipe escaped in quarantine table listing", async () => {
+    const { formatQuarantineReport } = await import("../../tools/rule-ingestion/report-formatter.mjs");
+
+    const paramWithPipe = "bad|param";
+    const report = makeReport({
+      quarantine: [makeQuarantineEntry(paramWithPipe)],
+      quarantineCount: 1,
+    });
+    const md = formatQuarantineReport(report);
+
+    // A raw | in a param within a table cell breaks the table structure
+    // The pipe in the param name must be escaped as &#124; or \\|
+    const lines = md.split("\n");
+    // Find the line containing the param
+    const paramLine = lines.find((l) => l.includes("bad"));
+    // If found in a table line (starts with |), inner pipes must be escaped
+    if (paramLine && paramLine.trimStart().startsWith("|")) {
+      // The cell content should not have a raw unescaped |
+      // We check that the param's pipe doesn't break the cell count
+      const cellCount = (paramLine.match(/(?<!\\)\|/g) || []).length;
+      // Standard table row for adapter table has 7 pipes (6 cells + 2 borders)
+      // Standard non-table line with a param in backticks shouldn't have extra pipes
+      assert.ok(cellCount <= 7, `excess unescaped pipes in line: ${paramLine}`);
+    }
+  });
+
+  test("I4-c: adapterId containing backtick → backtick escaped in ingest stats table", async () => {
+    const { formatQuarantineReport } = await import("../../tools/rule-ingestion/report-formatter.mjs");
+
+    const stats = {
+      adapters: [{ adapterId: "bad`adapter", admitted: 1, skipped: 0, affiliateExcluded: 0 }],
+      merged: { total: 1, emptyDropped: 0 },
+    };
+    const report = makeReport({ ingestStats: stats, quarantine: [], quarantineCount: 0 });
+    const md = formatQuarantineReport(report);
+
+    // The raw adapter ID with backtick should not produce malformed markdown
+    // Check no consecutive backtick sequences that would break code-span parsing
+    assert.ok(!md.includes("`bad`adapter"), "unescaped backtick in adapterId must not appear in table cell");
+  });
+
+  test("I4-d: promote skip param containing backtick → backtick escaped", async () => {
+    const { formatQuarantineReport } = await import("../../tools/rule-ingestion/report-formatter.mjs");
+
+    const paramWithBacktick = "bad`skip";
+    const promoteSkipped = [{ param: paramWithBacktick, reason: "domain-specific" }];
+    const report = makeReport({ quarantine: [], quarantineCount: 0 });
+    const md = formatQuarantineReport(report, { promoteSkipped });
+
+    assert.ok(!md.includes("`bad`skip`"), "unescaped backtick in promote skip param must not appear in output");
+    assert.ok(md.includes("bad"), "skip param content must still appear in output");
+  });
+
+  test("I4-e: reason string containing backtick → backtick escaped in quarantine listing", async () => {
+    const { formatQuarantineReport } = await import("../../tools/rule-ingestion/report-formatter.mjs");
+
+    const report = makeReport({
+      quarantine: [makeQuarantineEntry("normal_param", "GATE", "reason with `backtick`")],
+      quarantineCount: 1,
+    });
+    const md = formatQuarantineReport(report);
+
+    // The reason appears outside the backtick-wrapped param, so any backtick in reason
+    // can still break markdown rendering — must be escaped
+    assert.ok(!md.includes("`backtick`"), "unescaped backtick in reason must not appear in output");
+  });
+});
+
 describe("F9 — output length well under 1 MB with large fixture", () => {
   test("1000 quarantine entries + topN:20 → output < 100 KB", async () => {
     const { formatQuarantineReport } = await import("../../tools/rule-ingestion/report-formatter.mjs");

--- a/tools/rule-ingestion/adapters/index.mjs
+++ b/tools/rule-ingestion/adapters/index.mjs
@@ -27,6 +27,20 @@ import { clearurls } from "./clearurls.mjs";
  *   ClearURLs accumulates signals.length === 2, passing GATE 2 (corroboration-
  *   gate, #776). Single-source params remain at signals.length === 1 and are
  *   quarantined (recoverable false-positive guard).
+ *
+ * REGISTRY POLICY — ADAPTER INDEPENDENCE (#821):
+ * Each entry in ENABLED_ADAPTERS MUST be independently maintained by a separate
+ * team or organisation with its own review and update cadence. Two adapters that
+ * consume the same upstream dataset (even via different download URLs or formats)
+ * count as ONE effective signal, not two. Adding such a "mirror" adapter would
+ * silently corrupt the corroboration guarantee in corroboration-gate.mjs.
+ *
+ * Before adding a new adapter, verify:
+ *   1. The upstream source is maintained independently (separate team, separate
+ *      issue tracker, separate review process).
+ *   2. The license is compatible with MUGA's GPL v3 (see PROVENANCE.md, #774).
+ *   3. The adapter is listed in PROVENANCE.md with license, URL, and rationale.
+ *
  * @type {Adapter[]}
  */
 export const ENABLED_ADAPTERS = [adguardTp, clearurls];

--- a/tools/rule-ingestion/gates/corroboration-gate.mjs
+++ b/tools/rule-ingestion/gates/corroboration-gate.mjs
@@ -27,6 +27,16 @@
 /**
  * Minimum number of independent upstream signal sources required for a
  * candidate to pass GATE 2. Configurable at call-site via opts.minSignals.
+ *
+ * CORRECTNESS INVARIANT — INDEPENDENCE MAINTENANCE REQUIRED:
+ * The gate counts signals.length as independent corroboration only when each
+ * signal entry was produced by a DISTINCT, SEPARATELY MAINTAINED adapter
+ * (see tools/rule-ingestion/adapters/index.mjs). If two adapters share the
+ * same upstream dataset (e.g., one is a re-packaged mirror of the other),
+ * their combined signal count is NOT independent corroboration and defeats
+ * the false-positive guard this gate provides. Every adapter added to
+ * ENABLED_ADAPTERS must come from an independently maintained upstream source.
+ *
  * @type {number}
  */
 export const MIN_SIGNALS = 2;

--- a/tools/rule-ingestion/orchestrate-cli.mjs
+++ b/tools/rule-ingestion/orchestrate-cli.mjs
@@ -31,7 +31,7 @@
  */
 
 import { sign as cryptoSign, createPrivateKey, createHash } from "node:crypto";
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -241,7 +241,9 @@ export async function runOrchestrateCli({
 
   try {
     mkdirSync(dirname(resolvedPromotePath), { recursive: true });
-    writeFileSync(resolvedPromotePath, promoteFileContent, "utf8");
+    const tmpPath = resolvedPromotePath + ".tmp";
+    writeFileSync(tmpPath, promoteFileContent, "utf8");
+    renameSync(tmpPath, resolvedPromotePath);
   } catch (err) {
     throw new CliError(
       `[orchestrate-cli] ERROR: Cannot write promote artifact to "${resolvedPromotePath}": ${err.message}`,

--- a/tools/rule-ingestion/promote-rules.mjs
+++ b/tools/rule-ingestion/promote-rules.mjs
@@ -28,7 +28,13 @@ import { readFileSync, writeFileSync, renameSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { verifySignature } from "../../src/lib/remote-rules.js";
+import {
+  verifySignature,
+  PARAM_FORMAT_RE,
+  MAX_PARAM_LEN,
+  REMOTE_PARAM_DENYLIST,
+  AFFILIATE_PARAM_GUARD,
+} from "../../src/lib/remote-rules.js";
 import { TRUSTED_PUBLIC_KEYS } from "../../src/lib/remote-rules-keys.js";
 import { canonicalMessage } from "./orchestrate.mjs";
 
@@ -174,6 +180,12 @@ export async function runPromote({
       1
     );
   }
+  if (typeof current.published !== "string") {
+    throw new PromoteError(
+      `SCHEMA_ERROR: params.json.published must be a string, got ${typeof current.published}`,
+      1
+    );
+  }
   if (!Array.isArray(current.params)) {
     throw new PromoteError(
       `SCHEMA_ERROR: params.json.params must be an array`,
@@ -255,6 +267,31 @@ export async function runPromote({
     console.log(
       `[promote-rules] INFO: artifact.version (${art.version}) <= source.version (${current.version}) — artifact may be stale; proceeding on params delta`
     );
+  }
+
+  // ── Step 4b: Param format + denylist + affiliate-guard validation ───────────
+  // Applied after sig/freshness so we don't expose format info on unsigned data.
+  // Mirrors the REQ-VALIDATE-2/3/4/5 checks in remote-rules.js validateParams.
+  for (const param of art.params) {
+    if (param.length < 1 || param.length > MAX_PARAM_LEN || !PARAM_FORMAT_RE.test(param)) {
+      throw new PromoteError(
+        `PARAM_FORMAT_ERROR: promote artifact param "${param}" fails format validation (regex or length)`,
+        1
+      );
+    }
+    const lower = param.toLowerCase();
+    if (REMOTE_PARAM_DENYLIST.has(lower)) {
+      throw new PromoteError(
+        `DENYLIST_HIT: promote artifact param "${param}" is in REMOTE_PARAM_DENYLIST`,
+        1
+      );
+    }
+    if (AFFILIATE_PARAM_GUARD.has(lower)) {
+      throw new PromoteError(
+        `AFFILIATE_GUARD_HIT: promote artifact param "${param}" is in AFFILIATE_PARAM_GUARD`,
+        1
+      );
+    }
   }
 
   // ── Step 5: Build preservedSet + partition art.params ─────────────────────

--- a/tools/rule-ingestion/report-formatter.mjs
+++ b/tools/rule-ingestion/report-formatter.mjs
@@ -18,6 +18,23 @@
  */
 
 /**
+ * Escapes backticks and pipe characters in an upstream-derived string so it
+ * renders safely inside markdown code-spans and table cells.
+ *
+ * - Backtick (`) → escaped as `` \` `` inside inline code is not possible with
+ *   standard markdown, so we replace it with its HTML entity &#96; to prevent
+ *   breaking code-span delimiters.
+ * - Pipe (|)     → &#124; prevents the character from splitting table cells.
+ *
+ * @param {string} str  Raw upstream-derived string.
+ * @returns {string}    Safe string for use in markdown.
+ */
+function escMd(str) {
+  if (typeof str !== "string") return str;
+  return str.replace(/`/g, "&#96;").replace(/\|/g, "&#124;");
+}
+
+/**
  * Format a quarantine report into a markdown string suitable for
  * $GITHUB_STEP_SUMMARY or a PR body.
  *
@@ -63,9 +80,9 @@ export function formatQuarantineReport(reportObj, { promoteSkipped = [], topN = 
 
     for (const a of adapters) {
       const status = a.status === "failed" ? "FAILED" : "ok";
-      const errorCell = a.status === "failed" ? (a.error ?? "unknown error") : "";
+      const errorCell = a.status === "failed" ? escMd(a.error ?? "unknown error") : "";
       lines.push(
-        `| ${a.adapterId ?? "?"} | ${status} | ${a.admitted ?? 0} | ${a.skipped ?? 0} | ${a.affiliateExcluded ?? 0} | ${errorCell} |`
+        `| ${escMd(a.adapterId ?? "?")} | ${status} | ${a.admitted ?? 0} | ${a.skipped ?? 0} | ${a.affiliateExcluded ?? 0} | ${errorCell} |`
       );
     }
 
@@ -102,7 +119,7 @@ export function formatQuarantineReport(reportObj, { promoteSkipped = [], topN = 
     if (gateCounts.size > 0) {
       lines.push("**By gate:**");
       for (const [gate, count] of [...gateCounts.entries()].sort((a, b) => b[1] - a[1])) {
-        lines.push(`- ${gate}: ${count}`);
+        lines.push(`- ${escMd(gate)}: ${count}`);
       }
       lines.push("");
     }
@@ -116,8 +133,10 @@ export function formatQuarantineReport(reportObj, { promoteSkipped = [], topN = 
       const primaryRejection = Array.isArray(entry.rejections) && entry.rejections.length > 0
         ? entry.rejections[0]
         : null;
-      const reason = primaryRejection ? `${primaryRejection.gate}: ${primaryRejection.reason}` : "unknown";
-      lines.push(`- \`${entry.candidate?.param ?? entry.param}\` — ${reason}`);
+      const reason = primaryRejection
+        ? `${escMd(primaryRejection.gate)}: ${escMd(primaryRejection.reason)}`
+        : "unknown";
+      lines.push(`- \`${escMd(entry.candidate?.param ?? entry.param)}\` — ${reason}`);
     }
 
     if (remaining > 0) {
@@ -143,7 +162,7 @@ export function formatQuarantineReport(reportObj, { promoteSkipped = [], topN = 
     const remainingSkips = skips.length - toShowSkips.length;
 
     for (const s of toShowSkips) {
-      lines.push(`- \`${s.param}\` — ${s.reason}`);
+      lines.push(`- \`${escMd(s.param)}\` — ${escMd(s.reason)}`);
     }
 
     if (remainingSkips > 0) {

--- a/tools/rule-ingestion/verify-quarantine.mjs
+++ b/tools/rule-ingestion/verify-quarantine.mjs
@@ -19,7 +19,7 @@
  * exit live in main() so the module is import-safe.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 /** Repo-relative quarantine working dir. Trailing slash = directory match. */
@@ -65,7 +65,7 @@ export function isOutsideSrc(quarantinePath = QUARANTINE_PATH) {
  * @returns {string[]} Tracked file paths (empty when the invariant holds).
  */
 export function listTrackedQuarantineFiles(quarantinePath = QUARANTINE_PATH) {
-  const out = execSync(`git ls-files -- "${quarantinePath}"`, {
+  const out = execFileSync("git", ["ls-files", "--", quarantinePath], {
     encoding: "utf8",
   });
   return out


### PR DESCRIPTION
Closes #821

## Summary — six defense-in-depth items, all TDD

1. **Atomic write** for `promote-candidates.json` in orchestrate-cli (`.tmp` + `renameSync`, mirroring promote-rules) — no more corrupt artifact on mid-write crash.
2. **Promote-boundary validation**: params now checked against `PARAM_FORMAT_RE` + `MAX_PARAM_LEN` + `REMOTE_PARAM_DENYLIST` + `AFFILIATE_PARAM_GUARD` (imported from remote-rules.js) after signature verification — a signed-but-malformed artifact can no longer pollute `params.json` even if the signing step is bypassed.
3. **`published` field validated** in the promote source schema — closes the silent `published: undefined` → `?? null` absorption in pipeline.mjs.
4. **Markdown escaping** (`escMd`: backtick + pipe) on EVERY upstream-derived string in report-formatter (adapter ids, errors, gate names, rejection reasons, params) — no markdown injection into Step Summary / PR bodies.
5. **`execFileSync` (no shell)** in verify-quarantine — removes the latent command-injection surface on the path argument.
6. **Corroboration independence documented**: gate JSDoc + adapter registry policy (independence/license/provenance pre-conditions) — `signals.length >= 2` is only corroboration if sources are independently maintained.

## Test plan

- [x] 15 new tests (atomicity, 4 promote-validation rejects with exitCode 1, published-schema, 5 escaping sections, 2 no-shell guards)
- [x] `npm test` → green post-rebase