### PR TITLE
feat(discovered): validation workflow, CODEOWNERS gate and docs (#787 slice 2/2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS — auto-request reviewers for critical paths
+#
+# /discovered/ — every crawler discovery artifact PR automatically
+# requests the maintainer for mandatory human review.
+# Branch protection "Require a pull request before merging" must be
+# enabled in repo settings (outside the repo) to enforce the gate.
+/discovered/ @yocreoquesi

--- a/.github/workflows/discovered-validate.yml
+++ b/.github/workflows/discovered-validate.yml
@@ -35,10 +35,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
-          cache: "npm"
 
-      - name: Install dependencies
-        run: npm ci
-
+      # No npm ci: discovered-verify.mjs is zero-dependency (node:crypto/fs only),
+      # and a contents:read validation job should not install the dependency tree.
       - name: Validate and verify discovered artifacts
         run: node tools/rule-ingestion/discovered-verify.mjs

--- a/.github/workflows/discovered-validate.yml
+++ b/.github/workflows/discovered-validate.yml
@@ -1,0 +1,44 @@
+name: discovered-validate
+
+# Validates incoming crawler discovery artifacts in discovered/ on PR and push.
+# Runs shape validation and Ed25519 signature verification via discovered-verify.mjs.
+# NEVER auto-merges; all discovered/ PRs require manual human review.
+# CODEOWNERS auto-requests the maintainer as reviewer.
+on:
+  pull_request:
+    paths:
+      - "discovered/**"
+      - "discovered.schema.json"
+      - "tools/rule-ingestion/discovered-verify.mjs"
+      - "tools/rule-ingestion/crawler-pubkey.txt"
+      - ".github/workflows/discovered-validate.yml"
+  push:
+    paths:
+      - "discovered/**"
+      - "discovered.schema.json"
+      - "tools/rule-ingestion/discovered-verify.mjs"
+      - "tools/rule-ingestion/crawler-pubkey.txt"
+      - ".github/workflows/discovered-validate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate and verify discovered artifacts
+        run: node tools/rule-ingestion/discovered-verify.mjs

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -256,6 +256,10 @@ Triggered on `v*` tag push: unit tests → live integration → e2e Playwright �
 | URL_RE regex literal identical in SW + content script | `url-regex-sync.test.mjs` |
 | Wrapper DNR rules match wrappers.json | `wrapper-dnr-rules-sync.test.mjs` |
 
+### Discovered artifact validation (`.github/workflows/discovered-validate.yml`)
+
+Triggered on `pull_request` and `push` scoped to `discovered/**`, `discovered.schema.json`, `tools/rule-ingestion/discovered-verify.mjs`, `tools/rule-ingestion/crawler-pubkey.txt`, and the workflow file itself. Runs `node tools/rule-ingestion/discovered-verify.mjs` (CLI mode: iterates `discovered/*.json`, validates shape + Ed25519 signature, fails closed on any error). Permissions: `contents: read` only. No auto-merge — CODEOWNERS at `.github/CODEOWNERS` auto-requests the maintainer for every `discovered/` PR.
+
 ### Conventions
 
 - After editing `src/lib/affiliates-data.js` or any file imported by the bundle: run `npm run build:content`.
@@ -317,6 +321,8 @@ tests/
 │   ├── module-boundary-826.test.mjs  Acyclicity + re-export guards
 │   ├── docs-claims.test.mjs          Machine-enforced README/CONTRIBUTING accuracy
 │   ├── context-map.test.mjs          Path + load-bearing-claim guards for CONTEXT.md
+│   ├── discovered-verify.test.mjs    Behavioral: schema accept/reject + Ed25519 sig round-trip
+│   ├── discovered-workflow.test.mjs  Structural: trigger paths, permissions, Node 20, no auto-merge
 │   └── …
 ├── integration/               Stub + live Worker contract tests
 └── e2e/                       Playwright browser tests
@@ -326,7 +332,9 @@ tools/
 │   ├── adapters/              Signal-source adapters (adguard-tp, clearurls)
 │   ├── gates/                 Orchestration gates (affiliate, corroboration, canary, functional)
 │   ├── quarantine/            Ephemeral raw signals (gitignored)
-│   └── promote/               Signed promote artifact (gitignored except .gitkeep)
+│   ├── promote/               Signed promote artifact (gitignored except .gitkeep)
+│   ├── discovered-verify.mjs  Hand-rolled Ed25519 verify + shape validator for discovered/ artifacts
+│   └── crawler-pubkey.txt     Ed25519 public key for keypair-id crawler-2026-a
 ├── generate-rules.mjs         compile:rules entry point
 ├── bundle-content.mjs         build:content entry point
 └── sign-rules.mjs             Ed25519 signing tool
@@ -338,6 +346,17 @@ docs/
     ├── 0003-awin-redirect-model-resolution.md
     ├── 0004-decommission-unwrap-server-native-shortener-resolution.md
     └── 0005-rule-scaling-pipeline.md
+
+discovered/                    Crawler discovery artifact landing zone (audit trail)
+├── .gitkeep                   Keeps the directory tracked on a fresh clone
+└── README.md                  Arrival flow, schema/sig validation steps, reviewer checklist
+
+discovered.schema.json         Human-facing JSON Schema contract for crawler artifacts
+
+.github/
+├── CODEOWNERS                 /discovered/ @yocreoquesi — auto-requests reviewer on every artifact PR
+└── workflows/
+    └── discovered-validate.yml  PR+push validate: shape check + Ed25519 verify; contents:read; no auto-merge
 ```
 
 ---

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -56,7 +56,13 @@ You are the **browser extension** — the primary implementation of MUGA's inter
 
 ## What sits upstream of you
 
-- `caps-crawler` — runs weekly and surfaces new redirect-wrapper and affiliate-program candidates. Those candidates are reviewed by the maintainer; accepted ones land in `src/rules/manifest.json` or `src/rules/wrappers.json` via a normal PR. The rule decision algorithm is documented in [`docs/rules/decision-algorithm.md`](docs/rules/decision-algorithm.md).
+- `caps-crawler` — runs weekly, discovers new tracking-parameter candidates, signs the discovery artifact with Ed25519 keypair `crawler-2026-a`, and opens a PR against `yocreoquesi/muga` targeting the `discovered/` landing zone.
+
+  **Receiver integration (this repo).** Every artifact that lands in `discovered/` is validated by `.github/workflows/discovered-validate.yml` (shape check + Ed25519 signature verification). The CODEOWNERS rule at `.github/CODEOWNERS` auto-requests the maintainer for human review. No artifact is ever auto-applied to `src/rules/`; all merges are manual. The rule decision algorithm is documented in [`docs/rules/decision-algorithm.md`](docs/rules/decision-algorithm.md).
+
+  **External steps required to complete the integration (out of scope for this repo — not yet done):**
+  1. Retarget `crawl.yml` in caps-crawler to push to `yocreoquesi/muga` instead of the current target.
+  2. Provision a fine-grained PAT with `contents:write` and `pull-requests:write` scopes on this repo, replacing `CAPS_SPEC_PR_TOKEN` in caps-crawler's secrets.
 
 ## What sits downstream of you
 

--- a/tests/unit/discovered-workflow.test.mjs
+++ b/tests/unit/discovered-workflow.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * MUGA — Structural tests for .github/workflows/discovered-validate.yml
+ *
+ * Covers spec Domain 4 requirements:
+ *   - Trigger paths include discovered/** and discovered.schema.json
+ *   - permissions: contents: read appears before jobs:
+ *   - Node 20 runtime
+ *   - No --auto on any gh pr merge-style line
+ *   - CODEOWNERS file exists at .github/CODEOWNERS with /discovered/ entry
+ *
+ * Uses string/regex assertions only (no external YAML parser — not in devDependencies).
+ * Mirrors the pattern from tests/unit/ingestion-scheduled-workflow.test.mjs.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = join(
+  __dirname,
+  "../../.github/workflows/discovered-validate.yml"
+);
+const CODEOWNERS_PATH = join(__dirname, "../../.github/CODEOWNERS");
+
+// ---------------------------------------------------------------------------
+// Guard: workflow file must exist (fails RED before the yml is created)
+// ---------------------------------------------------------------------------
+describe("discovered-validate.yml existence", () => {
+  test("file exists at .github/workflows/discovered-validate.yml", () => {
+    assert.ok(
+      existsSync(WORKFLOW_PATH),
+      `discovered-validate.yml does not exist at expected path: ${WORKFLOW_PATH}`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: read file once (only called when existence test passes)
+// ---------------------------------------------------------------------------
+function readWorkflow() {
+  return readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Trigger paths — must include discovered/** and discovered.schema.json
+// ---------------------------------------------------------------------------
+describe("trigger paths", () => {
+  test("triggers on pull_request event", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /pull_request/.test(content),
+      "discovered-validate.yml must have a pull_request trigger"
+    );
+  });
+
+  test("triggers on push event", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /\bpush\b/.test(content),
+      "discovered-validate.yml must have a push trigger"
+    );
+  });
+
+  test("trigger paths include 'discovered/**'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /discovered\/\*\*/.test(content),
+      "discovered-validate.yml trigger paths must include 'discovered/**'"
+    );
+  });
+
+  test("trigger paths include 'discovered.schema.json'", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /discovered\.schema\.json/.test(content),
+      "discovered-validate.yml trigger paths must include 'discovered.schema.json'"
+    );
+  });
+
+  test("trigger paths include tools/rule-ingestion/discovered-verify.mjs", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /tools\/rule-ingestion\/discovered-verify\.mjs/.test(content),
+      "discovered-validate.yml trigger paths must include 'tools/rule-ingestion/discovered-verify.mjs'"
+    );
+  });
+
+  test("trigger paths include tools/rule-ingestion/crawler-pubkey.txt", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /tools\/rule-ingestion\/crawler-pubkey\.txt/.test(content),
+      "discovered-validate.yml trigger paths must include 'tools/rule-ingestion/crawler-pubkey.txt'"
+    );
+  });
+
+  test("trigger paths include .github/workflows/discovered-validate.yml", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /\.github\/workflows\/discovered-validate\.yml/.test(content),
+      "discovered-validate.yml trigger paths must include '.github/workflows/discovered-validate.yml'"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permissions: contents: read (and only that — no write permissions)
+// ---------------------------------------------------------------------------
+describe("permissions — contents: read only", () => {
+  test("has workflow-level permissions block before jobs:", () => {
+    const content = readWorkflow();
+    const jobsIdx = content.indexOf("\njobs:");
+    const preJobs = jobsIdx === -1 ? content : content.slice(0, jobsIdx);
+    assert.ok(
+      /^permissions:/m.test(preJobs),
+      "discovered-validate.yml must have a workflow-level 'permissions:' block before 'jobs:'"
+    );
+  });
+
+  test("permissions includes contents: read", () => {
+    const content = readWorkflow();
+    const jobsIdx = content.indexOf("\njobs:");
+    const preJobs = jobsIdx === -1 ? content : content.slice(0, jobsIdx);
+    assert.ok(
+      /contents:\s*read/.test(preJobs),
+      "permissions block must include 'contents: read'"
+    );
+  });
+
+  test("permissions does NOT include contents: write", () => {
+    const content = readWorkflow();
+    const jobsIdx = content.indexOf("\njobs:");
+    const preJobs = jobsIdx === -1 ? content : content.slice(0, jobsIdx);
+    assert.ok(
+      !/contents:\s*write/.test(preJobs),
+      "permissions block must NOT include 'contents: write' — read-only is required"
+    );
+  });
+
+  test("permissions does NOT include pull-requests: write", () => {
+    const content = readWorkflow();
+    const jobsIdx = content.indexOf("\njobs:");
+    const preJobs = jobsIdx === -1 ? content : content.slice(0, jobsIdx);
+    assert.ok(
+      !/pull-requests:\s*write/.test(preJobs),
+      "permissions block must NOT include 'pull-requests: write'"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Node 20 runtime
+// ---------------------------------------------------------------------------
+describe("Node runtime version", () => {
+  test("uses Node 20", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /node-version:\s*["']?20["']?/.test(content),
+      "discovered-validate.yml must use Node 20 (node-version: '20' or node-version: 20)"
+    );
+  });
+
+  test("does NOT use Node 22", () => {
+    const content = readWorkflow();
+    assert.ok(
+      !/node-version:\s*["']?22["']?/.test(content),
+      "discovered-validate.yml must NOT use Node 22 — repo convention is Node 20"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No auto-merge — workflow must never auto-merge PRs
+// ---------------------------------------------------------------------------
+describe("no auto-merge", () => {
+  test("does NOT use '--auto' flag in any gh pr merge command", () => {
+    const content = readWorkflow();
+    assert.ok(
+      !/gh\s+pr\s+merge\s+.*--auto/.test(content),
+      "discovered-validate.yml must NOT use 'gh pr merge --auto' — manual human review is required"
+    );
+  });
+
+  test("does NOT contain 'auto-merge' as a workflow action", () => {
+    const content = readWorkflow();
+    // Check for any auto-merge mechanism (--auto flag style)
+    assert.ok(
+      !/--auto\b/.test(content),
+      "discovered-validate.yml must NOT contain '--auto' flag (auto-merge is forbidden)"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHA pinning — all uses: lines must reference 40-char commit SHAs
+// ---------------------------------------------------------------------------
+describe("action SHA pinning", () => {
+  test("all 'uses:' lines reference a 40-char commit SHA", () => {
+    const content = readWorkflow();
+    const lines = content.split("\n");
+    const usesLines = lines.filter(l => /^\s+(-\s+)?uses:\s+\S/.test(l));
+
+    assert.ok(
+      usesLines.length > 0,
+      "discovered-validate.yml has no 'uses:' lines — check the file is being read correctly"
+    );
+
+    for (const line of usesLines) {
+      const pinned = /uses:\s+[a-zA-Z0-9/_.-]+@[a-f0-9]{40}(\s.*)?$/.test(line.trim());
+      assert.ok(
+        pinned,
+        `discovered-validate.yml has an unpinned action: "${line.trim()}"\n` +
+        "All 'uses:' references must use a 40-character commit SHA, not a tag or branch."
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verifier step — node tools/rule-ingestion/discovered-verify.mjs must be present
+// ---------------------------------------------------------------------------
+describe("verifier step", () => {
+  test("runs node tools/rule-ingestion/discovered-verify.mjs", () => {
+    const content = readWorkflow();
+    assert.ok(
+      /node\s+tools\/rule-ingestion\/discovered-verify\.mjs/.test(content),
+      "discovered-validate.yml must have a step that runs 'node tools/rule-ingestion/discovered-verify.mjs'"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CODEOWNERS — .github/CODEOWNERS must exist with /discovered/ entry
+// ---------------------------------------------------------------------------
+describe("CODEOWNERS file", () => {
+  test("CODEOWNERS file exists at .github/CODEOWNERS", () => {
+    assert.ok(
+      existsSync(CODEOWNERS_PATH),
+      `.github/CODEOWNERS does not exist at expected path: ${CODEOWNERS_PATH}`
+    );
+  });
+
+  test("CODEOWNERS contains /discovered/ entry", () => {
+    const content = readFileSync(CODEOWNERS_PATH, "utf8");
+    assert.ok(
+      /^\/discovered\//m.test(content),
+      "CODEOWNERS must contain a '/discovered/' ownership entry"
+    );
+  });
+});


### PR DESCRIPTION
## What

Slice 2/2 of the caps-crawler `discovered/` receiver (follows #871, merged):

- `.github/workflows/discovered-validate.yml` — PR/push-triggered validation of `discovered/*.json`: shape check + Ed25519 signature verification via `tools/rule-ingestion/discovered-verify.mjs`. `permissions: contents: read` only, Node 20, action SHAs pinned to repo convention, **no auto-merge anywhere**. No `npm ci` — the verifier is zero-dependency by design.
- `.github/CODEOWNERS` — `/discovered/ @yocreoquesi`: every artifact arrival auto-requests maintainer review (false-positive principle: human review is the gate).
- `tests/unit/discovered-workflow.test.mjs` — 25 structural assertions (triggers, permissions before `jobs:`, Node 20, pinned SHAs, no `--auto`, CODEOWNERS entry).
- `CONTEXT.md` §7/§8 + `ECOSYSTEM.md` — receiver wired into the living system map (path guard green: every named path exists on disk in this PR).

## Why

caps-spec is archived; crawler PRs dead-ended there. With #871 (schema + pubkey + verifier) plus this workflow, muga is the receiving end. Remaining step is external: repoint `caps-crawler/.github/workflows/crawl.yml` to `yocreoquesi/muga` (tracked in this issue, done right after this merges).

## Review notes

- ~180 changed lines, within budget.
- SDD verify verdict for this slice: PASS-WITH-WARNINGS, 0 critical; both warnings resolved before this PR (Node 20 convention, `npm ci` dropped).

Closes #787