### PR TITLE
feat(moat-expansion): ClearURLs adapter + read-only moat snapshot (#793 PR 2/6)

### DIFF
--- a/tests/unit/moat-expansion-extract.test.mjs
+++ b/tests/unit/moat-expansion-extract.test.mjs
@@ -1,0 +1,350 @@
+/**
+ * MUGA — moat-expansion ClearURLs adapter tests (#793).
+ *
+ * Tests for:
+ *   - extractReferralSignals: fixture-driven extraction correctness
+ *   - Empty referralMarketing providers excluded
+ *   - Bad-shape input throws CliError(1)
+ *   - Fetch failure fail-closed via injected failing fetch (CliError exit 2)
+ *   - Raw bytes written to quarantine path (injectable path)
+ *   - Determinism: same input → same output
+ *
+ * Also includes a smoke import test for moat-snapshot.mjs to verify no
+ * browser globals (chrome/window/document) are accessed at import time.
+ *
+ * Fixtures: tests/fixtures/moat-expansion/clearurls-mini.json
+ * No upstream content — muga-authored fixture only.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+import {
+  extractReferralSignals,
+  fetchRaw,
+} from "../../tools/moat-expansion/adapters/clearurls-moat.mjs";
+
+import { CliError } from "../../tools/moat-expansion/cli-error.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const FIXTURE_PATH = join(
+  __dirname,
+  "../../tests/fixtures/moat-expansion/clearurls-mini.json"
+);
+
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, "utf8");
+
+// ── extractReferralSignals ────────────────────────────────────────────────────
+
+describe("extractReferralSignals — extraction correctness", () => {
+  test("returns an array of tuples with provider, urlPattern, referralMarketing", () => {
+    const result = extractReferralSignals(FIXTURE_TEXT);
+    assert.ok(Array.isArray(result), "must return an array");
+    assert.ok(result.length > 0, "must return at least one tuple");
+    for (const entry of result) {
+      assert.ok(
+        typeof entry.provider === "string" && entry.provider.length > 0,
+        "each entry must have a non-empty provider string"
+      );
+      assert.ok(
+        typeof entry.urlPattern === "string",
+        "each entry must have a urlPattern string"
+      );
+      assert.ok(
+        Array.isArray(entry.referralMarketing),
+        "each entry must have a referralMarketing array"
+      );
+    }
+  });
+
+  test("extracts amazon with tag and newparam", () => {
+    const result = extractReferralSignals(FIXTURE_TEXT);
+    const amazon = result.find((e) => e.provider === "amazon");
+    assert.ok(amazon, "amazon provider must be present");
+    assert.ok(
+      amazon.referralMarketing.includes("tag"),
+      "amazon must include 'tag'"
+    );
+    assert.ok(
+      amazon.referralMarketing.includes("newparam"),
+      "amazon must include 'newparam'"
+    );
+  });
+
+  test("extracts ebay with campid", () => {
+    const result = extractReferralSignals(FIXTURE_TEXT);
+    const ebay = result.find((e) => e.provider === "ebay");
+    assert.ok(ebay, "ebay provider must be present");
+    assert.ok(
+      ebay.referralMarketing.includes("campid"),
+      "ebay must include 'campid'"
+    );
+  });
+
+  test("extracts unknown-foo with xparam", () => {
+    const result = extractReferralSignals(FIXTURE_TEXT);
+    const unknownFoo = result.find((e) => e.provider === "unknown-foo");
+    assert.ok(unknownFoo, "unknown-foo provider must be present");
+    assert.ok(
+      unknownFoo.referralMarketing.includes("xparam"),
+      "unknown-foo must include 'xparam'"
+    );
+  });
+
+  test("excludes empty-provider (referralMarketing is empty array)", () => {
+    const result = extractReferralSignals(FIXTURE_TEXT);
+    const emptyProv = result.find((e) => e.provider === "empty-provider");
+    assert.strictEqual(
+      emptyProv,
+      undefined,
+      "empty-provider must be excluded from results"
+    );
+  });
+
+  test("preserves urlPattern verbatim for each provider", () => {
+    const result = extractReferralSignals(FIXTURE_TEXT);
+    const amazon = result.find((e) => e.provider === "amazon");
+    assert.ok(
+      typeof amazon.urlPattern === "string" && amazon.urlPattern.length > 0,
+      "urlPattern must be a non-empty string"
+    );
+  });
+
+  test("determinism: same input produces identical output on two calls", () => {
+    const r1 = extractReferralSignals(FIXTURE_TEXT);
+    const r2 = extractReferralSignals(FIXTURE_TEXT);
+    assert.deepStrictEqual(r1, r2, "two calls with same input must produce identical results");
+  });
+});
+
+describe("extractReferralSignals — error handling", () => {
+  test("throws CliError(1) on invalid JSON", () => {
+    assert.throws(
+      () => extractReferralSignals("not valid json"),
+      (err) => {
+        assert.ok(err instanceof CliError, "must throw CliError");
+        assert.strictEqual(err.exitCode, 1, "exitCode must be 1 for bad JSON");
+        return true;
+      }
+    );
+  });
+
+  test("throws CliError(1) when providers key is missing", () => {
+    const badShape = JSON.stringify({ notProviders: {} });
+    assert.throws(
+      () => extractReferralSignals(badShape),
+      (err) => {
+        assert.ok(err instanceof CliError, "must throw CliError");
+        assert.strictEqual(err.exitCode, 1, "exitCode must be 1 for bad shape");
+        return true;
+      }
+    );
+  });
+
+  test("throws CliError(1) when providers is not an object", () => {
+    const badShape = JSON.stringify({ providers: "not-an-object" });
+    assert.throws(
+      () => extractReferralSignals(badShape),
+      (err) => {
+        assert.ok(err instanceof CliError, "must throw CliError");
+        assert.strictEqual(err.exitCode, 1, "exitCode must be 1 for non-object providers");
+        return true;
+      }
+    );
+  });
+});
+
+// ── fetchRaw ──────────────────────────────────────────────────────────────────
+
+describe("fetchRaw — fetch behavior with injectable fetch", () => {
+  function makeTmpDir() {
+    const dir = join(tmpdir(), `moat-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  test("writes raw content to quarantine path and returns raw text", async () => {
+    const tmpDir = makeTmpDir();
+    const quarantinePath = join(tmpDir, "clearurls.raw");
+
+    const fakeRaw = FIXTURE_TEXT;
+    const fakeFetch = async (_url, _opts) => ({
+      ok: true,
+      text: async () => fakeRaw,
+    });
+
+    const result = await fetchRaw({
+      fetchImpl: fakeFetch,
+      quarantinePath,
+    });
+
+    assert.strictEqual(result, fakeRaw, "fetchRaw must return the raw text");
+    assert.ok(existsSync(quarantinePath), "quarantine file must be written");
+    assert.strictEqual(
+      readFileSync(quarantinePath, "utf8"),
+      fakeRaw,
+      "quarantine file content must match fetched text"
+    );
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("creates quarantine directory if it does not exist", async () => {
+    const tmpDir = makeTmpDir();
+    // Use a nested path that does not exist yet
+    const quarantinePath = join(tmpDir, "subdir", "nested", "clearurls.raw");
+
+    const fakeFetch = async (_url, _opts) => ({
+      ok: true,
+      text: async () => FIXTURE_TEXT,
+    });
+
+    await fetchRaw({ fetchImpl: fakeFetch, quarantinePath });
+    assert.ok(existsSync(quarantinePath), "nested quarantine file must be created");
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("throws CliError(2) when fetch throws a network error", async () => {
+    const tmpDir = makeTmpDir();
+    const quarantinePath = join(tmpDir, "clearurls.raw");
+
+    const failFetch = async () => {
+      throw new Error("Network unreachable");
+    };
+
+    await assert.rejects(
+      () => fetchRaw({ fetchImpl: failFetch, quarantinePath }),
+      (err) => {
+        assert.ok(err instanceof CliError, "must throw CliError");
+        assert.strictEqual(err.exitCode, 2, "exitCode must be 2 for network failure");
+        return true;
+      }
+    );
+
+    assert.ok(!existsSync(quarantinePath), "no file must be written on fetch failure");
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("throws CliError(2) when response is non-2xx", async () => {
+    const tmpDir = makeTmpDir();
+    const quarantinePath = join(tmpDir, "clearurls.raw");
+
+    const failFetch = async () => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    await assert.rejects(
+      () => fetchRaw({ fetchImpl: failFetch, quarantinePath }),
+      (err) => {
+        assert.ok(err instanceof CliError, "must throw CliError");
+        assert.strictEqual(err.exitCode, 2, "exitCode must be 2 for non-2xx response");
+        return true;
+      }
+    );
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+// ── moat-snapshot.mjs smoke import ───────────────────────────────────────────
+
+import { loadMoatSnapshot } from "../../tools/moat-expansion/moat-snapshot.mjs";
+
+describe("moat-snapshot — import safety smoke test", () => {
+  test("loadMoatSnapshot can be imported without browser globals", () => {
+    // Importing at the top of this module is already the test — if it threw,
+    // the module would have failed to load. This test just verifies the export.
+    assert.ok(
+      typeof loadMoatSnapshot === "function",
+      "loadMoatSnapshot must be a named export function"
+    );
+  });
+});
+
+describe("moat-snapshot — shape assertions against real moat", () => {
+  test("returns an object with coveredByDomain, guardParams, knownByProgramId, landingParamSet", () => {
+    const snapshot = loadMoatSnapshot();
+    assert.ok(snapshot.coveredByDomain instanceof Map, "coveredByDomain must be a Map");
+    assert.ok(snapshot.guardParams instanceof Set, "guardParams must be a Set");
+    assert.ok(snapshot.knownByProgramId instanceof Map, "knownByProgramId must be a Map");
+    assert.ok(snapshot.landingParamSet instanceof Set, "landingParamSet must be a Set");
+  });
+
+  test("amazon-associates program is in knownByProgramId with param 'tag'", () => {
+    const { knownByProgramId } = loadMoatSnapshot();
+    assert.ok(
+      knownByProgramId.has("amazon-associates"),
+      "knownByProgramId must contain amazon-associates"
+    );
+    const entry = knownByProgramId.get("amazon-associates");
+    assert.strictEqual(entry.param, "tag", "amazon-associates param must be 'tag'");
+    assert.ok(
+      Array.isArray(entry.domains) && entry.domains.length > 0,
+      "amazon-associates must have a non-empty domains array"
+    );
+    assert.ok(
+      entry.domains.includes("amazon.com"),
+      "amazon-associates domains must include amazon.com"
+    );
+  });
+
+  test("ascsubtag is in guardParams (case-insensitive)", () => {
+    const { guardParams } = loadMoatSnapshot();
+    assert.ok(
+      guardParams.has("ascsubtag"),
+      "guardParams must contain 'ascsubtag' (from AFFILIATE_PARAM_GUARD, #794)"
+    );
+  });
+
+  test("awin landingParams (awc) are in landingParamSet", () => {
+    const { landingParamSet } = loadMoatSnapshot();
+    assert.ok(
+      landingParamSet.has("awc"),
+      "landingParamSet must contain 'awc' (from REDIRECT_NETWORK_PATTERNS awin)"
+    );
+  });
+
+  test("coveredByDomain has entries for amazon.com with 'tag' param", () => {
+    const { coveredByDomain } = loadMoatSnapshot();
+    assert.ok(
+      coveredByDomain.has("amazon.com"),
+      "coveredByDomain must have an entry for amazon.com"
+    );
+    const params = coveredByDomain.get("amazon.com");
+    assert.ok(
+      params.has("tag"),
+      "amazon.com must have 'tag' in covered params"
+    );
+  });
+
+  test("ebay-partner-network is in knownByProgramId with param 'campid'", () => {
+    const { knownByProgramId } = loadMoatSnapshot();
+    assert.ok(
+      knownByProgramId.has("ebay-partner-network"),
+      "knownByProgramId must contain ebay-partner-network"
+    );
+    const entry = knownByProgramId.get("ebay-partner-network");
+    assert.strictEqual(entry.param, "campid", "ebay-partner-network param must be 'campid'");
+  });
+
+  test("injectable seam works — custom guard overrides production guard", () => {
+    const customGuard = new Set(["testparam123"]);
+    const snapshot = loadMoatSnapshot({ guard: customGuard });
+    assert.ok(
+      snapshot.guardParams.has("testparam123"),
+      "injectable guard must override production AFFILIATE_PARAM_GUARD"
+    );
+    assert.ok(
+      !snapshot.guardParams.has("ascsubtag"),
+      "injected custom guard must not include production params"
+    );
+  });
+});

--- a/tools/moat-expansion/adapters/clearurls-moat.mjs
+++ b/tools/moat-expansion/adapters/clearurls-moat.mjs
@@ -1,0 +1,193 @@
+/**
+ * MUGA — moat-expansion ClearURLs moat adapter (#793).
+ *
+ * Fetches ClearURLs referralMarketing signals for affiliate-moat gap analysis.
+ * This adapter is the SEMANTIC INVERSE of tools/rule-ingestion/adapters/clearurls.mjs:
+ *   - rule-ingestion EXCLUDES referralMarketing (affiliate preserve)
+ *   - moat-expansion EXTRACTS referralMarketing as the primary signal
+ *
+ * License context: ClearURLs rules database is LGPL-3.0. We extract
+ * referralMarketing tuples as facts (signals-not-copies). Raw file is
+ * quarantined and never committed. See tools/rule-ingestion/PROVENANCE.md.
+ *
+ * Exit code contract (via CliError):
+ *   1 — unexpected JSON shape / validation failure
+ *   2 — fetch / network failure (non-2xx or thrown error)
+ *   3 — I/O write failure (quarantine path unwritable)
+ *
+ * Public API (named exports only — no default):
+ *   fetchRaw({ fetchImpl, url, timeoutMs, quarantinePath })
+ *     → Promise<string> — raw JSON text; writes to quarantine before returning
+ *   extractReferralSignals(rawText)
+ *     → Array<{provider, urlPattern, referralMarketing[]}> — PURE
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+import { CliError } from "../cli-error.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Canonical upstream URL for ClearURLs rules (data.min.json, master branch).
+const SOURCE_URL =
+  "https://raw.githubusercontent.com/ClearURLs/Rules/master/data.min.json";
+
+const USER_AGENT =
+  "muga-moat-expansion/1.0 (+https://github.com/yocreoquesi/muga)";
+
+// Production default quarantine path (relative to this adapter file).
+const DEFAULT_QUARANTINE_PATH = resolve(
+  __dirname,
+  "../quarantine/clearurls.raw"
+);
+
+// ── fetchRaw ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch the raw ClearURLs rules JSON and write it to the quarantine path.
+ *
+ * The quarantine directory is created at runtime via mkdirSync (recursive)
+ * if it does not exist — mirrors the rule-ingestion convention.
+ * The quarantine file is overwritten on each run (no archival of raw bytes).
+ *
+ * Fail-closed contract: on ANY failure (network, non-2xx, I/O), this
+ * function throws a CliError with the appropriate exit code. No partial
+ * output is produced.
+ *
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetchImpl] Injectable fetch (default: global fetch). Required for tests.
+ * @param {string} [opts.url] Override the upstream URL. Default: SOURCE_URL.
+ * @param {number} [opts.timeoutMs] Abort timeout in ms. Default: 30000.
+ * @param {string} [opts.quarantinePath] Override the quarantine file path. Default: production path.
+ * @returns {Promise<string>} Raw rules JSON text (after writing to quarantine).
+ * @throws {CliError} exitCode 2 on fetch/network failure; exitCode 3 on I/O failure.
+ */
+export async function fetchRaw({
+  fetchImpl = globalThis.fetch,
+  url = SOURCE_URL,
+  timeoutMs = 30_000,
+  quarantinePath = DEFAULT_QUARANTINE_PATH,
+} = {}) {
+  const controller = new AbortController();
+
+  let timer;
+  /** @type {Promise<never>} */
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(
+        new CliError(
+          `[moat-expansion] fetchRaw timeout after ${timeoutMs}ms`,
+          2
+        )
+      );
+    }, timeoutMs);
+  });
+
+  let rawText;
+  try {
+    const res = await Promise.race([
+      fetchImpl(url, {
+        headers: { "User-Agent": USER_AGENT },
+        signal: controller.signal,
+      }),
+      timeoutPromise,
+    ]);
+
+    if (!res.ok) {
+      throw new CliError(
+        `[moat-expansion] fetchRaw: upstream returned ${res.status} ${res.statusText}`,
+        2
+      );
+    }
+
+    rawText = await res.text();
+  } catch (err) {
+    if (err instanceof CliError) throw err;
+    // Network errors, AbortErrors, and other fetch-layer throws → exit 2
+    throw new CliError(
+      `[moat-expansion] fetchRaw: fetch failed — ${err.message}`,
+      2
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // Write raw bytes to quarantine (create dir if needed).
+  try {
+    mkdirSync(dirname(quarantinePath), { recursive: true });
+    writeFileSync(quarantinePath, rawText, "utf8");
+  } catch (err) {
+    throw new CliError(
+      `[moat-expansion] fetchRaw: cannot write quarantine file "${quarantinePath}": ${err.message}`,
+      3
+    );
+  }
+
+  return rawText;
+}
+
+// ── extractReferralSignals ────────────────────────────────────────────────────
+
+/**
+ * Extract referralMarketing tuples from a ClearURLs rules JSON string.
+ *
+ * PURE function — no I/O, no side effects. Deterministic on identical input.
+ *
+ * Extraction rules:
+ *   1. Parse JSON. Throw CliError(1) on invalid JSON.
+ *   2. Validate providers key is a non-null object. Throw CliError(1) if absent/wrong type.
+ *   3. For each provider, collect { provider, urlPattern, referralMarketing[] }.
+ *   4. EXCLUDE providers where referralMarketing is empty or absent.
+ *   5. Return the filtered array (order matches key-iteration order of providers object).
+ *
+ * @param {string} rawText Raw ClearURLs rules JSON string.
+ * @returns {Array<{provider: string, urlPattern: string, referralMarketing: string[]}>}
+ * @throws {CliError} exitCode 1 on invalid JSON or unexpected shape.
+ */
+export function extractReferralSignals(rawText) {
+  let data;
+  try {
+    data = JSON.parse(rawText);
+  } catch (err) {
+    throw new CliError(
+      `[moat-expansion] extractReferralSignals: invalid JSON — ${err.message}`,
+      1
+    );
+  }
+
+  // Validate shape: providers must be a non-null, non-array object.
+  if (
+    !data ||
+    typeof data !== "object" ||
+    !("providers" in data) ||
+    !data.providers ||
+    typeof data.providers !== "object" ||
+    Array.isArray(data.providers)
+  ) {
+    throw new CliError(
+      "[moat-expansion] extractReferralSignals: unexpected shape — missing or invalid 'providers' key",
+      1
+    );
+  }
+
+  const result = [];
+
+  for (const [provider, entry] of Object.entries(data.providers)) {
+    // Skip providers with absent or empty referralMarketing
+    if (!Array.isArray(entry?.referralMarketing) || entry.referralMarketing.length === 0) {
+      continue;
+    }
+
+    result.push({
+      provider,
+      urlPattern: typeof entry.urlPattern === "string" ? entry.urlPattern : "",
+      referralMarketing: entry.referralMarketing.slice(), // defensive copy
+    });
+  }
+
+  return result;
+}

--- a/tools/moat-expansion/cli-error.mjs
+++ b/tools/moat-expansion/cli-error.mjs
@@ -1,0 +1,35 @@
+/**
+ * MUGA — moat-expansion shared CliError (#793).
+ *
+ * Tiny shared error class for the moat-expansion tool suite.
+ * Mirrors the CliError pattern from tools/rule-ingestion/orchestrate-cli.mjs
+ * but is scoped to moat-expansion only — NOT imported cross-tool.
+ *
+ * Exit code contract:
+ *   0 — success
+ *   1 — validation / bad-JSON / unexpected shape
+ *   2 — fetch / network failure
+ *   3 — I/O error (write failure)
+ *
+ * Public API (named export only — no default):
+ *   CliError
+ */
+
+/**
+ * Structured error for moat-expansion CLI exit-code propagation.
+ *
+ * @example
+ *   throw new CliError("fetch failed: network unreachable", 2);
+ */
+export class CliError extends Error {
+  /**
+   * @param {string} message Human-readable error message.
+   * @param {number} exitCode Process exit code (1=validation, 2=fetch, 3=I/O).
+   */
+  constructor(message, exitCode) {
+    super(message);
+    this.name = "CliError";
+    /** @type {number} */
+    this.exitCode = exitCode;
+  }
+}

--- a/tools/moat-expansion/moat-snapshot.mjs
+++ b/tools/moat-expansion/moat-snapshot.mjs
@@ -1,0 +1,137 @@
+/**
+ * MUGA — moat-expansion moat snapshot loader (#793).
+ *
+ * Reads the live affiliate moat READ-ONLY via direct Node import from src/lib.
+ * These imports are verified safe at module load time: affiliates.js and
+ * redirect-networks.js have no chrome/window/document references at import
+ * time (only in factory functions or comments). remote-rules.js AFFILIATE_PARAM_GUARD
+ * is a plain frozen Set exported at module level — safe to import.
+ *
+ * Design D2/D3: direct import is the single source of truth; no extraction
+ * or vendored mirror needed. If import cost becomes an issue, a fallback
+ * vendored mirror with a guard-sync test can be substituted (documented in
+ * the design as the D3 fallback path).
+ *
+ * Injectable seam: production code imports src/lib tables directly; tests
+ * can pass pre-built snapshots via the optional `{ affiliatePatterns,
+ * redirectPatterns, guard }` parameter to avoid touching src/ at test time.
+ *
+ * Public API (named export only — no default):
+ *   loadMoatSnapshot({ affiliatePatterns?, redirectPatterns?, guard? }?)
+ *     → { coveredByDomain, guardParams, knownByProgramId }
+ */
+
+// Production imports — read-only; no modifications to src/ files.
+import { AFFILIATE_PATTERNS } from "../../src/lib/affiliates.js";
+import { REDIRECT_NETWORK_PATTERNS } from "../../src/lib/redirect-networks.js";
+import { AFFILIATE_PARAM_GUARD } from "../../src/lib/remote-rules.js";
+
+// ── loadMoatSnapshot ─────────────────────────────────────────────────────────
+
+/**
+ * Build a normalized snapshot of the live affiliate moat for the differ.
+ *
+ * Coverage sources (mirrors spec §Coverage Differ):
+ *   (a) AFFILIATE_PATTERNS — per-program {id, domains[], param}
+ *   (b) REDIRECT_NETWORK_PATTERNS — per-network landingParams[]
+ *   (c) AFFILIATE_PARAM_GUARD — global case-insensitive param blocklist
+ *
+ * The snapshot shape is designed for fast O(1) lookup during diffing:
+ *   - coveredByDomain: Map<domain, Set<param>>
+ *       For coverage source (a): allows the differ to check if a (domain, param)
+ *       pair is already covered by any AFFILIATE_PATTERNS entry.
+ *   - guardParams: Set<string> (lowercased)
+ *       For coverage source (c): case-insensitive param membership test.
+ *   - knownByProgramId: Map<programId, {param, domains[]}>
+ *       Allows the differ to resolve a lookup-table programId to its moat param
+ *       and domain set for coverage source (a) checks.
+ *
+ * Landing params from REDIRECT_NETWORK_PATTERNS (source b) are embedded in
+ * coveredByDomain under each redirectHost domain so the differ's uniform
+ * domain-lookup covers both (a) and (b) in one pass. Additionally they are
+ * available via the landingParamSet on the returned object for explicit (b)
+ * checks without a domain constraint.
+ *
+ * @param {object} [opts] Injectable overrides for testing.
+ * @param {Array} [opts.affiliatePatterns] Override AFFILIATE_PATTERNS.
+ * @param {Array} [opts.redirectPatterns] Override REDIRECT_NETWORK_PATTERNS.
+ * @param {Set|ReadonlySet} [opts.guard] Override AFFILIATE_PARAM_GUARD.
+ * @returns {{
+ *   coveredByDomain: Map<string, Set<string>>,
+ *   guardParams: Set<string>,
+ *   knownByProgramId: Map<string, {param: string, domains: string[]}>,
+ *   landingParamSet: Set<string>
+ * }}
+ */
+export function loadMoatSnapshot({
+  affiliatePatterns = AFFILIATE_PATTERNS,
+  redirectPatterns = REDIRECT_NETWORK_PATTERNS,
+  guard = AFFILIATE_PARAM_GUARD,
+} = {}) {
+  // ── (a) AFFILIATE_PATTERNS → coveredByDomain + knownByProgramId ────────────
+
+  /** @type {Map<string, Set<string>>} */
+  const coveredByDomain = new Map();
+
+  /** @type {Map<string, {param: string, domains: string[]}>} */
+  const knownByProgramId = new Map();
+
+  for (const pattern of affiliatePatterns) {
+    if (!pattern.id || !pattern.param || !Array.isArray(pattern.domains)) continue;
+
+    knownByProgramId.set(pattern.id, {
+      param: pattern.param,
+      domains: pattern.domains.slice(),
+    });
+
+    for (const domain of pattern.domains) {
+      // Normalize: strip leading www. for consistent lookup
+      const normalized = domain.replace(/^www\./, "");
+      if (!coveredByDomain.has(normalized)) {
+        coveredByDomain.set(normalized, new Set());
+      }
+      coveredByDomain.get(normalized).add(pattern.param);
+    }
+  }
+
+  // ── (b) REDIRECT_NETWORK_PATTERNS → landingParamSet + coveredByDomain ─────
+
+  /** @type {Set<string>} */
+  const landingParamSet = new Set();
+
+  for (const network of redirectPatterns) {
+    if (!Array.isArray(network.landingParams)) continue;
+    for (const param of network.landingParams) {
+      landingParamSet.add(param);
+    }
+
+    // Also index landing params under each redirectHost domain for uniform (a)+(b) lookup
+    if (!Array.isArray(network.redirectHosts)) continue;
+    for (const host of network.redirectHosts) {
+      // Skip wildcard entries (*.domain) — they can't be keyed by exact domain
+      if (host.startsWith("*.")) continue;
+      const normalized = host.replace(/^www\./, "");
+      if (!coveredByDomain.has(normalized)) {
+        coveredByDomain.set(normalized, new Set());
+      }
+      for (const param of network.landingParams) {
+        coveredByDomain.get(normalized).add(param);
+      }
+    }
+  }
+
+  // ── (c) AFFILIATE_PARAM_GUARD → guardParams (lowercased) ──────────────────
+
+  /** @type {Set<string>} */
+  const guardParams = new Set();
+  for (const param of guard) {
+    guardParams.add(param.toLowerCase());
+  }
+
+  return {
+    coveredByDomain,
+    guardParams,
+    knownByProgramId,
+    landingParamSet,
+  };
+}


### PR DESCRIPTION
PR 2/6 of the moat-expansion chain (stacked-to-main, follows #879). Part of #793.

## What

- `adapters/clearurls-moat.mjs`: `fetchRaw` (injectable fetch, AbortController timeout, runtime-created gitignored quarantine, fail-closed CliError on network/IO failure) + `extractReferralSignals` (pure: only providers with non-empty `referralMarketing` yield `{provider, urlPattern, referralMarketing[]}` tuples). Semantic INVERSE of the rule-ingestion ClearURLs adapter, which deliberately excludes that array.
- `moat-snapshot.mjs`: read-only Node import of the live moat — `AFFILIATE_PATTERNS`, `REDIRECT_NETWORK_PATTERNS` landingParams, `AFFILIATE_PARAM_GUARD` — normalized for the differ. Zero `src/` changes.
- `cli-error.mjs`: shared exit-code error within moat-expansion (rule-ingestion's is unexported; no cross-tool coupling).

## size:exception

715 changed lines, but 350 are the fixture-driven test file; source is 365 lines across three small modules. Splitting tests from the code they drive is not an honest cut (same rationale as #875).

Suite 4941/0, lint + typecheck clean.

## Chain

#879 → **this** → PR 3 (differ) → PR 4 (report) → PR 5 (CLI) → PR 6 (workflow).

Part of #793