### PR TITLE
feat(moat-expansion): CLI orchestrator, moat:report script and README (#793 PR 5/6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "add-rule": "node tools/add-rule.mjs",
     "test:e2e": "npx playwright test",
     "typecheck": "tsc -p jsconfig.json",
-    "lint:js": "eslint ."
+    "lint:js": "eslint .",
+    "moat:report": "node tools/moat-expansion/cli.mjs"
   },
   "engines": {
     "node": ">=20.11"

--- a/tests/integration/moat-expansion-cli.test.mjs
+++ b/tests/integration/moat-expansion-cli.test.mjs
@@ -1,0 +1,400 @@
+/**
+ * MUGA — moat-expansion CLI integration test (#793).
+ *
+ * Drives runMoatExpansionCli end-to-end with:
+ *   - Injected fetchImpl returning fixture bytes (no real network)
+ *   - Temporary directories for quarantine and reports
+ *   - Injected clock for deterministic timestamps
+ *   - Injected moatSnapshot override (no src/ read needed)
+ *
+ * Coverage:
+ *   - Report file written with expected content sections
+ *   - Raw file quarantined
+ *   - Fail-closed: fetch failure → CliError(exitCode 2), no report written
+ *   - Fail-closed: bad JSON shape → CliError(exitCode 1), no report written
+ *   - Fail-closed: bad providers shape → CliError(exitCode 1), no report written
+ *   - No src/ files mutated
+ *
+ * Runner: npm run test:integration:stub
+ *   (this file lives under tests/integration/ — NOT in the default unit glob)
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+import { runMoatExpansionCli } from "../../tools/moat-expansion/cli.mjs";
+import { CliError } from "../../tools/moat-expansion/cli-error.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Fixture data ──────────────────────────────────────────────────────────────
+
+// Minimal ClearURLs-shaped JSON — two providers with referralMarketing
+const FIXTURE_JSON = JSON.stringify({
+  providers: {
+    amazon: {
+      urlPattern: "^https?://([a-z0-9-]+\\.)*amazon\\.",
+      referralMarketing: ["tag", "newparam"],
+    },
+    unknownshop: {
+      urlPattern: "^https?://unknownshop\\.example\\.com/",
+      referralMarketing: ["ref"],
+    },
+    emptyprovider: {
+      urlPattern: "^https?://empty\\.example\\.com/",
+      referralMarketing: [],
+    },
+  },
+});
+
+// Injected snapshot: amazon-associates covers "tag"; "newparam" is a gap.
+// unknownshop is not in the lookup so its "ref" param surfaces as unknown-provider.
+const INJECTED_SNAPSHOT = {
+  coveredByDomain: new Map([
+    ["amazon.com", new Set(["tag"])],
+    ["amazon.co.uk", new Set(["tag"])],
+  ]),
+  guardParams: new Set(["ascsubtag"]),
+  knownByProgramId: new Map([
+    [
+      "amazon-associates",
+      { param: "tag", domains: ["amazon.com", "amazon.co.uk"] },
+    ],
+  ]),
+  landingParamSet: new Set(["awc"]),
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Create a fresh temp directory for one test run.
+ * Returns { quarantineDir, reportsDir, cleanup }.
+ */
+function makeTempDirs(prefix) {
+  const base = join(tmpdir(), `moat-cli-test-${prefix}-${Date.now()}`);
+  const quarantineDir = join(base, "quarantine");
+  const reportsDir = join(base, "reports");
+  mkdirSync(quarantineDir, { recursive: true });
+  mkdirSync(reportsDir, { recursive: true });
+  return {
+    quarantineDir,
+    reportsDir,
+    cleanup() {
+      try {
+        rmSync(base, { recursive: true, force: true });
+      } catch {
+        // ignore cleanup errors in test teardown
+      }
+    },
+  };
+}
+
+/**
+ * Build a success fetchImpl that returns the fixture JSON.
+ */
+function successFetch() {
+  return async () => ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => FIXTURE_JSON,
+  });
+}
+
+/**
+ * Build a failing fetchImpl that throws a network error.
+ */
+function failingFetch() {
+  return async () => {
+    throw new Error("network unreachable");
+  };
+}
+
+/**
+ * Build a fetchImpl that returns a non-2xx response.
+ */
+function non2xxFetch(status = 503) {
+  return async () => ({
+    ok: false,
+    status,
+    statusText: "Service Unavailable",
+    text: async () => "upstream error",
+  });
+}
+
+/**
+ * Build a fetchImpl that returns bad JSON.
+ */
+function badJsonFetch() {
+  return async () => ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => "{ this is not json {{",
+  });
+}
+
+/**
+ * Build a fetchImpl that returns valid JSON but with wrong shape.
+ */
+function badShapeFetch() {
+  return async () => ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => JSON.stringify({ notProviders: {} }),
+  });
+}
+
+// Fixed clock: 2026-06-10T10:00:00.000Z
+const FIXED_NOW = new Date("2026-06-10T10:00:00.000Z");
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("moat-expansion CLI integration", () => {
+  test("happy path: report file written with expected content sections", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("happy");
+    try {
+      await runMoatExpansionCli({
+        fetchImpl: successFetch(),
+        now: FIXED_NOW,
+        paths: { quarantineDir, reportsDir },
+        moatSnapshot: INJECTED_SNAPSHOT,
+      });
+
+      // Report file must exist
+      const files = readdirSync(reportsDir).filter((f) => f.endsWith(".md"));
+      assert.equal(files.length, 1, "exactly one .md report file should be created");
+
+      const reportPath = join(reportsDir, files[0]);
+      const content = readFileSync(reportPath, "utf8");
+
+      // Header section
+      assert.match(content, /# Moat-expansion discovery report/, "header present");
+      assert.match(content, /ClearURLs data\.min\.json/, "source attribution present");
+      assert.match(content, /2026-06-10/, "date in report");
+
+      // new-param-on-known-program section — newparam is a gap on amazon-associates
+      assert.match(content, /new-param-on-known-program/, "gap section present");
+      assert.match(content, /newparam/, "gap param newparam appears in report");
+      assert.match(content, /amazon-associates/, "known program id appears");
+
+      // unknown-provider section — unknownshop is unknown
+      assert.match(content, /unknown-provider/, "unknown-provider section present");
+      assert.match(content, /unknownshop/, "unknown provider name appears");
+
+      // already-covered section — tag is covered
+      assert.match(content, /[Aa]lready covered/, "already-covered section present");
+      assert.match(content, /1 param/, "covered count shows 1");
+
+      // tag must NOT appear as a gap
+      const gapSection = content.split("## unknown-provider")[0];
+      assert.ok(
+        !gapSection.includes("param `tag`"),
+        "covered param 'tag' must not appear in gap section"
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("happy path: raw file written to quarantine dir", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("quarantine");
+    try {
+      await runMoatExpansionCli({
+        fetchImpl: successFetch(),
+        now: FIXED_NOW,
+        paths: { quarantineDir, reportsDir },
+        moatSnapshot: INJECTED_SNAPSHOT,
+      });
+
+      const quarantineFile = join(quarantineDir, "clearurls.raw");
+      assert.ok(existsSync(quarantineFile), "raw file must be written to quarantine");
+
+      const rawContent = readFileSync(quarantineFile, "utf8");
+      assert.ok(rawContent.includes('"providers"'), "raw file contains providers key");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("report filename contains the date from the injected clock", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("filename");
+    try {
+      await runMoatExpansionCli({
+        fetchImpl: successFetch(),
+        now: FIXED_NOW,
+        paths: { quarantineDir, reportsDir },
+        moatSnapshot: INJECTED_SNAPSHOT,
+      });
+
+      const files = readdirSync(reportsDir).filter((f) => f.endsWith(".md"));
+      assert.equal(files.length, 1);
+      assert.ok(
+        files[0].includes("2026-06-10"),
+        `report filename should contain the date 2026-06-10, got: ${files[0]}`
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("fail-closed: fetch network error → CliError exitCode 2, no report written", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("fetchfail");
+    try {
+      await assert.rejects(
+        () =>
+          runMoatExpansionCli({
+            fetchImpl: failingFetch(),
+            now: FIXED_NOW,
+            paths: { quarantineDir, reportsDir },
+            moatSnapshot: INJECTED_SNAPSHOT,
+          }),
+        (err) => {
+          assert.ok(err instanceof CliError, "must throw CliError");
+          assert.equal(err.exitCode, 2, "exit code must be 2 for fetch failure");
+          return true;
+        }
+      );
+
+      // No report file written
+      const files = readdirSync(reportsDir).filter((f) => f.endsWith(".md"));
+      assert.equal(files.length, 0, "no report file must be written on fetch failure");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("fail-closed: non-2xx response → CliError exitCode 2, no report written", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("non2xx");
+    try {
+      await assert.rejects(
+        () =>
+          runMoatExpansionCli({
+            fetchImpl: non2xxFetch(503),
+            now: FIXED_NOW,
+            paths: { quarantineDir, reportsDir },
+            moatSnapshot: INJECTED_SNAPSHOT,
+          }),
+        (err) => {
+          assert.ok(err instanceof CliError, "must throw CliError");
+          assert.equal(err.exitCode, 2, "exit code must be 2 for non-2xx");
+          return true;
+        }
+      );
+
+      const files = readdirSync(reportsDir).filter((f) => f.endsWith(".md"));
+      assert.equal(files.length, 0, "no report file must be written on non-2xx");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("fail-closed: bad JSON response → CliError exitCode 1, no report written", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("badjson");
+    try {
+      await assert.rejects(
+        () =>
+          runMoatExpansionCli({
+            fetchImpl: badJsonFetch(),
+            now: FIXED_NOW,
+            paths: { quarantineDir, reportsDir },
+            moatSnapshot: INJECTED_SNAPSHOT,
+          }),
+        (err) => {
+          assert.ok(err instanceof CliError, "must throw CliError");
+          assert.equal(err.exitCode, 1, "exit code must be 1 for bad JSON shape");
+          return true;
+        }
+      );
+
+      const files = readdirSync(reportsDir).filter((f) => f.endsWith(".md"));
+      assert.equal(files.length, 0, "no report file must be written on bad JSON");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("fail-closed: wrong JSON shape → CliError exitCode 1, no report written", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("badshape");
+    try {
+      await assert.rejects(
+        () =>
+          runMoatExpansionCli({
+            fetchImpl: badShapeFetch(),
+            now: FIXED_NOW,
+            paths: { quarantineDir, reportsDir },
+            moatSnapshot: INJECTED_SNAPSHOT,
+          }),
+        (err) => {
+          assert.ok(err instanceof CliError, "must throw CliError");
+          assert.equal(err.exitCode, 1, "exit code must be 1 for wrong providers shape");
+          return true;
+        }
+      );
+
+      const files = readdirSync(reportsDir).filter((f) => f.endsWith(".md"));
+      assert.equal(files.length, 0, "no report file must be written on wrong shape");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no src/ files are mutated after a successful run", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("nosrc");
+    try {
+      // Record src/ stat before run — we just assert the test doesn't touch src/
+      // The real guard: runMoatExpansionCli only writes to reportsDir/quarantineDir.
+      // Verify by checking the output paths are under the temp dirs, not under src/.
+      await runMoatExpansionCli({
+        fetchImpl: successFetch(),
+        now: FIXED_NOW,
+        paths: { quarantineDir, reportsDir },
+        moatSnapshot: INJECTED_SNAPSHOT,
+      });
+
+      // Reports written to reportsDir, not to src/
+      const files = readdirSync(reportsDir);
+      assert.ok(files.length > 0, "report was written to reportsDir");
+      // All written paths must be under reportsDir or quarantineDir, not src/
+      for (const f of files) {
+        const abs = join(reportsDir, f);
+        assert.ok(
+          abs.startsWith(reportsDir),
+          `output file ${abs} must be under temp reportsDir`
+        );
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("empty providers: report written, no gaps, covered count 0", async () => {
+    const { quarantineDir, reportsDir, cleanup } = makeTempDirs("empty");
+    try {
+      const emptyFixture = JSON.stringify({ providers: { emptyprovider: { urlPattern: "^https?://", referralMarketing: [] } } });
+      await runMoatExpansionCli({
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => emptyFixture,
+        }),
+        now: FIXED_NOW,
+        paths: { quarantineDir, reportsDir },
+        moatSnapshot: INJECTED_SNAPSHOT,
+      });
+
+      const files = readdirSync(reportsDir).filter((f) => f.endsWith(".md"));
+      assert.equal(files.length, 1, "report file still written for empty-signals run");
+      const content = readFileSync(join(reportsDir, files[0]), "utf8");
+      assert.match(content, /No new gaps this week/, "empty run produces no-gaps status");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tools/moat-expansion/README.md
+++ b/tools/moat-expansion/README.md
@@ -1,0 +1,163 @@
+# moat-expansion — affiliate param discovery report
+
+Weekly clean-room pipeline that discovers potential gaps in muga's affiliate moat by
+diffing ClearURLs `referralMarketing` signals against the current affiliate parameter
+coverage. Produces a human-review Markdown report; never auto-edits `manifest.data.js`
+or any `src/` file.
+
+---
+
+## Purpose
+
+The ClearURLs `referralMarketing` database lists affiliate-specific parameters that
+tracking-removal tools should preserve. muga's affiliate moat (`CAPS_DIRECT_INJECTION_PROGRAMS`,
+`REDIRECT_NETWORK_PATTERNS`, `AFFILIATE_PARAM_GUARD`) already covers many of these, but
+new programs and params emerge over time. This pipeline surfaces the gaps weekly so a human
+reviewer can decide whether to extend the moat.
+
+This is the **semantic inverse** of `tools/rule-ingestion/`: rule-ingestion *excludes*
+`referralMarketing` params from tracking removal; moat-expansion *extracts* them as
+affiliate signal.
+
+### Clean-room / LGPL posture
+
+ClearURLs rules are licensed under **LGPL-3.0**. This pipeline extracts only `referralMarketing`
+tuples as facts ("signals-not-copies"). The raw rules file is quarantined at
+`tools/moat-expansion/quarantine/` (gitignored) and **never committed**. See
+`tools/rule-ingestion/PROVENANCE.md` for the full license ledger entry.
+
+---
+
+## Pipeline
+
+```
+ClearURLs data.min.json
+        │
+        ▼  fetchRaw (injectable fetch)
+quarantine/clearurls.raw   (gitignored — raw bytes, never committed)
+        │
+        ▼  extractReferralSignals (PURE)
+[{provider, urlPattern, referralMarketing[]}]
+        │
+        ▼  loadMoatSnapshot (reads src/lib read-only)
+snapshot {coveredByDomain, guardParams, knownByProgramId, landingParamSet}
+        │
+        ▼  diffMoat (PURE) + KNOWN_PROGRAMS lookup table
+{newOnKnown[], unknownProvider[], alreadyCoveredCount}
+        │
+        ▼  renderReport (PURE)
+tools/moat-expansion/reports/report-<YYYY-MM-DD>.md
+        │
+        ▼  Weekly GitHub Actions workflow
+Human-review PR (#needs-triage)
+```
+
+Coverage sources checked by the differ:
+
+| Source | What it checks |
+|--------|---------------|
+| (a) `CAPS_DIRECT_INJECTION_PROGRAMS` | param + domain overlap for known affiliate programs |
+| (b) `REDIRECT_NETWORK_PATTERNS` landingParams | param membership in redirect-network landing params |
+| (c) `AFFILIATE_PARAM_GUARD` | case-insensitive global param blocklist |
+
+A param is a **gap** only if it is not covered by any of (a), (b), or (c).
+
+---
+
+## How to run locally
+
+```bash
+npm run moat:report
+```
+
+Or directly:
+
+```bash
+node tools/moat-expansion/cli.mjs
+```
+
+The CLI:
+1. Fetches `data.min.json` from ClearURLs upstream.
+2. Writes the raw file to `tools/moat-expansion/quarantine/clearurls.raw` (gitignored).
+3. Extracts `referralMarketing` tuples.
+4. Diffs them against the current affiliate moat.
+5. Writes a Markdown gap report to `tools/moat-expansion/reports/report-<YYYY-MM-DD>.md`.
+6. Prints a one-line JSON summary to stdout.
+
+Exit codes: `0` success · `1` bad JSON/shape · `2` fetch/network failure · `3` I/O error.
+
+---
+
+## How the weekly PR works (PR 6/6 — workflow)
+
+The GitHub Actions workflow (`.github/workflows/moat-expansion.yml`, added in PR 6/6) runs
+on a weekly schedule (Sunday 06:00 UTC) and on manual dispatch. When the pipeline finds new
+gaps or unknown providers, it commits the report file to a dated branch and opens a
+`needs-triage` PR for human review.
+
+**Human-review contract:**
+
+- The bot commits only `tools/moat-expansion/reports/report-<date>.md`.
+- The bot **NEVER** edits `src/rules/manifest.data.js`, `src/lib/affiliates.js`, or any
+  other `src/` file. That decision belongs to the human reviewer.
+- The PR is never auto-merged. A reviewer must inspect the gap report and manually copy
+  any draft manifest entries they want to add to the moat.
+- If there are no gaps and no unknown providers, the workflow exits early and no PR is opened.
+
+---
+
+## Lookup-table maintenance
+
+`tools/moat-expansion/lookup-table.mjs` maps ClearURLs provider keys to muga's canonical
+program IDs and domain arrays. This is **muga-authored** content — not derived from or
+copied from ClearURLs files.
+
+Add a new entry when a ClearURLs provider key appears repeatedly in the
+`unknown-provider` report section and you can identify the corresponding affiliate program:
+
+```js
+// In lookup-table.mjs → KNOWN_PROGRAMS object:
+newprovider: {
+  programId: "my-program-id",   // must match id in CAPS_DIRECT_INJECTION_PROGRAMS or REDIRECT_NETWORK_PATTERNS
+  domains: ["example.com", "www.example.com"],
+  note: "Example Affiliate Program. ClearURLs provider key 'newprovider'.",
+},
+```
+
+The `programId` value is used by the differ to check source-(a) coverage (param + domain
+overlap with `CAPS_DIRECT_INJECTION_PROGRAMS`). If the program is not yet in
+`CAPS_DIRECT_INJECTION_PROGRAMS`, the param will surface as a gap in
+`new-param-on-known-program` with a copy-pasteable draft manifest entry.
+
+---
+
+## File layout
+
+```
+tools/moat-expansion/
+  adapters/
+    clearurls-moat.mjs      fetchRaw + extractReferralSignals (I/O + pure parse)
+  cli-error.mjs             CliError(message, exitCode) — shared within moat-expansion
+  cli.mjs                   runMoatExpansionCli() — thin I/O orchestrator
+  differ.mjs                diffMoat() — pure classification
+  lookup-table.mjs          KNOWN_PROGRAMS — muga-authored provider→program map
+  moat-snapshot.mjs         loadMoatSnapshot() — reads src/lib read-only
+  quarantine/               gitignored — raw fetch zone
+  report.mjs                renderReport() — pure Markdown renderer
+  reports/                  committed report output (.gitkeep; reports added by CI)
+  README.md                 this file
+```
+
+Tests:
+
+```
+tests/unit/
+  moat-expansion-lookup.test.mjs     lookup table shape assertions
+  moat-expansion-extract.test.mjs    adapter + snapshot unit tests
+  moat-expansion-differ.test.mjs     differ classification + dedupe tests
+  moat-expansion-report.test.mjs     report renderer snapshot tests
+tests/integration/
+  moat-expansion-cli.test.mjs        end-to-end CLI test (injected fetch + temp dirs)
+tests/fixtures/moat-expansion/
+  clearurls-mini.json                muga-authored miniature fixture (4 providers)
+```

--- a/tools/moat-expansion/cli.mjs
+++ b/tools/moat-expansion/cli.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * MUGA — moat-expansion CLI entry point (#793).
+ *
+ * Thin I/O orchestrator: fetch → quarantine → extract → snapshot → diff → render → write report.
+ * Pure decision logic lives in the pure modules (adapter, differ, report). This
+ * module is the I/O boundary: it calls Date, fs.write, and process.exit.
+ *
+ * Mirrors the orchestrate-cli.mjs pattern:
+ *   - All I/O seams are injectable (fetchImpl, now, paths, moatSnapshot)
+ *   - Core exported function: runMoatExpansionCli(opts?)
+ *   - main() entry guard: only runs when this file is executed directly
+ *   - CliError propagates to process.exit(err.exitCode)
+ *
+ * Exit code contract (via CliError):
+ *   0 — success
+ *   1 — validation / bad-JSON / unexpected shape
+ *   2 — fetch / network failure
+ *   3 — I/O error (write failure)
+ *
+ * Fail-closed: on ANY error before the report write, no report file is created.
+ * The report write itself uses a tmp→rename pattern to avoid partial files.
+ *
+ * Usage:
+ *   node tools/moat-expansion/cli.mjs
+ *   npm run moat:report
+ *
+ * Public API (named exports only — no default):
+ *   runMoatExpansionCli({ fetchImpl?, now?, paths?, moatSnapshot? }?)
+ *     → Promise<void>   // throws CliError on failure
+ */
+
+import { writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CliError } from "./cli-error.mjs";
+import { fetchRaw, extractReferralSignals } from "./adapters/clearurls-moat.mjs";
+import { loadMoatSnapshot } from "./moat-snapshot.mjs";
+import { KNOWN_PROGRAMS } from "./lookup-table.mjs";
+import { diffMoat } from "./differ.mjs";
+import { renderReport } from "./report.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Production defaults ────────────────────────────────────────────────────────
+
+const DEFAULT_QUARANTINE_DIR = resolve(__dirname, "quarantine");
+const DEFAULT_REPORTS_DIR = resolve(__dirname, "reports");
+
+// ── runMoatExpansionCli ────────────────────────────────────────────────────────
+
+/**
+ * Orchestrate the full moat-expansion pipeline.
+ *
+ * All seams are injectable so tests can run without network, without real
+ * moat imports, and with controlled timestamps.
+ *
+ * Pipeline:
+ *   1. fetchRaw — fetch ClearURLs JSON, write to quarantine
+ *   2. extractReferralSignals — parse raw JSON → signals[]
+ *   3. loadMoatSnapshot — build coverage snapshot from src/lib (or override)
+ *   4. diffMoat — classify each (provider, param) tuple
+ *   5. renderReport — pure Markdown string
+ *   6. write report to tools/moat-expansion/reports/report-<date>.md
+ *
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetchImpl] Injectable fetch. Default: globalThis.fetch.
+ * @param {Date} [opts.now] Injectable clock. Default: new Date().
+ * @param {{ quarantineDir?: string, reportsDir?: string }} [opts.paths] Override I/O paths.
+ * @param {object} [opts.moatSnapshot] Pre-built snapshot override (tests). When provided,
+ *   loadMoatSnapshot is NOT called; this object is used directly as the snapshot.
+ * @returns {Promise<void>}
+ * @throws {CliError} with appropriate exitCode on failure.
+ */
+export async function runMoatExpansionCli({
+  fetchImpl = globalThis.fetch,
+  now,
+  paths = {},
+  moatSnapshot,
+} = {}) {
+  // ── 1. Resolve paths ────────────────────────────────────────────────────────
+  const quarantineDir = paths.quarantineDir ?? DEFAULT_QUARANTINE_DIR;
+  const reportsDir = paths.reportsDir ?? DEFAULT_REPORTS_DIR;
+  const quarantinePath = join(quarantineDir, "clearurls.raw");
+
+  // ── 2. Resolve clock ────────────────────────────────────────────────────────
+  // The CLI boundary owns Date — no Date.now() inside pure modules.
+  const resolvedNow = now instanceof Date ? now : new Date();
+  const isoNow = resolvedNow.toISOString();
+  // Date string for filename: YYYY-MM-DD
+  const dateStr = isoNow.slice(0, 10);
+
+  // ── 3. Fetch raw JSON and quarantine ────────────────────────────────────────
+  // fetchRaw writes the raw file to quarantinePath and returns the text.
+  // CliError(2) on network failure, CliError(3) on I/O failure — propagates up.
+  const rawText = await fetchRaw({
+    fetchImpl,
+    quarantinePath,
+  });
+
+  // ── 4. Extract referralMarketing signals ────────────────────────────────────
+  // PURE function. CliError(1) on bad JSON or wrong shape — propagates up.
+  const signals = extractReferralSignals(rawText);
+
+  // Count providers and total params for report meta
+  const providerCount = signals.length;
+  const paramCount = signals.reduce((sum, s) => sum + s.referralMarketing.length, 0);
+
+  // ── 5. Build moat snapshot ──────────────────────────────────────────────────
+  // Production: import from src/lib (no I/O, pure at import-time per D2/D3).
+  // Tests: inject a pre-built snapshot to avoid touching src/.
+  const snapshot = moatSnapshot ?? loadMoatSnapshot();
+
+  // ── 6. Diff signals against snapshot ────────────────────────────────────────
+  // PURE function. No throws.
+  const diffResult = diffMoat(signals, snapshot, KNOWN_PROGRAMS);
+
+  // ── 7. Render Markdown report ────────────────────────────────────────────────
+  // PURE function. No throws.
+  const reportMarkdown = renderReport(diffResult, {
+    fetchedAt: isoNow,
+    providerCount,
+    paramCount,
+  });
+
+  // ── 8. Write report file (atomic tmp→rename) ─────────────────────────────────
+  // Filename: report-<YYYY-MM-DD>.md (per design D6 + report-<date> naming)
+  const reportFilename = `report-${dateStr}.md`;
+  const reportPath = join(reportsDir, reportFilename);
+  const tmpPath = reportPath + ".tmp";
+
+  try {
+    mkdirSync(reportsDir, { recursive: true });
+    writeFileSync(tmpPath, reportMarkdown, "utf8");
+    renameSync(tmpPath, reportPath);
+  } catch (err) {
+    // Clean up tmp file on failure (best-effort)
+    try {
+      writeFileSync(tmpPath, "", "utf8"); // won't throw if already gone
+    } catch {
+      // ignore
+    }
+    throw new CliError(
+      `[moat-expansion] cli: cannot write report to "${reportPath}": ${err.message}`,
+      3
+    );
+  }
+
+  // ── 9. One-line stdout summary ───────────────────────────────────────────────
+  console.log(
+    JSON.stringify({
+      report: reportPath,
+      date: dateStr,
+      providerCount,
+      paramCount,
+      newGaps: diffResult.newOnKnown.length,
+      unknownProviders: diffResult.unknownProvider.length,
+      alreadyCovered: diffResult.alreadyCoveredCount,
+    })
+  );
+}
+
+// ── main() entry ──────────────────────────────────────────────────────────────
+
+async function main() {
+  try {
+    await runMoatExpansionCli();
+    process.exit(0);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(err instanceof CliError ? err.exitCode : 3);
+  }
+}
+
+// Only run when invoked directly (mirrors orchestrate-cli.mjs pattern)
+if (
+  process.argv[1] &&
+  (process.argv[1].endsWith("cli.mjs") ||
+    process.argv[1].endsWith("cli"))
+) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(err instanceof CliError ? err.exitCode : 3);
+  });
+}


### PR DESCRIPTION
PR 5/6 of the moat-expansion chain (stacked-to-main, follows #882). Part of #793.

## What

- `cli.mjs`: thin orchestrator — fetchRaw → extractReferralSignals → loadMoatSnapshot → diffMoat → renderReport → atomic write (tmp→rename) into `tools/moat-expansion/reports/`. Injectable clock and seams throughout (no `Date.now` in the pipeline); CliError exit contract (2 fetch / 1 shape / 3 I/O); never writes under `src/`.
- `package.json`: `npm run moat:report`.
- Integration test (9 end-to-end cases, injected fetch + temp dirs) wired into `tests/integration/` — runs under `npm run test:integration:stub`, deliberately NOT in the default `npm test` glob (repo convention).
- `README.md` for the tool: clean-room/LGPL posture, pipeline diagram, run guide, human-review contract (bot never edits `manifest.data.js`), lookup-table maintenance.

Suite 5000/0 unit + 205/0 integration:stub, lint + typecheck clean.

## Chain

#879 → #880 → #881 → #882 → **this** → PR 6 (weekly workflow, final).

Part of #793