### PR TITLE
build: shared web-ext ignoreFiles + engines field + toolchain docs (#829)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,30 @@ Most contributions don't need a pull request. The fastest paths in:
 
 ## Development setup
 
-**Requirements:** Node.js 20+, npm, git
+**Requirements:** Node.js >=20.11, npm, git
+
+Node 20.11 is the minimum because `import.meta.dirname` (used in several tools and
+tests) was only unflagged in that patch release. CI pins to the `20.x` LTS line;
+running on a newer release (22.x, 23.x) is fine for local development.
+
+The `engines` field in `package.json` records this constraint so `npm install` will
+warn on non-compliant versions.
 
 ```bash
 git clone https://github.com/yocreoquesi/muga.git
 cd muga
 npm install
 ```
+
+### Optional toolchain dependencies
+
+| Tool | Required for | Notes |
+|------|-------------|-------|
+| `python3` + `Pillow` | `npm run promo-tiles` | Generates Chrome Web Store promo tiles. Not needed for extension builds or tests. Install with `pip install Pillow`. |
+
+The `promo-tiles` script (`tools/generate-promo-tiles.py`) requires Python 3 with the
+`Pillow` library. It is not required for normal development, running tests, or building
+the extension. If `python3` is not available on your machine, skip this command.
 
 ## Running tests
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "typecheck": "tsc -p jsconfig.json",
     "lint:js": "eslint ."
   },
+  "engines": {
+    "node": ">=20.11"
+  },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "@types/node": "^25.9.2",

--- a/tests/unit/docs-claims.test.mjs
+++ b/tests/unit/docs-claims.test.mjs
@@ -1,5 +1,5 @@
 /**
- * MUGA — Machine-enforced documentation claims guard (#828)
+ * MUGA — Machine-enforced documentation claims guard (#828, #829)
  *
  * PURPOSE: Numbers and file paths in README.md and CONTRIBUTING.md drift over
  * time. This test makes drift immediately visible: a failing test means the
@@ -15,6 +15,11 @@
  *      must use a non-numeric label so it cannot drift.
  *  (d) CONTRIBUTING.md project-structure table file paths all exist on disk
  *      (files that are listed in the structure block must be real files).
+ *  (e) package.json has engines.node (#829 — import.meta.dirname needs >=20.11)
+ *  (f) dev:* / lint commands carry NO inline _metadata ignore globs — the
+ *      shared web-ext-config.mjs covers them; only build:* commands need CLI
+ *      overrides (web-ext CLI --ignore-files replaces, doesn't merge).
+ *  (g) web-ext-config.mjs contains the _metadata ignore list (#829)
  *
  * Run with: npm test
  */
@@ -187,6 +192,70 @@ describe("docs-claims — machine-enforced README/CONTRIBUTING accuracy", () => 
     // assert the floor is positive and not absurdly high vs file count.
     assert.ok(floorN >= 1000 && floorN <= testFiles.length * 100,
       `Floor ${floorN} looks implausible for ${testFiles.length} test files — update the README floor honestly.`);
+  });
+
+  // ── (e) package.json engines.node (#829) ─────────────────────────────────
+  //
+  // import.meta.dirname was unflagged in Node 20.11. The engines field makes
+  // npm warn contributors who are running an older patch release.
+
+  test("(e) package.json has engines.node set to >=20.11", () => {
+    const pkg = JSON.parse(readRoot("package.json"));
+    assert.ok(
+      pkg.engines && typeof pkg.engines.node === "string",
+      "package.json must have an engines.node field (import.meta.dirname requires >=20.11)"
+    );
+    assert.match(
+      pkg.engines.node,
+      /20\.11/,
+      `engines.node "${pkg.engines.node}" must reference 20.11 as the minimum ` +
+      "(import.meta.dirname was unflagged in 20.11)"
+    );
+  });
+
+  // ── (f) dev / lint commands carry no inline _metadata globs (#829) ────────
+  //
+  // web-ext auto-loads web-ext-config.mjs from the cwd for `web-ext run` and
+  // `web-ext lint`. The _metadata triple-glob lives in that config, so adding
+  // --ignore-files to these commands would be redundant (and the CLI flag
+  // REPLACES the config's ignoreFiles, not merges — adding it would also drop
+  // everything else in the config).
+  //
+  // build:* commands are exempt: strip-test-seams.mjs copies src/ to a temp
+  // dir and then passes all remaining args (including --ignore-files) verbatim
+  // to web-ext build; those commands need explicit flags because the config
+  // file lives in the project root, not the temp dir.
+
+  test("(f) dev:chrome, dev:firefox, and lint commands do not carry inline _metadata ignore globs", () => {
+    const pkg = JSON.parse(readRoot("package.json"));
+    const scrutinised = ["dev:chrome", "dev:firefox", "lint"];
+    for (const cmd of scrutinised) {
+      const script = pkg.scripts?.[cmd] ?? "";
+      assert.ok(
+        !script.includes("_metadata"),
+        `scripts.${cmd} carries an inline _metadata ignore glob ("${script}"). ` +
+        "The shared web-ext-config.mjs already covers it for web-ext run/lint — " +
+        "adding --ignore-files here would REPLACE the config's ignoreFiles, not merge."
+      );
+    }
+  });
+
+  // ── (g) web-ext-config.mjs contains the _metadata ignore list (#829) ──────
+  //
+  // Asserts the shared config is the canonical home of the _metadata triple.
+  // If someone removes it from the config, this test fails before anything
+  // ships, keeping dev-mode reload loops visible.
+
+  test("(g) web-ext-config.mjs contains all three _metadata ignore globs", () => {
+    const config = readRoot("web-ext-config.mjs");
+    const required = ["_metadata", "_metadata/**", "_metadata/**/*"];
+    for (const glob of required) {
+      assert.ok(
+        config.includes(JSON.stringify(glob)),
+        `web-ext-config.mjs must include the ignore glob ${JSON.stringify(glob)} ` +
+        "so dev:chrome/dev:firefox/lint inherit _metadata exclusion without inline flags."
+      );
+    }
   });
 
   // ── (d) CONTRIBUTING structure block — all listed paths must exist ────────

--- a/tools/generate-promo-tiles.py
+++ b/tools/generate-promo-tiles.py
@@ -1,3 +1,6 @@
+# Requires: python3 with the Pillow library (pip install Pillow).
+# Not needed for extension builds or tests — only for regenerating Chrome Web Store promo images.
+# See the "Optional toolchain dependencies" section in CONTRIBUTING.md.
 """
 MUGA — Promo tile generator (violet/denoise palette)
 Generates:


### PR DESCRIPTION
Closes #829

## Summary

- **ignoreFiles investigation**: `web-ext-config.mjs` already centralizes the `_metadata` globs and dev/lint commands auto-load it; the explicit flags on `build:*` are NOT redundant — `strip-test-seams.mjs` (#827) builds from a temp copy where the root config doesn't auto-load, so the forwarded flags are the real exclusion mechanism there. Documented instead of "cleaned up" — removing them would have shipped `_metadata` in store zips.
- `"engines": { "node": ">=20.11" }` (floor justified by `import.meta.dirname` usage in tests).
- python3 + Pillow requirement for `promo-tiles` documented (top-of-file comment + CONTRIBUTING toolchain table — verified absent on a real dev machine).
- Node version policy in CONTRIBUTING: floor 20.11, CI on 20.x, newer locally fine.
- +4 guards in docs-claims.test.mjs (engines present, config carries the ignore list).

## Test plan

- [x] Full gate locally: `npm test` + `lint:js` + `typecheck` + `test:integration:stub`