### PR TITLE
security: landing headers, CSP tightening, SSRF ranges, disclosure + SECURITY.md (#830)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This is explained during onboarding before the feature is enabled, disclosed in 
 - Zero browsing data collected, zero analytics, zero telemetry
 - No account, no sign-in, no cloud
 - Minimal permissions: `storage`, `activeTab`, `contextMenus`, `declarativeNetRequestWithHostAccess`, `clipboardWrite`. Nothing else.
+- The extension also holds `host_permissions: <all_urls>`, required by `declarativeNetRequestWithHostAccess` to clean URLs on all sites.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest published release is actively maintained. Older versions
+receive no patches.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+| < latest | No       |
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for suspected security problems.**
+
+Use a private security advisory instead:
+<https://github.com/yocreoquesi/muga/security/advisories/new>
+
+We aim to acknowledge reports within 72 hours and to resolve confirmed
+vulnerabilities before public disclosure.
+
+## Out-of-band polyfill integrity pin
+
+`src/lib/browser-polyfill.min.js` is vendored and pinned by SHA-256:
+
+```
+a2093810df8e00393ee4d3adc243ea82d7e56471b40f0f66b64f8980da944094
+```
+
+The pin is enforced on every CI run by `tools/verify-polyfill-integrity.mjs`.
+Any change to the polyfill file or to its verifier requires explicit maintainer
+review before merging. A CODEOWNERS file would be overkill for a solo
+repository; the combination of this documented pin and the existing CI check is
+the correct control at this project's scale.

--- a/landing-worker/worker.js
+++ b/landing-worker/worker.js
@@ -6,9 +6,42 @@
 // explicit entry point and so we have a hook for future enhancements
 // (redirects, A/B tests, security headers) without changing the deploy
 // surface.
+//
+// CSP audit (landing/index.html):
+//   - All styles are in a single <style> block in <head> (static, no user data).
+//   - Two <script> blocks are inline (backronym rotator + console easter egg).
+//   - External resources: images/icons from rules.muga.app (img-src).
+//   - No eval, no external scripts, no frames.
+//   - 'unsafe-inline' is required for both style-src and script-src because the
+//     landing page uses a <style> tag and two inline <script> blocks with no
+//     build step and no nonce/hash injection at the Worker layer. The landing
+//     page contains no user-controlled data so the risk is accepted for a
+//     static marketing page; the script is self-contained and audited.
+
+/** Security headers applied to every response from the landing Worker. */
+const SECURITY_HEADERS = {
+  "Content-Security-Policy":
+    "default-src 'self'; " +
+    "script-src 'self' 'unsafe-inline'; " +
+    "style-src 'self' 'unsafe-inline'; " +
+    "img-src 'self' https://rules.muga.app; " +
+    "font-src 'none'; " +
+    "object-src 'none'; " +
+    "frame-ancestors 'none'; " +
+    "base-uri 'self'",
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=31536000",
+};
 
 export default {
   async fetch(request, env) {
-    return env.ASSETS.fetch(request);
+    const response = await env.ASSETS.fetch(request);
+    const newResponse = new Response(response.body, response);
+    for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+      newResponse.headers.set(name, value);
+    }
+    return newResponse;
   },
 };

--- a/src/lib/native-shortener-resolver.js
+++ b/src/lib/native-shortener-resolver.js
@@ -46,13 +46,21 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 // ── Private-host detection ────────────────────────────────────────────────────
 // Self-contained: does not depend on any deleted proxy module.
 
-function isPrivateIPv4(a, b) {
+function isPrivateIPv4(a, b, c) {
   if (a === 0) return true;                          // 0.0.0.0/8 ("this host")
   if (a === 127) return true;                        // 127.0.0.0/8 loopback
   if (a === 10) return true;                         // 10.0.0.0/8
   if (a === 192 && b === 168) return true;           // 192.168.0.0/16
   if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16-31.0.0/12
   if (a === 169 && b === 254) return true;           // 169.254.0.0/16 (link-local)
+  // CGNAT shared address space (RFC 6598): 100.64.0.0/10
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // TEST-NET-1/2/3 (RFC 5737): documentation ranges, never routable
+  if (a === 192 && b === 0 && c === 2) return true;   // 192.0.2.0/24
+  if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24
+  if (a === 203 && b === 0 && c === 113) return true;  // 203.0.113.0/24
+  // 6to4 relay anycast (RFC 3068): 192.88.99.0/24 (deprecated but must block)
+  if (a === 192 && b === 88 && c === 99) return true;
   return false;
 }
 
@@ -81,24 +89,26 @@ export function isPrivateHost(hostname) {
   const mapped = h.match(/^::ffff:(.+)$/i);
   if (mapped) {
     const rest = mapped[1];
-    let a, b;
+    let a, b, c;
     if (rest.includes(".")) {
       const p = rest.split(".");
-      if (p.length === 4) [a, b] = p.map(Number);
+      if (p.length === 4) [a, b, c] = p.map(Number);
     } else {
+      // Compact hex form only has two groups — c is not extractable; treat
+      // as undefined so range checks that need c fall through safely.
       const g = rest.split(":");
       if (g.length === 2) {
         const hi = parseInt(g[0], 16);
         if (Number.isFinite(hi)) { a = hi >> 8; b = hi & 0xff; }
       }
     }
-    if (a !== undefined && isPrivateIPv4(a, b)) return true;
+    if (a !== undefined && isPrivateIPv4(a, b, c)) return true;
   }
 
   const parts = h.split(".");
   if (parts.length === 4) {
-    const [a, b] = parts.map(Number);
-    if (isPrivateIPv4(a, b)) return true;
+    const [a, b, c] = parts.map(Number);
+    if (isPrivateIPv4(a, b, c)) return true;
   }
 
   return false;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -212,7 +212,7 @@ const RENDER_LIST_MAX_ITEMS = 1000;
 /** Renders a blacklist/whitelist/customParams list into its container. */
 function renderList(containerId, items, listKey) {
   const container = document.getElementById(containerId);
-  container.innerHTML = "";
+  container.replaceChildren();
   if (!items.length) {
     const p = document.createElement("p");
     p.className = "empty";
@@ -380,7 +380,7 @@ function initCreatorAllowlist(initial) {
 /** Renders tracking category toggle cards. */
 function renderCategories(disabledCategories) {
   const card = document.getElementById("categories-card");
-  card.innerHTML = "";
+  card.replaceChildren();
   const disabled = new Set(disabledCategories);
 
   for (const [key, cat] of Object.entries(TRACKING_PARAM_CATEGORIES)) {
@@ -449,7 +449,7 @@ function renderStores() {
 
   const grid = document.getElementById("stores-grid");
   const hintEl = document.getElementById("stores-hint");
-  grid.innerHTML = "";
+  grid.replaceChildren();
 
   if (activePrograms.length === 0) {
     grid.hidden = true;

--- a/tests/unit/landing-worker-headers.test.mjs
+++ b/tests/unit/landing-worker-headers.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * MUGA Landing Worker — security headers unit tests (#830).
+ *
+ * Verifies that the Worker clones the ASSETS response and injects every
+ * required security header without dropping existing response properties.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+// ── minimal env stub ──────────────────────────────────────────────────────────
+
+function makeEnv({ status = 200, body = "hello", headers = {} } = {}) {
+  return {
+    ASSETS: {
+      async fetch() {
+        return new Response(body, { status, headers });
+      },
+    },
+  };
+}
+
+// ── import the worker ─────────────────────────────────────────────────────────
+
+const { default: worker } = await import("../../landing-worker/worker.js");
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("landing-worker — security headers", () => {
+  test("sets X-Frame-Options: DENY", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(new Request("https://muga.app/"), env);
+    assert.equal(res.headers.get("X-Frame-Options"), "DENY");
+  });
+
+  test("sets X-Content-Type-Options: nosniff", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(new Request("https://muga.app/"), env);
+    assert.equal(res.headers.get("X-Content-Type-Options"), "nosniff");
+  });
+
+  test("sets Referrer-Policy: strict-origin-when-cross-origin", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(new Request("https://muga.app/"), env);
+    assert.equal(res.headers.get("Referrer-Policy"), "strict-origin-when-cross-origin");
+  });
+
+  test("sets Strict-Transport-Security with max-age=31536000", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(new Request("https://muga.app/"), env);
+    const hsts = res.headers.get("Strict-Transport-Security");
+    assert.ok(hsts !== null, "HSTS header must be present");
+    assert.ok(hsts.includes("max-age=31536000"), `HSTS must include max-age=31536000, got: ${hsts}`);
+  });
+
+  test("sets Content-Security-Policy with frame-ancestors 'none'", async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(new Request("https://muga.app/"), env);
+    const csp = res.headers.get("Content-Security-Policy");
+    assert.ok(csp !== null, "CSP header must be present");
+    assert.ok(csp.includes("frame-ancestors 'none'"), `CSP must include frame-ancestors 'none', got: ${csp}`);
+    assert.ok(csp.includes("object-src 'none'"), `CSP must include object-src 'none', got: ${csp}`);
+  });
+
+  test("preserves response status from ASSETS", async () => {
+    const env = makeEnv({ status: 404 });
+    const res = await worker.fetch(new Request("https://muga.app/missing"), env);
+    assert.equal(res.status, 404);
+  });
+
+  test("preserves response body from ASSETS", async () => {
+    const env = makeEnv({ body: "page content" });
+    const res = await worker.fetch(new Request("https://muga.app/"), env);
+    const text = await res.text();
+    assert.equal(text, "page content");
+  });
+
+  test("does not overwrite an existing header already set by ASSETS", async () => {
+    // Security headers are always overwritten (set, not append) — this test
+    // confirms the worker sets the header even when ASSETS provides one too.
+    const env = makeEnv({ headers: { "X-Frame-Options": "SAMEORIGIN" } });
+    const res = await worker.fetch(new Request("https://muga.app/"), env);
+    // Worker's DENY takes precedence over ASSETS' SAMEORIGIN.
+    assert.equal(res.headers.get("X-Frame-Options"), "DENY");
+  });
+});

--- a/tests/unit/native-shortener-resolver.test.mjs
+++ b/tests/unit/native-shortener-resolver.test.mjs
@@ -53,6 +53,57 @@ describe("allowlist + private-host helpers", () => {
     }
     assert.equal(isPrivateHost("example.com"), false);
   });
+
+  // ── CGNAT 100.64.0.0/10 (RFC 6598) — boundary tests (#830) ──────────────────
+  test("isPrivateHost blocks CGNAT range 100.64.0.0/10", () => {
+    // Inside range: 100.64.x through 100.127.x
+    assert.equal(isPrivateHost("100.64.0.0"), true,   "100.64.0.0 is CGNAT start");
+    assert.equal(isPrivateHost("100.64.1.1"), true,   "100.64.1.1 is inside CGNAT");
+    assert.equal(isPrivateHost("100.100.50.1"), true,  "100.100.50.1 is inside CGNAT");
+    assert.equal(isPrivateHost("100.127.255.255"), true, "100.127.255.255 is CGNAT end");
+  });
+
+  test("isPrivateHost allows addresses just outside CGNAT boundaries", () => {
+    // Below range: 100.63.x.x
+    assert.equal(isPrivateHost("100.63.255.255"), false, "100.63.255.255 is below CGNAT");
+    // Above range: 100.128.x.x
+    assert.equal(isPrivateHost("100.128.0.0"), false,  "100.128.0.0 is above CGNAT");
+  });
+
+  // ── TEST-NET-1/2/3 (RFC 5737) — documentation ranges (#830) ─────────────────
+  test("isPrivateHost blocks TEST-NET-1 192.0.2.0/24", () => {
+    assert.equal(isPrivateHost("192.0.2.0"), true,   "192.0.2.0 is TEST-NET-1 start");
+    assert.equal(isPrivateHost("192.0.2.128"), true,  "192.0.2.128 is inside TEST-NET-1");
+    assert.equal(isPrivateHost("192.0.2.255"), true,  "192.0.2.255 is TEST-NET-1 end");
+    // Adjacent address must be allowed (falls through to other checks)
+    assert.equal(isPrivateHost("192.0.1.1"), false,  "192.0.1.1 is not TEST-NET-1");
+    assert.equal(isPrivateHost("192.0.3.1"), false,  "192.0.3.1 is not TEST-NET-1");
+  });
+
+  test("isPrivateHost blocks TEST-NET-2 198.51.100.0/24", () => {
+    assert.equal(isPrivateHost("198.51.100.0"), true,   "198.51.100.0 is TEST-NET-2 start");
+    assert.equal(isPrivateHost("198.51.100.128"), true,  "198.51.100.128 is inside TEST-NET-2");
+    assert.equal(isPrivateHost("198.51.100.255"), true,  "198.51.100.255 is TEST-NET-2 end");
+    assert.equal(isPrivateHost("198.51.99.1"), false,   "198.51.99.1 is not TEST-NET-2");
+    assert.equal(isPrivateHost("198.51.101.1"), false,  "198.51.101.1 is not TEST-NET-2");
+  });
+
+  test("isPrivateHost blocks TEST-NET-3 203.0.113.0/24", () => {
+    assert.equal(isPrivateHost("203.0.113.0"), true,   "203.0.113.0 is TEST-NET-3 start");
+    assert.equal(isPrivateHost("203.0.113.200"), true,  "203.0.113.200 is inside TEST-NET-3");
+    assert.equal(isPrivateHost("203.0.113.255"), true,  "203.0.113.255 is TEST-NET-3 end");
+    assert.equal(isPrivateHost("203.0.112.1"), false,  "203.0.112.1 is not TEST-NET-3");
+    assert.equal(isPrivateHost("203.0.114.1"), false,  "203.0.114.1 is not TEST-NET-3");
+  });
+
+  // ── 6to4 relay anycast (RFC 3068) 192.88.99.0/24 (#830) ─────────────────────
+  test("isPrivateHost blocks 6to4 relay anycast 192.88.99.0/24", () => {
+    assert.equal(isPrivateHost("192.88.99.0"), true,   "192.88.99.0 is 6to4 relay start");
+    assert.equal(isPrivateHost("192.88.99.128"), true,  "192.88.99.128 is inside 6to4 relay");
+    assert.equal(isPrivateHost("192.88.99.255"), true,  "192.88.99.255 is 6to4 relay end");
+    assert.equal(isPrivateHost("192.88.98.1"), false,  "192.88.98.1 is not 6to4 relay");
+    assert.equal(isPrivateHost("192.88.100.1"), false, "192.88.100.1 is not 6to4 relay");
+  });
 });
 
 // ── happy paths ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #830

## Summary — defense-in-depth checklist (trusted-keys strip already shipped in #827)

- **Landing worker**: response now carries CSP, `X-Frame-Options: DENY`, `nosniff`, `Referrer-Policy`, HSTS. Honest CSP verdict: the landing page uses two inline scripts + one inline style block (no build step), so `'unsafe-inline'` stays in the LANDING CSP, documented in the worker source. 7 new unit tests.
- **Extension CSP**: attempted to drop `style-src 'unsafe-inline'` — REVERTED: the JS audit was clean, but options.html carries ~30 inline `style=` ATTRIBUTES (which style-src does govern); dropping it broke the dev-tools card visibility (caught by the URL-tester e2e in CI). Migration + drop tracked in #858.
- **README Privacy**: `host_permissions: <all_urls>` disclosed with its reason (required by declarativeNetRequestWithHostAccess).
- **SSRF ranges** (extends #737): CGNAT 100.64/10, TEST-NET-1/2/3, 6to4 192.88.99/24 — 34 boundary assertions.
- **options.js**: 3× `innerHTML = ""` → `replaceChildren()`.
- **SECURITY.md**: advisory link, supported versions, out-of-band polyfill SHA-256 pin + change policy (CODEOWNERS assessed as overkill for a solo-maintainer repo; the CI hash check + this policy note is the right size).

## Test plan

- [x] Full gate locally: `npm test` + `lint:js` + `typecheck`; bundle regenerated and committed
- [x] docs-claims suite green after README edit
