### PR TITLE
feat(discovered): caps-crawler receiver foundation — schema, pubkey, Ed25519 verifier (#787 slice 1/2)

### DIFF
--- a/discovered.schema.json
+++ b/discovered.schema.json
@@ -28,7 +28,8 @@
       "description": "Lowercase hostnames the crawler analyzed during this run.",
       "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
       }
     },
     "candidates": {
@@ -50,7 +51,8 @@
           },
           "first_seen_on": {
             "type": "string",
-            "description": "Hostname where this parameter was first observed."
+            "description": "Lowercase hostname where this parameter was first observed.",
+            "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$"
           },
           "injected_by": {
             "type": "string",

--- a/discovered.schema.json
+++ b/discovered.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/yocreoquesi/muga/blob/main/discovered.schema.json",
+  "title": "Crawler Discovery Artifact",
+  "description": "Human-facing contract for signed crawler discovery artifacts landing in discovered/. Enforcement is hand-rolled in tools/rule-ingestion/discovered-verify.mjs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "discovered_at",
+    "crawler_version",
+    "corpus",
+    "candidates",
+    "signature"
+  ],
+  "properties": {
+    "discovered_at": {
+      "type": "string",
+      "description": "ISO 8601 UTC timestamp of when the crawler run completed.",
+      "format": "date-time"
+    },
+    "crawler_version": {
+      "type": "string",
+      "description": "Git SHA hex of the crawler commit that produced this artifact. 7–40 hex characters.",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "corpus": {
+      "type": "array",
+      "description": "Lowercase hostnames the crawler analyzed during this run.",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "candidates": {
+      "type": "array",
+      "description": "Discovered tracking parameter candidates. An empty array is a valid heartbeat run.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "param",
+          "first_seen_on",
+          "injected_by",
+          "occurrence_count"
+        ],
+        "properties": {
+          "param": {
+            "type": "string",
+            "description": "Case-sensitive tracking parameter name."
+          },
+          "first_seen_on": {
+            "type": "string",
+            "description": "Hostname where this parameter was first observed."
+          },
+          "injected_by": {
+            "type": "string",
+            "description": "Identifier of the injecting system or script."
+          },
+          "occurrence_count": {
+            "type": "integer",
+            "description": "Number of times this parameter was observed during the run.",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "signature": {
+      "type": "string",
+      "description": "Ed25519 signature over the canonical JSON (keys sorted, signature field removed). Lowercase hex, exactly 128 characters (64 raw bytes).",
+      "pattern": "^[0-9a-f]{128}$"
+    }
+  }
+}

--- a/discovered/README.md
+++ b/discovered/README.md
@@ -1,0 +1,98 @@
+# discovered/ — Crawler Artifact Landing Zone
+
+This directory receives signed JSON artifacts produced by [caps-crawler](https://github.com/yocreoquesi/caps-crawler).
+Every file committed here is a permanent audit record. **Nothing in this directory is ever auto-deleted or auto-applied.**
+
+---
+
+## Artifact Arrival Flow
+
+1. caps-crawler signs a discovery artifact with the `crawler-2026-a` Ed25519 private key.
+2. The crawler opens a pull request adding `discovered/<date>.json` to this repository.
+3. The `discovered-validate.yml` workflow triggers on the PR and runs:
+   - **Schema validation** — checks the artifact conforms to `discovered.schema.json`.
+   - **Signature verification** — verifies the Ed25519 signature using the stored public key at `tools/rule-ingestion/crawler-pubkey.txt`.
+4. If validation passes, the workflow marks the PR ready for human review via CODEOWNERS.
+5. A maintainer reviews the artifact manually and merges (or rejects) the PR.
+6. **Merge is always a manual human action. Auto-merge is never permitted.**
+
+---
+
+## Schema and Signature Validation
+
+### Schema
+
+Every artifact must conform to `discovered.schema.json` (repo root).
+Required top-level fields:
+
+| Field             | Type                  | Constraint                     |
+| ----------------- | --------------------- | ------------------------------ |
+| `discovered_at`   | string                | ISO 8601 UTC                   |
+| `crawler_version` | string                | git SHA hex, 7–40 chars        |
+| `corpus`          | array of string       | lowercase hostnames, ≥1 entry  |
+| `candidates`      | array of objects      | empty array is valid heartbeat |
+| `signature`       | string                | hex lowercase, 128 chars       |
+
+Each `candidates` element:
+
+| Field             | Type    | Constraint  |
+| ----------------- | ------- | ----------- |
+| `param`           | string  | case-sensitive parameter name |
+| `first_seen_on`   | string  | hostname                      |
+| `injected_by`     | string  | (no further constraint)       |
+| `occurrence_count`| integer | ≥1                            |
+
+### Signature verification (manual)
+
+```bash
+node tools/rule-ingestion/discovered-verify.mjs
+```
+
+This script iterates every `discovered/*.json` file, validates shape and signature, and exits non-zero on the first failure.
+
+---
+
+## Reviewer Checklist
+
+Before merging a crawler artifact PR, a reviewer MUST:
+
+1. **Confirm the workflow is green** — both schema and signature checks must pass.
+2. **Spot-check the top-3 candidates by `occurrence_count`** — do the parameter names look like real tracking parameters, not internal application state or noise?
+3. **Confirm `crawler_version` resolves** — paste the value into the caps-crawler repo commit graph and confirm it resolves to a real, known commit.
+4. **Verify `discovered_at` is plausible** — timestamp should match the PR's creation window.
+5. **Check `corpus`** — the list of hostnames should be a recognizable subset of the crawler's configured target list.
+6. **Do not merge artifacts that fail any check above**, even if CI is green.
+
+---
+
+## Permanent Retention
+
+Artifacts in `discovered/` are part of the repository's audit trail.
+**Do not delete or prune committed artifact files.**
+If an artifact is later found to be erroneous or malicious, document the issue in the PR that identified it — do not delete the file.
+
+---
+
+## External Steps Required to Complete Integration
+
+The following two steps are **external to this repository** and must be completed separately by a maintainer. They are documented here only; they are NOT implemented in this change.
+
+### Step 1 — Retarget caps-crawler to yocreoquesi/muga
+
+In the caps-crawler repository, update `crawl.yml` so its PR target is `yocreoquesi/muga` (replacing the current target repo).
+
+### Step 2 — Provision a fine-grained PAT
+
+A maintainer must generate a GitHub fine-grained personal access token (PAT) scoped to the `yocreoquesi/muga` repository with the following permissions:
+
+- `contents: write` — to push the artifact file
+- `pull-requests: write` — to open the PR
+
+Store this PAT as the `CAPS_SPEC_PR_TOKEN` Actions secret in the muga repository settings, replacing any previous value. The caps-crawler `crawl.yml` references this secret name.
+
+---
+
+## Notes
+
+- Branch protection "require review before merge" must be enabled on the default branch in repository settings. This is a repository configuration step outside the repo itself.
+- An empty `candidates` array is a valid artifact (heartbeat run — the crawler ran but found no new candidates in the corpus).

--- a/tests/unit/discovered-verify.test.mjs
+++ b/tests/unit/discovered-verify.test.mjs
@@ -20,7 +20,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { join, dirname } from "node:path";
+import { dirname } from "node:path";
 
 import {
   sortKeys,

--- a/tests/unit/discovered-verify.test.mjs
+++ b/tests/unit/discovered-verify.test.mjs
@@ -257,6 +257,83 @@ describe("validateDiscoveredShape — corpus and candidate constraints", () => {
   });
 });
 
+describe("validateDiscoveredShape — hostname lowercase constraint", () => {
+  test("lowercase corpus hostname passes", () => {
+    const art = { ...validArtifact(), corpus: ["example.com"], signature: "ab".repeat(64) };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true, `expected ok=true for lowercase hostname, got code=${result.code}`);
+  });
+
+  test("uppercase corpus hostname fails with ERR_CORPUS_HOSTNAME_CASE", () => {
+    const art = { ...validArtifact(), corpus: ["Example.com"], signature: "ab".repeat(64) };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "uppercase corpus hostname must fail validation");
+    assert.strictEqual(result.code, "ERR_CORPUS_HOSTNAME_CASE:Example.com");
+  });
+
+  test("mixed-case corpus hostname fails", () => {
+    const art = { ...validArtifact(), corpus: ["eXaMpLe.com"], signature: "ab".repeat(64) };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "mixed-case corpus hostname must fail validation");
+  });
+
+  test("second corpus entry uppercase fails", () => {
+    const art = {
+      ...validArtifact(),
+      corpus: ["example.com", "ANOTHER.org"],
+      signature: "ab".repeat(64),
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "uppercase in any corpus entry must fail");
+    assert.strictEqual(result.code, "ERR_CORPUS_HOSTNAME_CASE:ANOTHER.org");
+  });
+
+  test("lowercase first_seen_on passes", () => {
+    const art = {
+      ...validArtifact(),
+      candidates: [{ ...VALID_CANDIDATE, first_seen_on: "example.com" }],
+      signature: "ab".repeat(64),
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true, `expected ok=true for lowercase first_seen_on, got code=${result.code}`);
+  });
+
+  test("uppercase first_seen_on fails with ERR_CANDIDATE_FIRST_SEEN_ON_CASE", () => {
+    const art = {
+      ...validArtifact(),
+      candidates: [{ ...VALID_CANDIDATE, first_seen_on: "Example.com" }],
+      signature: "ab".repeat(64),
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "uppercase first_seen_on must fail validation");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_FIRST_SEEN_ON_CASE");
+  });
+
+  test("mixed-case first_seen_on fails", () => {
+    const art = {
+      ...validArtifact(),
+      candidates: [{ ...VALID_CANDIDATE, first_seen_on: "eXaMpLe.CoM" }],
+      signature: "ab".repeat(64),
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "mixed-case first_seen_on must fail validation");
+  });
+
+  test("uppercase first_seen_on on second candidate fails with correct index", () => {
+    const art = {
+      ...validArtifact(),
+      candidates: [
+        { ...VALID_CANDIDATE, first_seen_on: "example.com" },
+        { ...VALID_CANDIDATE, param: "utm_source", first_seen_on: "UPPER.org" },
+      ],
+      signature: "ab".repeat(64),
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "uppercase first_seen_on in any candidate must fail");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_1_FIRST_SEEN_ON_CASE");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Section D — verifyDiscovered (Ed25519 signature verification)
 // ---------------------------------------------------------------------------

--- a/tests/unit/discovered-verify.test.mjs
+++ b/tests/unit/discovered-verify.test.mjs
@@ -257,6 +257,66 @@ describe("validateDiscoveredShape — corpus and candidate constraints", () => {
   });
 });
 
+describe("validateDiscoveredShape — type parity with discovered.schema.json", () => {
+  test("non-string discovered_at fails", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64), discovered_at: 42 };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "non-string discovered_at must fail validation");
+    assert.strictEqual(result.code, "ERR_DISCOVERED_AT_INVALID");
+  });
+
+  test("unparseable discovered_at string fails", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64), discovered_at: "not-a-date" };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "unparseable discovered_at must fail validation");
+    assert.strictEqual(result.code, "ERR_DISCOVERED_AT_INVALID");
+  });
+
+  test("non-string param fails", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, param: 123 }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "non-string param must fail validation");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_PARAM_INVALID");
+  });
+
+  test("empty param fails", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, param: "" }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "empty param must fail validation");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_PARAM_INVALID");
+  });
+
+  test("non-string injected_by fails", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, injected_by: 7 }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "non-string injected_by must fail validation");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_INJECTED_BY_INVALID");
+  });
+
+  test("empty injected_by fails", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, injected_by: "" }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "empty injected_by must fail validation");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_INJECTED_BY_INVALID");
+  });
+});
+
 describe("validateDiscoveredShape — hostname lowercase constraint", () => {
   test("lowercase corpus hostname passes", () => {
     const art = { ...validArtifact(), corpus: ["example.com"], signature: "ab".repeat(64) };

--- a/tests/unit/discovered-verify.test.mjs
+++ b/tests/unit/discovered-verify.test.mjs
@@ -1,0 +1,310 @@
+/**
+ * MUGA — Behavioral unit tests for tools/rule-ingestion/discovered-verify.mjs
+ *
+ * Covers spec Domains 2, 3, and 5:
+ *   Domain 2  — schema accept/reject (shape validation, additionalProperties:false)
+ *   Domain 3  — Ed25519 signature round-trip with ephemeral fixture keys
+ *   Domain 5  — all assertions behavioral (no source-grep / no ratchet assertions)
+ *
+ * Design constraints (§ Validator architecture, § Canonicalization + Ed25519 verify):
+ *   - discovered-verify.mjs is zero-dependency (node:crypto + node:fs only)
+ *   - Tests inject an ephemeral pubkey via the { pubKeyB64 } seam so no
+ *     production crawler private key is needed
+ *   - Signer mirrors crawler hex-sig format: sortKeys canonical → compact
+ *     JSON.stringify → UTF-8 bytes → Ed25519 sign → lowercase hex 128 chars
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import {
+  sortKeys,
+  canonicalDiscovered,
+  validateDiscoveredShape,
+  verifyDiscovered,
+} from "../../tools/rule-ingestion/discovered-verify.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Test fixture helpers — mirrors crawler hex-sig format
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a fresh Ed25519 keypair for test use.
+ * Returns raw 32-byte base64 public key (matching verifyDiscovered pubKeyB64 seam).
+ *
+ * @returns {{ privateKey: KeyObject, publicKeyB64: string }}
+ */
+function generateFixtureKeypair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  // Export DER SPKI (44 bytes: 12-byte header + 32-byte raw key) and strip header.
+  const derBytes = publicKey.export({ type: "spki", format: "der" });
+  const raw32 = derBytes.subarray(derBytes.length - 32);
+  const publicKeyB64 = Buffer.from(raw32).toString("base64");
+  return { privateKey, publicKeyB64 };
+}
+
+/**
+ * Signs a discovered artifact object using the crawler hex-sig format.
+ *
+ * Signing algorithm (matches discovered-verify.mjs canonicalization):
+ *   1. Deep-clone the object and strip `signature` if present.
+ *   2. sortKeys (recursive alphabetical) the clone.
+ *   3. JSON.stringify (compact, no spaces) → UTF-8 bytes.
+ *   4. Ed25519 sign → 64 raw bytes → lowercase hex 128 chars.
+ *
+ * @param {object} artifact - Unsigned artifact object (without `signature`).
+ * @param {KeyObject} privateKey - Ed25519 private key from generateFixtureKeypair().
+ * @returns {object} Signed artifact with `signature` field added.
+ */
+function signArtifact(artifact, privateKey) {
+  // Use the production canonicalization to sign — this keeps the round-trip symmetric.
+  const canonical = canonicalDiscovered(artifact);
+  const sigBytes = cryptoSign(null, Buffer.from(canonical, "utf8"), privateKey);
+  const signature = sigBytes.toString("hex"); // lowercase hex — 128 chars
+  return { ...artifact, signature };
+}
+
+// ---------------------------------------------------------------------------
+// Base valid fixture
+// ---------------------------------------------------------------------------
+
+const VALID_CANDIDATE = {
+  param: "fbclid",
+  first_seen_on: "example.com",
+  injected_by: "meta-pixel",
+  occurrence_count: 42,
+};
+
+function validArtifact() {
+  return {
+    candidates: [{ ...VALID_CANDIDATE }],
+    corpus: ["example.com"],
+    crawler_version: "abc1234",
+    discovered_at: "2026-06-01T00:00:00Z",
+    // signature deliberately absent — added by signArtifact()
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Section A — sortKeys (pure function)
+// ---------------------------------------------------------------------------
+
+describe("sortKeys — recursive key-sort", () => {
+  test("flat object keys are sorted alphabetically", () => {
+    const input = { z: 1, a: 2, m: 3 };
+    const result = sortKeys(input);
+    assert.deepStrictEqual(Object.keys(result), ["a", "m", "z"]);
+    assert.deepStrictEqual(result, { a: 2, m: 3, z: 1 });
+  });
+
+  test("nested object keys are sorted at every depth", () => {
+    const input = { outer: { z: 1, a: 2 }, b: "v" };
+    const result = sortKeys(input);
+    assert.deepStrictEqual(Object.keys(result), ["b", "outer"]);
+    assert.deepStrictEqual(Object.keys(result.outer), ["a", "z"]);
+  });
+
+  test("array element order is preserved", () => {
+    const input = { items: [3, 1, 2] };
+    const result = sortKeys(input);
+    assert.deepStrictEqual(result.items, [3, 1, 2]);
+  });
+
+  test("objects inside arrays are sorted recursively", () => {
+    const input = { items: [{ z: 1, a: 2 }, { m: 3, b: 4 }] };
+    const result = sortKeys(input);
+    assert.deepStrictEqual(Object.keys(result.items[0]), ["a", "z"]);
+    assert.deepStrictEqual(Object.keys(result.items[1]), ["b", "m"]);
+  });
+
+  test("non-object primitives pass through unchanged", () => {
+    assert.strictEqual(sortKeys(42), 42);
+    assert.strictEqual(sortKeys("hello"), "hello");
+    assert.strictEqual(sortKeys(null), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section B — canonicalDiscovered (pure function)
+// ---------------------------------------------------------------------------
+
+describe("canonicalDiscovered — strip signature + sortKeys + compact JSON", () => {
+  test("removes the signature field before serializing", () => {
+    const art = { ...validArtifact(), signature: "deadbeef".repeat(16) };
+    const canonical = canonicalDiscovered(art);
+    assert.ok(!canonical.includes('"signature"'), "canonical output must not contain signature field");
+  });
+
+  test("output is compact JSON (no spaces)", () => {
+    const art = validArtifact();
+    const canonical = canonicalDiscovered(art);
+    assert.ok(!canonical.includes(" "), "canonical output must not contain spaces (compact JSON)");
+  });
+
+  test("output keys are alphabetically sorted at the top level", () => {
+    const art = validArtifact();
+    const canonical = canonicalDiscovered(art);
+    // candidates must appear before corpus before crawler_version before discovered_at
+    const cIdx = canonical.indexOf('"candidates"');
+    const coIdx = canonical.indexOf('"corpus"');
+    const cvIdx = canonical.indexOf('"crawler_version"');
+    const dIdx = canonical.indexOf('"discovered_at"');
+    assert.ok(cIdx < coIdx, "candidates must appear before corpus in canonical output");
+    assert.ok(coIdx < cvIdx, "corpus must appear before crawler_version in canonical output");
+    assert.ok(cvIdx < dIdx, "crawler_version must appear before discovered_at in canonical output");
+  });
+
+  test("does not mutate the original object", () => {
+    const art = { ...validArtifact(), signature: "deadbeef".repeat(16) };
+    const originalSig = art.signature;
+    canonicalDiscovered(art);
+    assert.strictEqual(art.signature, originalSig, "original object must not be mutated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section C — validateDiscoveredShape (hand-rolled schema check)
+// ---------------------------------------------------------------------------
+
+describe("validateDiscoveredShape — valid artifacts pass", () => {
+  test("valid full artifact with one candidate passes", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64) };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true);
+  });
+
+  test("empty candidates array is valid (heartbeat)", () => {
+    const art = { ...validArtifact(), candidates: [], signature: "ab".repeat(64) };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true, `expected ok=true, got code=${result.code}`);
+  });
+});
+
+describe("validateDiscoveredShape — missing required top-level fields fail", () => {
+  const REQUIRED_FIELDS = [
+    "discovered_at",
+    "crawler_version",
+    "corpus",
+    "candidates",
+    "signature",
+  ];
+
+  for (const field of REQUIRED_FIELDS) {
+    test(`missing '${field}' fails with ok=false`, () => {
+      const art = { ...validArtifact(), signature: "ab".repeat(64) };
+      delete art[field];
+      const result = validateDiscoveredShape(art);
+      assert.strictEqual(result.ok, false, `expected ok=false when '${field}' is missing`);
+      assert.ok(result.code, "result must include a code string");
+    });
+  }
+});
+
+describe("validateDiscoveredShape — additionalProperties violations fail", () => {
+  test("extra top-level field fails", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64), unexpected_extra: "value" };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "extra top-level field must fail validation");
+    assert.ok(result.code, "result must include a code string");
+  });
+
+  test("extra candidate field fails", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, unknown_field: "bad" }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "extra candidate field must fail validation");
+    assert.ok(result.code, "result must include a code string");
+  });
+});
+
+describe("validateDiscoveredShape — corpus and candidate constraints", () => {
+  test("corpus must have at least one entry", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64), corpus: [] };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "empty corpus must fail validation");
+  });
+
+  test("occurrence_count must be an integer >= 1", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, occurrence_count: 0 }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "occurrence_count of 0 must fail validation");
+  });
+
+  test("signature must be exactly 128 hex lowercase chars", () => {
+    const art = { ...validArtifact(), signature: "tooshort" };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "short signature must fail validation");
+  });
+
+  test("crawler_version must be 7–40 hex chars", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64), crawler_version: "zz" };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "invalid crawler_version must fail validation");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section D — verifyDiscovered (Ed25519 signature verification)
+// ---------------------------------------------------------------------------
+
+describe("verifyDiscovered — signature round-trip with ephemeral fixture keys", () => {
+  test("valid artifact signed with fixture key verifies successfully", () => {
+    const { privateKey, publicKeyB64 } = generateFixtureKeypair();
+    const unsigned = validArtifact();
+    const signed = signArtifact(unsigned, privateKey);
+    const result = verifyDiscovered(signed, { pubKeyB64: publicKeyB64 });
+    assert.strictEqual(result.ok, true, `expected ok=true, got code=${result.code}`);
+  });
+
+  test("bit-flipped signature fails verification", () => {
+    const { privateKey, publicKeyB64 } = generateFixtureKeypair();
+    const signed = signArtifact(validArtifact(), privateKey);
+    // Flip the first byte of the signature (hex chars 0-1 → increment by 1 mod 256)
+    const firstByte = parseInt(signed.signature.slice(0, 2), 16);
+    const flipped = ((firstByte + 1) % 256).toString(16).padStart(2, "0");
+    const tamperedSig = flipped + signed.signature.slice(2);
+    const result = verifyDiscovered({ ...signed, signature: tamperedSig }, { pubKeyB64: publicKeyB64 });
+    assert.strictEqual(result.ok, false, "bit-flipped signature must fail verification");
+  });
+
+  test("tampered payload field fails verification", () => {
+    const { privateKey, publicKeyB64 } = generateFixtureKeypair();
+    const signed = signArtifact(validArtifact(), privateKey);
+    // Tamper with a field after signing
+    const tampered = { ...signed, crawler_version: "0000000" };
+    const result = verifyDiscovered(tampered, { pubKeyB64: publicKeyB64 });
+    assert.strictEqual(result.ok, false, "tampered field must fail verification");
+  });
+
+  test("wrong key rejects a validly signed artifact", () => {
+    const { privateKey } = generateFixtureKeypair();
+    const { publicKeyB64: wrongPubKeyB64 } = generateFixtureKeypair(); // different keypair
+    const signed = signArtifact(validArtifact(), privateKey);
+    const result = verifyDiscovered(signed, { pubKeyB64: wrongPubKeyB64 });
+    assert.strictEqual(result.ok, false, "wrong public key must reject verification");
+  });
+});
+
+describe("verifyDiscovered — shape validation is always run first", () => {
+  test("shape-invalid artifact returns ok=false even without pubkey check", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64), unexpected_extra: "value" };
+    // Even with a valid pubkey injected, shape check must reject first
+    const { publicKeyB64 } = generateFixtureKeypair();
+    const result = verifyDiscovered(art, { pubKeyB64: publicKeyB64 });
+    assert.strictEqual(result.ok, false, "shape-invalid artifact must fail before signature check");
+  });
+});

--- a/tools/rule-ingestion/crawler-pubkey.txt
+++ b/tools/rule-ingestion/crawler-pubkey.txt
@@ -1,0 +1,2 @@
+# keypair-id: crawler-2026-a
+47Iv61x1q1Uuy1gT4MBJX/Bek8a41P6dewh5POy3W28=

--- a/tools/rule-ingestion/discovered-verify.mjs
+++ b/tools/rule-ingestion/discovered-verify.mjs
@@ -128,10 +128,13 @@ export function canonicalDiscovered(obj) {
  * Checks:
  *   - All required top-level fields are present.
  *   - No unknown top-level fields (additionalProperties: false).
- *   - corpus is a non-empty array.
+ *   - corpus is a non-empty array of lowercase hostnames.
  *   - crawler_version matches [0-9a-f]{7,40}.
+ *   - discovered_at is a parseable ISO 8601 string.
  *   - signature matches [0-9a-f]{128}.
- *   - candidates is an array; each element passes candidate-level checks.
+ *   - candidates is an array; each element passes candidate-level checks
+ *     (param/injected_by non-empty strings, occurrence_count integer >= 1,
+ *     first_seen_on lowercase hostname).
  *
  * @param {object} obj - Parsed artifact object.
  * @returns {{ ok: boolean, code: string }} ok=true on success; ok=false with code on failure.
@@ -172,6 +175,11 @@ export function validateDiscoveredShape(obj) {
     return { ok: false, code: "ERR_CRAWLER_VERSION_INVALID" };
   }
 
+  // discovered_at: parseable ISO 8601 date-time string (parity with schema format: date-time).
+  if (typeof obj.discovered_at !== "string" || Number.isNaN(Date.parse(obj.discovered_at))) {
+    return { ok: false, code: "ERR_DISCOVERED_AT_INVALID" };
+  }
+
   // signature: exactly 128 lowercase hex chars.
   if (typeof obj.signature !== "string" || !SIGNATURE_RE.test(obj.signature)) {
     return { ok: false, code: "ERR_SIGNATURE_FORMAT" };
@@ -201,6 +209,16 @@ export function validateDiscoveredShape(obj) {
       if (!(field in candidate)) {
         return { ok: false, code: `ERR_CANDIDATE_${i}_MISSING_FIELD:${field}` };
       }
+    }
+
+    // param: non-empty case-sensitive string (parity with schema minLength 1).
+    if (typeof candidate.param !== "string" || candidate.param.length === 0) {
+      return { ok: false, code: `ERR_CANDIDATE_${i}_PARAM_INVALID` };
+    }
+
+    // injected_by: non-empty attribution string (parity with schema minLength 1).
+    if (typeof candidate.injected_by !== "string" || candidate.injected_by.length === 0) {
+      return { ok: false, code: `ERR_CANDIDATE_${i}_INJECTED_BY_INVALID` };
     }
 
     // occurrence_count: integer >= 1.

--- a/tools/rule-ingestion/discovered-verify.mjs
+++ b/tools/rule-ingestion/discovered-verify.mjs
@@ -40,6 +40,11 @@ const CRAWLER_VERSION_RE = /^[0-9a-f]{7,40}$/;
 // Regex for the artifact signature: exactly 128 lowercase hex characters (64 raw bytes).
 const SIGNATURE_RE = /^[0-9a-f]{128}$/;
 
+// Regex for a lowercase hostname. Mirrors the JSON Schema pattern on corpus[] items
+// and candidates[].first_seen_on. The crawler lowercases all hostnames at signing time;
+// enforcement here keeps schema and validator in parity.
+const HOSTNAME_LOWERCASE_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
 // Required top-level fields of a discovered artifact.
 const TOP_LEVEL_REQUIRED = [
   "candidates",
@@ -155,6 +160,13 @@ export function validateDiscoveredShape(obj) {
     return { ok: false, code: "ERR_CORPUS_EMPTY" };
   }
 
+  // corpus: each entry must be a lowercase hostname (mirrors JSON Schema pattern).
+  for (const hostname of obj.corpus) {
+    if (typeof hostname !== "string" || !HOSTNAME_LOWERCASE_RE.test(hostname)) {
+      return { ok: false, code: `ERR_CORPUS_HOSTNAME_CASE:${hostname}` };
+    }
+  }
+
   // crawler_version: 7–40 lowercase hex chars.
   if (typeof obj.crawler_version !== "string" || !CRAWLER_VERSION_RE.test(obj.crawler_version)) {
     return { ok: false, code: "ERR_CRAWLER_VERSION_INVALID" };
@@ -197,6 +209,14 @@ export function validateDiscoveredShape(obj) {
       candidate.occurrence_count < 1
     ) {
       return { ok: false, code: `ERR_CANDIDATE_${i}_OCCURRENCE_COUNT` };
+    }
+
+    // first_seen_on: must be a lowercase hostname (mirrors JSON Schema pattern).
+    if (
+      typeof candidate.first_seen_on !== "string" ||
+      !HOSTNAME_LOWERCASE_RE.test(candidate.first_seen_on)
+    ) {
+      return { ok: false, code: `ERR_CANDIDATE_${i}_FIRST_SEEN_ON_CASE` };
     }
   }
 

--- a/tools/rule-ingestion/discovered-verify.mjs
+++ b/tools/rule-ingestion/discovered-verify.mjs
@@ -1,0 +1,333 @@
+/** MUGA: hand-rolled Ed25519 verify + shape validator for crawler discovery artifacts (#787) */
+
+/**
+ * Verify and validate artifacts produced by caps-crawler and landing in discovered/.
+ *
+ * Why a dedicated helper instead of reusing remote-rules.js:
+ *   remote-rules.js uses a pipe-delimited canonicalization (`${version}|${published}|${params}`)
+ *   incompatible with the sorted-key JSON scheme used here. Mixing them would silently break.
+ *
+ * Zero npm dependencies — node:crypto and node:fs only.
+ *
+ * CLI usage (iterates discovered/*.json, fails-closed on any error):
+ *   node tools/rule-ingestion/discovered-verify.mjs
+ *
+ * Importable exports (named only, no default export):
+ *   sortKeys(value)
+ *   canonicalDiscovered(obj)
+ *   validateDiscoveredShape(obj)
+ *   verifyDiscovered(obj, { pubKeyB64 })
+ */
+
+import { createPublicKey, verify as cryptoVerify } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// 12-byte DER SPKI prefix for Ed25519 raw 32-byte public key.
+// SubjectPublicKeyInfo header: SEQUENCE { AlgorithmIdentifier { OID 1.3.101.112 } BIT STRING }
+// hex: 302a300506032b6570032100
+const DER_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+// Path to the stored crawler public key (co-located with this helper).
+const DEFAULT_PUBKEY_PATH = join(__dirname, "crawler-pubkey.txt");
+
+// Regex for a valid crawler_version: 7–40 lowercase hex characters.
+const CRAWLER_VERSION_RE = /^[0-9a-f]{7,40}$/;
+
+// Regex for the artifact signature: exactly 128 lowercase hex characters (64 raw bytes).
+const SIGNATURE_RE = /^[0-9a-f]{128}$/;
+
+// Required top-level fields of a discovered artifact.
+const TOP_LEVEL_REQUIRED = [
+  "candidates",
+  "corpus",
+  "crawler_version",
+  "discovered_at",
+  "signature",
+];
+
+// Allowed top-level fields (same set — additionalProperties: false).
+const TOP_LEVEL_ALLOWED = new Set(TOP_LEVEL_REQUIRED);
+
+// Required fields within each candidate object.
+const CANDIDATE_REQUIRED = ["first_seen_on", "injected_by", "occurrence_count", "param"];
+
+// Allowed candidate fields (same set — additionalProperties: false).
+const CANDIDATE_ALLOWED = new Set(CANDIDATE_REQUIRED);
+
+// ---------------------------------------------------------------------------
+// sortKeys — recursive alphabetical key-sort
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively rebuilds every object with keys in alphabetical sort order.
+ * Arrays preserve element order; elements that are objects are sorted recursively.
+ * Primitive values (string, number, boolean, null) pass through unchanged.
+ *
+ * WHY: the crawler signs over a compactly serialized representation of the payload
+ * after this transform, so the verifier must reproduce it exactly.
+ *
+ * @param {*} value - Any JSON-serializable value.
+ * @returns {*} The input with all nested object keys sorted.
+ */
+export function sortKeys(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  if (value !== null && typeof value === "object") {
+    const sorted = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortKeys(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// canonicalDiscovered — produce the signed message string
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces the canonical representation of a discovered artifact for signature
+ * verification. Algorithm (matches caps-crawler sign.mjs exactly):
+ *   1. Deep-clone the object via sortKeys (handles the recursion).
+ *   2. Delete the `signature` field from the clone.
+ *   3. JSON.stringify the sorted clone with no spacing (compact).
+ *
+ * The on-disk artifact file is pretty-printed, so the verifier MUST parse and
+ * re-canonicalize — NEVER verify over raw file bytes.
+ *
+ * @param {object} obj - Parsed artifact object (may or may not have `signature`).
+ * @returns {string} Compact JSON string ready for UTF-8 encoding and verification.
+ */
+export function canonicalDiscovered(obj) {
+  // sortKeys deep-clones the object, so the original is never mutated.
+  const clone = sortKeys(obj);
+  delete clone.signature;
+  return JSON.stringify(clone);
+}
+
+// ---------------------------------------------------------------------------
+// validateDiscoveredShape — hand-rolled shape check
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates the shape of a parsed discovered artifact object.
+ * Mirrors validatePayloadShape() conventions from remote-rules.js but enforces
+ * the discovered artifact schema — MUST NOT reuse that function.
+ *
+ * Checks:
+ *   - All required top-level fields are present.
+ *   - No unknown top-level fields (additionalProperties: false).
+ *   - corpus is a non-empty array.
+ *   - crawler_version matches [0-9a-f]{7,40}.
+ *   - signature matches [0-9a-f]{128}.
+ *   - candidates is an array; each element passes candidate-level checks.
+ *
+ * @param {object} obj - Parsed artifact object.
+ * @returns {{ ok: boolean, code: string }} ok=true on success; ok=false with code on failure.
+ */
+export function validateDiscoveredShape(obj) {
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    return { ok: false, code: "ERR_NOT_OBJECT" };
+  }
+
+  // Check for unknown top-level keys (additionalProperties: false).
+  for (const key of Object.keys(obj)) {
+    if (!TOP_LEVEL_ALLOWED.has(key)) {
+      return { ok: false, code: `ERR_UNKNOWN_FIELD:${key}` };
+    }
+  }
+
+  // Check all required top-level fields are present.
+  for (const field of TOP_LEVEL_REQUIRED) {
+    if (!(field in obj)) {
+      return { ok: false, code: `ERR_MISSING_FIELD:${field}` };
+    }
+  }
+
+  // corpus: array with at least one entry.
+  if (!Array.isArray(obj.corpus) || obj.corpus.length === 0) {
+    return { ok: false, code: "ERR_CORPUS_EMPTY" };
+  }
+
+  // crawler_version: 7–40 lowercase hex chars.
+  if (typeof obj.crawler_version !== "string" || !CRAWLER_VERSION_RE.test(obj.crawler_version)) {
+    return { ok: false, code: "ERR_CRAWLER_VERSION_INVALID" };
+  }
+
+  // signature: exactly 128 lowercase hex chars.
+  if (typeof obj.signature !== "string" || !SIGNATURE_RE.test(obj.signature)) {
+    return { ok: false, code: "ERR_SIGNATURE_FORMAT" };
+  }
+
+  // candidates: must be an array (empty is valid — heartbeat run).
+  if (!Array.isArray(obj.candidates)) {
+    return { ok: false, code: "ERR_CANDIDATES_NOT_ARRAY" };
+  }
+
+  // Validate each candidate object.
+  for (let i = 0; i < obj.candidates.length; i++) {
+    const candidate = obj.candidates[i];
+    if (candidate === null || typeof candidate !== "object" || Array.isArray(candidate)) {
+      return { ok: false, code: `ERR_CANDIDATE_${i}_NOT_OBJECT` };
+    }
+
+    // No unknown candidate fields (additionalProperties: false).
+    for (const key of Object.keys(candidate)) {
+      if (!CANDIDATE_ALLOWED.has(key)) {
+        return { ok: false, code: `ERR_CANDIDATE_${i}_UNKNOWN_FIELD:${key}` };
+      }
+    }
+
+    // All required candidate fields must be present.
+    for (const field of CANDIDATE_REQUIRED) {
+      if (!(field in candidate)) {
+        return { ok: false, code: `ERR_CANDIDATE_${i}_MISSING_FIELD:${field}` };
+      }
+    }
+
+    // occurrence_count: integer >= 1.
+    if (
+      !Number.isInteger(candidate.occurrence_count) ||
+      candidate.occurrence_count < 1
+    ) {
+      return { ok: false, code: `ERR_CANDIDATE_${i}_OCCURRENCE_COUNT` };
+    }
+  }
+
+  return { ok: true, code: "OK" };
+}
+
+// ---------------------------------------------------------------------------
+// verifyDiscovered — full verify: shape + Ed25519 signature
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates the shape and verifies the Ed25519 signature of a discovered artifact.
+ *
+ * Pubkey-injection seam: callers (especially tests) may pass { pubKeyB64 } to
+ * override the default production key from crawler-pubkey.txt. This allows the
+ * test suite to use ephemeral fixture keys without the production private key.
+ *
+ * Pubkey wrapping: the stored key is a raw 32-byte Ed25519 pubkey (base64-encoded).
+ * node:crypto requires a KeyObject from DER SPKI format. We prepend the fixed
+ * 12-byte DER SPKI prefix and call createPublicKey({ key, format:'der', type:'spki' }).
+ *
+ * @param {object} obj - Parsed artifact object.
+ * @param {{ pubKeyB64?: string }} [options] - Optional pubkey injection for tests.
+ * @returns {{ ok: boolean, code: string }}
+ */
+export function verifyDiscovered(obj, { pubKeyB64 } = {}) {
+  // Shape must be valid before we attempt crypto.
+  const shapeResult = validateDiscoveredShape(obj);
+  if (!shapeResult.ok) {
+    return shapeResult;
+  }
+
+  // Resolve the public key: injected (tests) or read from disk (production).
+  let resolvedPubKeyB64 = pubKeyB64;
+  if (!resolvedPubKeyB64) {
+    try {
+      const keyFileContent = readFileSync(DEFAULT_PUBKEY_PATH, "utf8");
+      // Skip comment lines (lines starting with #) and blank lines.
+      const keyLine = keyFileContent
+        .split("\n")
+        .map(line => line.trim())
+        .find(line => line.length > 0 && !line.startsWith("#"));
+      if (!keyLine) {
+        return { ok: false, code: "ERR_PUBKEY_NOT_FOUND" };
+      }
+      resolvedPubKeyB64 = keyLine;
+    } catch {
+      return { ok: false, code: "ERR_PUBKEY_READ_FAILED" };
+    }
+  }
+
+  // Wrap the raw 32-byte key in DER SPKI format and create a KeyObject.
+  let keyObject;
+  try {
+    const raw32 = Buffer.from(resolvedPubKeyB64, "base64");
+    if (raw32.length !== 32) {
+      return { ok: false, code: "ERR_PUBKEY_SIZE" };
+    }
+    const derKey = Buffer.concat([DER_SPKI_PREFIX, raw32]);
+    keyObject = createPublicKey({ key: derKey, format: "der", type: "spki" });
+  } catch {
+    return { ok: false, code: "ERR_PUBKEY_INVALID" };
+  }
+
+  // Produce the canonical signed message and verify.
+  let verified = false;
+  try {
+    const canonical = canonicalDiscovered(obj);
+    const msgBytes = Buffer.from(canonical, "utf8");
+    const sigBytes = Buffer.from(obj.signature, "hex");
+    verified = cryptoVerify(null, msgBytes, keyObject, sigBytes);
+  } catch {
+    return { ok: false, code: "ERR_VERIFY_EXCEPTION" };
+  }
+
+  if (!verified) {
+    return { ok: false, code: "ERR_SIGNATURE_INVALID" };
+  }
+
+  return { ok: true, code: "OK" };
+}
+
+// ---------------------------------------------------------------------------
+// CLI mode — iterate discovered/*.json, validate + verify each
+// ---------------------------------------------------------------------------
+
+/**
+ * CLI entry point. Run as `node tools/rule-ingestion/discovered-verify.mjs`.
+ * Iterates every discovered/*.json file, validates shape and verifies signature.
+ * Exits with code 0 on success, non-zero on any failure (fail-closed).
+ */
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const discoveredDir = join(__dirname, "../../discovered");
+  let files;
+
+  try {
+    files = readdirSync(discoveredDir).filter(f => f.endsWith(".json"));
+  } catch (err) {
+    process.stderr.write(`[discovered-verify] Cannot read discovered/ directory: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  if (files.length === 0) {
+    // No artifacts to verify — clean exit (workflow runs on path triggers,
+    // so this branch occurs only when discovered/ has no .json files yet).
+    process.stdout.write("[discovered-verify] No artifacts found in discovered/. Nothing to verify.\n");
+    process.exit(0);
+  }
+
+  let allOk = true;
+
+  for (const file of files) {
+    const filePath = join(discoveredDir, file);
+    let artifact;
+
+    try {
+      artifact = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch (err) {
+      process.stderr.write(`[discovered-verify] FAIL ${file}: JSON parse error — ${err.message}\n`);
+      allOk = false;
+      continue;
+    }
+
+    const result = verifyDiscovered(artifact);
+    if (result.ok) {
+      process.stdout.write(`[discovered-verify] OK   ${file}\n`);
+    } else {
+      process.stderr.write(`[discovered-verify] FAIL ${file}: ${result.code}\n`);
+      allOk = false;
+    }
+  }
+
+  process.exit(allOk ? 0 : 1);
+}


### PR DESCRIPTION
## What & Why

Caps-crawler (issue #787) sends signed discovery artifacts to a `discovered/` landing zone in this repo. Without a dedicated receiver — schema, public key, and verifier — those PRs dead-end at an archived caps-spec with no enforcement surface. This slice builds the receiver foundation so the crawler's output can be structurally validated and cryptographically verified before rules are promoted.

## Scope — Slice 1 / 2

| Layer | What |
|---|---|
| Landing zone | `discovered/.gitkeep` + `discovered/README.md` |
| Schema | `discovered.schema.json` — human-facing JSON Schema contract (draft-07) |
| Public key | `tools/rule-ingestion/crawler-pubkey.txt` — stored Ed25519 raw 32-byte pubkey (base64) |
| Verifier | `tools/rule-ingestion/discovered-verify.mjs` — zero-dependency (node:crypto + node:fs) shape check + Ed25519 verify |
| Tests | `tests/unit/discovered-verify.test.mjs` — 35 behavioral unit tests (TDD, ephemeral fixture keys) |
| Hostname enforcement | `fix(discovered)` commit: HOSTNAME_LOWERCASE_RE in validator + matching `pattern` in schema for `corpus[]` and `candidates[].first_seen_on` |

**Out of scope for this slice (Slice 2):** `.github/workflows/discovered-validate.yml`, `.github/CODEOWNERS`, `tests/unit/discovered-workflow.test.mjs`, `CONTEXT.md` edits, `ECOSYSTEM.md`.

## Chain

**PR 1 / 2** — stacked-to-main strategy.
PR 2 (validation workflow + CODEOWNERS + structural test + CONTEXT.md/ECOSYSTEM.md docs) opens after this merges.

## Size Exception

~840 changed lines total, accepted as `size:exception`:
- **310 lines** — TDD tests (kept with the code they drive per work-unit-commits convention)
- **~175 lines** — docs + JSON schema
- **333 lines** — verifier (productive logic under review)
- **73 lines** — schema properties

Splitting tests from verifier would break the work-unit boundary. Splitting schema+pubkey from verifier would create a broken intermediate state. The 333-line verifier is the only non-trivial review surface.

## Part of #787

(Issue closes only when Slice 2 lands.)

## External Follow-ups (documented in `discovered/README.md`)

Two human steps required after Slice 2 merges:
1. Retarget `crawl.yml` in caps-crawler to point at this repo's `discovered/` path.
2. Generate and configure a PAT with `contents:write` scope for the crawler's push step.

## Summary

- Adds `discovered/` landing zone with README and .gitkeep
- Adds `discovered.schema.json` with full artifact contract (timestamp, corpus, candidates, Ed25519 sig)
- Stores `crawler-2026-a` Ed25519 public key for signature verification
- Adds `discovered-verify.mjs` — zero-dependency shape validator + Ed25519 verifier with pubkey-injection seam for tests
- Enforces lowercase hostname constraint on `corpus[]` and `candidates[].first_seen_on` (schema + validator in parity)
- 35 unit tests (TDD, full suite 4814/0)

## Changes

| File | Change |
|---|---|
| `discovered/.gitkeep` | Landing zone directory |
| `discovered/README.md` | Receiver contract, external follow-up steps |
| `discovered.schema.json` | JSON Schema draft-07 for discovery artifacts |
| `tools/rule-ingestion/crawler-pubkey.txt` | Ed25519 raw pubkey (base64, with comment header) |
| `tools/rule-ingestion/discovered-verify.mjs` | Shape validator + Ed25519 verifier (zero-dep) |
| `tests/unit/discovered-verify.test.mjs` | 35 unit tests — sortKeys, canonicalize, validateShape, verifyDiscovered |

## Test Plan

- [x] `npm test` — 4814 pass, 0 fail, 1 pre-existing skip
- [x] TDD cycle: RED (8 new hostname tests failed first), then GREEN after implementation
- [x] Ed25519 round-trip tested with ephemeral fixture keys (no production private key in repo)
- [x] Bit-flip and payload-tamper tests confirm verifier is not trivially bypassable

## Contributor Checklist

- [x] Linked to issue: Part of #787
- [x] Conventional commits only — no Co-Authored-By trailers
- [x] Tests included with the code they verify (work-unit-commits)
- [x] Docs updated (discovered/README.md, schema description fields)
- [x] Zero new npm dependencies