### PR TITLE
fix(ingestion): skip AFFILIATE_PARAM_GUARD/DENYLIST collisions in promote instead of aborting the run (#898)

### DIFF
--- a/tests/unit/ingestion-promote-rules.test.mjs
+++ b/tests/unit/ingestion-promote-rules.test.mjs
@@ -1251,8 +1251,8 @@ describe("#821-I2 — Param format validation at promote boundary", () => {
     assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
   });
 
-  test("I2-c: param in REMOTE_PARAM_DENYLIST → PromoteError exitCode 1, bytes unchanged", async () => {
-    const { runPromote, PromoteError } = await import(
+  test("I2-c: param in REMOTE_PARAM_DENYLIST → skipped (not thrown), absent from merged (issue #898)", async () => {
+    const { runPromote } = await import(
       "../../tools/rule-ingestion/promote-rules.mjs"
     );
 
@@ -1260,57 +1260,116 @@ describe("#821-I2 — Param format validation at promote boundary", () => {
     const now = new Date("2026-06-01T12:00:00.000Z");
 
     // "q" is in REMOTE_PARAM_DENYLIST
-    const badParams = ["q"];
-    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", badParams);
+    const params = ["q"];
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", params);
     const sig = cryptoSign(null, Buffer.from(canonical, "utf8"), TEST_PRIV_KEY).toString("base64url");
-    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: badParams, sig };
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params, sig };
     const promotePath = join(tmpDir, "promote-candidates.json");
     writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
 
     const sourcePath = writeParamsJson(tmpDir, { version: 3, published: "2026-04-01T00:00:00.000Z", params: [] });
     const domainRulesPath = writeDomainRules(tmpDir, []);
-    const bytesBefore = readFileSync(sourcePath, "utf8");
 
-    await assert.rejects(
-      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
-      (err) => {
-        assert.ok(err instanceof PromoteError, "must be PromoteError");
-        assert.strictEqual(err.exitCode, 1, "denylist param → exitCode 1");
-        return true;
-      }
+    // Must NOT throw — denylist hit is now a skip, not a fatal error (#898)
+    const result = await runPromote({
+      promotePath, sourcePath, domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now,
+    });
+
+    // "q" must be in skipped with reason REMOTE_PARAM_DENYLIST
+    assert.ok(
+      result.skipped.some((s) => s.param === "q" && s.reason === "REMOTE_PARAM_DENYLIST"),
+      'skipped must contain { param: "q", reason: "REMOTE_PARAM_DENYLIST" }'
     );
-    assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
+    // "q" must NOT be in merged (never promoted)
+    assert.ok(!result.merged.includes("q"), '"q" must not be in merged');
   });
 
-  test("I2-d: param in AFFILIATE_PARAM_GUARD → PromoteError exitCode 1, bytes unchanged", async () => {
-    const { runPromote, PromoteError } = await import(
+  test("I2-d: param in AFFILIATE_PARAM_GUARD → skipped (not thrown), absent from merged (issue #898)", async () => {
+    const { runPromote } = await import(
       "../../tools/rule-ingestion/promote-rules.mjs"
     );
 
     const tmpDir = makeTmpDir();
     const now = new Date("2026-06-01T12:00:00.000Z");
 
-    // "tag" is in AFFILIATE_PARAM_GUARD (Amazon)
-    const badParams = ["tag"];
-    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", badParams);
+    // "campid" is in AFFILIATE_PARAM_GUARD (eBay) and NOT in REMOTE_PARAM_DENYLIST,
+    // so the AFFILIATE_PARAM_GUARD branch is exercised exclusively.
+    const params = ["campid"];
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", params);
     const sig = cryptoSign(null, Buffer.from(canonical, "utf8"), TEST_PRIV_KEY).toString("base64url");
-    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params: badParams, sig };
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params, sig };
     const promotePath = join(tmpDir, "promote-candidates.json");
     writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
 
     const sourcePath = writeParamsJson(tmpDir, { version: 3, published: "2026-04-01T00:00:00.000Z", params: [] });
     const domainRulesPath = writeDomainRules(tmpDir, []);
-    const bytesBefore = readFileSync(sourcePath, "utf8");
 
-    await assert.rejects(
-      () => runPromote({ promotePath, sourcePath, domainRulesPath, trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now }),
-      (err) => {
-        assert.ok(err instanceof PromoteError, "must be PromoteError");
-        assert.strictEqual(err.exitCode, 1, "affiliate guard param → exitCode 1");
-        return true;
-      }
+    // Must NOT throw — affiliate guard hit is now a skip, not a fatal error (#898)
+    const result = await runPromote({
+      promotePath, sourcePath, domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now,
+    });
+
+    // "campid" must be in skipped with reason AFFILIATE_PARAM_GUARD
+    assert.ok(
+      result.skipped.some((s) => s.param === "campid" && s.reason === "AFFILIATE_PARAM_GUARD"),
+      'skipped must contain { param: "campid", reason: "AFFILIATE_PARAM_GUARD" }'
     );
-    assert.strictEqual(readFileSync(sourcePath, "utf8"), bytesBefore, "params.json must be unchanged");
+    // "campid" must NOT be in merged (never promoted)
+    assert.ok(!result.merged.includes("campid"), '"campid" must not be in merged');
+  });
+
+  test("T-898: guard param (clickid) + denylist param (q) + valid tracker → promote succeeds, guard/denylist absent from artifact, valid param promoted", async () => {
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+
+    // clickid is in AFFILIATE_PARAM_GUARD; q is in REMOTE_PARAM_DENYLIST; utm_content is a valid tracker
+    const params = ["clickid", "q", "utm_content"];
+    const canonical = canonicalMessage(3, "2026-05-01T00:00:00.000Z", params);
+    const sig = cryptoSign(null, Buffer.from(canonical, "utf8"), TEST_PRIV_KEY).toString("base64url");
+    const artifact = { version: 3, published: "2026-05-01T00:00:00.000Z", params, sig };
+    const promotePath = join(tmpDir, "promote-candidates.json");
+    writeFileSync(promotePath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+
+    const sourcePath = writeParamsJson(tmpDir, { version: 3, published: "2026-04-01T00:00:00.000Z", params: [] });
+    const domainRulesPath = writeDomainRules(tmpDir, []);
+
+    // Must NOT throw — guard/denylist hits are skipped; valid params are promoted
+    const result = await runPromote({
+      promotePath, sourcePath, domainRulesPath,
+      trustedKeys: TEST_TRUSTED_KEYS, subtle: globalThis.crypto.subtle, now,
+    });
+
+    // Run must succeed (written:true because utm_content is new)
+    assert.strictEqual(result.verified, true, "must be verified");
+    assert.strictEqual(result.written, true, "must write (utm_content is new)");
+
+    // Guard/denylist params must be in skipped, not in merged
+    assert.ok(
+      result.skipped.some((s) => s.param === "clickid" && s.reason === "AFFILIATE_PARAM_GUARD"),
+      'skipped must contain { param: "clickid", reason: "AFFILIATE_PARAM_GUARD" }'
+    );
+    assert.ok(
+      result.skipped.some((s) => s.param === "q" && s.reason === "REMOTE_PARAM_DENYLIST"),
+      'skipped must contain { param: "q", reason: "REMOTE_PARAM_DENYLIST" }'
+    );
+    assert.ok(!result.merged.includes("clickid"), '"clickid" must not be in merged');
+    assert.ok(!result.merged.includes("q"), '"q" must not be in merged');
+
+    // Valid tracker param must be promoted
+    assert.ok(result.merged.includes("utm_content"), '"utm_content" must be in merged');
+
+    // Written artifact must not contain guard/denylist params
+    const { readFileSync } = await import("node:fs");
+    const written = JSON.parse(readFileSync(sourcePath, "utf8"));
+    assert.ok(!written.params.includes("clickid"), "written artifact must not contain clickid");
+    assert.ok(!written.params.includes("q"), "written artifact must not contain q");
+    assert.ok(written.params.includes("utm_content"), "written artifact must contain utm_content");
   });
 });
 

--- a/tools/rule-ingestion/promote-rules.mjs
+++ b/tools/rule-ingestion/promote-rules.mjs
@@ -272,6 +272,18 @@ export async function runPromote({
   // ── Step 4b: Param format + denylist + affiliate-guard validation ───────────
   // Applied after sig/freshness so we don't expose format info on unsigned data.
   // Mirrors the REQ-VALIDATE-2/3/4/5 checks in remote-rules.js validateParams.
+  //
+  // PARAM_FORMAT_ERROR (length/regex) → fatal throw: a malformed param name is an
+  // anomaly class distinct from guard/denylist collisions and is kept as exit-1.
+  //
+  // DENYLIST_HIT / AFFILIATE_GUARD_HIT → SKIP (issue #898): these params are
+  // dropped from the promoted artifact and recorded in skipped[]. Aborting the
+  // whole run over a single guard-colliding candidate (e.g. `clickid` from
+  // AdGuard upstream) discards all ~179 other valid candidates — pure brittleness.
+  // Any AFFILIATE_PARAM_GUARD param is rejected by validateParams on fetch and can
+  // never be delivered via remote rules; promoting it is a no-op. Skipping is the
+  // safe (cheap) direction under the asymmetric-risk principle.
+  const guardSkipped = [];
   for (const param of art.params) {
     if (param.length < 1 || param.length > MAX_PARAM_LEN || !PARAM_FORMAT_RE.test(param)) {
       throw new PromoteError(
@@ -281,18 +293,25 @@ export async function runPromote({
     }
     const lower = param.toLowerCase();
     if (REMOTE_PARAM_DENYLIST.has(lower)) {
-      throw new PromoteError(
-        `DENYLIST_HIT: promote artifact param "${param}" is in REMOTE_PARAM_DENYLIST`,
-        1
+      console.log(
+        `[promote-rules] skip: ${param} is in REMOTE_PARAM_DENYLIST — excluded from promote (issue #898)`
       );
+      guardSkipped.push({ param, reason: "REMOTE_PARAM_DENYLIST" });
+      continue;
     }
     if (AFFILIATE_PARAM_GUARD.has(lower)) {
-      throw new PromoteError(
-        `AFFILIATE_GUARD_HIT: promote artifact param "${param}" is in AFFILIATE_PARAM_GUARD`,
-        1
+      console.log(
+        `[promote-rules] skip: ${param} is in AFFILIATE_PARAM_GUARD — excluded from promote (issue #898)`
       );
+      guardSkipped.push({ param, reason: "AFFILIATE_PARAM_GUARD" });
+      continue;
     }
   }
+
+  // Build the filtered param list: exclude guard/denylist hits found above.
+  const filteredArtParams = art.params.filter(
+    (p) => !guardSkipped.some((s) => s.param === p)
+  );
 
   // ── Step 5: Build preservedSet + partition art.params ─────────────────────
   // FAIL-CLOSED: missing/unreadable domain-rules.json → exit 3 (I/O); non-array
@@ -316,10 +335,11 @@ export async function runPromote({
   }
 
   const preservedSet = loadPreservedSet(domainRules);
-  const skipped = [];
+  // Pre-populate skipped with guard/denylist hits from step 4b (#898).
+  const skipped = [...guardSkipped];
   const cleanParams = [];
 
-  for (const param of art.params) {
+  for (const param of filteredArtParams) {
     if (preservedSet.has(param)) {
       console.log(
         `[promote-rules] skip: ${param} collides with preserveParams — excluded from merge`


### PR DESCRIPTION
## What
The weekly self-scaling ingestion pipeline (#785) has been **failing** since ~April — its last scheduled runs (2026-06-14, 2026-06-07) aborted at `npm run pipeline:rules` with:
```
AFFILIATE_GUARD_HIT: promote artifact param "clickid" is in AFFILIATE_PARAM_GUARD
##[error]Process completed with exit code 1.
```

## Root cause
A guard-scope inconsistency: GATE 1 (`gates/affiliate-guard.mjs`) deliberately uses a NARROW set (genuine affiliate-attribution names) and correctly passes `clickid` (a generic tracker AdGuard emits weekly). But `promote-rules.mjs` step 4b validated the artifact against the BROADER `AFFILIATE_PARAM_GUARD` (which contains `clickid`) and threw a **fatal** `PromoteError(exit 1)`, killing the whole run over one param. Same brittleness class as #813.

`clickid` is already in `TRACKING_PARAMS` (stripped locally) and any `AFFILIATE_PARAM_GUARD` param is rejected by the client's `validateParams` on fetch — so it can never be delivered via remote rules. Promoting it is a no-op; aborting over it is pure brittleness.

## Fix (localized to promote-rules.mjs step 4b)
`AFFILIATE_PARAM_GUARD` + `REMOTE_PARAM_DENYLIST` collisions are now **SKIPPED** — the param is dropped from the artifact and recorded in the existing `skipped[]` report (surfaced in `surface-input.json` as `promoteSkipped`), and the run continues. `PARAM_FORMAT_ERROR` (length/regex) stays fatal (separate anomaly class). No change to `AFFILIATE_PARAM_GUARD` membership or GATE 1.

## Safety (moat invariants, independently verified)
- **No affiliate param can be stripped**: the only write path is `computeMerge` = a union that only ADDS candidates to `params.json`, never removes; skipped params never enter the merge. Skip is the cheap (safe) asymmetric-risk direction.
- **The removed throw was a redundant internal backstop, not a security boundary**: `promote-candidates.json` is MUGA's own same-run output (signing happens after promote), and the client independently re-validates fetched params against the same guard — defense-in-depth fully intact.

## Verification
Independent fresh-context adversarial review: **GO**, empirically proven — a real signed artifact containing `clickid` + a denylist param was run through the actual promote function: no throw, both skipped + recorded with correct reasons, valid params promoted. Tests flipped from "throws on guard hit" to "skips + continues" (I2-c denylist, I2-d affiliate guard) + new T-898 regression (`clickid` skipped, valid params promoted). `npm run typecheck` / `lint:js` / `test` pass (5088 pass, 0 fail, 1 skip).

Unblocks the weekly auto-ingest pipeline (#785) and is a prerequisite for #888.

Closes #898. Refs #813, #785, #888, ADR-0005.
