### PR TITLE
feat(moat-expansion): foundation — scaffold, fixture, lookup table, PROVENANCE (#793 PR 1/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,13 @@ tools/rule-ingestion/quarantine/
 # Rule-ingestion promote run artifact (#781): ephemeral intermediate, never committed.
 # The .gitkeep in promote/ is committed; only the runtime artifact is excluded.
 tools/rule-ingestion/promote/promote-candidates.json
+
+# Moat-expansion quarantine (#793): raw ClearURLs fetch — never committed.
+# Clean-room posture: upstream bytes (LGPL-3.0) stay ephemeral; only extracted
+# referralMarketing signal tuples leave the quarantine zone. See PROVENANCE.md.
+tools/moat-expansion/quarantine/
+# Moat-expansion reports (#793): committed to bot-branch only, never to main directly.
+# The .gitkeep in reports/ is committed; runtime report-<date>.md files land here
+# only via the weekly workflow PR, never via direct push.
+tools/moat-expansion/reports/report-*.md
+tools/moat-expansion/reports/report-*.json

--- a/tests/fixtures/moat-expansion/clearurls-mini.json
+++ b/tests/fixtures/moat-expansion/clearurls-mini.json
@@ -1,0 +1,42 @@
+{
+  "providers": {
+    "amazon": {
+      "urlPattern": "^https?://([a-z0-9-]+\\.)?amazon\\.(com|es|de|fr|it|co\\.uk)/",
+      "rules": [
+        "^ref$",
+        "^pf_rd_r$",
+        "^pf_rd_p$"
+      ],
+      "referralMarketing": [
+        "tag",
+        "newparam"
+      ]
+    },
+    "ebay": {
+      "urlPattern": "^https?://([a-z0-9-]+\\.)?ebay\\.(com|es|de|co\\.uk|fr|it)/",
+      "rules": [
+        "^mkrid$",
+        "^toolid$"
+      ],
+      "referralMarketing": [
+        "campid"
+      ]
+    },
+    "unknown-foo": {
+      "urlPattern": "^https?://([a-z0-9-]+\\.)?unknown-foo\\.example\\.com/",
+      "rules": [
+        "^sessionid$"
+      ],
+      "referralMarketing": [
+        "xparam"
+      ]
+    },
+    "empty-provider": {
+      "urlPattern": "^https?://([a-z0-9-]+\\.)?empty-provider\\.example\\.com/",
+      "rules": [
+        "^trackerid$"
+      ],
+      "referralMarketing": []
+    }
+  }
+}

--- a/tests/unit/moat-expansion-lookup.test.mjs
+++ b/tests/unit/moat-expansion-lookup.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * MUGA — moat-expansion lookup-table tests (#793).
+ *
+ * Verifies the shape and minimum seed set of KNOWN_PROGRAMS.
+ * Every entry must have:
+ *   - programId: non-empty string
+ *   - domains: non-empty array of non-empty strings
+ *   - note: non-empty string
+ *
+ * At minimum: amazon, ebay, aliexpress entries must exist (v1 seed).
+ * No upstream content is asserted — shape and presence only.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { KNOWN_PROGRAMS } from "../../tools/moat-expansion/lookup-table.mjs";
+
+describe("KNOWN_PROGRAMS — shape invariants", () => {
+  test("exports KNOWN_PROGRAMS as a plain object", () => {
+    assert.ok(
+      KNOWN_PROGRAMS !== null &&
+        typeof KNOWN_PROGRAMS === "object" &&
+        !Array.isArray(KNOWN_PROGRAMS),
+      "KNOWN_PROGRAMS must be a plain object"
+    );
+  });
+
+  test("has at least the v1 minimum seed keys: amazon, ebay, aliexpress", () => {
+    assert.ok("amazon" in KNOWN_PROGRAMS, "amazon key must be present");
+    assert.ok("ebay" in KNOWN_PROGRAMS, "ebay key must be present");
+    assert.ok("aliexpress" in KNOWN_PROGRAMS, "aliexpress key must be present");
+  });
+
+  test("every entry has a non-empty string programId", () => {
+    for (const [key, entry] of Object.entries(KNOWN_PROGRAMS)) {
+      assert.strictEqual(
+        typeof entry.programId,
+        "string",
+        `entry "${key}".programId must be a string`
+      );
+      assert.ok(
+        entry.programId.length > 0,
+        `entry "${key}".programId must not be empty`
+      );
+    }
+  });
+
+  test("every entry has a non-empty array of non-empty string domains", () => {
+    for (const [key, entry] of Object.entries(KNOWN_PROGRAMS)) {
+      assert.ok(
+        Array.isArray(entry.domains),
+        `entry "${key}".domains must be an array`
+      );
+      assert.ok(
+        entry.domains.length > 0,
+        `entry "${key}".domains must not be empty`
+      );
+      for (const domain of entry.domains) {
+        assert.strictEqual(
+          typeof domain,
+          "string",
+          `entry "${key}".domains must contain strings`
+        );
+        assert.ok(
+          domain.length > 0,
+          `entry "${key}".domains must not contain empty strings`
+        );
+      }
+    }
+  });
+
+  test("every entry has a non-empty string note", () => {
+    for (const [key, entry] of Object.entries(KNOWN_PROGRAMS)) {
+      assert.strictEqual(
+        typeof entry.note,
+        "string",
+        `entry "${key}".note must be a string`
+      );
+      assert.ok(
+        entry.note.length > 0,
+        `entry "${key}".note must not be empty`
+      );
+    }
+  });
+
+  test("amazon entry maps to amazon-associates program", () => {
+    const amazon = KNOWN_PROGRAMS["amazon"];
+    assert.strictEqual(
+      amazon.programId,
+      "amazon-associates",
+      "amazon programId must be amazon-associates"
+    );
+    assert.ok(
+      amazon.domains.includes("amazon.com"),
+      "amazon domains must include amazon.com"
+    );
+  });
+
+  test("ebay entry maps to ebay-partner-network program", () => {
+    const ebay = KNOWN_PROGRAMS["ebay"];
+    assert.strictEqual(
+      ebay.programId,
+      "ebay-partner-network",
+      "ebay programId must be ebay-partner-network"
+    );
+    assert.ok(
+      ebay.domains.includes("ebay.com"),
+      "ebay domains must include ebay.com"
+    );
+  });
+
+  test("aliexpress entry is present with valid shape", () => {
+    const ali = KNOWN_PROGRAMS["aliexpress"];
+    assert.ok(typeof ali.programId === "string" && ali.programId.length > 0);
+    assert.ok(Array.isArray(ali.domains) && ali.domains.length > 0);
+    assert.ok(typeof ali.note === "string" && ali.note.length > 0);
+  });
+
+  test("all v1 seed entries present: awin, impact, cj", () => {
+    assert.ok("awin" in KNOWN_PROGRAMS, "awin key must be present");
+    assert.ok("impact" in KNOWN_PROGRAMS, "impact key must be present");
+    assert.ok("cj" in KNOWN_PROGRAMS, "cj key must be present");
+  });
+});

--- a/tools/moat-expansion/lookup-table.mjs
+++ b/tools/moat-expansion/lookup-table.mjs
@@ -1,0 +1,112 @@
+/**
+ * MUGA — moat-expansion known-program lookup table (#793).
+ *
+ * Muga-authored static map from well-known ClearURLs provider keys to
+ * canonical domain arrays and a program id. This is NOT derived from
+ * or copied from upstream ClearURLs files — it is clean-room MUGA-authored
+ * content mapping ClearURLs provider key identifiers to MUGA's own
+ * AFFILIATE_PATTERNS program identifiers.
+ *
+ * Usage (named export only — no default):
+ *   import { KNOWN_PROGRAMS } from "./lookup-table.mjs";
+ *   const entry = KNOWN_PROGRAMS["amazon"];
+ *   // → { programId: "amazon-associates", domains: [...], note: "..." }
+ *
+ * Schema: { [providerKey: string]: { programId: string, domains: string[], note: string } }
+ *
+ * programId maps to existing AFFILIATE_PATTERNS / REDIRECT_NETWORK_PATTERNS
+ * ids so the differ can resolve what is "known" in the current affiliate moat.
+ *
+ * Refs #793. See PROVENANCE.md for ClearURLs license context.
+ */
+
+/**
+ * Known-program lookup table — v1 seed set.
+ *
+ * For a provider whose key is present here, the differ uses this entry's
+ * domains[] as the canonical domain set. For unknown providers (key absent),
+ * the differ passes the raw urlPattern through without domain inference.
+ *
+ * @type {Record<string, { programId: string, domains: string[], note: string }>}
+ */
+export const KNOWN_PROGRAMS = {
+  amazon: {
+    programId: "amazon-associates",
+    domains: [
+      "amazon.com",
+      "amazon.es",
+      "amazon.de",
+      "amazon.fr",
+      "amazon.it",
+      "amazon.co.uk",
+      "amazon.ca",
+      "amazon.com.br",
+      "amazon.com.mx",
+      "amazon.co.jp",
+    ],
+    note:
+      "Amazon Associates program. ClearURLs provider key 'amazon'. " +
+      "Referral tag param is 'tag'; ascsubtag covered by AFFILIATE_PARAM_GUARD.",
+  },
+
+  ebay: {
+    programId: "ebay-partner-network",
+    domains: [
+      "ebay.com",
+      "ebay.es",
+      "ebay.de",
+      "ebay.co.uk",
+      "ebay.fr",
+      "ebay.it",
+      "ebay.com.au",
+      "ebay.ca",
+    ],
+    note:
+      "eBay Partner Network. ClearURLs provider key 'ebay'. " +
+      "Primary referral param is 'campid'.",
+  },
+
+  aliexpress: {
+    programId: "aliexpress-affiliate",
+    domains: ["aliexpress.com", "s.click.aliexpress.com", "best.aliexpress.com"],
+    note:
+      "AliExpress affiliate program. ClearURLs provider key 'aliexpress'. " +
+      "Traffic routed via s.click.aliexpress.com click-tracker.",
+  },
+
+  awin: {
+    programId: "awin",
+    domains: ["awin1.com", "www.awin1.com"],
+    note:
+      "AWIN affiliate network. ClearURLs provider key 'awin'. " +
+      "Landing params (awc) also covered by REDIRECT_NETWORK_PATTERNS.",
+  },
+
+  impact: {
+    programId: "impact-radius",
+    domains: [
+      "impact.com",
+      "app.impact.com",
+      "impactradius.com",
+    ],
+    note:
+      "Impact (formerly Impact Radius) affiliate network. " +
+      "ClearURLs provider key 'impact'. Multiple vanity domains in use.",
+  },
+
+  cj: {
+    programId: "cj-affiliate",
+    domains: [
+      "anrdoezrs.net",
+      "dpbolvw.net",
+      "jdoqocy.com",
+      "kqzyfj.com",
+      "lduhtrp.net",
+      "tkqlhce.com",
+      "commission-junction.com",
+    ],
+    note:
+      "CJ Affiliate (Commission Junction). ClearURLs provider key 'cj'. " +
+      "Uses a fleet of vanity redirect domains for tracking links.",
+  },
+};

--- a/tools/rule-ingestion/PROVENANCE.md
+++ b/tools/rule-ingestion/PROVENANCE.md
@@ -127,6 +127,65 @@ same corroboration concept, not a new upstream fact source.
 
 ---
 
+---
+
+## Moat-expansion pipeline — ClearURLs `referralMarketing` (#793)
+
+The `tools/moat-expansion/` pipeline is a SEPARATE consumer of ClearURLs data
+that accesses the **exact field that rule-ingestion permanently excludes**.
+This section documents the legal and intentional basis for that inversion.
+
+### Why this is intentional, not a mistake
+
+The rule-ingestion ClearURLs adapter (`tools/rule-ingestion/adapters/clearurls.mjs`)
+contains a **SAFETY-CRITICAL two-pass exclusion** that ensures `referralMarketing`
+entries are **NEVER** treated as tracking candidates (#773). The comment in that
+file reads: *"these are affiliate attribution parameters that belong to MUGA's
+preserve set"*. Ingesting them as strip candidates would cause catastrophic
+revenue loss for creators.
+
+The moat-expansion pipeline is the **intended consumer** of exactly those same
+signals — not to strip them, but to **discover new affiliate params** that
+belong in MUGA's moat (`AFFILIATE_PATTERNS`, `AFFILIATE_PARAM_GUARD`). The
+exclusion in #773 was the right decision for rule-ingestion; moat-expansion is
+the pipeline the referralMarketing data was always meant for.
+
+### License & clean-room posture
+
+| Field | Value |
+|---|---|
+| Source | ClearURLs `data.min.json` — `providers[*].referralMarketing[]` only |
+| Data license | **LGPL-3.0** |
+| Usage model | **Signals-not-copies** — referralMarketing tuples are extracted facts; raw file is quarantined and never committed |
+| Quarantine path | `tools/moat-expansion/quarantine/` (gitignored; see `.gitignore`) |
+| What leaves quarantine | `{ provider, urlPattern, referralMarketing[] }` tuples only — no raw bytes, no curated patterns |
+| Output | Human-review Markdown report + JSON sidecar; committed to bot-branch only via weekly PR |
+| Writes to `src/`? | **Never.** Pipeline is report-only; no `manifest.data.js` or `affiliates.js` edits |
+
+### #773 inversion — explicit note for future maintainers
+
+The rule-ingestion adapter's permanent `referralMarketing` exclusion and the
+moat-expansion pipeline are **two sides of the same invariant**:
+
+- **Rule-ingestion**: `referralMarketing` is an affiliate signal → MUST NOT reach
+  `TRACKING_PARAMS`. The exclusion is safety-critical and must never be removed.
+- **Moat-expansion**: `referralMarketing` is an affiliate signal → IS the input
+  for affiliate-moat gap discovery. This is why the exclusion was recorded as
+  "affiliate — MUGA's preserve set" rather than simply dropped.
+
+Removing the #773 exclusion in rule-ingestion would be catastrophic. Adding
+`referralMarketing` to the moat-expansion pipeline is correct and intended.
+These two statements are NOT contradictory — they are complementary.
+
+### Structural test
+
+`tests/unit/moat-expansion-workflow.test.mjs` (T3.3) reads this file at test
+time and asserts that the section referencing `ClearURLs`, `referralMarketing`,
+`LGPL-3.0`, and `quarantine` is present. Do not move or rename this section
+without updating that test.
+
+---
+
 ## Adding a new source — checklist
 
 1. Verify the **data** license (not the addon's) against its `LICENSE` file.


### PR DESCRIPTION
PR 1/6 of the moat-expansion chain (stacked-to-main). Part of #793.

## What

- `tools/moat-expansion/` scaffold: gitignored quarantine zone (raw ClearURLs bytes never committed — clean-room LGPL-3.0 posture), `reports/` with committed `.gitkeep`.
- `lookup-table.mjs`: muga-authored known-program map (amazon, ebay, aliexpress, awin, impact, cj) — ClearURLs provider key → `{programId, domains[], note}`. No upstream content copied; domain inference for unknown providers is deliberately NOT attempted in v1.
- `tests/fixtures/moat-expansion/clearurls-mini.json`: muga-authored miniature fixture (4 synthetic providers).
- `PROVENANCE.md`: ClearURLs `referralMarketing` ledger entry — the #773 exclusion inverted (that array was excluded from tracker ingestion precisely because it is affiliate signal; this pipeline is its intended consumer).

348 lines, within budget. Zero `src/` changes (tooling only). Suite 4919/0, lint + typecheck clean.

## Chain

**this** → PR 2 (adapter + moat snapshot) → PR 3 (differ) → PR 4 (report) → PR 5 (CLI) → PR 6 (weekly workflow).

Part of #793