### PR TITLE
feat(gate2): three-arm OR — entropy + cross-site-frequency corroboration arms (#798 PR 3/4)

### DIFF
--- a/docs/adr/0005-rule-scaling-pipeline.md
+++ b/docs/adr/0005-rule-scaling-pipeline.md
@@ -113,7 +113,6 @@ The pipeline lives in `tools/rule-ingestion/` as build tooling that runs in CI a
 
 **Neutral:**
 
-- The `entropy` and `crossSiteFrequency` candidate fields are currently `null` — placeholders for the GATE 2 heuristic arms tracked in [#798](https://github.com/yocreoquesi/muga/issues/798). Today only `signals.length` drives corroboration. This ADR documents the shipped two-source floor; the heuristic arms are a future deepening, not a change to the architecture here.
 - Two upstream sources are enabled today (AdGuard, ClearURLs). Brave, uBlock/uAssets, and Neat URL are recorded in the ledger as GPL/MPL-compatible candidates but are not wired. Adding one follows the documented `PROVENANCE.md` checklist; the architecture does not change.
 
 ## Verification
@@ -127,4 +126,47 @@ The architecture this ADR documents shipped and is verified by the implementatio
 5. **No silent caps** — the review-surface formatter tests assert per-adapter and merged stats, gate-rejection breakdowns, and promote skips all render, with null-safe fallback and no path leakage.
 6. **End-to-end governance** — `auto-ingest-rules.yml` ran the full inline gate suite and squash-merged the v2.3.0 ingestion PRs (#806–#809); the merged `params.json` is exactly the artifact the gates passed.
 
-This ADR is **Accepted** as the standing record of the architecture. A follow-up ADR will be filed only if a future change alters the gate stack's structure, the clean-room posture, or the in-repo build-tooling decision — for example, if the GATE 2 heuristic arms ([#798](https://github.com/yocreoquesi/muga/issues/798)) change corroboration from a discrete signal count to a scored model, or if a source is added that requires a new legal posture.
+This ADR is **Accepted** as the standing record of the architecture. A follow-up ADR will be filed only if a future change alters the gate stack's structure, the clean-room posture, or the in-repo build-tooling decision.
+
+## Amendment — GATE 2 heuristic arms (#798)
+
+**Date**: 2026-06-10
+**Trigger**: This ADR's own amendment clause — the GATE 2 corroboration predicate changed from a single-arm signal count to a three-arm OR structure, which is the structural gate-stack change the final paragraph above identified as amendment-worthy.
+
+### What changed
+
+GATE 2 (`corroboration-gate`) moved from a signal-count-only predicate to a **three-arm OR predicate**:
+
+```
+pass iff:
+  signals.length >= MIN_SIGNALS (arm 1 — unchanged)
+  OR (entropy !== null && entropy >= ENTROPY_FLOOR)    (arm 2 — new)
+  OR (crossSiteFrequency !== null && csf >= CSF_FLOOR) (arm 3 — new)
+```
+
+Exported constants:
+- `ENTROPY_FLOOR = 4.0` — minimum mean Shannon entropy (bits) of observed URL parameter values.
+- `CSF_FLOOR = 3` — minimum count of distinct `first_seen_on` hostnames across all verified `discovered/` artifacts.
+- Both are overridable at call-site via `gateOpts.corroborationGate.{ entropyFloor, csfFloor }`, mirroring the existing `minSignals` override pattern.
+
+Accepted results now carry a `passedArm` field (`"signals"` | `"entropy"` | `"csf"`) identifying which arm caused acceptance. When multiple arms qualify, the first in the precedence order above is recorded.
+
+Rejected results carry an extended `detail` object with all evaluated arm values (`signalCount`, `minSignals`, `entropy`, `entropyFloor`, `crossSiteFrequency`, `csfFloor`) for quarantine-report transparency.
+
+### Null-skip guard preserves prior behavior
+
+A `null` value on arm 2 or arm 3 causes that arm to be **skipped entirely** — it does not count as failing. Candidates where enrichment produced no data (entropy/CSF both null) fall through to the signal-count arm exactly as they did before this change. No behavioral regression for the un-enriched case.
+
+### Heuristic arms are analytical scores, not signal sources
+
+`entropy` and `crossSiteFrequency` are **analytical aggregates** derived from caps-crawler `discovered/` artifact metadata, populated by `enrich-candidates.mjs` between ingest and orchestration. They are **NOT** entries in `signals[]`. caps-crawler is **NOT** a corroboration source under the independence invariant (#821). `signals[]` semantics are unchanged — each entry must still come from a DISTINCT, SEPARATELY MAINTAINED upstream adapter. See `tools/rule-ingestion/PROVENANCE.md`.
+
+### Gate-stack structure
+
+The gate order, count, and fail-safe postures documented in this ADR are **unchanged**. GATE 2 still rejects malformed/uncorroborated candidates (reject posture). The change is additive: two new acceptance paths within the same gate, not a new gate.
+
+### Verification
+
+- T-06 in `tests/unit/corroboration-gate.test.mjs` was rewritten to assert that entropy arm acceptance is active (single signal + `entropy >= 4.0` → `rejected: false, passedArm: "entropy"`).
+- New arm tests cover: each arm passes alone, null-skip guards, below-floor rejection, floor overrides via opts, and multi-arm precedence ordering.
+- Full suite (`npm test`) passes with no regressions.

--- a/tests/unit/corroboration-gate.test.mjs
+++ b/tests/unit/corroboration-gate.test.mjs
@@ -223,6 +223,14 @@ describe("checkCorroborationGate — CSF arm (#798)", () => {
     assert.equal(result.passedArm, "csf");
   });
 
+  test("entropy present but below floor + CSF at floor → accepted with passedArm 'csf'", () => {
+    // The entropy arm FAILING (not just null-skipping) must not block the CSF arm.
+    const candidate = { signals: ["x"], entropy: 2.0, crossSiteFrequency: 3 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "csf");
+  });
+
   test("crossSiteFrequency below floor (2 < 3) → rejected", () => {
     // Spec: Scenario "CSF below floor — arm skipped as failing"
     const candidate = { signals: ["x"], entropy: null, crossSiteFrequency: 2 };

--- a/tests/unit/corroboration-gate.test.mjs
+++ b/tests/unit/corroboration-gate.test.mjs
@@ -1,13 +1,17 @@
 /**
- * MUGA: GATE 2 — corroboration-gate tests (#776).
+ * MUGA: GATE 2 — corroboration-gate tests (#776, #798).
  *
- * Verifies the corroboration predicate: a candidate is accepted only when
- * ≥ MIN_SIGNALS independent upstream sources reported it. Signal count is the
- * SOLE predicate — entropy/CSF arms are NOT evaluated (deferred to #798).
+ * Verifies the corroboration predicate: a candidate is accepted when ANY of
+ * three arms passes — signals arm (≥ MIN_SIGNALS), entropy arm
+ * (entropy >= ENTROPY_FLOOR), or CSF arm (crossSiteFrequency >= CSF_FLOOR).
+ * Null values on heuristic arms cause that arm to be skipped (not treated as
+ * failing). The accepted result includes a `passedArm` field identifying which
+ * arm caused acceptance; multiple arms record the first in precedence order.
  *
  * Tests cover: module shape, threshold boundaries, opts override, malformed
  * candidate handling (REJECTS — inverse of GATE 1/3's accept-malformed posture),
- * no-mutation purity, and partitionCandidates batch behavior.
+ * no-mutation purity, partitionCandidates batch behavior, and three-arm OR
+ * predicate with null-skip guards and floor overrides (#798).
  */
 
 import { test, describe } from "node:test";
@@ -15,6 +19,8 @@ import assert from "node:assert/strict";
 
 import {
   MIN_SIGNALS,
+  ENTROPY_FLOOR,
+  CSF_FLOOR,
   checkCorroborationGate,
   partitionCandidates,
 } from "../../tools/rule-ingestion/gates/corroboration-gate.mjs";
@@ -24,6 +30,14 @@ import {
 describe("corroboration-gate module shape", () => {
   test("MIN_SIGNALS is 2", () => {
     assert.equal(MIN_SIGNALS, 2);
+  });
+
+  test("ENTROPY_FLOOR is 4.0", () => {
+    assert.equal(ENTROPY_FLOOR, 4.0);
+  });
+
+  test("CSF_FLOOR is 3", () => {
+    assert.equal(CSF_FLOOR, 3);
   });
 
   test("checkCorroborationGate is a function", () => {
@@ -42,63 +56,61 @@ describe("corroboration-gate module shape", () => {
   });
 });
 
-// ── T-02: Accept at/above threshold ──────────────────────────────────────────
+// ── T-02: Accept at/above threshold (signals arm) ────────────────────────────
 
-describe("checkCorroborationGate — accept", () => {
-  test("exactly two signals → accepted", () => {
-    const candidate = { param: "utm_source", signals: ["adguard-tp", "clearurls"] };
-    assert.deepEqual(checkCorroborationGate(candidate), { rejected: false });
+describe("checkCorroborationGate — accept via signals arm", () => {
+  test("exactly two signals → accepted with passedArm 'signals'", () => {
+    const candidate = { param: "utm_source", signals: ["adguard-tp", "clearurls"], entropy: null, crossSiteFrequency: null };
+    assert.deepEqual(checkCorroborationGate(candidate), { rejected: false, passedArm: "signals" });
   });
 
-  test("three signals → accepted", () => {
-    const candidate = { signals: ["adguard-tp", "clearurls", "brave"] };
-    assert.deepEqual(checkCorroborationGate(candidate), { rejected: false });
+  test("three signals → accepted with passedArm 'signals'", () => {
+    const candidate = { signals: ["adguard-tp", "clearurls", "brave"], entropy: null, crossSiteFrequency: null };
+    assert.deepEqual(checkCorroborationGate(candidate), { rejected: false, passedArm: "signals" });
   });
 });
 
-// ── T-03: Reject below threshold ─────────────────────────────────────────────
+// ── T-03: Reject below threshold — all arms null ─────────────────────────────
 
 describe("checkCorroborationGate — reject below threshold", () => {
-  test("one signal → rejected with signalCount 1", () => {
-    const candidate = { param: "fbclid", signals: ["adguard-tp"] };
-    assert.deepEqual(checkCorroborationGate(candidate), {
-      rejected: true,
-      reason: "corroboration-below-threshold",
-      detail: { signalCount: 1, minSignals: 2 },
-    });
+  test("one signal, null arms → rejected; detail includes arm values", () => {
+    const candidate = { param: "fbclid", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+    assert.equal(result.reason, "corroboration-below-threshold");
+    assert.equal(result.detail.signalCount, 1);
+    assert.equal(result.detail.minSignals, 2);
+    assert.equal(result.detail.entropy, null);
+    assert.equal(result.detail.crossSiteFrequency, null);
+    assert.equal(result.detail.entropyFloor, 4.0);
+    assert.equal(result.detail.csfFloor, 3);
   });
 
-  test("zero signals → rejected with signalCount 0", () => {
-    const candidate = { param: "ref", signals: [] };
-    assert.deepEqual(checkCorroborationGate(candidate), {
-      rejected: true,
-      reason: "corroboration-below-threshold",
-      detail: { signalCount: 0, minSignals: 2 },
-    });
+  test("zero signals, null arms → rejected with signalCount 0", () => {
+    const candidate = { param: "ref", signals: [], entropy: null, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+    assert.equal(result.detail.signalCount, 0);
   });
 });
 
 // ── T-04: Opts override ───────────────────────────────────────────────────────
 
 describe("checkCorroborationGate — opts override", () => {
-  test("minSignals:1 accepts single-source candidate", () => {
-    const candidate = { signals: ["adguard-tp"] };
-    assert.deepEqual(
-      checkCorroborationGate(candidate, { minSignals: 1 }),
-      { rejected: false }
-    );
+  test("minSignals:1 accepts single-source candidate with passedArm 'signals'", () => {
+    const candidate = { signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate, { minSignals: 1 });
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "signals");
   });
 
   test("minSignals:3 rejects two-source candidate with correct detail", () => {
-    const candidate = { signals: ["adguard-tp", "clearurls"] };
-    assert.deepEqual(
-      checkCorroborationGate(candidate, { minSignals: 3 }),
-      {
-        rejected: true,
-        reason: "corroboration-below-threshold",
-        detail: { signalCount: 2, minSignals: 3 },
-      }
-    );
+    const candidate = { signals: ["adguard-tp", "clearurls"], entropy: null, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate, { minSignals: 3 });
+    assert.equal(result.rejected, true);
+    assert.equal(result.reason, "corroboration-below-threshold");
+    assert.equal(result.detail.signalCount, 2);
+    assert.equal(result.detail.minSignals, 3);
   });
 });
 
@@ -110,55 +122,166 @@ describe("checkCorroborationGate — malformed → rejected", () => {
   // defeat the gate's entire purpose.
 
   test("null candidate → rejected with signalCount 0", () => {
-    assert.deepEqual(checkCorroborationGate(null), {
-      rejected: true,
-      reason: "corroboration-below-threshold",
-      detail: { signalCount: 0, minSignals: 2 },
-    });
+    const result = checkCorroborationGate(null);
+    assert.equal(result.rejected, true);
+    assert.equal(result.reason, "corroboration-below-threshold");
+    assert.equal(result.detail.signalCount, 0);
+    assert.equal(result.detail.minSignals, 2);
   });
 
   test("undefined candidate → rejected with signalCount 0", () => {
-    assert.deepEqual(checkCorroborationGate(undefined), {
-      rejected: true,
-      reason: "corroboration-below-threshold",
-      detail: { signalCount: 0, minSignals: 2 },
-    });
+    const result = checkCorroborationGate(undefined);
+    assert.equal(result.rejected, true);
+    assert.equal(result.detail.signalCount, 0);
   });
 
   test("empty object (no signals field) → rejected with signalCount 0", () => {
-    assert.deepEqual(checkCorroborationGate({}), {
-      rejected: true,
-      reason: "corroboration-below-threshold",
-      detail: { signalCount: 0, minSignals: 2 },
-    });
+    const result = checkCorroborationGate({});
+    assert.equal(result.rejected, true);
+    assert.equal(result.detail.signalCount, 0);
   });
 
   test("signals: null → rejected with signalCount 0", () => {
-    assert.deepEqual(checkCorroborationGate({ signals: null }), {
-      rejected: true,
-      reason: "corroboration-below-threshold",
-      detail: { signalCount: 0, minSignals: 2 },
-    });
+    const result = checkCorroborationGate({ signals: null });
+    assert.equal(result.rejected, true);
+    assert.equal(result.detail.signalCount, 0);
   });
 
   test("signals is a string (not array) → rejected with signalCount 0", () => {
-    assert.deepEqual(checkCorroborationGate({ signals: "adguard-tp" }), {
-      rejected: true,
-      reason: "corroboration-below-threshold",
-      detail: { signalCount: 0, minSignals: 2 },
-    });
+    const result = checkCorroborationGate({ signals: "adguard-tp" });
+    assert.equal(result.rejected, true);
+    assert.equal(result.detail.signalCount, 0);
   });
 });
 
-// ── T-06: Entropy does not rescue single-source candidate ─────────────────────
+// ── T-06: Three-arm OR predicate — heuristic arms (#798) ─────────────────────
+//
+// T-06 was previously "entropy ignored / single-source still rejected."
+// That behaviour is REPLACED: entropy and CSF arms are now ACTIVE (#798).
+// A single-signal candidate with entropy >= ENTROPY_FLOOR MUST now pass.
 
-describe("checkCorroborationGate — entropy ignored", () => {
-  test("non-null entropy on single-source candidate still rejected", () => {
-    // WHY: entropy/CSF evaluation is deferred to #798 — these fields are
-    // HARDCODED null at ingestion time. Including an entropy arm here = dead code.
-    const candidate = { param: "track", signals: ["adguard-tp"], entropy: 4.5, crossSiteFrequency: null };
+describe("checkCorroborationGate — entropy arm (#798)", () => {
+  test("single signal + entropy >= ENTROPY_FLOOR → accepted with passedArm 'entropy'", () => {
+    // Spec: Scenario "Entropy arm passes, signals insufficient"
+    const candidate = { param: "track", signals: ["adguard-tp"], entropy: 5.0, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "entropy");
+  });
+
+  test("entropy exactly at floor (4.0) → accepted", () => {
+    const candidate = { signals: ["x"], entropy: 4.0, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "entropy");
+  });
+
+  test("entropy below floor (2.0 < 4.0) → rejected", () => {
+    // Spec: Scenario "Entropy below floor — arm skipped as failing"
+    const candidate = { signals: ["x"], entropy: 2.0, crossSiteFrequency: null };
     const result = checkCorroborationGate(candidate);
     assert.equal(result.rejected, true);
+  });
+
+  test("entropy null → arm skipped, does not rescue", () => {
+    const candidate = { signals: ["x"], entropy: null, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+  });
+
+  test("entropy undefined → arm skipped, does not rescue", () => {
+    const candidate = { signals: ["x"] }; // no entropy key at all
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+  });
+
+  test("entropyFloor override: entropy 3.1 passes at floor 3.0 (fails at default 4.0)", () => {
+    // Spec: Scenario "Floor override"
+    const candidate = { signals: ["x"], entropy: 3.1, crossSiteFrequency: null };
+    // Default floor → rejected
+    assert.equal(checkCorroborationGate(candidate).rejected, true);
+    // Override to 3.0 → accepted
+    const result = checkCorroborationGate(candidate, { entropyFloor: 3.0 });
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "entropy");
+  });
+});
+
+describe("checkCorroborationGate — CSF arm (#798)", () => {
+  test("single signal + crossSiteFrequency >= CSF_FLOOR → accepted with passedArm 'csf'", () => {
+    // Spec: Scenario "CSF arm passes, signals insufficient"
+    const candidate = { signals: ["x"], entropy: null, crossSiteFrequency: 3 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "csf");
+  });
+
+  test("crossSiteFrequency exactly at floor (3) → accepted", () => {
+    const candidate = { signals: [], entropy: null, crossSiteFrequency: 3 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "csf");
+  });
+
+  test("crossSiteFrequency below floor (2 < 3) → rejected", () => {
+    // Spec: Scenario "CSF below floor — arm skipped as failing"
+    const candidate = { signals: ["x"], entropy: null, crossSiteFrequency: 2 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+  });
+
+  test("crossSiteFrequency null → arm skipped, does not rescue", () => {
+    const candidate = { signals: ["x"], entropy: null, crossSiteFrequency: null };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+  });
+
+  test("csfFloor override: csf 2 passes at floor 2 (fails at default 3)", () => {
+    const candidate = { signals: ["x"], entropy: null, crossSiteFrequency: 2 };
+    // Default → rejected
+    assert.equal(checkCorroborationGate(candidate).rejected, true);
+    // Override to 2 → accepted
+    const result = checkCorroborationGate(candidate, { csfFloor: 2 });
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "csf");
+  });
+});
+
+describe("checkCorroborationGate — multi-arm precedence (#798)", () => {
+  test("all three arms pass → passedArm is 'signals' (first in precedence)", () => {
+    const candidate = { signals: ["a", "b"], entropy: 5.0, crossSiteFrequency: 4 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "signals");
+  });
+
+  test("signals fail, entropy and CSF pass → passedArm is 'entropy' (second in precedence)", () => {
+    const candidate = { signals: ["a"], entropy: 5.0, crossSiteFrequency: 4 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "entropy");
+  });
+
+  test("signals fail, entropy null, CSF passes → passedArm is 'csf'", () => {
+    const candidate = { signals: ["a"], entropy: null, crossSiteFrequency: 5 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, false);
+    assert.equal(result.passedArm, "csf");
+  });
+});
+
+describe("checkCorroborationGate — reject detail includes arm values (#798)", () => {
+  test("rejected result detail contains entropy/csf/floor values for quarantine transparency", () => {
+    const candidate = { signals: ["x"], entropy: 2.5, crossSiteFrequency: 1 };
+    const result = checkCorroborationGate(candidate);
+    assert.equal(result.rejected, true);
+    // Detail must include evaluated arm values
+    assert.equal(result.detail.entropy, 2.5);
+    assert.equal(result.detail.crossSiteFrequency, 1);
+    assert.equal(result.detail.entropyFloor, 4.0);
+    assert.equal(result.detail.csfFloor, 3);
+    assert.equal(result.detail.signalCount, 1);
+    assert.equal(result.detail.minSignals, 2);
   });
 });
 
@@ -179,9 +302,9 @@ describe("checkCorroborationGate — purity", () => {
 
 describe("partitionCandidates", () => {
   test("mixed candidates → correct buckets, order preserved", () => {
-    const A = { param: "utm_source", signals: ["adguard-tp", "clearurls"] };
-    const B = { param: "some_tracker", signals: ["adguard-tp"] };
-    const C = { param: "gclid", signals: ["adguard-tp", "clearurls", "brave"] };
+    const A = { param: "utm_source", signals: ["adguard-tp", "clearurls"], entropy: null, crossSiteFrequency: null };
+    const B = { param: "some_tracker", signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null };
+    const C = { param: "gclid", signals: ["adguard-tp", "clearurls", "brave"], entropy: null, crossSiteFrequency: null };
 
     const { accepted, rejected } = partitionCandidates([A, B, C]);
 
@@ -189,27 +312,28 @@ describe("partitionCandidates", () => {
     assert.equal(rejected.length, 1);
     assert.strictEqual(rejected[0].candidate, B);
     assert.equal(rejected[0].reason, "corroboration-below-threshold");
-    assert.deepEqual(rejected[0].detail, { signalCount: 1, minSignals: 2 });
+    assert.equal(rejected[0].detail.signalCount, 1);
+    assert.equal(rejected[0].detail.minSignals, 2);
   });
 
   test("empty input → {accepted:[], rejected:[]}", () => {
     assert.deepEqual(partitionCandidates([]), { accepted: [], rejected: [] });
   });
 
-  test("all accepted", () => {
+  test("all accepted via signals arm", () => {
     const candidates = [
-      { signals: ["a", "b"] },
-      { signals: ["c", "d"] },
+      { signals: ["a", "b"], entropy: null, crossSiteFrequency: null },
+      { signals: ["c", "d"], entropy: null, crossSiteFrequency: null },
     ];
     const { accepted, rejected } = partitionCandidates(candidates);
     assert.equal(accepted.length, 2);
     assert.equal(rejected.length, 0);
   });
 
-  test("all rejected", () => {
+  test("all rejected when no arm passes", () => {
     const candidates = [
-      { signals: ["a"] },
-      { signals: [] },
+      { signals: ["a"], entropy: null, crossSiteFrequency: null },
+      { signals: [], entropy: null, crossSiteFrequency: null },
     ];
     const { accepted, rejected } = partitionCandidates(candidates);
     assert.equal(accepted.length, 0);
@@ -217,8 +341,21 @@ describe("partitionCandidates", () => {
   });
 
   test("opts forwarded — minSignals:1 makes single-source accepted", () => {
-    const candidates = [{ signals: ["adguard-tp"] }];
+    const candidates = [{ signals: ["adguard-tp"], entropy: null, crossSiteFrequency: null }];
     const { accepted, rejected } = partitionCandidates(candidates, { minSignals: 1 });
+    assert.equal(accepted.length, 1);
+    assert.equal(rejected.length, 0);
+  });
+
+  test("opts forwarded — entropyFloor override accepts candidate via entropy arm", () => {
+    // Spec: Scenario "partitionCandidates forwards gateOpts to each check"
+    // candidate with 1 signal, entropy 3.6, default floor 4.0 → rejected
+    // with entropyFloor: 3.5 → accepted
+    const cLow = { signals: ["x"], entropy: 3.6, crossSiteFrequency: null };
+    const { accepted: accDefault } = partitionCandidates([cLow]);
+    assert.equal(accDefault.length, 0); // default floor 4.0, fails
+
+    const { accepted, rejected } = partitionCandidates([cLow], { entropyFloor: 3.5 });
     assert.equal(accepted.length, 1);
     assert.equal(rejected.length, 0);
   });

--- a/tests/unit/ingestion-orchestrator.test.mjs
+++ b/tests/unit/ingestion-orchestrator.test.mjs
@@ -542,10 +542,13 @@ describe("R10 — GATE2 malformed-candidate fail-closed", () => {
     );
     assert.ok(corrobRejection, "rejection by corroboration-gate must exist");
     assert.strictEqual(corrobRejection.reason, "corroboration-below-threshold");
-    assert.deepStrictEqual(corrobRejection.evidence.detail, {
-      signalCount: 0,
-      minSignals: 2,
-    });
+    // Detail now includes all evaluated arm values for quarantine transparency (#798)
+    assert.strictEqual(corrobRejection.evidence.detail.signalCount, 0);
+    assert.strictEqual(corrobRejection.evidence.detail.minSignals, 2);
+    assert.strictEqual(corrobRejection.evidence.detail.entropy, null);
+    assert.strictEqual(corrobRejection.evidence.detail.crossSiteFrequency, null);
+    assert.strictEqual(corrobRejection.evidence.detail.entropyFloor, 4.0);
+    assert.strictEqual(corrobRejection.evidence.detail.csfFloor, 3);
 
     // Must not appear in params
     assert.ok(

--- a/tests/unit/orchestrate-cli-enrichment.test.mjs
+++ b/tests/unit/orchestrate-cli-enrichment.test.mjs
@@ -188,7 +188,10 @@ describe("W1+W2 — discoveredDir wires enrichment before orchestration", () => 
     const reportPath = join(tmpDir, "quarantine-report.json");
     const discoveredDir = join(tmpDir, "discovered");
 
-    // Single-signal candidate → fails corroboration → goes to quarantine with full candidate object
+    // Single-signal candidate → corroboration check depends on heuristic arms.
+    // Artifact gives value_entropy: 2.0 which is BELOW ENTROPY_FLOOR (4.0) and
+    // crossSiteFrequency: 1 which is BELOW CSF_FLOOR (3).
+    // All three arms fail → quarantined, with enriched field values in the entry.
     const singleSignalCandidates = [
       {
         param: "fbclid",
@@ -199,8 +202,19 @@ describe("W1+W2 — discoveredDir wires enrichment before orchestration", () => 
       },
     ];
 
+    // Artifact with low entropy (below floor) so the entropy arm does NOT rescue
+    const lowEntropyArtifactCandidates = [
+      {
+        param: "fbclid",
+        first_seen_on: "ads.example.com",
+        injected_by: "meta-pixel",
+        occurrence_count: 10,
+        value_entropy: 2.0, // below ENTROPY_FLOOR 4.0
+      },
+    ];
+
     writeCandidatesJson(candidatesPath, singleSignalCandidates);
-    writeDiscoveredArtifact(discoveredDir, "artifact-a.json", FIXTURE_ARTIFACT_CANDIDATES);
+    writeDiscoveredArtifact(discoveredDir, "artifact-a.json", lowEntropyArtifactCandidates);
 
     const verifyStub = () => ({ ok: true, code: "OK" });
 
@@ -218,16 +232,17 @@ describe("W1+W2 — discoveredDir wires enrichment before orchestration", () => 
     assert.ok(existsSync(reportPath), "quarantine-report.json must be written");
     const report = JSON.parse(readFileSync(reportPath, "utf8"));
 
-    // fbclid fails corroboration (1 signal < MIN_SIGNALS 2) → quarantined
-    assert.strictEqual(report.quarantineCount, 1, "fbclid must be quarantined (1 signal)");
+    // fbclid: 1 signal < MIN_SIGNALS, entropy 2.0 < ENTROPY_FLOOR 4.0, CSF 1 < CSF_FLOOR 3
+    // → all arms fail → quarantined
+    assert.strictEqual(report.quarantineCount, 1, "fbclid must be quarantined (all arms below floor)");
     const entry = report.quarantine[0];
     assert.ok(entry, "quarantine must have one entry");
 
-    // The candidate in the report must carry enriched fields
+    // The candidate in the report must carry enriched fields (populated by enrich-candidates)
     assert.strictEqual(
       entry.candidate.entropy,
-      4.5,
-      "quarantined candidate.entropy must be 4.5 (from artifact value_entropy)"
+      2.0,
+      "quarantined candidate.entropy must be 2.0 (from artifact value_entropy 2.0)"
     );
     assert.strictEqual(
       entry.candidate.crossSiteFrequency,

--- a/tools/rule-ingestion/PROVENANCE.md
+++ b/tools/rule-ingestion/PROVENANCE.md
@@ -83,6 +83,50 @@ the issue is the NC *license term* a commercial user would be accepting by
 extracting from the database, plus the reputational and good-faith cost of
 ignoring a maintainer's clearly stated NonCommercial intent. We respect it.
 
+## Heuristic arms — analytical scores, not signal sources (#798)
+
+The `entropy` and `crossSiteFrequency` fields on ingestion candidates are
+**analytical aggregates**, not corroboration signals. Understanding the
+distinction is essential before adding any new source or extending the gate.
+
+**What they are:**
+
+- `entropy` — the arithmetic mean of `value_entropy` values found in verified
+  `discovered/` artifact files (populated by `enrich-candidates.mjs`).
+  `value_entropy` is the mean Shannon entropy (bits) of observed URL parameter
+  VALUES in a caps-crawler run. It measures how randomised/opaque the values are.
+- `crossSiteFrequency` — the count of DISTINCT `first_seen_on` hostnames for
+  a param across all verified `discovered/` artifact files. It measures how
+  broadly a param was observed across different sites.
+
+Both fields are derived from caps-crawler crawl metadata stored in `discovered/`.
+They are set by `enrich-candidates.mjs` between ingest and orchestration and are
+`null` when no artifact data is available for a param.
+
+**What they are NOT:**
+
+- They are **NOT** entries in `signals[]`. The `signals[]` array records which
+  independent upstream **adapter** (AdGuard, ClearURLs, …) reported a param.
+  Each signal entry must come from a DISTINCT, SEPARATELY MAINTAINED upstream
+  source per the independence invariant (#821).
+- caps-crawler is **NOT** a corroboration source. It does not produce a signal
+  entry. Adding caps-crawler to `ENABLED_ADAPTERS` or `signals[]` would violate
+  the independence invariant and must never be done.
+- The heuristic arms do not change `signals[]` semantics. Two params can share
+  identical `signals[]` contents yet differ in `entropy`/`crossSiteFrequency`
+  depending on observed value patterns and site breadth.
+
+**Why this matters for PROVENANCE:**
+
+GATE 2 now accepts a candidate via three arms: signal count, entropy, or CSF
+(see `corroboration-gate.mjs` and ADR-0005 amendment). A reader might assume
+that passing via the entropy or CSF arm implies a new corroboration source was
+added. It was not. The heuristic arms use MUGA's own analytical pipeline over
+existing caps-crawler artifact metadata — they are a _scoring_ deepening of the
+same corroboration concept, not a new upstream fact source.
+
+---
+
 ## Adding a new source — checklist
 
 1. Verify the **data** license (not the addon's) against its `LICENSE` file.

--- a/tools/rule-ingestion/README.md
+++ b/tools/rule-ingestion/README.md
@@ -259,7 +259,9 @@ This order is guaranteed by the `DEFAULT_GATES` array literal in
 Candidates missing `signals` (null, absent, or non-array) are rejected by
 `corroboration-gate` with `signalCount = 0`. They **never appear in
 `autoMerge` or `promote-candidates.json`**. The quarantine sidecar captures
-the full `evidence.detail = { signalCount, minSignals }` for audit.
+the full `evidence.detail` for audit — since #798 it carries the evaluated
+three-arm state: `{ signalCount, minSignals, entropy, entropyFloor,
+crossSiteFrequency, csfFloor }`.
 
 ### Signing format + verification path
 

--- a/tools/rule-ingestion/gates/corroboration-gate.mjs
+++ b/tools/rule-ingestion/gates/corroboration-gate.mjs
@@ -1,13 +1,23 @@
 /**
- * MUGA: GATE 2 — corroboration-gate (#776)
+ * MUGA: GATE 2 — corroboration-gate (#776, #798)
  *
  * Reduces false positives by requiring INDEPENDENT CORROBORATION: a candidate
- * is accepted only when ≥ MIN_SIGNALS independent upstream signal sources
- * reported it. Signal count is the SOLE predicate.
+ * is accepted when ANY of the three arms passes (OR predicate):
+ *   1. signals.length >= MIN_SIGNALS  (signal-count arm)
+ *   2. entropy !== null && entropy >= ENTROPY_FLOOR  (entropy arm)
+ *   3. crossSiteFrequency !== null && crossSiteFrequency >= CSF_FLOOR  (CSF arm)
  *
- * WHY signal-count-only: entropy and cross-site-frequency fields are HARDCODED
- * null at ingestion time (candidate.mjs:46-47). Adding entropy/CSF arms here
- * would be dead code — deferred to #798 where real heuristics are planned.
+ * Null values on heuristic arms (entropy/CSF) cause that arm to be SKIPPED
+ * entirely — they do not count as failing. This preserves the existing
+ * signal-count-only behaviour for candidates where enrichment produced no data.
+ *
+ * Accepted results include a `passedArm` field ("signals" | "entropy" | "csf")
+ * identifying which arm caused acceptance; when multiple arms qualify, the FIRST
+ * in the precedence order above is recorded.
+ *
+ * Rejected results include an extended `detail` object with all evaluated arm
+ * values (signalCount, minSignals, entropy, entropyFloor, crossSiteFrequency,
+ * csfFloor) for quarantine-report transparency.
  *
  * WHY malformed → REJECT (inverse of GATE 1/3 accept-malformed posture):
  * - GATE 1/3 reject = "this param is dangerous to strip" → accept-malformed
@@ -16,17 +26,26 @@
  *   would defeat the gate entirely. A candidate with no provable signals IS
  *   the failure mode GATE 2 exists to catch (signalCount 0 < MIN_SIGNALS).
  *
+ * INDEPENDENCE INVARIANT (#821): entropy and crossSiteFrequency are ANALYTICAL
+ * SCORES derived from caps-crawler discovered/ artifact metadata; they are NOT
+ * entries in signals[]. caps-crawler is NOT a corroboration source. The signals[]
+ * semantics are unchanged — each entry must still come from a DISTINCT,
+ * SEPARATELY MAINTAINED upstream adapter (see adapters/index.mjs).
+ *
  * Public API (named exports only — no default):
- *   MIN_SIGNALS              → number (default threshold = 2)
- *   checkCorroborationGate   → (candidate, opts?) → { rejected }
+ *   MIN_SIGNALS              → number (default signal threshold = 2)
+ *   ENTROPY_FLOOR            → number (default entropy threshold = 4.0)
+ *   CSF_FLOOR                → number (default cross-site-frequency threshold = 3)
+ *   checkCorroborationGate   → (candidate, opts?) → { rejected, passedArm? }
  *   partitionCandidates      → (candidates, opts?) → { accepted, rejected }
  */
 
-// ── Threshold constant ────────────────────────────────────────────────────────
+// ── Threshold constants ───────────────────────────────────────────────────────
 
 /**
  * Minimum number of independent upstream signal sources required for a
- * candidate to pass GATE 2. Configurable at call-site via opts.minSignals.
+ * candidate to pass GATE 2 via the signals arm. Configurable at call-site
+ * via opts.minSignals.
  *
  * CORRECTNESS INVARIANT — INDEPENDENCE MAINTENANCE REQUIRED:
  * The gate counts signals.length as independent corroboration only when each
@@ -41,37 +60,100 @@
  */
 export const MIN_SIGNALS = 2;
 
+/**
+ * Minimum mean Shannon entropy (bits) of observed URL parameter values for a
+ * candidate to pass GATE 2 via the entropy arm. Derived from the
+ * `value_entropy` field populated by enrich-candidates.mjs (caps-crawler
+ * artifact metadata). Configurable at call-site via opts.entropyFloor.
+ *
+ * Set to 4.0 — aligns with the runtime ENTROPY_THRESHOLD used for value-level
+ * entropy classification. A mean of 4.0 bits indicates reasonably high-entropy
+ * observed values (consistent with token/session parameters, not static paths).
+ *
+ * @type {number}
+ */
+export const ENTROPY_FLOOR = 4.0;
+
+/**
+ * Minimum cross-site frequency (count of DISTINCT first_seen_on hostnames
+ * across all verified discovered/ artifacts) for a candidate to pass GATE 2
+ * via the CSF arm. Populated by enrich-candidates.mjs. Configurable at
+ * call-site via opts.csfFloor.
+ *
+ * Set to 3 — requires a param to have appeared on at least 3 distinct sites,
+ * providing breadth corroboration even when fewer than MIN_SIGNALS adapters
+ * report it.
+ *
+ * @type {number}
+ */
+export const CSF_FLOOR = 3;
+
 // ── Predicate ─────────────────────────────────────────────────────────────────
 
 /**
- * Checks a single ingestion candidate against the corroboration threshold.
+ * Checks a single ingestion candidate against the three-arm OR corroboration
+ * predicate.
  *
- * Returns `{ rejected: false }` when `candidate.signals.length >= minSignals`.
- * Returns `{ rejected: true, reason, detail }` when under-corroborated,
- * including when the candidate is null / missing `signals` / signals is
- * not an array — all treated as signalCount = 0 (under-corroborated by
- * definition).
+ * Returns `{ rejected: false, passedArm }` when ANY of the following is true:
+ *   1. signals.length >= minSignals              (passedArm: "signals")
+ *   2. entropy !== null && entropy >= entropyFloor  (passedArm: "entropy")
+ *   3. crossSiteFrequency !== null && csf >= csfFloor  (passedArm: "csf")
+ *
+ * Null/undefined values on arms 2 and 3 cause that arm to be skipped entirely
+ * (not treated as failing). When multiple arms qualify, the FIRST in the
+ * precedence order above is recorded as passedArm.
+ *
+ * Returns `{ rejected: true, reason, detail }` when no arm passes. The detail
+ * object includes all evaluated arm values for quarantine-report transparency.
  *
  * PURE: no file writes, no network calls, no singleton mutations.
  *
- * @param {{ signals?: string[] } | null | undefined} candidate
- * @param {{ minSignals?: number }} [opts]
- * @returns {{ rejected: boolean, reason?: string, detail?: { signalCount: number, minSignals: number } }}
+ * @param {{ signals?: string[], entropy?: number | null, crossSiteFrequency?: number | null } | null | undefined} candidate
+ * @param {object} [opts]
+ * @param {number} [opts.minSignals]
+ * @param {number} [opts.entropyFloor]
+ * @param {number} [opts.csfFloor]
+ * @returns {{ rejected: boolean, passedArm?: string, reason?: string, detail?: object }}
  */
-export function checkCorroborationGate(candidate, { minSignals = MIN_SIGNALS } = {}) {
+export function checkCorroborationGate(candidate, {
+  minSignals = MIN_SIGNALS,
+  entropyFloor = ENTROPY_FLOOR,
+  csfFloor = CSF_FLOOR,
+} = {}) {
   // Array.isArray is the correct guard — strings, null, undefined all yield 0.
   const signalCount = Array.isArray(candidate?.signals)
     ? candidate.signals.length
     : 0;
 
+  const entropy = candidate?.entropy ?? null;
+  const csf = candidate?.crossSiteFrequency ?? null;
+
+  // Arm 1: signals
   if (signalCount >= minSignals) {
-    return { rejected: false };
+    return { rejected: false, passedArm: "signals" };
+  }
+
+  // Arm 2: entropy (null-skip guard — null does NOT rescue)
+  if (entropy !== null && entropy >= entropyFloor) {
+    return { rejected: false, passedArm: "entropy" };
+  }
+
+  // Arm 3: cross-site frequency (null-skip guard — null does NOT rescue)
+  if (csf !== null && csf >= csfFloor) {
+    return { rejected: false, passedArm: "csf" };
   }
 
   return {
     rejected: true,
     reason: "corroboration-below-threshold",
-    detail: { signalCount, minSignals },
+    detail: {
+      signalCount,
+      minSignals,
+      entropy,
+      entropyFloor,
+      crossSiteFrequency: csf,
+      csfFloor,
+    },
   };
 }
 
@@ -82,11 +164,15 @@ export function checkCorroborationGate(candidate, { minSignals = MIN_SIGNALS } =
  * buckets in a single pass. Input order is preserved in both output arrays.
  *
  * Forwards `opts` to each `checkCorroborationGate` call so callers can
- * override the threshold at batch level (mirrors GATE 3's partition signature).
+ * override thresholds at batch level (mirrors GATE 3's partition signature).
+ * Supports the full opts shape: { minSignals?, entropyFloor?, csfFloor? }.
  *
- * @param {Array<{ signals?: string[] }>} candidates
- * @param {{ minSignals?: number }} [opts]
- * @returns {{ accepted: Array, rejected: Array<{ candidate: object, reason: string, detail: { signalCount: number, minSignals: number } }> }}
+ * @param {Array<{ signals?: string[], entropy?: number | null, crossSiteFrequency?: number | null }>} candidates
+ * @param {object} [opts]
+ * @param {number} [opts.minSignals]
+ * @param {number} [opts.entropyFloor]
+ * @param {number} [opts.csfFloor]
+ * @returns {{ accepted: Array, rejected: Array<{ candidate: object, reason: string, detail: object }> }}
  */
 export function partitionCandidates(candidates, opts = {}) {
   const accepted = [];


### PR DESCRIPTION
PR 3/4 of the GATE 2 heuristic-arms chain (stacked-to-main, follows #876). Part of #798.

## What

- `gates/corroboration-gate.mjs`: GATE 2 passes iff `signals >= MIN_SIGNALS` **OR** `entropy >= ENTROPY_FLOOR (4.0)` **OR** `crossSiteFrequency >= CSF_FLOOR (3)`. Null/undefined arms skip cleanly (guarded with `!== null` BEFORE comparison — no `null >= 0` coercion trap, verified adversarially). Floors exported and overridable via the existing `gateOpts` seam. Accepted results carry `passedArm`; rejected `detail` exposes all evaluated arm values for the quarantine report.
- T-06 fully replaced (it asserted entropy was ignored — that era is over); 17 new arm tests including at-floor, below-floor, null/undefined skip, floor overrides, and csf-rescues-failed-entropy precedence.
- `docs/adr/0005` amendment + `PROVENANCE.md` independence statement: the arms are analytical scores — caps-crawler does NOT become a corroboration signal source (#821), `signals[]` untouched.

## Moat safety

Adversarial verify confirmed `runOrchestration` evaluates all four gates with no short-circuit: a GATE 2 pass can never bypass GATE 1 (affiliate-guard) or GATE 4. This reduces false negatives without touching affiliate protection.

SDD verify verdict: **PASS, 0 critical** (both warnings closed in 12fa5c5).

## Chain

#874 → #875 → #876 → **this** → PR 4 (caps-crawler `value_entropy` emission).

Part of #798