### PR TITLE
test(live): Origin-gate expectation matches the Worker's 404 cloaking

### DIFF
--- a/tests/integration/live/worker-contract.test.mjs
+++ b/tests/integration/live/worker-contract.test.mjs
@@ -98,7 +98,7 @@ describe("live Worker contract — response envelope shape (#608)", () => {
 
 describe("live Worker contract — Origin gate (#608)", () => {
   test(
-    "request without a recognised Origin receives 403 or 401",
+    "request without a recognised Origin receives a deliberate 4xx rejection",
     { skip: LIVE ? false : SKIP_REASON },
     async () => {
       const target = `${WORKER_BASE}/v1/unwrap?url=${encodeURIComponent(SAMPLE_SHORT_URL)}`;
@@ -106,10 +106,15 @@ describe("live Worker contract — Origin gate (#608)", () => {
         // No Origin header — simulates a rogue non-extension caller.
         signal: AbortSignal.timeout(10_000),
       });
+      // The live Worker answers 404 (not 403/401) to callers without a
+      // recognised Origin — endpoint cloaking: an unauthorized probe cannot
+      // even confirm the route exists. Verified live 2026-06-10: no-Origin,
+      // bogus-Origin and / all return 404 uniformly, while the
+      // recognised-Origin reachability/envelope tests above get 200.
       assert.ok(
-        res.status === 403 || res.status === 401 || res.status === 400,
-        `Worker must reject requests without a recognised Origin. Got HTTP ${res.status}. ` +
-          "The Origin gate prevents cross-site abuse of the Worker endpoint."
+        [400, 401, 403, 404].includes(res.status),
+        `Worker must reject requests without a recognised Origin (any deliberate ` +
+          `4xx counts; the live gate cloaks with 404). Got HTTP ${res.status}.`
       );
     }
   );


### PR DESCRIPTION
Second and final main-only red: with the #868 glob fix in place, the live Worker tests ran for the first time and exposed a wrong EXPECTATION (not a wrong Worker): the Origin-gate test demanded 403/401/400, but the live Worker deliberately cloaks unauthorized callers with **404** (no-Origin, bogus-Origin and `/` all return 404 uniformly — probed live; recognised-Origin requests get 200, as the passing reachability/envelope tests show). Cloaking is the stronger posture: an unauthorized probe can't even confirm the route exists.

Fix: rejection = any deliberate 4xx (400/401/403/404), with the live-verified behavior documented in the test.

- [x] `MUGA_LIVE_TESTS=1` against the real Worker locally: 3/3 live tests pass
- [x] Full unit suite green