### PR TITLE
feat(gate2): persist passedArm audit trail in quarantine report (#878)

### DIFF
--- a/tests/unit/ingestion-orchestrator-cli.test.mjs
+++ b/tests/unit/ingestion-orchestrator-cli.test.mjs
@@ -631,6 +631,113 @@ describe("#821-I1 — Atomic write: no .tmp sibling left after successful write"
   });
 });
 
+// ── #878: Accepted-arm audit trail persisted in the sidecar ───────────────────
+
+describe("#878 — passedArm audit in quarantine report (not in signed artifact)", () => {
+  /** Empty discovered dir → enrichment is a no-op (entropy/csf stay null). */
+  function emptyDiscoveredDir(dir) {
+    const d = join(dir, "discovered-empty");
+    mkdirSync(d, { recursive: true });
+    return d;
+  }
+
+  test("sidecar carries passedArmDistribution + per-param autoMerge trail (signals arm)", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [
+      passCandidate("utm_source"), // 2 signals → signals arm
+      failCandidate("bad-param"),  // quarantined
+    ]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+      discoveredDir: emptyDiscoveredDir(tmpDir),
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+
+    // Distribution: only the passing candidate counts, via the signals arm.
+    assert.deepStrictEqual(report.passedArmDistribution, {
+      signals: 1,
+      entropy: 0,
+      csf: 0,
+    });
+
+    // Per-param trail: quarantined candidate must NOT appear.
+    assert.deepStrictEqual(report.autoMerge, [
+      { param: "utm_source", passedArm: "signals" },
+    ]);
+  });
+
+  test("signed promote artifact stays exactly {version, published, params, sig} (no leak)", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [passCandidate("utm_source")]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+      discoveredDir: emptyDiscoveredDir(tmpDir),
+    });
+
+    const artifact = JSON.parse(readFileSync(promotePath, "utf8"));
+    assert.deepStrictEqual(
+      Object.keys(artifact).sort(),
+      ["params", "published", "sig", "version"],
+      "audit fields must NOT leak into the signed promote artifact"
+    );
+    assert.ok(!("passedArmDistribution" in artifact));
+    assert.ok(!("autoMerge" in artifact));
+  });
+
+  test("all-quarantined run → empty distribution + empty autoMerge trail", async () => {
+    const { runOrchestrateCli } = await import(
+      "../../tools/rule-ingestion/orchestrate-cli.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const candidatesPath = writeCandidatesFixture(tmpDir, [failCandidate("bad-param")]);
+    const keyPath = writeTmpPrivKey(tmpDir, TEST_PRIV_KEY);
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    const reportPath = join(tmpDir, "quarantine-report.json");
+
+    await runOrchestrateCli({
+      candidatesPath,
+      promotePath,
+      reportPath,
+      version: 1,
+      now: new Date("2024-01-01T00:00:00.000Z"),
+      keyPath,
+      discoveredDir: emptyDiscoveredDir(tmpDir),
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.deepStrictEqual(report.passedArmDistribution, { signals: 0, entropy: 0, csf: 0 });
+    assert.deepStrictEqual(report.autoMerge, []);
+  });
+});
+
 // ── n3: Dedup at CLI boundary ─────────────────────────────────────────────────
 
 describe("R4 — Dedup at CLI boundary", () => {

--- a/tests/unit/ingestion-orchestrator.test.mjs
+++ b/tests/unit/ingestion-orchestrator.test.mjs
@@ -558,6 +558,88 @@ describe("R10 — GATE2 malformed-candidate fail-closed", () => {
   });
 });
 
+// ── #878: Accepted-arm audit trail (acceptances parallel to autoMerge) ────────
+
+describe("#878 — acceptances surface corroboration passedArm", () => {
+  const realGate2 = DEFAULT_GATES.find((d) => d.gate === "corroboration-gate");
+
+  /** Build the 4-gate set with the REAL corroboration gate in position 2. */
+  function gatesWithRealGate2() {
+    return [
+      stubPass("affiliate-guard"),
+      realGate2,
+      stubPass("canary-gate"),
+      stubPass("functional-bias-gate"),
+    ];
+  }
+
+  test("acceptances is parallel to autoMerge (same order + length)", () => {
+    const a = makeCandidate("alpha"); // signals arm
+    const b = makeCandidate("beta", { signals: [], entropy: 5.0 }); // entropy arm
+    const result = runOrchestration({
+      candidates: [a, b],
+      gates: gatesWithRealGate2(),
+      version: 1,
+      published: "2024-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(result.acceptances.length, result.autoMerge.length);
+    assert.strictEqual(result.acceptances[0].candidate, a);
+    assert.strictEqual(result.acceptances[1].candidate, b);
+  });
+
+  test("records passedArm per accepted arm (signals / entropy / csf)", () => {
+    const bySignals = makeCandidate("s", { signals: ["a", "b"] });
+    const byEntropy = makeCandidate("e", { signals: [], entropy: 4.2, crossSiteFrequency: null });
+    const byCsf = makeCandidate("c", { signals: [], entropy: null, crossSiteFrequency: 3 });
+
+    const result = runOrchestration({
+      candidates: [bySignals, byEntropy, byCsf],
+      gates: gatesWithRealGate2(),
+      version: 1,
+      published: "2024-01-01T00:00:00.000Z",
+    });
+
+    const arm = (i) =>
+      result.acceptances[i].accepted.find((x) => x.gate === "corroboration-gate")
+        ?.passedArm;
+    assert.strictEqual(arm(0), "signals");
+    assert.strictEqual(arm(1), "entropy");
+    assert.strictEqual(arm(2), "csf");
+  });
+
+  test("quarantined candidates never appear in acceptances", () => {
+    const passing = makeCandidate("ok");
+    const failing = makeCandidate("bad", { signals: null, entropy: null, crossSiteFrequency: null });
+
+    const result = runOrchestration({
+      candidates: [passing, failing],
+      gates: gatesWithRealGate2(),
+      version: 1,
+      published: "2024-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(result.acceptances.length, 1);
+    assert.strictEqual(result.acceptances[0].candidate, passing);
+    assert.ok(
+      !result.acceptances.some((e) => e.candidate === failing),
+      "rejected candidate must be absent from acceptances"
+    );
+  });
+
+  test("gates without normalizeAccepted contribute no accept metadata", () => {
+    const result = runOrchestration({
+      candidates: [makeCandidate("x")],
+      gates: ALL_PASS_GATES, // all stubs, none expose normalizeAccepted
+      version: 1,
+      published: "2024-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(result.acceptances.length, 1);
+    assert.deepStrictEqual(result.acceptances[0].accepted, []);
+  });
+});
+
 // ── T-12/T-13/T-14: Signing round-trip ───────────────────────────────────────
 
 describe("R6 — Signing round-trip verify", () => {

--- a/tools/rule-ingestion/orchestrate-cli.mjs
+++ b/tools/rule-ingestion/orchestrate-cli.mjs
@@ -228,11 +228,32 @@ export async function runOrchestrateCli({
   const published = (now instanceof Date ? now : new Date()).toISOString();
 
   // ── 6. Run orchestration ────────────────────────────────────────────────────
-  const { autoMerge, quarantine, artifactBody } = runOrchestration({
+  const { autoMerge, quarantine, acceptances, artifactBody } = runOrchestration({
     candidates,
     version,
     published,
   });
+
+  // ── 6b. Accepted-arm audit trail (#878) ─────────────────────────────────────
+  // Surface WHICH corroboration arm rescued each auto-merged param so a reviewer
+  // sees why something passed without re-running the gate (no-silent-decisions).
+  // Lives in the UNSIGNED sidecar only — the signed promote artifact stays
+  // {version, published, params, sig} by contract (orchestrate-cli R5-S1).
+  // passedArm is null if the corroboration gate did not run / emit it.
+  const autoMergeAudit = acceptances.map(({ candidate, accepted }) => {
+    const corrob = accepted.find((a) => a.gate === "corroboration-gate");
+    return { param: candidate.param, passedArm: corrob?.passedArm ?? null };
+  });
+
+  // Rescue-arm distribution: the data that justifies recalibrating the heuristic
+  // floors (ENTROPY_FLOOR, CSF_FLOOR) once real crawler artifacts accumulate.
+  const passedArmDistribution = autoMergeAudit.reduce(
+    (dist, { passedArm }) => {
+      if (passedArm) dist[passedArm] += 1;
+      return dist;
+    },
+    { signals: 0, entropy: 0, csf: 0 }
+  );
 
   // ── 7. Sign the canonical message ───────────────────────────────────────────
   // Inline sign block — mirrors sign-rules.mjs:211-215 verbatim (ADR: no shared helper)
@@ -288,7 +309,9 @@ export async function runOrchestrateCli({
     generatedAt: published,
     autoMergeCount: autoMerge.length,
     quarantineCount: quarantine.length,
+    passedArmDistribution, // #878 — rescue-arm counts over auto-merged candidates
     ingestStats: candidateReport.stats ?? null,  // null-safe: tolerates stats-less old candidates.json (#782)
+    autoMerge: autoMergeAudit, // #878 — per-param { param, passedArm } accept trail
     quarantine, // full QuarantineEntry[] with candidate + rejections
   };
 
@@ -319,6 +342,7 @@ export async function runOrchestrateCli({
       version: artifactBody.version,
       autoMergeCount: autoMerge.length,
       quarantineCount: quarantine.length,
+      passedArmDistribution, // #878
       sha256,
     })
   );

--- a/tools/rule-ingestion/orchestrate.mjs
+++ b/tools/rule-ingestion/orchestrate.mjs
@@ -21,10 +21,14 @@ import { checkFunctionalBiasGate } from "./gates/functional-bias-gate.mjs";
 
 /**
  * Ordered array of gate descriptors. Each descriptor has:
- *   gate      — string label (must match spec R2-S2 table)
- *   check     — (candidate, opts) → { rejected, ...nativePayload }
- *   optsKey   — key into gateOpts to extract per-gate options
- *   normalize — (verdict) → { gate, reason, evidence }
+ *   gate             — string label (must match spec R2-S2 table)
+ *   check            — (candidate, opts) → { rejected, ...nativePayload }
+ *   optsKey          — key into gateOpts to extract per-gate options
+ *   normalize        — (rejected verdict) → { gate, reason, evidence }
+ *   normalizeAccepted — (accepted verdict) → { gate, ...auditMeta }  [OPTIONAL]
+ *                       Surfaces accept-path audit data (e.g. corroboration
+ *                       passedArm, #878). Descriptors without it contribute no
+ *                       accept metadata.
  *
  * ORDER IS FIXED AND MUST NOT CHANGE. Array iteration IS the gate evaluation
  * order. No Set or object-key iteration anywhere in the decision path.
@@ -48,6 +52,13 @@ export const DEFAULT_GATES = [
       gate: "corroboration-gate",
       reason: v.reason,
       evidence: { detail: v.detail },
+    }),
+    // Accepted-side audit (#878): capture WHICH arm corroborated an accepted
+    // candidate ("signals" | "entropy" | "csf"). Symmetric to normalize, but for
+    // the no-short-circuit accept path. Only this gate emits accept metadata.
+    normalizeAccepted: (v) => ({
+      gate: "corroboration-gate",
+      passedArm: v.passedArm,
     }),
   },
   {
@@ -130,8 +141,13 @@ export function buildParams(autoMerge) {
  * @returns {{
  *   autoMerge: object[],
  *   quarantine: Array<{ candidate: object, rejections: Array<{ gate: string, reason: string, evidence: object }> }>,
+ *   acceptances: Array<{ candidate: object, accepted: Array<{ gate: string, passedArm?: string }> }>,
  *   artifactBody: { version: number, published: string, params: string[] }
  * }}
+ *   `acceptances` is PARALLEL to `autoMerge` (same order, same length): entry i
+ *   holds the accept-path audit metadata (from each gate's normalizeAccepted, if
+ *   any) for autoMerge[i]. Gates without normalizeAccepted contribute nothing, so
+ *   `accepted` may be empty. Quarantined candidates never appear here (#878).
  */
 export function runOrchestration({
   candidates,
@@ -142,9 +158,11 @@ export function runOrchestration({
 }) {
   const autoMerge = [];
   const quarantine = [];
+  const acceptances = [];
 
   for (const candidate of candidates) {
     const rejections = [];
+    const accepted = [];
 
     // Evaluate EVERY gate in order — no short-circuit (R3)
     for (const descriptor of gates) {
@@ -153,11 +171,16 @@ export function runOrchestration({
 
       if (verdict.rejected) {
         rejections.push(descriptor.normalize(verdict));
+      } else if (descriptor.normalizeAccepted) {
+        // Accept-path audit, collected only for candidates that ultimately
+        // auto-merge (a later gate may still quarantine this one).
+        accepted.push(descriptor.normalizeAccepted(verdict));
       }
     }
 
     if (rejections.length === 0) {
       autoMerge.push(candidate);
+      acceptances.push({ candidate, accepted });
     } else {
       quarantine.push({ candidate, rejections });
     }
@@ -166,5 +189,5 @@ export function runOrchestration({
   const params = buildParams(autoMerge);
   const artifactBody = { version, published, params };
 
-  return { autoMerge, quarantine, artifactBody };
+  return { autoMerge, quarantine, acceptances, artifactBody };
 }


### PR DESCRIPTION
## What
Persist the corroboration gate's `passedArm` ("signals" | "entropy" | "csf") for **accepted** candidates into the unsigned quarantine-report sidecar, so a reviewer can see which arm rescued each accepted param without re-running the gate.

`runOrchestration` previously normalized only rejected verdicts, dropping `passedArm` at the boundary (follow-up from the #798 adversarial verify, WARNING W1).

## Changes
- `orchestrate.mjs`: optional `normalizeAccepted` on the corroboration descriptor + a parallel `acceptances` array in `runOrchestration`'s return (symmetric to normalize/rejections). `autoMerge` shape unchanged.
- `orchestrate-cli.mjs`: per-param `{ param, passedArm }` trail + a `{ signals, entropy, csf }` `passedArmDistribution`, persisted in the unsigned quarantine-report sidecar and echoed in the stdout summary.

## Safety constraint (upheld + regression-tested)
The **signed** promote artifact stays exactly `{version, published, params, sig}` — audit metadata never enters the signed payload, only the unsigned sidecar. A regression test asserts the signed artifact key-set and negative `in` checks.

## Why it matters
Once real crawler artifacts accumulate, the rescue-arm distribution (entropy vs csf vs signals) is the data that justifies recalibrating `ENTROPY_FLOOR=4.0` and `CSF_FLOOR=3`. No-silent-decisions principle.

## Verification
Fresh-context review on this branch:
- `npm run typecheck` — PASS
- `npm run lint:js` — PASS
- `npm test` — PASS (5032 pass, 0 fail, 1 skipped)
- Backward compatibility intact (new return key only; gate envelope untouched).
- Tests are behavior-based (real corroboration gate + on-disk JSON assertions), no source-grep assertions (#824-compliant).

Closes #878
Refs: #798, #877
