### PR TITLE
fix(sw): single-flight rules loaders + firstUsed/migrations out of hot path (#833)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -43,6 +43,18 @@ const _affiliateDomains = getAffiliateDomains();
 
 let _firstUsedSet = false;
 
+// Idempotent firstUsed bootstrap. Called from onInstalled + onStartup so the
+// hot path (handleProcessUrl) only sees a free boolean check, not a storage
+// read, on the first processed URL. Sets firstUsed only when absent (#833).
+async function _initFirstUsed() {
+  if (_firstUsedSet) return;
+  try {
+    const stats = await getStats();
+    if (!stats.firstUsed) await setStats({ firstUsed: Date.now() });
+    _firstUsedSet = true;
+  } catch { /* best-effort; handleProcessUrl fallback still guards */ }
+}
+
 // B4: fetch domain-rules dynamically (import assertions incompatible with Firefox;
 //       top-level await disallowed in Chrome MV3 service workers).
 // Cache-first: on each SW restart we attempt to read from chrome.storage.session
@@ -77,8 +89,8 @@ async function _loadDomainRules() {
     await cacheDomainRules(data);
   } catch (err) {
     console.error("[MUGA] domain-rules.json fetch failed (attempt", _domainRulesFetchAttempts, "):", err);
-    // Null out so the next handleProcessUrl call retries (up to the cap)
-    _domainRulesReady = null;
+    // Do NOT null _domainRulesReady here — concurrent callers share this promise.
+    // handleProcessUrl nulls it after all callers finish awaiting, enabling retry.
   }
 }
 
@@ -120,8 +132,8 @@ async function _loadPathRules() {
     console.warn("[MUGA] path rules fetch failed:", err);
     pathStripRules     = [];
     pathAffiliateRules = [];
-    // Null out so the next handleProcessUrl call retries (up to the cap)
-    _pathRulesReady = null;
+    // Do NOT null _pathRulesReady here — concurrent callers share this promise.
+    // handleProcessUrl nulls it after all callers finish awaiting, enabling retry.
   }
 }
 
@@ -1128,9 +1140,20 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
   // _domainRulesReady / _pathRulesReady are nulled on fetch failure to allow
   // retry on the next call. Both loaders run in a single outer Promise.all so
   // all three JSON files (domain + 2× path) are in flight at once.
+  // Single-flight: each ref is assigned once per attempt so concurrent callers
+  // share the in-flight promise rather than racing to increment the attempt counter.
+  // After the shared await, null the ref only if the load failed and more retries
+  // remain — this keeps the single-flight guarantee while still allowing retry.
   if (!_domainRulesReady) _domainRulesReady = _loadDomainRules();
   if (!_pathRulesReady)   _pathRulesReady   = _loadPathRules();
   await Promise.all([_domainRulesReady, _pathRulesReady]);
+  if (domainRules.length === 0 && _domainRulesFetchAttempts < DOMAIN_RULES_MAX_ATTEMPTS) {
+    _domainRulesReady = null;
+  }
+  if (pathStripRules.length === 0 && pathAffiliateRules.length === 0 &&
+      _pathRulesFetchAttempts < PATH_RULES_MAX_ATTEMPTS) {
+    _pathRulesReady = null;
+  }
   const prefs = await getPrefsWithCache();
 
   if (!prefs.enabled || !prefs.onboardingDone) {
@@ -1159,12 +1182,17 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
     return { cleanUrl: rawUrl, action: "error", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
   }
 
-  // Record first use timestamp for nudge threshold (stored locally)
+  // firstUsed is initialized in onInstalled/onStartup (idempotent); the flag
+  // is set there so this hot path is a free boolean check on every call after
+  // the first SW lifetime event.
   if (!_firstUsedSet) {
     const localStats = await getStats();
     if (localStats.firstUsed) {
       _firstUsedSet = true;
     } else {
+      // Fallback: lifecycle events haven't fired yet (e.g., Firefox temporary
+      // add-on loaded without install/startup). Set here so the timestamp is
+      // as accurate as possible rather than relying on a future startup event.
       await setStats({ firstUsed: Date.now() });
       _firstUsedSet = true;
     }
@@ -1295,6 +1323,10 @@ chrome.runtime.onStartup.addListener(async () => {
   // ADR-0004 phase 5 (#701): migrate privacyProxyEnabled → followShortenersEnabled
   // on first startup after upgrade. Best-effort; failure must not break startup.
   migrateLegacyProxyPref().catch(() => {});
+  // #833: bootstrap firstUsed + run migrations here so the hot path is free.
+  _initFirstUsed();
+  migrateStatsToLocal();
+  migrateConsentToLocal();
 });
 
 // --- Dedup flag: prevent opening onboarding twice in the same background lifetime ---
@@ -1336,6 +1368,10 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   maybeFetchRemoteRules(_remoteRulesDeps());
   // ADR-0004 phase 5 (#701): migrate privacyProxyEnabled → followShortenersEnabled
   migrateLegacyProxyPref().catch(() => {});
+  // #833: bootstrap firstUsed + run migrations so hot path is free.
+  _initFirstUsed();
+  migrateStatsToLocal();
+  migrateConsentToLocal();
 
   if (prefs.contextMenuEnabled !== false) {
     await syncContextMenus(true);

--- a/tests/unit/sw-robustness-833.test.mjs
+++ b/tests/unit/sw-robustness-833.test.mjs
@@ -1,0 +1,292 @@
+/**
+ * MUGA — Behavioral tests for #833 SW robustness fixes.
+ *
+ * 1. Single-flight rules loaders: concurrent handleProcessUrl callers must
+ *    share one in-flight promise and increment the attempt counter only once
+ *    per actual fetch, not once per concurrent caller.
+ *
+ * 2. firstUsed bootstrap: _initFirstUsed must be idempotent and must set
+ *    firstUsed only when absent, protecting the original timestamp across
+ *    retries in the same SW lifetime.
+ *
+ * All tests are behavioral — they exercise pure extracted helpers that mirror
+ * the production logic. No swSource string scanning; SW is not importable
+ * in Node (top-level chrome.* calls).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+// ── 1. Single-flight loader helper ───────────────────────────────────────────
+//
+// Mirrors the _loadDomainRules / _loadPathRules + handleProcessUrl gating
+// pattern after the #833 fix. Key invariants:
+//
+//   a) Two concurrent callers sharing a null ref both await the SAME promise —
+//      the attempt counter increments once per actual fetch, not twice.
+//   b) After the shared await completes (failure case), the ref is nulled so
+//      the next independent call can retry.
+//   c) A successful load leaves the ref populated; subsequent callers skip
+//      the fetch entirely.
+//   d) Once MAX_ATTEMPTS is reached, the loader logs and returns without
+//      another fetch; the ref stays set (resolves immediately as no-op).
+
+function makeSingleFlightLoader({ maxAttempts = 3 } = {}) {
+  let rules = [];
+  let readyRef = null;
+  let attempts = 0;
+
+  // Pure loader — mirrors _loadDomainRules sans Chrome APIs.
+  async function _load(fetchFn) {
+    if (attempts >= maxAttempts) return; // at cap — no-op
+    try {
+      attempts++;
+      rules = await fetchFn();
+    } catch {
+      // Do NOT null readyRef here — concurrent callers already have it.
+      // handleProcessUrl nulls it post-await if load failed.
+    }
+  }
+
+  // Caller site — mirrors handleProcessUrl's gating and post-await null-out.
+  async function handleCall(fetchFn) {
+    if (!readyRef) readyRef = _load(fetchFn);
+    await readyRef;
+    // Post-await: null for retry only when load failed and cap not reached.
+    if (rules.length === 0 && attempts < maxAttempts) {
+      readyRef = null;
+    }
+    return rules.slice();
+  }
+
+  return { handleCall, getAttempts: () => attempts, getRules: () => rules };
+}
+
+describe("Single-flight loader — concurrent callers share one in-flight promise", () => {
+  test("two concurrent callers produce exactly one fetch attempt on success", async () => {
+    let fetchCount = 0;
+    const loader = makeSingleFlightLoader();
+    const fetch = async () => { fetchCount++; return ["rule-a"]; };
+
+    const [r1, r2] = await Promise.all([
+      loader.handleCall(fetch),
+      loader.handleCall(fetch),
+    ]);
+
+    assert.strictEqual(fetchCount, 1, "fetch must be called exactly once despite two concurrent callers");
+    assert.strictEqual(loader.getAttempts(), 1, "attempt counter must be 1, not 2");
+    assert.deepStrictEqual(r1, ["rule-a"]);
+    assert.deepStrictEqual(r2, ["rule-a"]);
+  });
+
+  test("two concurrent callers produce exactly one fetch attempt on failure", async () => {
+    let fetchCount = 0;
+    const loader = makeSingleFlightLoader();
+    const fetch = async () => { fetchCount++; throw new Error("network"); };
+
+    await Promise.all([
+      loader.handleCall(fetch).catch(() => {}),
+      loader.handleCall(fetch).catch(() => {}),
+    ]);
+
+    assert.strictEqual(fetchCount, 1, "fetch must fire once even when it fails");
+    assert.strictEqual(loader.getAttempts(), 1, "attempt counter must be 1, not 2 (the race bug)");
+  });
+
+  test("after failure, next independent call retries (ref nulled post-await)", async () => {
+    let fetchCount = 0;
+    const loader = makeSingleFlightLoader();
+    const failFetch = async () => { fetchCount++; throw new Error("net"); };
+    const okFetch   = async () => { fetchCount++; return ["rule-ok"]; };
+
+    // First call — fails
+    await loader.handleCall(failFetch);
+    assert.strictEqual(loader.getAttempts(), 1);
+
+    // Second independent call — should retry
+    const rules = await loader.handleCall(okFetch);
+    assert.strictEqual(loader.getAttempts(), 2, "second independent call must increment to 2");
+    assert.deepStrictEqual(rules, ["rule-ok"]);
+    assert.strictEqual(fetchCount, 2, "two distinct fetch calls should have been made");
+  });
+
+  test("after success, ref stays set and subsequent calls skip fetch", async () => {
+    let fetchCount = 0;
+    const loader = makeSingleFlightLoader();
+    const fetch = async () => { fetchCount++; return ["cached"]; };
+
+    await loader.handleCall(fetch);
+    await loader.handleCall(fetch); // ref is non-null and rules populated — no retry
+    await loader.handleCall(fetch);
+
+    assert.strictEqual(fetchCount, 1, "only one fetch for multiple calls after success");
+    assert.strictEqual(loader.getAttempts(), 1);
+  });
+
+  test("attempt cap: once maxAttempts reached, further calls are no-ops", async () => {
+    let fetchCount = 0;
+    const loader = makeSingleFlightLoader({ maxAttempts: 2 });
+    const failFetch = async () => { fetchCount++; throw new Error("net"); };
+
+    // Two failing attempts exhaust the cap
+    await loader.handleCall(failFetch);
+    await loader.handleCall(failFetch);
+    assert.strictEqual(loader.getAttempts(), 2);
+
+    // After the cap, ref is NOT nulled — loader resolves immediately as no-op
+    const rules = await loader.handleCall(failFetch);
+    assert.strictEqual(loader.getAttempts(), 2, "attempt counter must not exceed maxAttempts");
+    assert.strictEqual(fetchCount, 2, "the no-op call after the cap must not fetch again");
+    assert.deepStrictEqual(rules, []);
+  });
+
+  test("five concurrent callers all get the same result from one fetch", async () => {
+    let fetchCount = 0;
+    const loader = makeSingleFlightLoader();
+    const fetch = async () => {
+      fetchCount++;
+      // Simulate async work
+      await new Promise(r => setImmediate(r));
+      return ["shared-rule"];
+    };
+
+    const results = await Promise.all(Array.from({ length: 5 }, () => loader.handleCall(fetch)));
+    assert.strictEqual(fetchCount, 1);
+    for (const r of results) {
+      assert.deepStrictEqual(r, ["shared-rule"]);
+    }
+  });
+});
+
+// ── 2. firstUsed idempotent bootstrap ────────────────────────────────────────
+//
+// Mirrors _initFirstUsed() and the hot-path fallback in handleProcessUrl.
+// Invariants:
+//   a) When firstUsed is absent, setStats is called with a timestamp.
+//   b) When firstUsed is already present, setStats is NOT called (idempotent).
+//   c) The module flag (_firstUsedSet) prevents repeated storage reads in the
+//      hot path across multiple processUrl calls in the same SW lifetime.
+//   d) A throw between read and set (simulating concurrent writes) doesn't
+//      reset firstUsed to a later timestamp — the idempotent read-first
+//      pattern ensures the original timestamp is preserved.
+
+function makeFirstUsedBootstrap() {
+  let _firstUsedSet = false;
+
+  // Mirrors _initFirstUsed from service-worker.js after #833 fix.
+  async function initFirstUsed({ getStats, setStats, now = Date.now }) {
+    if (_firstUsedSet) return;
+    try {
+      const stats = await getStats();
+      if (!stats.firstUsed) await setStats({ firstUsed: now() });
+      _firstUsedSet = true;
+    } catch { /* best-effort */ }
+  }
+
+  // Mirrors the hot-path fallback in handleProcessUrl.
+  async function hotPathGuard({ getStats, setStats, now = Date.now }) {
+    if (_firstUsedSet) return; // free boolean check — no storage read
+    const localStats = await getStats();
+    if (localStats.firstUsed) {
+      _firstUsedSet = true;
+    } else {
+      await setStats({ firstUsed: now() });
+      _firstUsedSet = true;
+    }
+  }
+
+  return { initFirstUsed, hotPathGuard, isSet: () => _firstUsedSet };
+}
+
+describe("firstUsed bootstrap — idempotent lifecycle initialization", () => {
+  test("sets firstUsed when absent on first call", async () => {
+    const { initFirstUsed } = makeFirstUsedBootstrap();
+    const statsStore = {};
+    await initFirstUsed({
+      getStats: async () => ({ ...statsStore }),
+      setStats: async (d) => { Object.assign(statsStore, d); },
+      now: () => 1000,
+    });
+    assert.strictEqual(statsStore.firstUsed, 1000);
+  });
+
+  test("does not overwrite existing firstUsed (idempotent)", async () => {
+    const { initFirstUsed } = makeFirstUsedBootstrap();
+    const statsStore = { firstUsed: 500 };
+    let setCalled = false;
+    await initFirstUsed({
+      getStats: async () => ({ ...statsStore }),
+      setStats: async () => { setCalled = true; },
+      now: () => 9999,
+    });
+    assert.strictEqual(setCalled, false, "setStats must not be called when firstUsed already set");
+    assert.strictEqual(statsStore.firstUsed, 500, "original timestamp must be preserved");
+  });
+
+  test("_firstUsedSet flag prevents re-entry on subsequent lifecycle calls", async () => {
+    const bootstrap = makeFirstUsedBootstrap();
+    let getCount = 0;
+    const deps = {
+      getStats: async () => { getCount++; return {}; },
+      setStats: async () => {},
+    };
+    await bootstrap.initFirstUsed(deps);
+    await bootstrap.initFirstUsed(deps); // second lifecycle event — same SW lifetime
+    assert.strictEqual(getCount, 1, "getStats must only be called once per SW lifetime");
+    assert.strictEqual(bootstrap.isSet(), true);
+  });
+
+  test("hot path is free boolean check after lifecycle event sets the flag", async () => {
+    const bootstrap = makeFirstUsedBootstrap();
+    let getCount = 0;
+    const deps = {
+      getStats: async () => { getCount++; return {}; },
+      setStats: async () => {},
+    };
+    // Lifecycle event runs first
+    await bootstrap.initFirstUsed(deps);
+    getCount = 0; // reset counter
+
+    // Hot path should not touch storage
+    await bootstrap.hotPathGuard(deps);
+    await bootstrap.hotPathGuard(deps);
+    await bootstrap.hotPathGuard(deps);
+    assert.strictEqual(getCount, 0, "hot path must not call getStats after _firstUsedSet is true");
+  });
+
+  test("sequential lifecycle events only call setStats once (_firstUsedSet guards second call)", async () => {
+    // onInstalled and onStartup are sequential, not concurrent. The _firstUsedSet
+    // flag short-circuits the second call so getStats/setStats are not called again.
+    const bootstrap = makeFirstUsedBootstrap();
+    let setCount = 0;
+    let getCount = 0;
+    const statsStore = {};
+    const deps = {
+      getStats: async () => { getCount++; return { ...statsStore }; },
+      setStats: async (d) => { setCount++; Object.assign(statsStore, d); },
+      now: () => 1000,
+    };
+    await bootstrap.initFirstUsed(deps); // onInstalled fires
+    await bootstrap.initFirstUsed(deps); // onStartup fires later — must be no-op
+    assert.strictEqual(setCount, 1, "setStats must be called exactly once across sequential lifecycle events");
+    assert.strictEqual(getCount, 1, "getStats must be called exactly once — _firstUsedSet guards second call");
+  });
+
+  test("firstUsed preserves original timestamp even if init is called twice with different now()", async () => {
+    const bootstrap = makeFirstUsedBootstrap();
+    const statsStore = {};
+    let call = 0;
+    const deps = {
+      getStats: async () => ({ ...statsStore }),
+      setStats: async (d) => { Object.assign(statsStore, d); },
+      now: () => ++call === 1 ? 100 : 999,
+    };
+    await bootstrap.initFirstUsed(deps);
+    // Simulate a throw mid-way by resetting the flag and calling again
+    // (regression: if initFirstUsed ran again with a later now(), it must not overwrite)
+    statsStore.firstUsed = 100; // already set from first call
+    const secondBootstrap = makeFirstUsedBootstrap(); // new instance, same store
+    await secondBootstrap.initFirstUsed(deps); // sees existing firstUsed=100, must not overwrite
+    assert.strictEqual(statsStore.firstUsed, 100, "original timestamp must survive re-init");
+  });
+});


### PR DESCRIPTION
Closes #833

## Summary

- **Single-flight rules loaders**: the domain-rules and path-rules loaders no longer null their in-flight ref inside their own catch — `handleProcessUrl` nulls after the shared await completes (failed + cap not reached). Concurrent callers always share one promise; the retry budget (3) now means 3 REAL attempts instead of being burned 2-at-a-time by races.
- **firstUsed + migrations into lifecycle handlers**: `firstUsed` initialization moved to `onInstalled`/`onStartup` (idempotent), removing a `getStats()` read from the first-URL hot path and the late-timestamp-overwrite window. The module-level `migrateStatsToLocal()`/`migrateConsentToLocal()` calls STAY as the documented idempotent safety net; the same calls now also run in both lifecycle handlers (belt-and-suspenders per the existing comment's contract).
- 12 new behavioral tests, 0 source-grep asserts (no ratchet impact); no source-window tests needed touching.

## Test plan

- [x] `npm test` green post-rebase; SW-focused suites 302/302