### PR TITLE
chore(docs,test): fix ghost sync:manifest reference + add PrivacyProxy src guard (#887, #701)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,7 +184,7 @@ Leaf/data modules (`affiliates-data.js`, `redirect-networks.js`, `prefs.js`, `st
 | `src/rules/rules-manifest.json` | `affiliates-data.js` + `domain-rules.json` | `npm run compile:rules` |
 | `src/rules/wrapper-dnr-rules.json` | `src/rules/wrappers.json` (Ed25519-signed) | `npm run build:dnr` |
 | `src/content/cleaner-bundle.js` | `src/content/cleaner-bundle-src.mjs` (esbuild) | `npm run build:content` |
-| `src/rules/manifest.data.js` | caps-spec vendored manifest | `npm run sync:manifest` |
+| `src/rules/manifest.data.js` | caps-spec vendored manifest | hand-maintained; edit directly and update `EXPECTED_PROGRAM_IDS` in `tests/unit/caps-manifest-sync.test.mjs` |
 
 **Rule:** if you edit `affiliates-data.js` run `npm run compile:rules && npm run build:content`. If you edit `wrappers.json` run `npm run build:dnr`. CI fails if any artifact under `src/rules/` or `src/content/cleaner-bundle.js` is out of sync.
 

--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -4,8 +4,8 @@
  * AFFILIATE_PATTERNS is the consolidated view of caps-spec's
  * direct-injection programs joined with MUGA's hand-maintained OUR_TAGS
  * map. The program identity (id, name, domains, param) is sourced from
- * the vendored `caps-spec/manifest.json` (#523 phase 1, run
- * `npm run sync:manifest` to refresh). The per-host affiliate tag values
+ * the vendored `caps-spec/manifest.json` (#523 phase 1, now hand-maintained
+ * in `src/rules/manifest.data.js`). The per-host affiliate tag values
  * MUGA injects on its own behalf live in OUR_TAGS in this file — they
  * are intentionally NOT in the open standard.
  *
@@ -24,8 +24,8 @@
  *   }
  *
  * To add a NEW per-marketplace tag for an existing program: edit
- * OUR_TAGS only. To add a NEW program: it must first land in caps-spec,
- * then `npm run sync:manifest` updates the vendored module.
+ * OUR_TAGS only. To add a NEW program: edit `src/rules/manifest.data.js`
+ * directly and update `EXPECTED_PROGRAM_IDS` in `tests/unit/caps-manifest-sync.test.mjs`.
  *
  * ── #826 module split ────────────────────────────────────────────────────
  * The static tracking-param dataset (TRACKING_PARAMS, TRACKING_PREFIXES,

--- a/tests/unit/privacy-proxy-src-guard.test.mjs
+++ b/tests/unit/privacy-proxy-src-guard.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * MUGA — ADR-0004 phase 5: PrivacyProxy decommission guard (#701 item 9)
+ *
+ * The Privacy Proxy ("PrivacyProxy", CamelCase) was fully decommissioned in
+ * ADR-0004 phase 5. This test asserts that the identifier "PrivacyProxy"
+ * (exact CamelCase) never reappears in src/ .js files.
+ *
+ * EXEMPTION: the storage migration legitimately references the OLD storage key
+ * `privacyProxyEnabled` (lowercase-p camelCase) in src/lib/storage-migrations.js,
+ * src/lib/prefs.js, and src/background/service-worker.js comments. That string
+ * is NOT "PrivacyProxy" (different casing), so a plain substring check on
+ * "PrivacyProxy" does NOT match it — no special exclusion logic is needed.
+ * Do NOT ban `privacyProxyEnabled`; it must remain until the migration is retired.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "../..");
+
+/**
+ * Recursively collect all .js files under a directory.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function collectJsFiles(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectJsFiles(full));
+    } else if (entry.name.endsWith(".js")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const srcDir = join(root, "src");
+const jsFiles = collectJsFiles(srcDir);
+
+describe("ADR-0004 phase 5: PrivacyProxy decommission guard (#701 item 9)", () => {
+  test("no .js file under src/ contains the literal identifier 'PrivacyProxy'", () => {
+    const offenders = [];
+    for (const filePath of jsFiles) {
+      const fileText = readFileSync(filePath, "utf8");
+      if (fileText.includes("PrivacyProxy")) {
+        offenders.push(filePath.replace(root + "\\", "").replace(root + "/", ""));
+      }
+    }
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `The following file(s) contain the banned identifier 'PrivacyProxy'.\n` +
+        `ADR-0004 phase 5 fully decommissioned the Privacy Proxy — this identifier must not reappear.\n` +
+        `See docs/adr/0004-*.md for rationale.\n` +
+        `NOTE: 'privacyProxyEnabled' (lowercase-p) is exempt — it is the legacy storage migration key.\n` +
+        `Offending files:\n  ${offenders.join("\n  ")}`,
+    );
+  });
+});


### PR DESCRIPTION
Two small cleanups bundled.

## #887 — ghost `npm run sync:manifest` reference
`CONTEXT.md` and `src/lib/affiliates.js` told contributors to run `npm run sync:manifest` to regenerate `src/rules/manifest.data.js`, but that script does not exist — it (and `scripts/sync-affiliate-manifest.mjs`) were **intentionally deleted in commit `7468b35`** (caps-spec consolidation, #715: *"git rm scripts/sync-affiliate-manifest.mjs, remove sync:manifest from package.json scripts"*). No automated path regenerates `manifest.data.js` today; it is hand-maintained.

**Fix:** correct the docs to describe the real process instead of resurrecting a fake alias (pointing one at `import-upstream.mjs` would be wrong — that tool only diffs tracking params against AdGuard Filter 17, it never touches `manifest.data.js`):
- `CONTEXT.md` generator column for `manifest.data.js` → "hand-maintained; edit directly and update `EXPECTED_PROGRAM_IDS` in `tests/unit/caps-manifest-sync.test.mjs`".
- `src/lib/affiliates.js` header (×2) → drop the `sync:manifest` instruction, describe the hand-maintained flow.

A contributor following the docs no longer hits `npm error Missing script: "sync:manifest"`.

## #701 item 9 — PrivacyProxy src guard
ADR-0004 phase 5 decommissioned the "Privacy Proxy". The CamelCase identifier `PrivacyProxy` is currently **zero** in `src/`. New `tests/unit/privacy-proxy-src-guard.test.mjs` walks `src/**/*.js` and asserts the identifier never reappears, citing ADR-0004 on failure.

The legitimate migration key `privacyProxyEnabled` (lowercase-p, in `storage-migrations.js`/`prefs.js`/SW comments) is a different string and is intentionally NOT matched — the migration must remain until retired. The test variable is named `fileText` (not `*Source`) so it scores 0 on the `source-grep-ratchet` (#824 clean).

## Verification
Root cause confirmed (`git show 7468b35`); `grep PrivacyProxy src/` = 0; `npm run typecheck` / `lint:js` / `test` pass (5054 pass, 0 fail, 1 skip).

Closes #887. Completes item 9 of #701 (only phase 6 — external Cloudflare shutdown — then remains). Refs ADR-0004, #715.
