### PR TITLE
refactor(lib): extract prefs + storage-migrations from storage.js (#826 PR2)

### DIFF
--- a/src/lib/prefs.js
+++ b/src/lib/prefs.js
@@ -1,0 +1,197 @@
+/**
+ * MUGA: User preferences
+ *
+ * User preference defaults and accessors (getPrefs / setPrefs).
+ * Extracted from storage.js (#826 PR2) — pure relocation, zero behaviour change.
+ *
+ * Storage bucket: chrome.storage.sync (synced across devices, 100 KB quota).
+ * Consent-tier fields (onboardingDone / consentVersion / consentDate) are
+ * overlaid from per-device chrome.storage.local via consent-storage (#355, ADR-0001).
+ */
+
+// Per-device consent overlay for getPrefs (#355, ADR-0001).
+import { getConsent } from "./consent-storage.js";
+// Per-device pref overrides on top of synced behavioural prefs (#364).
+import { getOverrides as getPerDeviceOverrides } from "./per-device-prefs.js";
+// Consent version-comparison for feature gating during hard re-onboard (#370).
+import { evaluate as evaluateConsentPolicy } from "./consent-policy.js";
+// E2E fixture overrides (#407). Returns null in production.
+import { getTestFixtures } from "./test-fixtures.js";
+
+// ── Sync: user preferences ──────────────────────────────────────────────────
+
+export const PREF_DEFAULTS = {
+  enabled: true,
+  injectOwnAffiliate: false,  // set to true only if user opts in during onboarding (#224)
+  notifyForeignAffiliate: false,
+  stripAllAffiliates: false,
+  blacklist: [],     // e.g. ["amazon.es", "booking.com::aid::123456"]
+  whitelist: [],     // e.g. ["amazon.es::tag::youtuber-21"]
+  customParams: [],  // e.g. ["ref_code", "promo_id"]
+  dnrEnabled: true,
+  contextMenuEnabled: true,
+  blockPings: true,
+  ampRedirect: true,
+  unwrapRedirects: true,
+  language: "en",
+  onboardingDone: false,
+  consentVersion: null,   // e.g. "1.0". Bump to re-trigger onboarding on ToS changes.
+  consentDate: null,      // Unix timestamp (ms) of when the user accepted
+  disabledCategories: [],  // e.g. ["utm", "ads"]. Params in these categories are not stripped.
+  toastDuration: 15,  // seconds: how long the affiliate notification stays visible
+  paramBreakdown: true,
+  showReportButton: true,
+  domainStats: true,
+  // Remote rules toggle — lives in sync so the opt-in preference follows the user
+  // across devices. Default false per REQ-OPT-1: zero network activity on fresh install.
+  remoteRulesEnabled: false,
+  // Honor Creator Mode toggle (#435, B12). Pure plumbing for B13/B14: no
+  // behaviour change. Default false so existing users see no functional
+  // difference. The feature is opt-in because honoring creator referral
+  // chains may route through redirect networks the user did not consent to
+  // contact otherwise.
+  honorCreatorMode: false,
+  // Per-creator allowlist (#445, B13). Referrer-domain-shaped strings
+  // (e.g., "youtube.com/@LinusTechTips", "dot-css-news.com") that the user
+  // has explicitly opted into for Honor Creator Mode. Empty by default.
+  // Capped at 100 entries (storage hygiene): 100 × ~80 chars ≈ 8 KB, within
+  // sync's 8 KB-per-item / 100 KB-total budget. CRUD lives in
+  // src/lib/creator-allowlist.js (pure module, immutable arrays).
+  creatorAllowlist: [],
+  // Canonical Extractor toggle (#442, B7). Default ON: when the wrapper
+  // engine detects an opaque wrapper (host matched but no destination in
+  // the URL), the cleaner consults a content-script-supplied "canonical
+  // bundle" (<link rel=canonical> + JSON-LD @id) BEFORE giving up. Disable
+  // here to bypass that tier entirely without uninstalling content scripts.
+  canonicalExtractorEnabled: true,
+  // Cross-Site Frequency Tracker toggle (#446, B16). Default ON: a local-
+  // only correlation map of (paramName, hashedValue) per first-party
+  // domain, used to surface likely cross-site identifiers in the popup.
+  // Privacy-sensitive enough to deserve its own toggle even though the
+  // data never leaves the device — turning it off makes observe() a
+  // no-op and hides the freq subgroup in the suspicious-params section.
+  crossSiteFrequencyEnabled: true,
+  // Attribution Ledger persistence (#460, A2). When ON (default), the SW
+  // writes the rolling ring buffer of recent navigation events to
+  // chrome.storage.local under "attributionLedger" so the popup can
+  // render a "Recent activity" section that survives SW restarts. When
+  // OFF, the writer is gated to a no-op; the section just stays empty.
+  // Privacy-sensitive (it carries URLs), so we expose it as its own
+  // toggle even though the data is local-only.
+  attributionLedgerEnabled: true,
+  // EXPERIMENTAL shape-based param heuristic (#544). Default OFF: a multi-
+  // signal heuristic that strips params whose VALUE SHAPE matches a tracker
+  // pattern (suspicious key prefix + length>16 + Shannon entropy>4.0 +
+  // base64/hex/uuid charset — ALL four required). False-positive risk is
+  // real (auth tokens / session IDs LOOK like trackers), so it ships behind
+  // a flag and is gated by a hard-coded allowlist of well-known oauth /
+  // session keys (state, code, csrf_token, access_token, …) that never
+  // strip even when all four signals fire. With the flag OFF, behaviour is
+  // byte-identical to the #530 baseline (the benchmark stays 117/117).
+  experimentalParamClassesEnabled: false,
+  // User-promoted custom strip rules (#536). Populated by the popup's
+  // "Strip locally" button on flagged Suspicious-params rows. Each entry
+  // is a bare param name (lowercased on read by the cleaner) that
+  // processUrl strips on EVERY host — the user has explicitly trusted
+  // the rule. Affiliate-preservation still wins (the affiliateParamSet
+  // skip in stripTrackingParams runs before custom-rule matching), so a
+  // user can never accidentally strip their own creator's referral tag.
+  // Lives in sync so the rule list follows the user across devices.
+  // Default empty — opt-in by user click only.
+  userCustomRules: [],
+  // Follow shortener redirects natively (ADR-0004 phase 2, #699; renamed from
+  // privacyProxyEnabled in phase 5, #701). When ON, MUGA resolves the eight
+  // generic shorteners in-browser via fetch(redirect:"manual"). Default OFF:
+  // requires the eight shortener host permissions, granted from the options toggle.
+  // Migration: on startup, if chrome.storage.sync contains privacyProxyEnabled=true,
+  // this field is set to true and the old key is deleted (see migrateLegacyProxyPref).
+  followShortenersEnabled: false,
+  // NOTE (ADR-0004 phase 5, 2026-06-01): privacyProxyEnabled was the Privacy Proxy
+  // toggle removed in phase 5. Retained as a deprecation comment only — do NOT add
+  // it back to PREF_DEFAULTS. Any live value is migrated to followShortenersEnabled
+  // on first startup by migrateLegacyProxyPref().
+  //
+  // NOTE (ADR-0004 phase 5, 2026-06-01): useNativeShortenerResolution was the
+  // dual-path selector removed in phase 5. Native resolution is now the ONLY path.
+  // Do NOT add it back to PREF_DEFAULTS.
+};
+
+/**
+ * Reads all user preferences. Behavioural prefs come from
+ * `chrome.storage.sync` (cross-device). Consent fields
+ * (`onboardingDone`, `consentVersion`, `consentDate`) are overlaid
+ * from per-device `chrome.storage.local` via consent-storage (#355,
+ * ADR-0001). Per-device behavioural overrides (`injectOwnAffiliate`,
+ * `remoteRulesEnabled` after a user declines a sync-inherited prompt)
+ * are overlaid from per-device-prefs (#364) — local wins.
+ *
+ * Reads in parallel for minimum latency.
+ *
+ * @returns {Promise<object>} Preferences merged with PREF_DEFAULTS.
+ */
+export async function getPrefs() {
+  try {
+    const [sync, consent, overrides, fixtures] = await Promise.all([
+      new Promise((resolve, reject) => {
+        chrome.storage.sync.get(PREF_DEFAULTS, (result) => {
+          if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+          else resolve(result);
+        });
+      }),
+      getConsent(),
+      getPerDeviceOverrides(),
+      getTestFixtures(),
+    ]);
+
+    // Consent overlay (#355). Local wins over sync.
+    const overlay = {};
+    if (consent.onboardingDone) overlay.onboardingDone = true;
+    if (consent.consentVersion !== null) overlay.consentVersion = consent.consentVersion;
+    if (consent.consentDate !== null) overlay.consentDate = consent.consentDate;
+
+    // Hard-reonboard gate (#370). When ConsentPolicy says material change
+    // pending, force `onboardingDone: false` so existing feature gates
+    // (`if (!prefs.onboardingDone) return`) bail until the user re-accepts.
+    // Soft re-onboard does NOT gate features — the user's prior consent
+    // remains valid for previously accepted behaviour.
+    // Under e2e fixtures (#407), the gate fires against the fixture
+    // manifest + required version so tests can drive the dormant path.
+    const policy = evaluateConsentPolicy({
+      stored: consent,
+      ...(fixtures?.requiredConsentVersion ? { requiredVersion: fixtures.requiredConsentVersion } : {}),
+      ...(fixtures?.consentManifest ? { manifest: fixtures.consentManifest } : {}),
+    });
+    if (policy.status === "hard-reonboard") {
+      overlay.onboardingDone = false;
+    }
+
+    // Per-device pref overlay (#364). Any key set in overrides wins
+    // over sync. Boolean shape is enforced at the source (overrides
+    // can only be set via per-device-prefs.setOverrides).
+    return { ...sync, ...overlay, ...overrides };
+  } catch (err) {
+    console.error("[MUGA] getPrefs failed:", err);
+    return { ...PREF_DEFAULTS };
+  }
+}
+
+/**
+ * Writes a partial preferences object to chrome.storage.sync.
+ * @param {object} partial - Key/value pairs to merge into stored prefs.
+ * @returns {Promise<void>}
+ */
+export async function setPrefs(partial) {
+  try {
+    return await new Promise((resolve, reject) => {
+      chrome.storage.sync.set(partial, () => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        } else {
+          resolve();
+        }
+      });
+    });
+  } catch (err) {
+    console.error("[MUGA] setPrefs failed:", err);
+  }
+}

--- a/src/lib/storage-migrations.js
+++ b/src/lib/storage-migrations.js
@@ -1,0 +1,117 @@
+/**
+ * MUGA: One-time storage migrations
+ *
+ * Extracted from storage.js (#826 PR2) — pure relocation, zero behaviour change.
+ *
+ * Design rule: this module must NOT import from storage.js to avoid circularity.
+ * The two helpers below need local-storage reads/writes that would normally go
+ * through getStats/setStats — instead they call chrome.storage.local directly,
+ * keeping the module dependency-free from its sibling.
+ */
+
+// ── One-time migration ────────────────────────────────────────────────────────
+
+/**
+ * One-time migration: moves stats out of chrome.storage.sync into
+ * chrome.storage.local. Safe to call on every startup. Exits immediately
+ * if migration already done or no old data exists.
+ */
+export async function migrateStatsToLocal() {
+  const STAT_DEFAULTS = {
+    stats: { urlsCleaned: 0, junkRemoved: 0, referralsSpotted: 0 },
+    firstUsed: null,
+    nudgeDismissed: false,
+  };
+
+  const syncData = await new Promise((resolve, reject) =>
+    chrome.storage.sync.get({ stats: null, firstUsed: null, nudgeDismissed: null }, (result) => {
+      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+      else resolve(result);
+    })
+  ).catch(() => ({ stats: null, firstUsed: null, nudgeDismissed: null }));
+
+  const hasOldStats =
+    syncData.stats !== null ||
+    syncData.firstUsed !== null ||
+    syncData.nudgeDismissed !== null;
+
+  if (!hasOldStats) return;
+
+  // Copy to local (only if local doesn't already have data)
+  const localData = await new Promise((resolve, reject) =>
+    chrome.storage.local.get(STAT_DEFAULTS, (result) => {
+      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+      else resolve(result);
+    })
+  ).catch(() => ({ ...STAT_DEFAULTS }));
+
+  const merged = {
+    stats: syncData.stats ?? localData.stats,
+    firstUsed: syncData.firstUsed ?? localData.firstUsed,
+    nudgeDismissed: syncData.nudgeDismissed ?? localData.nudgeDismissed,
+  };
+
+  await new Promise((resolve, reject) =>
+    chrome.storage.local.set(merged, () => {
+      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+      else resolve();
+    })
+  );
+
+  // Remove from sync
+  await new Promise((resolve, reject) =>
+    chrome.storage.sync.remove(["stats", "firstUsed", "nudgeDismissed"], () => {
+      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+      else resolve();
+    })
+  ).catch(() => {}); // best-effort: old keys already migrated, removal is non-critical
+}
+
+/**
+ * One-time migration (ADR-0004 phase 5, #701): renames `privacyProxyEnabled` →
+ * `followShortenersEnabled` in chrome.storage.sync. Safe to call on every
+ * startup. Exits immediately if the old key is absent.
+ *
+ * If the user had `privacyProxyEnabled = true` they were using native shortener
+ * resolution (the default since phase 4 / 2.2.0-beta.1), so we preserve their
+ * intent by setting `followShortenersEnabled = true`. A false value needs no
+ * migration because `followShortenersEnabled` already defaults to false.
+ */
+export async function migrateLegacyProxyPref() {
+  try {
+    const data = await new Promise((resolve, reject) =>
+      chrome.storage.sync.get({ privacyProxyEnabled: null }, (result) => {
+        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+        else resolve(result);
+      })
+    ).catch(() => ({ privacyProxyEnabled: null }));
+
+    if (data.privacyProxyEnabled === null) return; // key absent — nothing to do
+
+    const updates = {};
+    if (data.privacyProxyEnabled === true) {
+      // Preserve user's intent: they had the feature enabled.
+      updates.followShortenersEnabled = true;
+    }
+    // Write followShortenersEnabled only when migrating a `true` value; a false
+    // or absent old value needs no write (the new key already defaults to false).
+    // The old key is removed unconditionally below regardless.
+    if (Object.keys(updates).length > 0) {
+      await new Promise((resolve, reject) =>
+        chrome.storage.sync.set(updates, () => {
+          if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
+          else resolve();
+        })
+      );
+    }
+    // Remove the deprecated key.
+    await new Promise((resolve) =>
+      chrome.storage.sync.remove("privacyProxyEnabled", () => {
+        void chrome.runtime.lastError; // non-critical
+        resolve();
+      })
+    );
+  } catch {
+    // Migration is best-effort — a failure here must never break startup.
+  }
+}

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -4,19 +4,23 @@
  * Two buckets:
  *   chrome.storage.sync:  user preferences (synced across devices, 100KB quota)
  *   chrome.storage.local: stats and ephemeral state (device-only, 10MB quota)
+ *
+ * #826 PR2: PREF_DEFAULTS + pref accessors live in ./prefs.js.
+ *           One-time migrations live in ./storage-migrations.js.
+ *           Full pre-split public API is re-exported here so all 11 importers
+ *           keep working unchanged.
  */
 
-// Per-device consent overlay for getPrefs (#355, ADR-0001).
-import { getConsent } from "./consent-storage.js";
-// Per-device pref overrides on top of synced behavioural prefs (#364).
-import { getOverrides as getPerDeviceOverrides } from "./per-device-prefs.js";
-// Consent version-comparison for feature gating during hard re-onboard (#370).
-import { evaluate as evaluateConsentPolicy } from "./consent-policy.js";
-// E2E fixture overrides (#407). Returns null in production.
-import { getTestFixtures } from "./test-fixtures.js";
 // Allowlist guard for the per-shortener counters (ADR-0004 phase 4, #700):
 // only the eight GENERIC_SHORTENERS may be recorded — never arbitrary hosts.
 import { isGenericShortener } from "./opaque-networks.js";
+
+// ── Re-exports: prefs domain ──────────────────────────────────────────────────
+// Keeps the full pre-split public API available at the storage.js import path.
+export { PREF_DEFAULTS, getPrefs, setPrefs } from "./prefs.js";
+
+// ── Re-exports: one-time migrations ──────────────────────────────────────────
+export { migrateStatsToLocal, migrateLegacyProxyPref } from "./storage-migrations.js";
 
 // ── Firefox MV2 compat: chrome.* APIs must return Promises ──────────────────
 //
@@ -81,184 +85,6 @@ import { isGenericShortener } from "./opaque-networks.js";
     wrapMethod(chrome.contextMenus, "removeAll");
   }
 })();
-
-// ── Sync: user preferences ──────────────────────────────────────────────────
-
-export const PREF_DEFAULTS = {
-  enabled: true,
-  injectOwnAffiliate: false,  // set to true only if user opts in during onboarding (#224)
-  notifyForeignAffiliate: false,
-  stripAllAffiliates: false,
-  blacklist: [],     // e.g. ["amazon.es", "booking.com::aid::123456"]
-  whitelist: [],     // e.g. ["amazon.es::tag::youtuber-21"]
-  customParams: [],  // e.g. ["ref_code", "promo_id"]
-  dnrEnabled: true,
-  contextMenuEnabled: true,
-  blockPings: true,
-  ampRedirect: true,
-  unwrapRedirects: true,
-  language: "en",
-  onboardingDone: false,
-  consentVersion: null,   // e.g. "1.0". Bump to re-trigger onboarding on ToS changes.
-  consentDate: null,      // Unix timestamp (ms) of when the user accepted
-  disabledCategories: [],  // e.g. ["utm", "ads"]. Params in these categories are not stripped.
-  toastDuration: 15,  // seconds: how long the affiliate notification stays visible
-  paramBreakdown: true,
-  showReportButton: true,
-  domainStats: true,
-  // Remote rules toggle — lives in sync so the opt-in preference follows the user
-  // across devices. Default false per REQ-OPT-1: zero network activity on fresh install.
-  remoteRulesEnabled: false,
-  // Honor Creator Mode toggle (#435, B12). Pure plumbing for B13/B14: no
-  // behaviour change. Default false so existing users see no functional
-  // difference. The feature is opt-in because honoring creator referral
-  // chains may route through redirect networks the user did not consent to
-  // contact otherwise.
-  honorCreatorMode: false,
-  // Per-creator allowlist (#445, B13). Referrer-domain-shaped strings
-  // (e.g., "youtube.com/@LinusTechTips", "dot-css-news.com") that the user
-  // has explicitly opted into for Honor Creator Mode. Empty by default.
-  // Capped at 100 entries (storage hygiene): 100 × ~80 chars ≈ 8 KB, within
-  // sync's 8 KB-per-item / 100 KB-total budget. CRUD lives in
-  // src/lib/creator-allowlist.js (pure module, immutable arrays).
-  creatorAllowlist: [],
-  // Canonical Extractor toggle (#442, B7). Default ON: when the wrapper
-  // engine detects an opaque wrapper (host matched but no destination in
-  // the URL), the cleaner consults a content-script-supplied "canonical
-  // bundle" (<link rel=canonical> + JSON-LD @id) BEFORE giving up. Disable
-  // here to bypass that tier entirely without uninstalling content scripts.
-  canonicalExtractorEnabled: true,
-  // Cross-Site Frequency Tracker toggle (#446, B16). Default ON: a local-
-  // only correlation map of (paramName, hashedValue) per first-party
-  // domain, used to surface likely cross-site identifiers in the popup.
-  // Privacy-sensitive enough to deserve its own toggle even though the
-  // data never leaves the device — turning it off makes observe() a
-  // no-op and hides the freq subgroup in the suspicious-params section.
-  crossSiteFrequencyEnabled: true,
-  // Attribution Ledger persistence (#460, A2). When ON (default), the SW
-  // writes the rolling ring buffer of recent navigation events to
-  // chrome.storage.local under "attributionLedger" so the popup can
-  // render a "Recent activity" section that survives SW restarts. When
-  // OFF, the writer is gated to a no-op; the section just stays empty.
-  // Privacy-sensitive (it carries URLs), so we expose it as its own
-  // toggle even though the data is local-only.
-  attributionLedgerEnabled: true,
-  // EXPERIMENTAL shape-based param heuristic (#544). Default OFF: a multi-
-  // signal heuristic that strips params whose VALUE SHAPE matches a tracker
-  // pattern (suspicious key prefix + length>16 + Shannon entropy>4.0 +
-  // base64/hex/uuid charset — ALL four required). False-positive risk is
-  // real (auth tokens / session IDs LOOK like trackers), so it ships behind
-  // a flag and is gated by a hard-coded allowlist of well-known oauth /
-  // session keys (state, code, csrf_token, access_token, …) that never
-  // strip even when all four signals fire. With the flag OFF, behaviour is
-  // byte-identical to the #530 baseline (the benchmark stays 117/117).
-  experimentalParamClassesEnabled: false,
-  // User-promoted custom strip rules (#536). Populated by the popup's
-  // "Strip locally" button on flagged Suspicious-params rows. Each entry
-  // is a bare param name (lowercased on read by the cleaner) that
-  // processUrl strips on EVERY host — the user has explicitly trusted
-  // the rule. Affiliate-preservation still wins (the affiliateParamSet
-  // skip in stripTrackingParams runs before custom-rule matching), so a
-  // user can never accidentally strip their own creator's referral tag.
-  // Lives in sync so the rule list follows the user across devices.
-  // Default empty — opt-in by user click only.
-  userCustomRules: [],
-  // Follow shortener redirects natively (ADR-0004 phase 2, #699; renamed from
-  // privacyProxyEnabled in phase 5, #701). When ON, MUGA resolves the eight
-  // generic shorteners in-browser via fetch(redirect:"manual"). Default OFF:
-  // requires the eight shortener host permissions, granted from the options toggle.
-  // Migration: on startup, if chrome.storage.sync contains privacyProxyEnabled=true,
-  // this field is set to true and the old key is deleted (see migrateLegacyProxyPref).
-  followShortenersEnabled: false,
-  // NOTE (ADR-0004 phase 5, 2026-06-01): privacyProxyEnabled was the Privacy Proxy
-  // toggle removed in phase 5. Retained as a deprecation comment only — do NOT add
-  // it back to PREF_DEFAULTS. Any live value is migrated to followShortenersEnabled
-  // on first startup by migrateLegacyProxyPref().
-  //
-  // NOTE (ADR-0004 phase 5, 2026-06-01): useNativeShortenerResolution was the
-  // dual-path selector removed in phase 5. Native resolution is now the ONLY path.
-  // Do NOT add it back to PREF_DEFAULTS.
-};
-
-/**
- * Reads all user preferences. Behavioural prefs come from
- * `chrome.storage.sync` (cross-device). Consent fields
- * (`onboardingDone`, `consentVersion`, `consentDate`) are overlaid
- * from per-device `chrome.storage.local` via consent-storage (#355,
- * ADR-0001). Per-device behavioural overrides (`injectOwnAffiliate`,
- * `remoteRulesEnabled` after a user declines a sync-inherited prompt)
- * are overlaid from per-device-prefs (#364) — local wins.
- *
- * Reads in parallel for minimum latency.
- *
- * @returns {Promise<object>} Preferences merged with PREF_DEFAULTS.
- */
-export async function getPrefs() {
-  try {
-    const [sync, consent, overrides, fixtures] = await Promise.all([
-      new Promise((resolve, reject) => {
-        chrome.storage.sync.get(PREF_DEFAULTS, (result) => {
-          if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
-          else resolve(result);
-        });
-      }),
-      getConsent(),
-      getPerDeviceOverrides(),
-      getTestFixtures(),
-    ]);
-
-    // Consent overlay (#355). Local wins over sync.
-    const overlay = {};
-    if (consent.onboardingDone) overlay.onboardingDone = true;
-    if (consent.consentVersion !== null) overlay.consentVersion = consent.consentVersion;
-    if (consent.consentDate !== null) overlay.consentDate = consent.consentDate;
-
-    // Hard-reonboard gate (#370). When ConsentPolicy says material change
-    // pending, force `onboardingDone: false` so existing feature gates
-    // (`if (!prefs.onboardingDone) return`) bail until the user re-accepts.
-    // Soft re-onboard does NOT gate features — the user's prior consent
-    // remains valid for previously accepted behaviour.
-    // Under e2e fixtures (#407), the gate fires against the fixture
-    // manifest + required version so tests can drive the dormant path.
-    const policy = evaluateConsentPolicy({
-      stored: consent,
-      ...(fixtures?.requiredConsentVersion ? { requiredVersion: fixtures.requiredConsentVersion } : {}),
-      ...(fixtures?.consentManifest ? { manifest: fixtures.consentManifest } : {}),
-    });
-    if (policy.status === "hard-reonboard") {
-      overlay.onboardingDone = false;
-    }
-
-    // Per-device pref overlay (#364). Any key set in overrides wins
-    // over sync. Boolean shape is enforced at the source (overrides
-    // can only be set via per-device-prefs.setOverrides).
-    return { ...sync, ...overlay, ...overrides };
-  } catch (err) {
-    console.error("[MUGA] getPrefs failed:", err);
-    return { ...PREF_DEFAULTS };
-  }
-}
-
-/**
- * Writes a partial preferences object to chrome.storage.sync.
- * @param {object} partial - Key/value pairs to merge into stored prefs.
- * @returns {Promise<void>}
- */
-export async function setPrefs(partial) {
-  try {
-    return await new Promise((resolve, reject) => {
-      chrome.storage.sync.set(partial, () => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-        } else {
-          resolve();
-        }
-      });
-    });
-  } catch (err) {
-    console.error("[MUGA] setPrefs failed:", err);
-  }
-}
 
 // ── Local: stats and nudge state ─────────────────────────────────────────────
 
@@ -764,94 +590,5 @@ export function incrementShortenerStat(host, outcome) {
   else _pendingShortenerStats[host].fail += 1;
   if (!_shortenerStatsFlushTimer) {
     _shortenerStatsFlushTimer = setTimeout(_flushShortenerStats, 50);
-  }
-}
-
-// ── One-time migration ────────────────────────────────────────────────────────
-
-/**
- * One-time migration: moves stats out of chrome.storage.sync into
- * chrome.storage.local. Safe to call on every startup. Exits immediately
- * if migration already done or no old data exists.
- */
-export async function migrateStatsToLocal() {
-  const syncData = await new Promise((resolve, reject) =>
-    chrome.storage.sync.get({ stats: null, firstUsed: null, nudgeDismissed: null }, (result) => {
-      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
-      else resolve(result);
-    })
-  ).catch(() => ({ stats: null, firstUsed: null, nudgeDismissed: null }));
-
-  const hasOldStats =
-    syncData.stats !== null ||
-    syncData.firstUsed !== null ||
-    syncData.nudgeDismissed !== null;
-
-  if (!hasOldStats) return;
-
-  // Copy to local (only if local doesn't already have data)
-  const localData = await getStats();
-  const merged = {
-    stats: syncData.stats ?? localData.stats,
-    firstUsed: syncData.firstUsed ?? localData.firstUsed,
-    nudgeDismissed: syncData.nudgeDismissed ?? localData.nudgeDismissed,
-  };
-  await setStats(merged);
-
-  // Remove from sync
-  await new Promise((resolve, reject) =>
-    chrome.storage.sync.remove(["stats", "firstUsed", "nudgeDismissed"], () => {
-      if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
-      else resolve();
-    })
-  ).catch(() => {}); // best-effort: old keys already migrated, removal is non-critical
-}
-
-/**
- * One-time migration (ADR-0004 phase 5, #701): renames `privacyProxyEnabled` →
- * `followShortenersEnabled` in chrome.storage.sync. Safe to call on every
- * startup. Exits immediately if the old key is absent.
- *
- * If the user had `privacyProxyEnabled = true` they were using native shortener
- * resolution (the default since phase 4 / 2.2.0-beta.1), so we preserve their
- * intent by setting `followShortenersEnabled = true`. A false value needs no
- * migration because `followShortenersEnabled` already defaults to false.
- */
-export async function migrateLegacyProxyPref() {
-  try {
-    const data = await new Promise((resolve, reject) =>
-      chrome.storage.sync.get({ privacyProxyEnabled: null }, (result) => {
-        if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
-        else resolve(result);
-      })
-    ).catch(() => ({ privacyProxyEnabled: null }));
-
-    if (data.privacyProxyEnabled === null) return; // key absent — nothing to do
-
-    const updates = {};
-    if (data.privacyProxyEnabled === true) {
-      // Preserve user's intent: they had the feature enabled.
-      updates.followShortenersEnabled = true;
-    }
-    // Write followShortenersEnabled only when migrating a `true` value; a false
-    // or absent old value needs no write (the new key already defaults to false).
-    // The old key is removed unconditionally below regardless.
-    if (Object.keys(updates).length > 0) {
-      await new Promise((resolve, reject) =>
-        chrome.storage.sync.set(updates, () => {
-          if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
-          else resolve();
-        })
-      );
-    }
-    // Remove the deprecated key.
-    await new Promise((resolve) =>
-      chrome.storage.sync.remove("privacyProxyEnabled", () => {
-        void chrome.runtime.lastError; // non-critical
-        resolve();
-      })
-    );
-  } catch {
-    // Migration is best-effort — a failure here must never break startup.
   }
 }

--- a/tests/unit/docs-prefs-table.test.mjs
+++ b/tests/unit/docs-prefs-table.test.mjs
@@ -2,7 +2,11 @@
  * Regression test: docs/data_architect.md sync-prefs table vs PREF_DEFAULTS
  *
  * Asserts that the set of keys documented in the "chrome.storage.sync" table
- * in data_architect.md exactly matches the keys in PREF_DEFAULTS (src/lib/storage.js).
+ * in data_architect.md exactly matches the keys in PREF_DEFAULTS (src/lib/prefs.js).
+ *
+ * #826 PR2: PREF_DEFAULTS was extracted from storage.js into prefs.js.
+ * storage.js re-exports it for backward compat; the canonical definition
+ * lives in prefs.js and that is the file this test scans.
  *
  * Fails with a clear diff on mismatch so documentation drift is caught immediately.
  */
@@ -16,15 +20,15 @@ import { join, dirname } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..");
 
-// ── Parse PREF_DEFAULTS keys from storage.js ─────────────────────────────────
+// ── Parse PREF_DEFAULTS keys from prefs.js (#826 PR2 — canonical location) ──
 
-const storageSource = readFileSync(join(ROOT, "src", "lib", "storage.js"), "utf8");
+const storageSource = readFileSync(join(ROOT, "src", "lib", "prefs.js"), "utf8");
 
 // Extract the PREF_DEFAULTS object body between the outermost braces
 const prefDefaultsMatch = storageSource.match(
   /export\s+const\s+PREF_DEFAULTS\s*=\s*\{([\s\S]*?)\n\};/
 );
-assert.ok(prefDefaultsMatch, "Could not locate PREF_DEFAULTS export in src/lib/storage.js");
+assert.ok(prefDefaultsMatch, "Could not locate PREF_DEFAULTS export in src/lib/prefs.js");
 
 const prefBody = prefDefaultsMatch[1];
 

--- a/tests/unit/module-boundary-826.test.mjs
+++ b/tests/unit/module-boundary-826.test.mjs
@@ -1,19 +1,26 @@
 /**
- * MUGA — Module-boundary guard for #826 affiliates split
+ * MUGA — Module-boundary guards for the #826 architecture split
  *
- * Asserts the acyclicity and re-export completeness of the three-module
- * split introduced in #826 PR1:
+ * Asserts the acyclicity and re-export completeness of BOTH three-module
+ * splits introduced in #826:
  *
+ * PR1 — affiliates split:
  *   affiliates-data.js   — static tracking-param dataset (domain a)
  *   redirect-networks.js — redirect-network table + lookup helpers (domain c)
  *   affiliates.js        — affiliate-program registry + re-export hub (domain b)
  *
- * Guards:
- *   (1) affiliates-data.js must NOT import from affiliates.js (acyclicity)
- *   (2) redirect-networks.js must NOT import from affiliates.js (acyclicity)
- *   (3) affiliates.js re-export surface covers the full pre-split public API
- *       (snapshot comparison — all names that the old monolith exported must
- *       still be resolvable from affiliates.js)
+ * PR2 — storage split:
+ *   prefs.js              — PREF_DEFAULTS + getPrefs/setPrefs (sync domain)
+ *   storage-migrations.js — one-time migration helpers (migrateStatsToLocal,
+ *                           migrateLegacyProxyPref)
+ *   storage.js            — stats, session, domain-rules, remote-params,
+ *                           shortener counters + re-export hub (pre-split API)
+ *
+ * Guards (per split):
+ *   (1) extracted data/leaf modules must NOT import from their hub (acyclicity)
+ *   (2) the hub's re-export surface covers the full pre-split public API
+ *       (snapshot comparison — all names the old monolith exported must
+ *       still be resolvable from the hub)
  *
  * Run with: npm test
  */
@@ -31,11 +38,15 @@ function readLib(name) {
   return readFileSync(join(ROOT, "src", "lib", name), "utf8");
 }
 
-// ── Pinned pre-split public API surface ───────────────────────────────────
+// ════════════════════════════════════════════════════════════════════════════
+// PR1 — affiliates split
+// ════════════════════════════════════════════════════════════════════════════
+
+// ── Pinned pre-split public API surface (affiliates.js) ───────────────────
 // These are all named exports the monolithic affiliates.js exposed before the
 // #826 split. affiliates.js must continue to export each of them (either
 // directly or via re-export) so all existing importers work unchanged.
-const EXPECTED_EXPORTS = new Set([
+const AFFILIATES_EXPECTED_EXPORTS = new Set([
   "TRACKING_PARAMS",
   "TRACKING_PREFIXES",
   "TRACKING_PARAM_CATEGORIES",
@@ -137,7 +148,7 @@ describe("module-boundary — affiliates.js re-export surface (#826)", () => {
       new URL("../../src/lib/affiliates.js", import.meta.url).href
     );
     const actual = new Set(Object.keys(mod));
-    const missing = [...EXPECTED_EXPORTS].filter((name) => !actual.has(name));
+    const missing = [...AFFILIATES_EXPECTED_EXPORTS].filter((name) => !actual.has(name));
     assert.deepEqual(
       missing,
       [],
@@ -159,6 +170,136 @@ describe("module-boundary — affiliates.js re-export surface (#826)", () => {
     assert.ok(
       src.includes('from "./redirect-networks.js"'),
       "affiliates.js must re-export from redirect-networks.js"
+    );
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// PR2 — storage split
+// ════════════════════════════════════════════════════════════════════════════
+
+// ── Pinned pre-split public API surface (storage.js) ──────────────────────
+// These are all named exports the monolithic storage.js exposed before the
+// #826 split. storage.js must continue to export each of them (either
+// directly or via re-export) so all 11 importers work unchanged.
+const STORAGE_EXPECTED_EXPORTS = new Set([
+  "PREF_DEFAULTS",
+  "getPrefs",
+  "setPrefs",
+  "getStats",
+  "setStats",
+  "getDevMode",
+  "setDevMode",
+  "incrementStat",
+  "DOMAIN_STATS_MAX",
+  "incrementDomainStat",
+  "getDomainStats",
+  "sessionStorage",
+  "cacheDomainRules",
+  "getCachedDomainRules",
+  "getRemoteParams",
+  "setRemoteParams",
+  "getShortenerStats",
+  "flushShortenerStats",
+  "incrementShortenerStat",
+  "migrateStatsToLocal",
+  "migrateLegacyProxyPref",
+]);
+
+// ── Guard (1): prefs.js must not import from storage.js ───────────────────
+
+describe("module-boundary — prefs.js (#826 PR2)", () => {
+  const src = readLib("prefs.js");
+
+  test("prefs.js does not import from storage.js (acyclicity guard)", () => {
+    const re = /from\s+["']\.\/storage\.js["']/g;
+    assert.ok(
+      !re.test(src),
+      "prefs.js must not import from storage.js — this would create a circular dependency"
+    );
+  });
+
+  test("prefs.js exports PREF_DEFAULTS", () => {
+    assert.ok(
+      src.includes("export const PREF_DEFAULTS"),
+      "prefs.js must export PREF_DEFAULTS"
+    );
+  });
+
+  test("prefs.js exports getPrefs", () => {
+    assert.ok(
+      src.includes("export async function getPrefs"),
+      "prefs.js must export getPrefs"
+    );
+  });
+
+  test("prefs.js exports setPrefs", () => {
+    assert.ok(
+      src.includes("export async function setPrefs"),
+      "prefs.js must export setPrefs"
+    );
+  });
+});
+
+// ── Guard (2): storage-migrations.js must not import from storage.js ──────
+
+describe("module-boundary — storage-migrations.js (#826 PR2)", () => {
+  const src = readLib("storage-migrations.js");
+
+  test("storage-migrations.js does not import from storage.js (acyclicity guard)", () => {
+    const re = /from\s+["']\.\/storage\.js["']/g;
+    assert.ok(
+      !re.test(src),
+      "storage-migrations.js must not import from storage.js — this would create a circular dependency"
+    );
+  });
+
+  test("storage-migrations.js exports migrateStatsToLocal", () => {
+    assert.ok(
+      src.includes("export async function migrateStatsToLocal"),
+      "storage-migrations.js must export migrateStatsToLocal"
+    );
+  });
+
+  test("storage-migrations.js exports migrateLegacyProxyPref", () => {
+    assert.ok(
+      src.includes("export async function migrateLegacyProxyPref"),
+      "storage-migrations.js must export migrateLegacyProxyPref"
+    );
+  });
+});
+
+// ── Guard (3): storage.js re-export surface covers the full pre-split API ─
+
+describe("module-boundary — storage.js re-export surface (#826 PR2)", () => {
+  test("storage.js re-exports the complete pre-split public API", async () => {
+    // Dynamic import resolves re-exports transparently.
+    const mod = await import(
+      new URL("../../src/lib/storage.js", import.meta.url).href
+    );
+    const actual = new Set(Object.keys(mod));
+    const missing = [...STORAGE_EXPECTED_EXPORTS].filter((name) => !actual.has(name));
+    assert.deepEqual(
+      missing,
+      [],
+      `storage.js is missing expected exports after #826 PR2 split: ${missing.join(", ")}. ` +
+      "Add explicit re-exports to restore backward compatibility."
+    );
+  });
+
+  test("storage.js re-exports from prefs.js (source-level check)", () => {
+    const src = readLib("storage.js");
+    assert.ok(
+      src.includes('from "./prefs.js"'),
+      "storage.js must re-export from prefs.js"
+    );
+  });
+
+  test("storage.js re-exports from storage-migrations.js (source-level check)", () => {
+    const src = readLib("storage.js");
+    assert.ok(
+      src.includes('from "./storage-migrations.js"'),
+      "storage.js must re-export from storage-migrations.js"
     );
   });
 });

--- a/tests/unit/shortener-stats-sw.test.mjs
+++ b/tests/unit/shortener-stats-sw.test.mjs
@@ -21,7 +21,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "../..");
 
 const swSource = readFileSync(join(root, "src/background/service-worker.js"), "utf8");
-const storageSource = readFileSync(join(root, "src/lib/storage.js"), "utf8");
+// #826 PR2: PREF_DEFAULTS moved to prefs.js; migrations moved to storage-migrations.js.
+// Source-scan tests that inspect those domains read the new canonical files.
+const prefsSource = readFileSync(join(root, "src/lib/prefs.js"), "utf8");
+const migrationsSource = readFileSync(join(root, "src/lib/storage-migrations.js"), "utf8");
 const require = createRequire(import.meta.url);
 const pkg = require("../../package.json");
 const mv3 = require("../../src/manifest.json");
@@ -30,17 +33,18 @@ const mv2 = require("../../src/manifest.v2.json");
 // ── 1. Pref cleanup (phase 5) ────────────────────────────────────────────────
 
 describe("ADR-0004 phase 5: useNativeShortenerResolution removed from PREF_DEFAULTS", () => {
+  // #826 PR2: PREF_DEFAULTS lives in prefs.js — scan that file for the content guards.
   test("PREF_DEFAULTS does NOT contain useNativeShortenerResolution (vestigial flag removed)", () => {
     // The flag was the dual-path selector; with proxy gone it is meaningless.
     // It must NOT be in PREF_DEFAULTS — this would re-sync it to all devices.
     assert.ok(
-      !/useNativeShortenerResolution\s*:/.test(storageSource.split("PREF_DEFAULTS")[1]?.split("};")[0] ?? ""),
+      !/useNativeShortenerResolution\s*:/.test(prefsSource.split("PREF_DEFAULTS")[1]?.split("};")[0] ?? ""),
       "PREF_DEFAULTS must NOT contain useNativeShortenerResolution after phase 5"
     );
   });
 
   test("PREF_DEFAULTS does NOT contain privacyProxyEnabled (deprecated key removed)", () => {
-    const prefsBlock = storageSource.split("PREF_DEFAULTS")[1]?.split("};")[0] ?? "";
+    const prefsBlock = prefsSource.split("PREF_DEFAULTS")[1]?.split("};")[0] ?? "";
     assert.ok(
       !/privacyProxyEnabled\s*:/.test(prefsBlock),
       "PREF_DEFAULTS must NOT contain privacyProxyEnabled after phase 5"
@@ -48,7 +52,7 @@ describe("ADR-0004 phase 5: useNativeShortenerResolution removed from PREF_DEFAU
   });
 
   test("PREF_DEFAULTS still contains followShortenersEnabled", () => {
-    const prefsBlock = storageSource.split("PREF_DEFAULTS")[1]?.split("};")[0] ?? "";
+    const prefsBlock = prefsSource.split("PREF_DEFAULTS")[1]?.split("};")[0] ?? "";
     assert.ok(
       /followShortenersEnabled\s*:/.test(prefsBlock),
       "PREF_DEFAULTS must contain followShortenersEnabled"
@@ -56,20 +60,23 @@ describe("ADR-0004 phase 5: useNativeShortenerResolution removed from PREF_DEFAU
   });
 });
 
-// ── 2. Migration function exported from storage.js ───────────────────────────
+// ── 2. Migration function exported from storage-migrations.js ────────────────
+// #826 PR2: migrateLegacyProxyPref was extracted to storage-migrations.js and
+// is re-exported from storage.js for backward compat. Source-scan checks read
+// the canonical implementation file; the re-export keeps all callers unchanged.
 
 describe("ADR-0004 phase 5: migrateLegacyProxyPref exported", () => {
-  test("storage.js exports migrateLegacyProxyPref", async () => {
+  test("storage-migrations.js exports migrateLegacyProxyPref", async () => {
     // Dynamic import not possible (Chrome APIs not available), so scan source.
     assert.ok(
-      storageSource.includes("export async function migrateLegacyProxyPref"),
-      "storage.js must export migrateLegacyProxyPref for one-time pref rename on startup"
+      migrationsSource.includes("export async function migrateLegacyProxyPref"),
+      "storage-migrations.js must export migrateLegacyProxyPref for one-time pref rename on startup"
     );
   });
 
   test("migration reads privacyProxyEnabled from chrome.storage.sync", () => {
-    const fnStart = storageSource.indexOf("export async function migrateLegacyProxyPref");
-    const fnSlice = storageSource.slice(fnStart, fnStart + 2000);
+    const fnStart = migrationsSource.indexOf("export async function migrateLegacyProxyPref");
+    const fnSlice = migrationsSource.slice(fnStart, fnStart + 2000);
     assert.ok(
       fnSlice.includes("privacyProxyEnabled"),
       "migrateLegacyProxyPref must read privacyProxyEnabled"
@@ -77,8 +84,8 @@ describe("ADR-0004 phase 5: migrateLegacyProxyPref exported", () => {
   });
 
   test("migration sets followShortenersEnabled when old pref was true", () => {
-    const fnStart = storageSource.indexOf("export async function migrateLegacyProxyPref");
-    const fnSlice = storageSource.slice(fnStart, fnStart + 2000);
+    const fnStart = migrationsSource.indexOf("export async function migrateLegacyProxyPref");
+    const fnSlice = migrationsSource.slice(fnStart, fnStart + 2000);
     assert.ok(
       fnSlice.includes("followShortenersEnabled"),
       "migrateLegacyProxyPref must set followShortenersEnabled"
@@ -86,8 +93,8 @@ describe("ADR-0004 phase 5: migrateLegacyProxyPref exported", () => {
   });
 
   test("migration removes the old privacyProxyEnabled key", () => {
-    const fnStart = storageSource.indexOf("export async function migrateLegacyProxyPref");
-    const fnSlice = storageSource.slice(fnStart, fnStart + 2000);
+    const fnStart = migrationsSource.indexOf("export async function migrateLegacyProxyPref");
+    const fnSlice = migrationsSource.slice(fnStart, fnStart + 2000);
     assert.ok(
       fnSlice.includes('remove("privacyProxyEnabled"') || fnSlice.includes("remove('privacyProxyEnabled'"),
       "migrateLegacyProxyPref must call chrome.storage.sync.remove for privacyProxyEnabled"

--- a/tests/unit/shortener-stats.test.mjs
+++ b/tests/unit/shortener-stats.test.mjs
@@ -173,11 +173,12 @@ describe("shortener stats storage key", () => {
   test("shortenerStats is NEVER transmitted — it is a local-only key (doc check)", () => {
     // This is a structural/convention test: the key must NOT appear in
     // PREF_DEFAULTS (sync storage). We verify by reading the source text.
-    const storageSource = readFileSync(join(root, "src", "lib", "storage.js"), "utf8");
+    // #826 PR2: PREF_DEFAULTS was extracted to prefs.js — read the canonical file.
+    const storageSource = readFileSync(join(root, "src", "lib", "prefs.js"), "utf8");
 
     // Extract PREF_DEFAULTS body — this lives in chrome.storage.sync (transmitted)
     const match = storageSource.match(/export\s+const\s+PREF_DEFAULTS\s*=\s*\{([\s\S]*?)\n\};/);
-    assert.ok(match, "PREF_DEFAULTS must be found in storage.js");
+    assert.ok(match, "PREF_DEFAULTS must be found in prefs.js");
     const prefBody = match[1];
     assert.ok(
       !prefBody.includes("shortenerStats"),


### PR DESCRIPTION
Closes #826 — PR 2 of 2 (PR1: affiliates split, merged as #860)

## Summary

Pure relocation, zero behavior change. `storage.js` (857 lines, 11 importers, the lowest-covered module: 54% lines / 40% branches per the #822 baseline) becomes:

| File | Lines | Domain |
|---|---|---|
| `prefs.js` (new) | 197 | PREF_DEFAULTS + sync-storage pref CRUD |
| `storage-migrations.js` (new) | 117 | One-time migrations (stats→local, legacy proxy pref) |
| `storage.js` | 594 | Stats counters, caches, session wrapper + **re-export hub** |

- Consent boundary respected: `onboardingDone`/`consentVersion`/`consentDate` stay in consent-storage.js; `getPrefs` overlays them at runtime exactly as before.
- Acyclicity decision: the migration functions inline their trivial chrome.storage calls instead of importing back into storage.js — one-shot startup code; a clean graph beats DRY here.
- Export-surface parity: all 21 pre-split names still resolvable from storage.js (snapshot-pinned); the 11 importers (incl. the service worker, whose import line is pinned by windowed tests) are byte-untouched.
- `module-boundary-826.test.mjs` now carries BOTH split families (rebase onto PR1 merged the two guard sets; 22 tests).

## Test plan

- [x] Full gate post-rebase-onto-PR1: `npm test` 4756/0 + `lint:js` + `typecheck` + module-boundary 22/22