### PR TITLE
feat(discovered): optional value_entropy in artifact schema + verifier (#798 PR 1/4)

### DIFF
--- a/discovered.schema.json
+++ b/discovered.schema.json
@@ -62,6 +62,11 @@
             "type": "integer",
             "description": "Number of times this parameter was observed during the run.",
             "minimum": 1
+          },
+          "value_entropy": {
+            "type": "number",
+            "description": "Mean Shannon entropy (bits) of observed URL parameter values.",
+            "minimum": 0
           }
         }
       }

--- a/tests/fixtures/discovered/artifact-a.json
+++ b/tests/fixtures/discovered/artifact-a.json
@@ -1,0 +1,25 @@
+{
+  "discovered_at": "2026-05-01T00:00:00Z",
+  "crawler_version": "abc1234",
+  "corpus": [
+    "ads.example.com",
+    "shop.example.com"
+  ],
+  "candidates": [
+    {
+      "param": "fbclid",
+      "first_seen_on": "ads.example.com",
+      "injected_by": "meta-pixel",
+      "occurrence_count": 18,
+      "value_entropy": 3.2
+    },
+    {
+      "param": "utm_source",
+      "first_seen_on": "shop.example.com",
+      "injected_by": "google-analytics",
+      "occurrence_count": 44,
+      "value_entropy": 2.8
+    }
+  ],
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab"
+}

--- a/tests/fixtures/discovered/artifact-b.json
+++ b/tests/fixtures/discovered/artifact-b.json
@@ -1,0 +1,25 @@
+{
+  "discovered_at": "2026-05-15T00:00:00Z",
+  "crawler_version": "def5678",
+  "corpus": [
+    "news.example.com",
+    "shop.example.com"
+  ],
+  "candidates": [
+    {
+      "param": "fbclid",
+      "first_seen_on": "news.example.com",
+      "injected_by": "meta-pixel",
+      "occurrence_count": 7,
+      "value_entropy": 4.1
+    },
+    {
+      "param": "utm_source",
+      "first_seen_on": "shop.example.com",
+      "injected_by": "google-analytics",
+      "occurrence_count": 31,
+      "value_entropy": 3.6
+    }
+  ],
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab"
+}

--- a/tests/fixtures/discovered/artifact-no-entropy.json
+++ b/tests/fixtures/discovered/artifact-no-entropy.json
@@ -1,0 +1,16 @@
+{
+  "discovered_at": "2026-04-01T00:00:00Z",
+  "crawler_version": "ccd9abc",
+  "corpus": [
+    "legacy.example.com"
+  ],
+  "candidates": [
+    {
+      "param": "ref",
+      "first_seen_on": "legacy.example.com",
+      "injected_by": "legacy-tracker",
+      "occurrence_count": 3
+    }
+  ],
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab"
+}

--- a/tests/unit/discovered-verify.test.mjs
+++ b/tests/unit/discovered-verify.test.mjs
@@ -445,3 +445,117 @@ describe("verifyDiscovered — shape validation is always run first", () => {
     assert.strictEqual(result.ok, false, "shape-invalid artifact must fail before signature check");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Section E — validateDiscoveredShape: optional value_entropy field (#798)
+// ---------------------------------------------------------------------------
+
+describe("validateDiscoveredShape — value_entropy optional field (spec: discovered-artifact #798)", () => {
+  test("candidate without value_entropy field is valid (backward compat)", () => {
+    const art = { ...validArtifact(), signature: "ab".repeat(64) };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true, `expected ok=true when value_entropy absent, got code=${result.code}`);
+  });
+
+  test("candidate with value_entropy: 0 is valid (minimum boundary)", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, value_entropy: 0 }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true, `expected ok=true for value_entropy=0, got code=${result.code}`);
+  });
+
+  test("candidate with value_entropy: 4.2 is valid", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, value_entropy: 4.2 }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true, `expected ok=true for value_entropy=4.2, got code=${result.code}`);
+  });
+
+  test("candidate with value_entropy: -1 fails (below minimum 0)", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, value_entropy: -1 }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "expected ok=false for negative value_entropy");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_VALUE_ENTROPY_INVALID");
+  });
+
+  test("candidate with value_entropy: -0.0001 fails (just below 0)", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, value_entropy: -0.0001 }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "expected ok=false for value_entropy just below 0");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_VALUE_ENTROPY_INVALID");
+  });
+
+  test("candidate with value_entropy: 'high' (string) fails with ERR_CANDIDATE_0_VALUE_ENTROPY_INVALID", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, value_entropy: "high" }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "expected ok=false for string value_entropy");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_VALUE_ENTROPY_INVALID");
+  });
+
+  test("candidate with value_entropy: NaN fails (not a finite number)", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, value_entropy: NaN }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "expected ok=false for NaN value_entropy");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_VALUE_ENTROPY_INVALID");
+  });
+
+  test("candidate with value_entropy: Infinity fails (not a finite number)", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [{ ...VALID_CANDIDATE, value_entropy: Infinity }],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "expected ok=false for Infinity value_entropy");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_0_VALUE_ENTROPY_INVALID");
+  });
+
+  test("second candidate invalid value_entropy reports correct index", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [
+        { ...VALID_CANDIDATE, value_entropy: 3.5 },
+        { ...VALID_CANDIDATE, param: "utm_source", value_entropy: NaN },
+      ],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, false, "expected ok=false when second candidate has NaN value_entropy");
+    assert.strictEqual(result.code, "ERR_CANDIDATE_1_VALUE_ENTROPY_INVALID");
+  });
+
+  test("artifact with all candidates having valid value_entropy passes", () => {
+    const art = {
+      ...validArtifact(),
+      signature: "ab".repeat(64),
+      candidates: [
+        { ...VALID_CANDIDATE, value_entropy: 3.5 },
+        { ...VALID_CANDIDATE, param: "utm_source", value_entropy: 4.8 },
+      ],
+    };
+    const result = validateDiscoveredShape(art);
+    assert.strictEqual(result.ok, true, `expected ok=true for all valid value_entropy, got code=${result.code}`);
+  });
+});

--- a/tools/rule-ingestion/discovered-verify.mjs
+++ b/tools/rule-ingestion/discovered-verify.mjs
@@ -60,8 +60,9 @@ const TOP_LEVEL_ALLOWED = new Set(TOP_LEVEL_REQUIRED);
 // Required fields within each candidate object.
 const CANDIDATE_REQUIRED = ["first_seen_on", "injected_by", "occurrence_count", "param"];
 
-// Allowed candidate fields (same set — additionalProperties: false).
-const CANDIDATE_ALLOWED = new Set(CANDIDATE_REQUIRED);
+// Allowed candidate fields. Includes optional fields not in CANDIDATE_REQUIRED.
+// additionalProperties: false is enforced by checking every key against this set.
+const CANDIDATE_ALLOWED = new Set([...CANDIDATE_REQUIRED, "value_entropy"]);
 
 // ---------------------------------------------------------------------------
 // sortKeys — recursive alphabetical key-sort
@@ -235,6 +236,19 @@ export function validateDiscoveredShape(obj) {
       !HOSTNAME_LOWERCASE_RE.test(candidate.first_seen_on)
     ) {
       return { ok: false, code: `ERR_CANDIDATE_${i}_FIRST_SEEN_ON_CASE` };
+    }
+
+    // value_entropy: optional field — presence-then-type guard.
+    // When present: must be a finite number >= 0.
+    // Absence is valid (backward compat with artifacts from older crawler versions).
+    if ("value_entropy" in candidate) {
+      if (
+        typeof candidate.value_entropy !== "number" ||
+        !Number.isFinite(candidate.value_entropy) ||
+        candidate.value_entropy < 0
+      ) {
+        return { ok: false, code: `ERR_CANDIDATE_${i}_VALUE_ENTROPY_INVALID` };
+      }
     }
   }
 


### PR DESCRIPTION
PR 1/4 of the GATE 2 heuristic-arms chain (stacked-to-main). Part of #798.

## What

- `discovered.schema.json`: candidates gain an OPTIONAL `value_entropy` (number ≥ 0) — mean Shannon entropy in bits of the param's observed values, computed crawler-side. Never raw values.
- `discovered-verify.mjs`: accepts the optional field with a presence-then-type guard (finite number ≥ 0 → `ERR_CANDIDATE_i_VALUE_ENTROPY_INVALID` otherwise). Schema/validator parity maintained.
- Fixtures under `tests/fixtures/discovered/` for the upcoming enrichment tests (PR 2a).

## Why

GATE 2's entropy + CSF arms (#798) need ingestion-time data. The crawler is the only place param VALUES exist; it will emit the score (PR 4, caps-crawler) once this schema tolerance lands. Artifacts WITHOUT the field remain fully valid — no version bump, no deploy-order hazard.

## Chain

PR 2a (enrichment module) → PR 2b (pipeline wiring) → PR 3 (gate three-arm OR + ADR) → PR 4 (caps-crawler emission).

Part of #798