### PR TITLE
feat(ingestion): enrich-candidates — CSF + entropy aggregation from discovered/ (#798 PR 2a/4)

### DIFF
--- a/tests/unit/enrich-candidates.test.mjs
+++ b/tests/unit/enrich-candidates.test.mjs
@@ -129,6 +129,37 @@ describe("aggregateDiscovered — CSF deduplication and entropy accumulation", (
     assert.strictEqual(entry.entCount, 0, "entCount must be 0 when no value_entropy field present");
   });
 
+  test("anti-poison: param present in two artifacts, value_entropy in only one — mean uses only the present value", () => {
+    const withEntropy = {
+      discovered_at: "2026-05-01T00:00:00Z",
+      crawler_version: "abc1234",
+      corpus: ["one.example.com"],
+      candidates: [
+        { param: "track_id", first_seen_on: "one.example.com", injected_by: "wrapper-x", occurrence_count: 2, value_entropy: 3.8 },
+      ],
+      signature: "ab".repeat(64),
+    };
+    const withoutEntropy = {
+      discovered_at: "2026-05-08T00:00:00Z",
+      crawler_version: "def5678",
+      corpus: ["two.example.com"],
+      candidates: [
+        { param: "track_id", first_seen_on: "two.example.com", injected_by: "wrapper-y", occurrence_count: 1 },
+      ],
+      signature: "cd".repeat(64),
+    };
+    const map = aggregateDiscovered([withEntropy, withoutEntropy]);
+
+    const entry = map.get("track_id");
+    assert.ok(entry, "track_id entry must exist");
+    assert.strictEqual(entry.hosts.size, 2, "CSF must count both hostnames");
+    assert.strictEqual(entry.entCount, 1, "entropy count must ignore the artifact lacking value_entropy");
+    assert.ok(
+      Math.abs(entry.entSum - 3.8) < 1e-9,
+      `mean source must be 3.8 alone — the field-less mention must not halve it (entSum ${entry.entSum})`
+    );
+  });
+
   test("empty artifacts array returns empty Map without throwing", () => {
     assert.doesNotThrow(() => {
       const map = aggregateDiscovered([]);

--- a/tests/unit/enrich-candidates.test.mjs
+++ b/tests/unit/enrich-candidates.test.mjs
@@ -1,0 +1,417 @@
+/**
+ * MUGA — Behavioral unit tests for tools/rule-ingestion/enrich-candidates.mjs (#798)
+ *
+ * Covers spec Domain candidate-enrichment (all 4 requirements) and Domain tests:
+ *   - aggregateDiscovered: CSF deduplication, entropy accumulation, empty artifacts
+ *   - enrichCandidates: entropy mean, crossSiteFrequency, null passthrough, absent param
+ *   - readVerifiedArtifacts: injected verify stub (happy path, sig-fail, JSON-parse-fail)
+ *
+ * Fixture values (computed from tests/fixtures/discovered/):
+ *   artifact-a.json:
+ *     fbclid  → first_seen_on: "ads.example.com",  value_entropy: 3.2
+ *     utm_source → first_seen_on: "shop.example.com", value_entropy: 2.8
+ *   artifact-b.json:
+ *     fbclid  → first_seen_on: "news.example.com", value_entropy: 4.1
+ *     utm_source → first_seen_on: "shop.example.com", value_entropy: 3.6
+ *   artifact-no-entropy.json:
+ *     ref     → first_seen_on: "legacy.example.com", no value_entropy
+ *
+ * Expected aggregated values:
+ *   fbclid:     CSF = 2 (ads.example.com + news.example.com), entropy = (3.2 + 4.1) / 2 = 3.65
+ *   utm_source: CSF = 1 (shop.example.com deduplicated), entropy = (2.8 + 3.6) / 2 = 3.2
+ *   ref:        CSF = 1 (legacy.example.com), entropy = null (no value_entropy in artifact)
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+import {
+  aggregateDiscovered,
+  enrichCandidates,
+  readVerifiedArtifacts,
+} from "../../tools/rule-ingestion/enrich-candidates.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Fixture loading helpers
+// ---------------------------------------------------------------------------
+
+const FIXTURES_DIR = join(__dirname, "../fixtures/discovered");
+
+function loadFixture(name) {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), "utf8"));
+}
+
+/** Create a fresh temp directory for each readVerifiedArtifacts test */
+function makeTmpDir() {
+  const d = join(
+    tmpdir(),
+    `muga-enrich-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+/** Write a JSON file into a temp dir */
+function writeTmpJson(dir, name, obj) {
+  writeFileSync(join(dir, name), JSON.stringify(obj, null, 2) + "\n", "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Section A — aggregateDiscovered (pure function)
+// ---------------------------------------------------------------------------
+
+describe("aggregateDiscovered — CSF deduplication and entropy accumulation", () => {
+  test("returns a Map with an entry for each param seen across artifacts", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const map = aggregateDiscovered([artifactA, artifactB]);
+
+    assert.ok(map instanceof Map, "aggregateDiscovered must return a Map");
+    assert.ok(map.has("fbclid"), "Map must have fbclid entry");
+    assert.ok(map.has("utm_source"), "Map must have utm_source entry");
+  });
+
+  test("fbclid: CSF = 2 — distinct hostnames across artifact-a and artifact-b", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const map = aggregateDiscovered([artifactA, artifactB]);
+
+    const entry = map.get("fbclid");
+    assert.ok(entry, "fbclid entry must exist");
+    assert.ok(entry.hosts instanceof Set, "entry.hosts must be a Set");
+    assert.strictEqual(entry.hosts.size, 2, "fbclid must have CSF 2 (ads.example.com + news.example.com)");
+  });
+
+  test("utm_source: CSF = 1 — shop.example.com deduplicated across both artifacts", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const map = aggregateDiscovered([artifactA, artifactB]);
+
+    const entry = map.get("utm_source");
+    assert.ok(entry, "utm_source entry must exist");
+    assert.strictEqual(
+      entry.hosts.size,
+      1,
+      "utm_source must have CSF 1 (shop.example.com appears in both artifacts but is deduplicated)"
+    );
+  });
+
+  test("fbclid: entropy accumulator sums 3.2 + 4.1 with entCount = 2", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const map = aggregateDiscovered([artifactA, artifactB]);
+
+    const entry = map.get("fbclid");
+    assert.ok(entry, "fbclid entry must exist");
+    assert.strictEqual(entry.entCount, 2, "entCount must be 2 (both artifacts have value_entropy)");
+    assert.ok(
+      Math.abs(entry.entSum - (3.2 + 4.1)) < 1e-9,
+      `entSum must equal 3.2 + 4.1 = 7.3, got ${entry.entSum}`
+    );
+  });
+
+  test("artifact without value_entropy: entCount stays 0 for that param", () => {
+    const noEntropy = loadFixture("artifact-no-entropy.json");
+    const map = aggregateDiscovered([noEntropy]);
+
+    const entry = map.get("ref");
+    assert.ok(entry, "ref entry must exist");
+    assert.strictEqual(entry.entCount, 0, "entCount must be 0 when no value_entropy field present");
+  });
+
+  test("empty artifacts array returns empty Map without throwing", () => {
+    assert.doesNotThrow(() => {
+      const map = aggregateDiscovered([]);
+      assert.ok(map instanceof Map, "must return a Map");
+      assert.strictEqual(map.size, 0, "Map must be empty");
+    });
+  });
+
+  test("artifacts with empty candidates arrays produce no entries", () => {
+    const emptyArtifact = {
+      discovered_at: "2026-05-01T00:00:00Z",
+      crawler_version: "abc1234",
+      corpus: ["example.com"],
+      candidates: [],
+      signature: "ab".repeat(64),
+    };
+    const map = aggregateDiscovered([emptyArtifact]);
+    assert.strictEqual(map.size, 0, "Map must be empty for artifact with no candidates");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section B — enrichCandidates (pure function)
+// ---------------------------------------------------------------------------
+
+describe("enrichCandidates — entropy mean and crossSiteFrequency from aggregate", () => {
+  test("fbclid: entropy = 3.65 (mean of 3.2 and 4.1)", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const artifacts = [artifactA, artifactB];
+    const candidates = [
+      { param: "fbclid", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, artifacts);
+
+    assert.strictEqual(enriched.length, 1, "enriched must have same length as input");
+    const c = enriched[0];
+    assert.ok(
+      Math.abs(c.entropy - 3.65) < 1e-9,
+      `fbclid entropy must be 3.65, got ${c.entropy}`
+    );
+  });
+
+  test("utm_source: crossSiteFrequency = 1 (deduplicated)", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const artifacts = [artifactA, artifactB];
+    const candidates = [
+      { param: "utm_source", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, artifacts);
+
+    assert.strictEqual(enriched[0].crossSiteFrequency, 1, "utm_source CSF must be 1 (deduped)");
+  });
+
+  test("utm_source: entropy = 3.2 (mean of 2.8 and 3.6)", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const artifacts = [artifactA, artifactB];
+    const candidates = [
+      { param: "utm_source", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, artifacts);
+
+    assert.ok(
+      Math.abs(enriched[0].entropy - 3.2) < 1e-9,
+      `utm_source entropy must be 3.2, got ${enriched[0].entropy}`
+    );
+  });
+
+  test("ref: entropy = null when no value_entropy in any artifact mentioning it", () => {
+    const noEntropy = loadFixture("artifact-no-entropy.json");
+    const artifacts = [noEntropy];
+    const candidates = [
+      { param: "ref", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, artifacts);
+
+    assert.strictEqual(enriched[0].entropy, null, "entropy must be null when no value_entropy present");
+  });
+
+  test("ref: crossSiteFrequency = 1 even without value_entropy", () => {
+    const noEntropy = loadFixture("artifact-no-entropy.json");
+    const artifacts = [noEntropy];
+    const candidates = [
+      { param: "ref", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, artifacts);
+
+    assert.strictEqual(enriched[0].crossSiteFrequency, 1, "CSF must still be 1 for ref even without value_entropy");
+  });
+
+  test("param absent from all artifacts → entropy: null, crossSiteFrequency: null", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifacts = [artifactA];
+    const candidates = [
+      { param: "unknown_param_xyz", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, artifacts);
+
+    assert.strictEqual(enriched[0].entropy, null, "entropy must be null for absent param");
+    assert.strictEqual(enriched[0].crossSiteFrequency, null, "crossSiteFrequency must be null for absent param");
+  });
+
+  test("empty artifacts array → all candidates remain null/null", () => {
+    const candidates = [
+      { param: "fbclid", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, []);
+
+    assert.strictEqual(enriched[0].entropy, null, "entropy must be null with empty artifacts");
+    assert.strictEqual(enriched[0].crossSiteFrequency, null, "crossSiteFrequency must be null with empty artifacts");
+  });
+
+  test("returns a new array — does not mutate original candidates", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const original = { param: "fbclid", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" };
+    const candidates = [original];
+    const enriched = enrichCandidates(candidates, [artifactA]);
+
+    assert.notStrictEqual(enriched, candidates, "must return a new array");
+    assert.notStrictEqual(enriched[0], original, "must return new candidate objects");
+    assert.strictEqual(original.entropy, null, "original must not be mutated");
+    assert.strictEqual(original.crossSiteFrequency, null, "original must not be mutated");
+  });
+
+  test("multiple candidates are all enriched independently", () => {
+    const artifactA = loadFixture("artifact-a.json");
+    const artifactB = loadFixture("artifact-b.json");
+    const artifacts = [artifactA, artifactB];
+    const candidates = [
+      { param: "fbclid", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+      { param: "utm_source", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null, firstSeenAt: "2026-01-01T00:00:00Z" },
+    ];
+    const enriched = enrichCandidates(candidates, artifacts);
+
+    assert.strictEqual(enriched.length, 2);
+    assert.ok(enriched[0].entropy !== null, "fbclid entropy must be populated");
+    assert.ok(enriched[1].entropy !== null, "utm_source entropy must be populated");
+    assert.strictEqual(enriched[0].crossSiteFrequency, 2, "fbclid CSF must be 2");
+    assert.strictEqual(enriched[1].crossSiteFrequency, 1, "utm_source CSF must be 1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section C — readVerifiedArtifacts (thin I/O wrapper)
+// ---------------------------------------------------------------------------
+
+describe("readVerifiedArtifacts — thin fs wrapper with injectable verify", () => {
+  test("happy path: reads all JSON files and returns verified artifacts", () => {
+    const dir = makeTmpDir();
+    const artifact = {
+      discovered_at: "2026-05-01T00:00:00Z",
+      crawler_version: "abc1234",
+      corpus: ["example.com"],
+      candidates: [
+        {
+          param: "fbclid",
+          first_seen_on: "example.com",
+          injected_by: "meta-pixel",
+          occurrence_count: 5,
+          value_entropy: 2.5,
+        },
+      ],
+      signature: "ab".repeat(64),
+    };
+    writeTmpJson(dir, "artifact-ok.json", artifact);
+
+    // Inject a verify stub that always succeeds
+    const verifyStub = () => ({ ok: true, code: "OK" });
+    const results = readVerifiedArtifacts(dir, { verify: verifyStub });
+
+    assert.ok(Array.isArray(results), "must return an array");
+    assert.strictEqual(results.length, 1, "must return 1 artifact");
+    assert.strictEqual(results[0].crawler_version, "abc1234");
+  });
+
+  test("empty dir returns empty array without throwing", () => {
+    const dir = makeTmpDir();
+    const verifyStub = () => ({ ok: true, code: "OK" });
+
+    assert.doesNotThrow(() => {
+      const results = readVerifiedArtifacts(dir, { verify: verifyStub });
+      assert.deepStrictEqual(results, [], "must return empty array for empty dir");
+    });
+  });
+
+  test("non-JSON files are ignored (only *.json files are read)", () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "readme.txt"), "ignored", "utf8");
+    writeFileSync(join(dir, "notes.md"), "also ignored", "utf8");
+
+    const verifyStub = () => ({ ok: true, code: "OK" });
+    const results = readVerifiedArtifacts(dir, { verify: verifyStub });
+    assert.deepStrictEqual(results, []);
+  });
+
+  test("JSON parse failure: warns and skips the file (does NOT throw or abort)", () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "malformed.json"), "{ invalid json !!!", "utf8");
+
+    const verifyStub = () => ({ ok: true, code: "OK" });
+
+    // Should not throw — malformed JSON must be skipped with a warning
+    assert.doesNotThrow(() => {
+      const results = readVerifiedArtifacts(dir, { verify: verifyStub });
+      assert.deepStrictEqual(results, [], "malformed file must be skipped → empty result");
+    });
+  });
+
+  test("verify failure (sig tamper): throws CliError (fail-closed, exit 3)", () => {
+    const dir = makeTmpDir();
+    const artifact = {
+      discovered_at: "2026-05-01T00:00:00Z",
+      crawler_version: "abc1234",
+      corpus: ["example.com"],
+      candidates: [],
+      signature: "ab".repeat(64),
+    };
+    writeTmpJson(dir, "tampered.json", artifact);
+
+    // Inject a verify stub that always fails (simulates signature mismatch)
+    const verifyStub = () => ({ ok: false, code: "ERR_SIGNATURE_INVALID" });
+
+    assert.throws(
+      () => readVerifiedArtifacts(dir, { verify: verifyStub }),
+      (err) => {
+        assert.ok(err instanceof Error, "must throw an Error");
+        assert.ok(
+          err.exitCode === 3 || (err.message && err.message.includes("3")),
+          `CliError must have exitCode 3 or mention exit 3, got exitCode=${err.exitCode}`
+        );
+        return true;
+      },
+      "readVerifiedArtifacts must throw (fail-closed) on verify failure"
+    );
+  });
+
+  test("one valid + one tampered: throws on tampered before processing continues", () => {
+    const dir = makeTmpDir();
+    const validArtifact = {
+      discovered_at: "2026-05-01T00:00:00Z",
+      crawler_version: "abc1234",
+      corpus: ["example.com"],
+      candidates: [],
+      signature: "ab".repeat(64),
+    };
+    writeTmpJson(dir, "valid.json", validArtifact);
+    writeTmpJson(dir, "tampered.json", { ...validArtifact, crawler_version: "bad0000" });
+
+    const verifyStub = (artifact) => {
+      // Fail on the tampered artifact
+      if (artifact.crawler_version === "bad0000") {
+        return { ok: false, code: "ERR_SIGNATURE_INVALID" };
+      }
+      return { ok: true, code: "OK" };
+    };
+
+    assert.throws(
+      () => readVerifiedArtifacts(dir, { verify: verifyStub }),
+      /exit.*3|exitCode.*3/i,
+      "must throw CliError on any verify failure"
+    );
+  });
+
+  test("one valid + one malformed JSON: returns valid, skips malformed (no throw)", () => {
+    const dir = makeTmpDir();
+    const validArtifact = {
+      discovered_at: "2026-05-01T00:00:00Z",
+      crawler_version: "abc1234",
+      corpus: ["good.example.com"],
+      candidates: [],
+      signature: "ab".repeat(64),
+    };
+    writeTmpJson(dir, "valid.json", validArtifact);
+    writeFileSync(join(dir, "bad.json"), "not json!!!", "utf8");
+
+    const verifyStub = () => ({ ok: true, code: "OK" });
+
+    assert.doesNotThrow(() => {
+      const results = readVerifiedArtifacts(dir, { verify: verifyStub });
+      assert.strictEqual(results.length, 1, "must return only the valid artifact");
+      assert.strictEqual(results[0].corpus[0], "good.example.com");
+    });
+  });
+});

--- a/tools/rule-ingestion/enrich-candidates.mjs
+++ b/tools/rule-ingestion/enrich-candidates.mjs
@@ -1,0 +1,226 @@
+/** MUGA: Enrichment stage — aggregate discovered artifacts into per-param CSF and entropy (#798) */
+
+/**
+ * Pure enrichment stage that populates `crossSiteFrequency` and `entropy` on
+ * candidate objects before the gate stack runs.
+ *
+ * Architecture (D1 — pure core + thin I/O wrapper):
+ *   aggregateDiscovered(artifacts) → Map<param, {hosts, entSum, entCount}>
+ *   enrichCandidates(candidates, artifacts) → new candidates[] (PURE)
+ *   readVerifiedArtifacts(discoveredDir, {verify}) → artifacts[] (thin fs wrapper)
+ *
+ * `enrichCandidates` accepts the raw artifacts array so callers can compose
+ * aggregation and enrichment in tests without touching the filesystem.
+ *
+ * Error semantics (D2 — fail-closed):
+ *   JSON parse error → console.warn + skip (enrichment continues, spec §Malformed artifact skipped)
+ *   verifyDiscovered failure → CliError exit 3 (fail-closed, defense in depth)
+ *
+ * Zero npm dependencies — node:fs and node:path only.
+ *
+ * Named exports only, no default export (project convention):
+ *   aggregateDiscovered(artifacts)
+ *   enrichCandidates(candidates, artifacts)
+ *   readVerifiedArtifacts(discoveredDir, { verify })
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { verifyDiscovered } from "./discovered-verify.mjs";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** @type {string} Module prefix for console warnings (matches project style). */
+const LOG_PREFIX = "[enrich-candidates]";
+
+// ---------------------------------------------------------------------------
+// CliError — mirrors orchestrate-cli.mjs pattern (no shared helper — per ADR)
+// ---------------------------------------------------------------------------
+
+/**
+ * CLI-boundary error carrying a numeric exit code.
+ * Exit 3 is the canonical I/O / integrity error code (mirrors orchestrate-cli.mjs).
+ *
+ * @extends {Error}
+ */
+class CliError extends Error {
+  /**
+   * @param {string} message Human-readable error message.
+   * @param {number} exitCode Process exit code (3 for integrity / I/O errors).
+   */
+  constructor(message, exitCode) {
+    super(message);
+    this.name = "CliError";
+    this.exitCode = exitCode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// aggregateDiscovered — pure aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregates a list of parsed discovered artifacts into a per-param lookup map.
+ *
+ * For each candidate across all artifacts:
+ *   - `hosts` accumulates distinct `first_seen_on` hostnames (Set → CSF = hosts.size).
+ *   - `entSum` and `entCount` accumulate `value_entropy` values so the caller can
+ *     compute the arithmetic mean (entCount === 0 → entropy is null for that param).
+ *
+ * @param {object[]} artifacts - Array of parsed (but not necessarily signature-verified)
+ *   artifact objects. Each must have a `candidates` array.
+ * @returns {Map<string, {hosts: Set<string>, entSum: number, entCount: number}>}
+ *   Per-param aggregate. Empty Map when `artifacts` is empty or contains no candidates.
+ */
+export function aggregateDiscovered(artifacts) {
+  /** @type {Map<string, {hosts: Set<string>, entSum: number, entCount: number}>} */
+  const map = new Map();
+
+  for (const artifact of artifacts) {
+    const candidates = artifact.candidates;
+    if (!Array.isArray(candidates)) {
+      continue;
+    }
+
+    for (const candidate of candidates) {
+      const param = candidate.param;
+      if (!param) {
+        continue;
+      }
+
+      let entry = map.get(param);
+      if (!entry) {
+        entry = { hosts: new Set(), entSum: 0, entCount: 0 };
+        map.set(param, entry);
+      }
+
+      // CSF: accumulate distinct first_seen_on hostnames (Set deduplicates automatically).
+      if (candidate.first_seen_on) {
+        entry.hosts.add(candidate.first_seen_on);
+      }
+
+      // Entropy: accumulate only when value_entropy is a finite number (field is optional).
+      if (
+        "value_entropy" in candidate &&
+        typeof candidate.value_entropy === "number" &&
+        Number.isFinite(candidate.value_entropy)
+      ) {
+        entry.entSum += candidate.value_entropy;
+        entry.entCount += 1;
+      }
+    }
+  }
+
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// enrichCandidates — PURE transform
+// ---------------------------------------------------------------------------
+
+/**
+ * Produces a new candidates array with `entropy` and `crossSiteFrequency` populated
+ * from the aggregated artifact map.
+ *
+ * Rules (spec §Entropy passthrough, §CSF semantics):
+ *   - entropy     = arithmetic mean of value_entropy across artifacts for this param;
+ *                   null when no artifact mentioning the param carries value_entropy.
+ *   - crossSiteFrequency = count of distinct first_seen_on hostnames for this param;
+ *                          null when the param is absent from all artifacts.
+ *
+ * This function is PURE: it never reads the filesystem. Pass the artifacts array
+ * directly (obtained from readVerifiedArtifacts or from test fixtures).
+ *
+ * @param {object[]} candidates - Pipeline candidate objects (makeCandidate shape).
+ * @param {object[]} artifacts  - Parsed artifact objects to aggregate.
+ * @returns {object[]} New candidates array (never mutates input).
+ */
+export function enrichCandidates(candidates, artifacts) {
+  const aggregate = aggregateDiscovered(artifacts);
+
+  return candidates.map((candidate) => {
+    const entry = aggregate.get(candidate.param);
+
+    let entropy = null;
+    let crossSiteFrequency = null;
+
+    if (entry) {
+      // crossSiteFrequency: count of distinct hostnames. null when 0 (should not occur
+      // if the param is in the map, but guard defensively).
+      crossSiteFrequency = entry.hosts.size > 0 ? entry.hosts.size : null;
+
+      // entropy: mean of value_entropy values; null when no artifact carried the field.
+      entropy = entry.entCount > 0 ? entry.entSum / entry.entCount : null;
+    }
+
+    return { ...candidate, entropy, crossSiteFrequency };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// readVerifiedArtifacts — thin I/O wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads every `*.json` file in `discoveredDir`, verifies each artifact, and
+ * returns the successfully verified artifacts as a parsed array.
+ *
+ * Error semantics (D2 — fail-closed):
+ *   JSON parse error  → logs a warning and skips the file (enrichment continues).
+ *   verify() failure  → throws CliError(exit 3) — fail-closed for integrity protection.
+ *
+ * The `verify` option is injectable for tests (avoids Ed25519 key setup in unit tests).
+ * Default: verifyDiscovered from discovered-verify.mjs.
+ *
+ * @param {string} discoveredDir - Directory path to scan for `*.json` files.
+ * @param {{ verify?: function }} [opts] - Optional overrides.
+ * @param {function} [opts.verify=verifyDiscovered] - Verification function.
+ *   Signature: (artifact: object) => { ok: boolean, code: string }
+ * @returns {object[]} Array of verified artifact objects. Empty array when no files found.
+ * @throws {CliError} exitCode 3 when any artifact fails verification (signature tamper).
+ */
+export function readVerifiedArtifacts(discoveredDir, { verify = verifyDiscovered } = {}) {
+  /** @type {string[]} */
+  let files;
+
+  files = readdirSync(discoveredDir).filter((f) => f.endsWith(".json"));
+
+  if (files.length === 0) {
+    return [];
+  }
+
+  /** @type {object[]} */
+  const results = [];
+
+  for (const file of files) {
+    const filePath = join(discoveredDir, file);
+
+    // Step 1: Parse JSON — warn + skip on malformed input (spec §Malformed artifact skipped).
+    let artifact;
+    try {
+      artifact = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch (err) {
+      console.warn(
+        `${LOG_PREFIX} WARN: Skipping ${file} — JSON parse error: ${err.message}`
+      );
+      continue;
+    }
+
+    // Step 2: Verify signature and shape — fail-closed on any failure (D2).
+    const result = verify(artifact);
+    if (!result.ok) {
+      throw new CliError(
+        `${LOG_PREFIX} ERROR: Artifact ${file} failed verification (${result.code}). ` +
+          `Aborting enrichment — possible tampering detected. Exit 3.`,
+        3
+      );
+    }
+
+    results.push(artifact);
+  }
+
+  return results;
+}

--- a/tools/rule-ingestion/enrich-candidates.mjs
+++ b/tools/rule-ingestion/enrich-candidates.mjs
@@ -176,7 +176,7 @@ export function enrichCandidates(candidates, artifacts) {
  * Default: verifyDiscovered from discovered-verify.mjs.
  *
  * @param {string} discoveredDir - Directory path to scan for `*.json` files.
- * @param {{ verify?: function }} [opts] - Optional overrides.
+ * @param {object} [opts] - Optional overrides.
  * @param {function} [opts.verify=verifyDiscovered] - Verification function.
  *   Signature: (artifact: object) => { ok: boolean, code: string }
  * @returns {object[]} Array of verified artifact objects. Empty array when no files found.


### PR DESCRIPTION
PR 2a/4 of the GATE 2 heuristic-arms chain (stacked-to-main, follows #874). Part of #798.

## What

New `tools/rule-ingestion/enrich-candidates.mjs`:
- `aggregateDiscovered(artifacts)` — per-param aggregate: CSF = distinct `first_seen_on` hostnames deduped ACROSS artifacts; entropy accumulator over optional `value_entropy`.
- `enrichCandidates(candidates, aggregate)` — pure, returns a NEW array with `entropy` (mean) and `crossSiteFrequency` populated; `null` (not 0) when no data — the gate null-skips.
- `readVerifiedArtifacts(dir, { verify })` — injectable seam defaulting to the real `verifyDiscovered`; signature failure fails CLOSED (CliError exit 3), JSON parse error warns + skips.

24 behavioral tests including CSF cross-file dedupe, anti-poison entropy mean (field-less mentions don't halve it), and fail-closed I/O.

## size:exception

~674 changed lines, but 448 are the test file and the module + its tests are one irreducible work unit (tests-with-code). Productive source under review: 226 lines. Adversarial SDD verify: **PASS, 0 critical** (the 1 warning — a missing anti-poison test — was closed in ee3b13d).

## Chain

#874 (schema, merged) → **this** → PR 2b (pipeline wiring) → PR 3 (gate three-arm OR) → PR 4 (caps-crawler emission).

Part of #798