### PR TITLE
test(coverage): add node --test coverage script + CI artifact (#822)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,40 @@ jobs:
       - name: Lint extension
         run: npm run lint
 
+  coverage:
+    # Non-blocking: runs only on push to main so coverage overhead does not
+    # slow the PR gate. Upload the text report as an artifact for baseline
+    # tracking. No threshold gate yet — establish baseline first (#822).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        # --experimental-test-coverage instruments all loaded source files.
+        # The coverage summary is printed to stdout alongside spec output;
+        # Node 20 does not support the lcov reporter (added in Node 22), so
+        # we capture the full stdout (spec + coverage table) to a text file.
+        run: npm run test:coverage > coverage.txt 2>&1; exit 0
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        with:
+          name: coverage-report
+          path: coverage.txt
+          retention-days: 30
+
   e2e:
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "npm run build:chrome && npm run build:firefox",
     "lint": "bash scripts/with-firefox-manifest.sh npx --no-install web-ext lint --source-dir src/",
     "test": "node --test --test-reporter=spec tests/unit/*.mjs",
+    "test:coverage": "node --experimental-test-coverage --test-coverage-exclude=\"**/node_modules/**\" --test --test-reporter=spec tests/unit/*.mjs",
     "test:integration": "node --test --test-reporter=spec tests/integration/*.mjs",
     "check:i18n": "node tools/check-i18n-fixme.mjs",
     "verify:quarantine": "node tools/rule-ingestion/verify-quarantine.mjs",


### PR DESCRIPTION
Closes #822

## Summary

- `test:coverage` script using Node's built-in `--experimental-test-coverage` (zero new deps). `--test-coverage-exclude` for node_modules is load-bearing: without it Node collapses to a single meaningless 100% line. `spec` reporter (lcov reporter needs Node 22+; CI floats on 20).
- New parallel `coverage` job in ci.yml — **push-to-main only**, so the PR gate pays zero overhead. Output uploaded as a 30-day artifact (`upload-artifact` SHA-pinned, passes the workflow-hardening guards).
- No threshold gate yet — deferred until the baseline stabilizes across a few main pushes.

## Baseline (2026-06-10)

**Overall: 93.91% lines / 90.25% branches / 94.79% funcs** — materially healthier than the audit feared.

Lowest-covered modules (the real targets for follow-up tests):

| File | Lines | Branches |
|---|---|---|
| `src/lib/storage.js` | 54.5% | 40.5% |
| `src/lib/migration-storage.js` | 55.3% | 57.1% |
| `src/lib/migration-prompt.js` | 56.2% | — |
| `src/lib/per-device-prefs.js` | 61.8% | 57.1% |
| `src/lib/consent-storage.js` | 72.2% | 80.0% |

(`service-worker.js` not importable in Node — expected; its coverage story is #826's module extraction.)

## Test plan

- [x] `npm run test:coverage` runs locally, per-file table produced
- [x] `npm test` unchanged and green; workflow-hardening pin guards pass