### PR TITLE
fix(content): storage-listener once-guard + bounce-state latch re-arm (#832)

### DIFF
--- a/src/content/bounce-state-cleaner.js
+++ b/src/content/bounce-state-cleaner.js
@@ -253,6 +253,12 @@
     }
   }
 
+  // Latch re-arm (#832): track the previous gate state so a disable→re-enable
+  // cycle on the same intermediary page re-cleans storage that was written
+  // in between. When the gate transitions from true→false we reset _haveCleaned
+  // so the next gate-open event triggers a fresh cleanup pass.
+  let _prevGateEnabled = false;
+
   let _warnedOrder = false;
   document.addEventListener("muga:history-gate", (e) => {
     if (!e || !e.detail || e.detail.nonce !== _capturedNonce) {
@@ -263,6 +269,12 @@
       return;
     }
     const enabled = !!(e.detail.enabled);
+    // Re-arm the latch when the gate closes so a subsequent re-enable cleans
+    // any storage written while MUGA was disabled.
+    if (_prevGateEnabled && !enabled) {
+      _haveCleaned = false;
+    }
+    _prevGateEnabled = enabled;
     if (enabled) attemptCleanup();
   });
 })();

--- a/src/content/history-defuser.js
+++ b/src/content/history-defuser.js
@@ -137,9 +137,21 @@
 
   // Re-read on storage changes so toggling MUGA off in the popup closes
   // the gate without a page reload.
+  //
+  // Once-guard (#832): the IIFE's window.__mugaHistoryDefuserGate check
+  // (above) already prevents this block from running more than once per
+  // window lifetime, making duplicate listener registration impossible in
+  // practice. The _storageListenerInstalled boolean is defense-in-depth:
+  // it makes the once-only intent explicit and guards against any future
+  // refactor that might extract this block into a callable function or
+  // remove the top-level gate.
+  let _storageListenerInstalled = false;
   if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.onChanged) {
-    chrome.storage.onChanged.addListener((_changes, area) => {
-      if (area === "sync" || area === "local") readPrefsAndGate();
-    });
+    if (!_storageListenerInstalled) {
+      _storageListenerInstalled = true;
+      chrome.storage.onChanged.addListener((_changes, area) => {
+        if (area === "sync" || area === "local") readPrefsAndGate();
+      });
+    }
   }
 })();

--- a/tests/unit/bounce-state-cleaner.test.mjs
+++ b/tests/unit/bounce-state-cleaner.test.mjs
@@ -20,7 +20,12 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
 import { createBounceStateCleaner } from "../../src/lib/bounce-state-cleaner.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -287,5 +292,73 @@ describe("createBounceStateCleaner — factory contract", () => {
     assert.equal(result.cleaned, false);
     assert.equal(local.__size, 1);
     assert.equal(session.__size, 1);
+  });
+});
+
+// ── Content-script IIFE wiring — structural (#832) ───────────────────────
+//
+// The IIFE in src/content/bounce-state-cleaner.js keeps a _haveCleaned
+// latch that prevents double-cleaning on the same page load. Bug #832:
+// on a disable->re-enable cycle while staying on an intermediary page,
+// _haveCleaned stays true and storage written between the disable and
+// re-enable is never wiped.
+//
+// Fix: track the previous gate state and reset _haveCleaned on a
+// true->false gate transition so the next enabled event re-cleans.
+//
+// These are source-analysis tests (no DOM). They verify the structural
+// contracts that make the latch re-arm sound without requiring jsdom.
+
+describe("bounce-state-cleaner — content-script IIFE latch re-arm (#832)", () => {
+  const iifeSrc = readFileSync(
+    join(__dirname, "../../src/content/bounce-state-cleaner.js"), "utf8",
+  );
+
+  test("IIFE tracks previous gate state with a _prevGateEnabled variable", () => {
+    assert.ok(
+      /_prevGateEnabled/.test(iifeSrc),
+      "bounce-state-cleaner.js must declare _prevGateEnabled to track the previous gate state",
+    );
+  });
+
+  test("IIFE resets _haveCleaned when gate transitions from true to false", () => {
+    // The reset must be conditional on the previous value being true and
+    // the new value being false (true->false transition).
+    assert.ok(
+      /_prevGateEnabled\s*&&\s*!enabled/.test(iifeSrc),
+      "bounce-state-cleaner.js must check _prevGateEnabled && !enabled to detect gate close",
+    );
+    assert.ok(
+      /_haveCleaned\s*=\s*false/.test(iifeSrc),
+      "bounce-state-cleaner.js must assign _haveCleaned = false as part of the latch re-arm",
+    );
+  });
+
+  test("IIFE updates _prevGateEnabled after each gate event", () => {
+    // Must update the previous-state variable so subsequent transitions
+    // are detected correctly.
+    assert.ok(
+      /_prevGateEnabled\s*=\s*enabled/.test(iifeSrc),
+      "bounce-state-cleaner.js must update _prevGateEnabled = enabled after each gate event",
+    );
+  });
+
+  test("IIFE still preserves nonce validation from #811 (#832 must not break it)", () => {
+    // The nonce check must remain — any gate event that fails nonce
+    // validation must be rejected before the latch re-arm logic runs.
+    assert.ok(
+      /detail\.nonce\s*!==\s*_capturedNonce/.test(iifeSrc) ||
+      /e\.detail\.nonce\s*!==\s*_capturedNonce/.test(iifeSrc),
+      "bounce-state-cleaner.js must retain the nonce validation guard from #811",
+    );
+  });
+
+  test("IIFE still latches _haveCleaned after successful clean", () => {
+    // The latch must still be set on cleaned === true so a single page
+    // load does not wipe storage on every repeated gate-open event.
+    assert.ok(
+      /_haveCleaned\s*=\s*true/.test(iifeSrc),
+      "bounce-state-cleaner.js must still set _haveCleaned = true after a successful clean",
+    );
   });
 });

--- a/tests/unit/history-defuser.test.mjs
+++ b/tests/unit/history-defuser.test.mjs
@@ -298,6 +298,32 @@ describe("history-defuser — content-script wiring", () => {
       "gate script must dispatch muga:history-gate events");
   });
 
+  test("content/history-defuser.js guards storage listener with a once-flag (#832)", () => {
+    // Defense-in-depth guard: a _storageListenerInstalled boolean (or equivalent
+    // named flag) must gate the addListener call so that any hypothetical
+    // re-execution path (or future refactor) cannot accumulate duplicate listeners.
+    // The IIFE guard (window.__mugaHistoryDefuserGate) already prevents double
+    // execution in practice; this flag is explicit defense-in-depth + documentation.
+    const src = readFileSync(
+      join(__dirname, "../../src/content/history-defuser.js"), "utf8"
+    );
+    assert.ok(
+      /_storageListenerInstalled/.test(src),
+      "content/history-defuser.js must use a _storageListenerInstalled boolean to guard addListener",
+    );
+    // The flag must be set to true before or immediately after addListener so
+    // subsequent code paths cannot re-register.
+    assert.ok(
+      /_storageListenerInstalled\s*=\s*true/.test(src),
+      "content/history-defuser.js must set _storageListenerInstalled = true after registering",
+    );
+    // The addListener must be conditional on the flag being falsy.
+    assert.ok(
+      /!\s*_storageListenerInstalled/.test(src) || /if\s*\(\s*!_storageListenerInstalled/.test(src),
+      "content/history-defuser.js must check !_storageListenerInstalled before calling addListener",
+    );
+  });
+
   test("content/history-defuser-mainworld.js is an IIFE that wraps both history methods", () => {
     const src = readFileSync(
       join(__dirname, "../../src/content/history-defuser-mainworld.js"), "utf8"


### PR DESCRIPTION
Closes #832

## Summary

- `history-defuser.js`: explicit `_storageListenerInstalled` once-guard on the `chrome.storage.onChanged` registration. Honest framing: #811's IIFE re-execution guard already prevents double registration in practice — this is defense-in-depth against future refactors that extract or re-enter that block.
- `bounce-state-cleaner.js`: the `_haveCleaned` latch now re-arms on the true→false gate transition, so a disable→re-enable cycle on an intermediary page re-cleans storage written in between (previously the latch was permanent per page). Inserted AFTER the #811 nonce validation — spoofed gate events still can't touch the latch.

## Test plan

- [x] +6 tests across both files' suites
- [x] `npm test` green post-rebase; `npx playwright test --list` parses (95 specs)