### PR TITLE
chore(release): v2.3.0 — version bumps + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-10
+
+Self-scaling ruleset pipeline (EPIC C, ingestion from ClearURLs + AdGuard) and a 25-issue June 2026 audit wave covering security, parity, robustness, and quality infrastructure.
+
+### Features
+
+- **Self-scaling ruleset pipeline (EPIC C, #780–#782, #785 family)**. Clean-room ingestion from ClearURLs and AdGuard with corroboration, affiliate-safety, canary, and functional-bias gates. Auto-merge for pass-all candidates; quarantine surface with full exclusion accounting (#782). Scheduled self-contained CI ingestion workflow (#781). Ed25519-signed promotion into the remote-rules source (#780).
+
+### Security
+
+- **Consent gate now covers all DNR rulesets** (#810). `amp_redirect` and `wrapper_unwrap` were active before the user completed onboarding consent. Both rulesets are now gated on consent and the `ampRedirect`/`unwrapRedirects` pref toggles actually control the DNR layer.
+- **Nonce-validated `muga:history-gate` events** (#811). Cross-world event listeners now require a handshake nonce — pages can no longer spoof the defuser gate.
+- **Workflow hardening** (#812). PR-body injection escaping, SHA-pinned actions, line-by-line PEM masking, bot identity enforcement in ingestion CI.
+- **Settings-import param validation** (#818). Imported remote-rules params are now validated against the canonical 64-char limit and denylist rules.
+- **SSRF ranges extended + landing security headers** (#830). CGNAT and TEST-NET ranges added to SSRF blocklist; landing worker now ships security headers; SECURITY.md added.
+
+### Fixed
+
+- **Firefox MV2 wrapper_unwrap parity** (#820). `wrapper_unwrap` DNR ruleset declared in `manifest.v2.json` — pre-navigation unwrapping now works on Firefox.
+- **Shortener stat lost-update race** (#817). `incrementShortenerStat` now uses a pending-flush batch to avoid concurrent-write data loss.
+- **AliExpress `aff_request_id` contradiction** (#816). Removed from `aliexpress` `stripParams` — it is a required landing param, not a tracking param.
+- **fr/it/ja toast translations + popup count animation** (#819). Missing locales restored; count-one `<span>` celebration animation fixed.
+- **Bounce-state latch re-arm + listener once-guard** (#832). Latch re-arms correctly after a navigation; event listener registered with `once: true` to prevent duplicate firings.
+- **Single-flight rules loaders** (#833). Concurrent rule-fetch calls are now deduplicated; `firstUsed` and migrations moved out of the hot path.
+- **Latent data-shape guards** (#831). Specificity, duplicates, origin-normalization, and anchoring guards added to rule processing.
+
+### Robustness
+
+- **Ingestion adapter timeouts + per-adapter isolation** (#813). A silent upstream outage no longer produces a deceptively green scheduled run; each adapter is independently isolated with a fetch timeout.
+- **Pipeline boundary hardening** (#821). Atomic writes, promote-side validation, markdown escaping, no-shell exec in ingestion pipeline.
+
+### Quality
+
+- **Release publishing gated on integration + E2E** (#814). `release.yml` now requires integration and E2E suites to pass before store artifacts are built.
+- **Affiliate commission-preservation invariant** (#815). End-to-end STRIP coherence guards and redirect-URL pass-through invariant pinned in tests.
+- **Coverage tooling + baseline** (#822). `node --test --experimental-test-coverage` script added; CI uploads coverage artifact.
+- **TypeScript checkJs + ESLint flat config** (#823). `jsconfig.json` + `eslint.config.mjs` introduced; 5 real bugs caught at introduction.
+- **Source-grep ratchet** (#824). Tombstone cleanup and flaky-vector fixes; ratchet enforces no-regression on source-level invariants.
+- **PR gate decoupled from live Worker** (#825). Integration stub suite runs on every PR; live Worker contract runs on `main` pushes only.
+
+### Architecture
+
+- **`affiliates.js` and `storage.js` split into focused modules** (#826). Acyclicity and export-parity guards enforce module boundaries going forward.
+- **Test fixtures stripped from store artifacts** (#827). `strip-test-seams.mjs` ships an inert stub; test-only fixtures never reach the extension bundle.
+- **i18n split into per-locale modules** (#834). `TRANSLATIONS` object extracted into one file per locale for tree-shaking and maintainability.
+- **Docs drift fixed with machine-enforced claims tests** (#828). README/CONTRIBUTING claims validated against code at CI time.
+
 ## [2.2.0] - 2026-06-01
 
 Beta release (2.2.0-beta.1) completing ADR-0004 phase 4: native shortener resolution becomes the default path; the proxy remains as fallback.
@@ -950,7 +997,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/yocreoquesi/muga/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/yocreoquesi/muga/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/yocreoquesi/muga/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/yocreoquesi/muga/compare/v1.17.0...v2.0.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.2.0-blue)](#)
+[![Version](https://img.shields.io/badge/version-2.3.0-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen)](#development)
 [![CAPS](https://img.shields.io/badge/CAPS-Basic%20%2B%20Contextual-2ea44f)](CONFORMANCE.md)
 # MUGA: The URL denoise extension for the web
@@ -17,7 +17,7 @@
 
 > **MUGA?** Maximally Unannoying Garbage Auditor. **MUGA.** Make URLs Quiet Again. **MUGA!** The web, with the noise turned down.
 
-> **2.2.0 shipped.** The creator-agnostic denoise pivot (ADR-0002) is complete. See [CHANGELOG](CHANGELOG.md) for what landed and [ADR-0002](docs/adr/0002-denoise-pivot-creator-agnostic.md) for the full rationale.
+> **2.3.0 shipped.** Self-scaling ruleset pipeline (EPIC C), full consent-gate coverage for all DNR rulesets, Firefox wrapper_unwrap parity, 25-issue June 2026 audit wave. See [CHANGELOG](CHANGELOG.md) for the full release notes.
 
 [Privacy policy](https://rules.muga.app/) · [Comparison vs other URL cleaners](https://rules.muga.app/comparison.html) · [FAQ](docs/faq.md) · [Objectives & non-goals](OBJECTIVES.md) · [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) · [ADRs](docs/adr/) · [Maintainer ops docs](docs/ops/README.md)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://rules.muga.app/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "2.2.0"
+    "softwareVersion": "2.3.0"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.2.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.3.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 2.2.0
+> Version: 2.3.0
 > Last updated: 2026-05-25
 > Status: Listing for Chrome Web Store and Firefox AMO under the 2.1 denoise pivot (creator-agnostic positioning — see ADR-0002). Lead headline: "Shorter, cleaner URLs — fair to every creator". The 2.0-era anti-redirect framing has been removed; MUGA no longer takes a stance against affiliate-redirect networks (their click IS the attribution event and MUGA respects it). Third-party retailer brand names previously enumerated were removed after Chrome Web Store flagged the list as keyword spam (rejection routing ID FZSL, 2026-05). URL Unwrapper section rewritten with honest scope: generic shorteners only (bit.ly, t.co, tinyurl.com, etc.); affiliate redirects pass through unchanged. Privacy claims (no telemetry / no analytics) remain firm but are no longer in the headline.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;&middot;&nbsp; Version 2.2.0 &nbsp;&middot;&nbsp; 2026-06-01 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: The web, with the noise turned down &nbsp;&middot;&nbsp; Version 2.3.0 &nbsp;&middot;&nbsp; 2026-06-10 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim: what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">2.2.0</span>
+      <span class="at-a-glance-value">2.3.0</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>

--- a/landing/index.html
+++ b/landing/index.html
@@ -28,7 +28,7 @@
   "operatingSystem": "Chrome, Firefox",
   "description": "Open-source browser extension that quiets 450+ noise patterns from URLs while preserving creator affiliate referrals.",
   "offers": { "@type": "Offer", "price": "0" },
-  "softwareVersion": "2.2.0",
+  "softwareVersion": "2.3.0",
   "license": "https://www.gnu.org/licenses/gpl-3.0.html"
 }
 </script>
@@ -407,7 +407,7 @@
     <a href="/" class="brand" aria-label="MUGA home">
       <img class="brand-mark" src="https://rules.muga.app/assets/muga-mark.svg" alt="" width="22" height="22">
       <span>muga.app</span>
-      <span class="ver">v2.2.0</span>
+      <span class="ver">v2.3.0</span>
     </a>
     <nav class="nav-links" aria-label="Primary">
       <a href="https://rules.muga.app/transparency.html">Transparency</a>
@@ -420,7 +420,7 @@
 
   <section class="hero">
     <div class="wrap">
-      <div class="eyebrow"><span class="dot"></span> v2.2.0 · Chrome + Firefox · GPL v3</div>
+      <div class="eyebrow"><span class="dot"></span> v2.3.0 · Chrome + Firefox · GPL v3</div>
       <h1>The web,<br><span class="mark">with the noise turned down.</span></h1>
       <p class="lede">
         MUGA quiets <b>450+ noise patterns</b> from every link you open. Locally, in your browser.
@@ -636,7 +636,7 @@
     </div>
     <div class="footer-meta">
       <span>© 2026 muga.app · Released under GPL v3</span>
-      <span>v2.2.0 · published 2026-05-25</span>
+      <span>v2.3.0 · published 2026-06-10</span>
     </div>
   </div>
 </footer>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muga",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The denoise extension for the web. Removes 450+ noise patterns from URLs while honoring creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "MUGA: The denoise extension for the web",
   "short_name": "MUGA",
-  "version": "2.2.0",
-  "version_name": "2.2.0-beta.1",
+  "version": "2.3.0",
+  "version_name": "2.3.0",
   "description": "Quiet the noise. Honor creator referrals. 450+ noise patterns removed (utm, fbclid, gclid). No analytics, no telemetry. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "MUGA: The denoise extension for the web",
   "short_name": "MUGA",
-  "version": "2.2.0",
-  "version_name": "2.2.0-beta.1",
+  "version": "2.3.0",
+  "version_name": "2.3.0",
   "description": "Quiet the noise. Honor creator referrals. 450+ noise patterns removed (utm, fbclid, gclid). No analytics, no telemetry. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.2.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.3.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/tests/unit/shortener-stats-sw.test.mjs
+++ b/tests/unit/shortener-stats-sw.test.mjs
@@ -253,32 +253,32 @@ describe("ADR-0004 phase 5: proxy artifacts removed from service-worker", () => 
 
 // ── 6. Version integrity ─────────────────────────────────────────────────────
 
-describe("ADR-0004 phase 4: beta version 2.2.0-beta.1 (phase 5 preserves)", () => {
-  test("package.json version is 2.2.0", () => {
-    assert.equal(pkg.version, "2.2.0", "package.json must be 2.2.0");
+describe("Version integrity — manifest versions match package.json", () => {
+  test("package.json version is 2.3.0", () => {
+    assert.equal(pkg.version, "2.3.0", "package.json must be 2.3.0");
   });
 
-  test("manifest.json version is 2.2.0", () => {
-    assert.equal(mv3.version, "2.2.0", "src/manifest.json version must be 2.2.0");
+  test("manifest.json version is 2.3.0", () => {
+    assert.equal(mv3.version, "2.3.0", "src/manifest.json version must be 2.3.0");
   });
 
-  test("manifest.v2.json version is 2.2.0", () => {
-    assert.equal(mv2.version, "2.2.0", "src/manifest.v2.json version must be 2.2.0");
+  test("manifest.v2.json version is 2.3.0", () => {
+    assert.equal(mv2.version, "2.3.0", "src/manifest.v2.json version must be 2.3.0");
   });
 
-  test("manifest.json has version_name 2.2.0-beta.1", () => {
+  test("manifest.json version_name matches version (stable release, no beta suffix)", () => {
     assert.equal(
       mv3.version_name,
-      "2.2.0-beta.1",
-      "MV3 manifest must have version_name: '2.2.0-beta.1'"
+      "2.3.0",
+      "MV3 manifest version_name must be '2.3.0'"
     );
   });
 
-  test("manifest.v2.json has version_name 2.2.0-beta.1", () => {
+  test("manifest.v2.json version_name matches version (stable release, no beta suffix)", () => {
     assert.equal(
       mv2.version_name,
-      "2.2.0-beta.1",
-      "MV2 manifest must have version_name: '2.2.0-beta.1'"
+      "2.3.0",
+      "MV2 manifest version_name must be '2.3.0'"
     );
   });
 });


### PR DESCRIPTION
Release prep for v2.3.0 (no tag in this PR — tag push happens after merge, on explicit go).

## Summary

- 2.2.0 → 2.3.0 across all version touchpoints: package.json, both manifests (beta suffix dropped — stable release), README badge, store-listing, privacy pages, landing, transparency docs.
- CHANGELOG 2.3.0 entry (2026-06-10, 8 subsections): the self-scaling ruleset pipeline (EPIC C #785 family) + the full June audit wave (#810–#834, 25 issues).
- AMO release-notes truncation verified: entry truncates to ~2.7k chars with GitHub Release link, under the 3k hard limit.
- User-visible highlights: consent gating now fully effective pre-onboarding (#810), Firefox gains pre-navigation wrapper unwrapping (#820), fr/it/ja toasts restored (#819), popup count animation fix (#819).

## Test plan

- [x] Full gate: `npm test` (4756/0, incl. version-consistency + amo-truncation + docs-claims) + `lint:js` + `typecheck`