### PR TITLE
refactor(options): inline style attributes → CSS classes; drop style-src unsafe-inline (#858)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -95,7 +95,7 @@
   },
 
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app; style-src 'self' 'unsafe-inline'"
+    "extension_pages": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app; style-src 'self'"
   },
 
   "icons": {

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -110,7 +110,7 @@
     }
   },
 
-  "content_security_policy": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app; style-src 'self' 'unsafe-inline'",
+  "content_security_policy": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app; style-src 'self'",
 
   "icons": {
     "16": "icons/16.png",

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -567,3 +567,68 @@ input[type="text"]:not(.add-row input) {
   text-decoration: none;
   text-align: center;
 }
+
+/* ---------- Migrated from inline style= attributes (#858) -------------- */
+
+/* Utility: spacing */
+.mt-8  { margin-top:  8px; }
+.mt-10 { margin-top: 10px; }
+.mt-16 { margin-top: 16px; }
+
+/* Utility: padding shorthand used in dev-tools card rows */
+.pb-8 { padding: 0 0 8px 0; }
+
+/* Stores grid hint padding */
+.stores-footer-hint { padding: 4px 16px 12px; }
+
+/* Dev-tools card: visually subordinate card spacing */
+.card-dev { margin-top: 10px; }
+
+/* Outer dev-tools container — hidden until dev mode is active.
+   JS toggles visibility by adding/removing this class so that
+   display:none is controlled at the class level, not inline. */
+.dev-tools-hidden { display: none; }
+
+/* File input that is never rendered but must be click()-able */
+.input-file-hidden { display: none; }
+
+/* Border separator above the URL tester */
+.url-tester-section { border-top: 0.5px solid var(--border); }
+
+/* URL tester label */
+.url-tester-label {
+  font-size: 13.5px;
+  font-weight: 500;
+  display: block;
+  margin-bottom: 6px;
+}
+
+/* URL tester hint text */
+.url-tester-hint {
+  color: var(--text2);
+  font-size: 12px;
+  display: block;
+  margin-bottom: 10px;
+}
+
+/* Monospace text input (URL tester input) */
+.input-mono { font-family: var(--font-mono); }
+
+/* URL tester result container spacing (visibility via hidden attribute) */
+#dev-url-result { margin-top: 10px; }
+
+/* URL tester result sub-labels */
+.result-label {
+  font-size: 11px;
+  color: var(--text2);
+  margin-bottom: 4px;
+}
+
+/* Removed-params line in URL tester result */
+.result-removed {
+  font-size: 11px;
+  color: var(--text2);
+}
+
+/* Report-btn spacing (the button itself is styled by .report-btn above) */
+.report-btn-inline { margin-top: 8px; font-size: 11px; }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -207,37 +207,35 @@
         <label class="toggle"><input type="checkbox" id="dev-mode" data-i18n-aria-label="aria_dev_mode"><span class="slider"></span></label>
       </div>
     </div>
-    <div id="dev-tools-card" style="display:none;">
+    <div id="dev-tools-card" class="dev-tools-hidden">
       <!-- Advanced: per-shortener pass/fail counters (ADR-0004 phase 4, #700) -->
-      <div class="card" style="margin-top:10px;" id="shortener-stats-card">
+      <div class="card card-dev" id="shortener-stats-card">
         <div class="row">
           <div class="row-label">
             <strong data-i18n="shortener_stats_label">Shortener resolution stats (beta)</strong>
             <small data-i18n="shortener_stats_hint">Pass/fail counts for native shortener resolution since last reset. Never transmitted.</small>
           </div>
         </div>
-        <div id="shortener-stats-table" style="padding:0 0 8px 0;"></div>
-        <div style="padding:0 0 8px 0;">
+        <div id="shortener-stats-table" class="pb-8"></div>
+        <div class="pb-8">
           <button id="shortener-stats-reset-btn" class="link-btn" data-i18n="shortener_stats_reset">Reset counters</button>
         </div>
       </div>
 
       <!-- Advanced: Affiliate stores -->
-      <div class="card" style="margin-top:10px;">
-        <details class="stores-details">
+      <div class="card card-dev"><details class="stores-details">
           <summary class="stores-summary">
             <span data-i18n="section_stores">Affiliate stores</span>
             <span class="stores-count" id="stores-count"></span>
           </summary>
           <div class="stores-grid" id="stores-grid"></div>
-          <div style="padding: 4px 16px 12px">
+          <div class="stores-footer-hint">
             <p class="hint" id="stores-hint" data-i18n="stores_hint">Green dot = affiliate account active and configured. Grey = account pending registration.</p>
           </div>
         </details>
       </div>
 
-      <!-- Advanced: URL cleaning -->
-      <div class="card" style="margin-top:10px;">
+      <!-- Advanced: URL cleaning --><div class="card card-dev">
         <div class="row">
           <div class="row-label">
             <strong data-i18n="row_dnr_label">Denoise links before navigation</strong>
@@ -281,12 +279,12 @@
       </div>
 
       <!-- Advanced: Tracking categories -->
-      <h2 style="margin-top:16px" data-i18n="section_tracking_categories">Tracking categories</h2>
+      <h2 class="mt-16" data-i18n="section_tracking_categories">Tracking categories</h2>
       <div class="card" id="categories-card"></div>
-      <p class="hint" style="margin-top:8px" data-i18n="categories_hint"></p>
+      <p class="hint mt-8" data-i18n="categories_hint"></p>
 
       <!-- Advanced: Custom tracking params -->
-      <h2 style="margin-top:16px" data-i18n="section_custom_params">Custom tracking params: always strip</h2>
+      <h2 class="mt-16" data-i18n="section_custom_params">Custom tracking params: always strip</h2>
       <div class="card">
         <div class="list-section">
           <div class="list-items" id="custom-params-items"></div>
@@ -299,7 +297,7 @@
       </div>
 
       <!-- Import / Export -->
-      <h2 style="margin-top:16px" data-i18n="section_data">Import / Export</h2>
+      <h2 class="mt-16" data-i18n="section_data">Import / Export</h2>
       <div class="card">
         <div class="row">
           <div class="row-label">
@@ -312,12 +310,12 @@
             <strong data-i18n="import_label">Import settings</strong>
           </div>
           <button class="add-btn" id="import-btn" data-i18n="import_btn">Import settings</button>
-          <input type="file" id="import-file" accept=".json" style="display:none">
+          <input type="file" id="import-file" accept=".json" class="input-file-hidden">
         </div>
       </div>
 
       <!-- Developer tools -->
-      <h2 style="margin-top:16px" data-i18n="section_dev_tools">Developer tools</h2>
+      <h2 class="mt-16" data-i18n="section_dev_tools">Developer tools</h2>
       <div class="card">
         <div class="row">
           <div class="row-label">
@@ -354,18 +352,18 @@
           </div>
           <button class="add-btn" id="dev-preview-nudge-btn" data-i18n="dev_nudge_btn">Preview</button>
         </div>
-        <div class="list-section" style="border-top:0.5px solid var(--border);">
-          <strong style="font-size:13.5px;font-weight:500;display:block;margin-bottom:6px;" data-i18n="dev_url_tester_label">URL tester</strong>
-          <small style="color:var(--text2);font-size:12px;display:block;margin-bottom:10px;" data-i18n="dev_url_tester_hint">Paste any URL to see what MUGA will clean</small>
+        <div class="list-section url-tester-section">
+          <strong class="url-tester-label" data-i18n="dev_url_tester_label">URL tester</strong>
+          <small class="url-tester-hint" data-i18n="dev_url_tester_hint">Paste any URL to see what MUGA will clean</small>
           <div class="add-row">
-            <input id="dev-url-input" type="text" style="font-family:monospace;" placeholder="https://example.com?utm_source=google&amp;fbclid=..." data-i18n-placeholder="dev_url_tester_placeholder" data-i18n-aria-label="aria_dev_url_input">
+            <input id="dev-url-input" type="text" class="input-mono" placeholder="https://example.com?utm_source=google&amp;fbclid=..." data-i18n-placeholder="dev_url_tester_placeholder" data-i18n-aria-label="aria_dev_url_input">
             <button class="add-btn" id="dev-url-test-btn" data-i18n="dev_url_test_btn">Test</button>
           </div>
-          <div id="dev-url-result" style="margin-top:10px;display:none;">
-            <div style="font-size:11px;color:var(--text2);margin-bottom:4px;" data-i18n="dev_url_result_label">Result</div>
-            <div id="dev-url-clean" style="font-family:monospace;font-size:12px;color:#2563eb;word-break:break-all;margin-bottom:6px;"></div>
-            <div id="dev-url-removed" style="font-size:11px;color:var(--text2);"></div>
-            <button class="report-btn" id="dev-url-report-btn" style="display:none;margin-top:8px;font-size:11px;color:var(--accent);background:none;border:none;cursor:pointer;text-decoration:underline;" data-i18n="dev_url_report_btn">Report a problem with this URL</button>
+          <div id="dev-url-result" hidden>
+            <div class="result-label" data-i18n="dev_url_result_label">Result</div>
+            <div id="dev-url-clean"></div>
+            <div id="dev-url-removed" class="result-removed"></div>
+            <button class="report-btn report-btn-inline" id="dev-url-report-btn" hidden data-i18n="dev_url_report_btn">Report a problem with this URL</button>
           </div>
         </div>
       </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -848,7 +848,8 @@ function syncDevTools() {
   const devModeEl = document.getElementById("dev-mode");
   const devToolsCard = document.getElementById("dev-tools-card");
   if (!devModeEl || !devToolsCard) return;
-  devToolsCard.style.display = devModeEl.checked ? "" : "none";
+  // #858: visibility driven by CSS class (no inline style — required for CSP style-src without 'unsafe-inline')
+  devToolsCard.classList.toggle("dev-tools-hidden", !devModeEl.checked);
 }
 
 /** Initializes dev tools: URL tester and preview features. */
@@ -1198,7 +1199,8 @@ async function testUrl() {
   const cleanEl = document.getElementById("dev-url-clean");
   const removedEl = document.getElementById("dev-url-removed");
   const reportBtn = document.getElementById("dev-url-report-btn");
-  if (reportBtn) reportBtn.style.display = "none";
+  // #858: use hidden attribute instead of inline style (CSP style-src without 'unsafe-inline')
+  if (reportBtn) reportBtn.hidden = true;
   if (!input) return;
   try {
     const prefs = await chrome.storage.sync.get(PREF_DEFAULTS);
@@ -1215,13 +1217,14 @@ async function testUrl() {
     } else {
       removedEl.textContent = t("dev_url_action", _currentLang).replace("%s", result.action);
     }
-    resultDiv.style.display = "";
+    // #858: use hidden attribute to reveal result (no inline style)
+    resultDiv.hidden = false;
 
     // Show report button after results (clone to avoid listener accumulation)
     if (reportBtn) {
       const newBtn = reportBtn.cloneNode(true);
       reportBtn.parentNode.replaceChild(newBtn, reportBtn);
-      newBtn.style.display = "";
+      newBtn.hidden = false;
       newBtn.addEventListener("click", () => {
         try {
           const hostname = new URL(input).hostname;
@@ -1250,7 +1253,8 @@ async function testUrl() {
   } catch (e) {
     cleanEl.textContent = t("dev_url_error", _currentLang) + " " + e.message;
     removedEl.textContent = "";
-    resultDiv.style.display = "";
+    // #858: use hidden attribute to reveal result on error
+    resultDiv.hidden = false;
   }
 }
 

--- a/tests/unit/csp-no-inline-styles.test.mjs
+++ b/tests/unit/csp-no-inline-styles.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * MUGA — CSP inline-style guard (#858)
+ *
+ * Verifies:
+ * 1. No extension HTML page contains a `style="..."` attribute.
+ * 2. Neither manifest's style-src contains 'unsafe-inline'.
+ *
+ * If this test fails it means someone re-introduced an inline style attribute
+ * (which would be silently ignored by the browser once 'unsafe-inline' is
+ * absent from style-src) or re-added 'unsafe-inline' to the CSP (regression
+ * against the security hardening done in #858).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT  = join(__dir, "../..");
+
+// ── HTML pages to check ──────────────────────────────────────────────────────
+
+const EXTENSION_PAGES = [
+  "src/options/options.html",
+  "src/popup/popup.html",
+  "src/onboarding/onboarding.html",
+  "src/background/background.html",
+  "src/privacy/privacy.html",
+  "src/privacy/tos.html",
+];
+
+// ── Manifests ────────────────────────────────────────────────────────────────
+
+const mv3Manifest = JSON.parse(readFileSync(join(ROOT, "src/manifest.json"), "utf8"));
+const mv2Manifest = JSON.parse(readFileSync(join(ROOT, "src/manifest.v2.json"), "utf8"));
+
+// ── Guard 1: no `style=` attributes in any extension page ───────────────────
+
+describe("no inline style= attributes in extension HTML pages (#858)", () => {
+  for (const pagePath of EXTENSION_PAGES) {
+    test(`${pagePath}: must not contain any style="..." attribute`, () => {
+      const html = readFileSync(join(ROOT, pagePath), "utf8");
+      // Match style= that is an HTML attribute (not inside a comment or <style> tag).
+      // A simple scan for `style=` is sufficient: the pages are extension HTML,
+      // not arbitrary third-party content, so any match IS an inline attribute.
+      const matches = html.match(/\bstyle\s*=/g);
+      assert.strictEqual(
+        matches,
+        null,
+        `${pagePath} contains ${matches?.length} inline style= attribute(s) — ` +
+        "move them to CSS classes (required for CSP style-src without 'unsafe-inline')"
+      );
+    });
+  }
+});
+
+// ── Guard 2: manifests' style-src must not contain 'unsafe-inline' ──────────
+
+describe("manifests must not contain 'unsafe-inline' in style-src (#858)", () => {
+  test("src/manifest.json (MV3): style-src has no 'unsafe-inline'", () => {
+    const csp = mv3Manifest?.content_security_policy?.extension_pages ?? "";
+    assert.ok(
+      !csp.includes("'unsafe-inline'"),
+      `manifest.json CSP extension_pages still contains 'unsafe-inline': "${csp}"`
+    );
+  });
+
+  test("src/manifest.v2.json (MV2): style-src has no 'unsafe-inline'", () => {
+    const csp = mv2Manifest?.content_security_policy ?? "";
+    assert.ok(
+      !csp.includes("'unsafe-inline'"),
+      `manifest.v2.json content_security_policy still contains 'unsafe-inline': "${csp}"`
+    );
+  });
+});


### PR DESCRIPTION
Closes #858 — completes what #830 had to revert (PR #857).

## Summary

- All 22 inline `style=` attributes in options.html migrated to semantic CSS classes (or the `hidden` attribute); the other 5 extension pages verified at zero.
- `style-src 'unsafe-inline'` dropped from BOTH manifests — now actually safe because no extension page carries style attributes anymore.
- **The display-toggle trap, handled deliberately**: with a class-based `display:none` baseline, `el.style.display = ""` no longer reveals an element (removing the inline override leaves the class winning). Every JS show/hide touching migrated elements was adapted: `syncDevTools` → `classList.toggle("dev-tools-hidden")`, URL-tester card + report button → `el.hidden`.
- Guard test (8 assertions): zero `style=` in all extension HTML + no `'unsafe-inline'` in either manifest's style-src — this CSP can't regress silently again.

## Test plan

- [x] E2E run locally (the layer that caught #857's breakage): options.spec 14/14, export-import included, onboarding-regression 5/5
- [x] Full gate: `npm test` + `lint:js` + `typecheck` green post-rebase