### PR TITLE
ci(rules): drop [skip ci] from auto-ingest commit so --auto merge can complete

### DIFF
--- a/.github/workflows/auto-ingest-rules.yml
+++ b/.github/workflows/auto-ingest-rules.yml
@@ -198,7 +198,13 @@ jobs:
           BRANCH="auto-ingest/$DATE"
           git checkout -B "$BRANCH"
           git add tools/rules-source/params.json docs/rules/v1/params.json
-          git commit -m "chore(rules): auto-ingest params ($DATE) [skip ci]"
+          # NO [skip ci]: the PR needs ci.yml (test/e2e) to run so branch
+          # protection's required checks pass and `--auto` merge can complete.
+          # [skip ci] here skips those checks → the PR stays BLOCKED forever.
+          # The redundant post-merge push run is harmless: publish-rules.yml is
+          # idempotent (no-op commit guard) and deploy-landing.yml is path-scoped
+          # to landing/**, so neither re-fires on a params-only change.
+          git commit -m "chore(rules): auto-ingest params ($DATE)"
           git push -u origin "$BRANCH" --force-with-lease
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           echo "DATE=$DATE" >> "$GITHUB_ENV"

--- a/tests/unit/ingestion-scheduled-workflow.test.mjs
+++ b/tests/unit/ingestion-scheduled-workflow.test.mjs
@@ -274,11 +274,19 @@ describe("PR merge flags", () => {
 // Commit message contains [skip ci]
 // ---------------------------------------------------------------------------
 describe("commit message", () => {
-  test("commit message contains [skip ci]", () => {
+  test("params commit does NOT use [skip ci] (would block the required PR checks)", () => {
     const content = readWorkflow();
+    // Resolves the contradiction with the `--auto` contract above: branch
+    // protection on main requires the test + e2e checks, and `gh pr merge
+    // --auto` only completes once they pass. [skip ci] on the PR-branch commit
+    // skips ci.yml → the checks never report → the PR stays BLOCKED forever.
+    // A CI loop is NOT a risk: the post-merge push re-runs ci.yml (read-only)
+    // and publish-rules.yml (idempotent no-op guard; its own commit carries
+    // [skip ci]), so nothing re-triggers the ingestion workflow.
     assert.ok(
-      /\[skip ci\]/.test(content),
-      "workflow commit message must contain '[skip ci]' to prevent CI loop"
+      !/git commit -m "chore\(rules\): auto-ingest params[^"]*\[skip ci\]/.test(content),
+      "the auto-ingest params commit must NOT carry [skip ci] — it skips the " +
+      "required PR checks and blocks the --auto merge forever"
     );
   });
 });


### PR DESCRIPTION
## Problem

The weekly `auto-ingest-rules` PR needs a **manual admin-merge** every run — `gh pr merge --auto` never completes on its own. Root cause: the params commit carries **`[skip ci]`** (line 201), which skips `ci.yml` on the bot's PR. Branch protection on `main` requires the `test` + `e2e` checks, so with no checks reported the PR is permanently `BLOCKED`.

This also contradicted the workflow's own `--auto` contract, whose comment states the `MUGA_PR_TOKEN` PAT triggers `ci.yml` so `--auto` can merge once checks pass — `[skip ci]` defeats exactly that.

## Fix

Remove `[skip ci]` from the params commit so `ci.yml` runs on the PR → required checks pass → `--auto` merges hands-off (now that *Allow auto-merge* is enabled).

## Why this is safe (no CI loop, no double-publish)

Verified each post-merge push trigger:
- **`ci.yml`** (push→main): read-only test/e2e, creates no commit.
- **`publish-rules.yml`** (push→main, `paths: tools/rules-source/**`): re-signs, but `sign-rules.mjs` is deterministic and the step commits only if the file changed (`git diff --cached --quiet` guard) — a no-op since auto-ingest already committed the signed artifact. Its own commit also carries `[skip ci]`.
- **`deploy-landing.yml`** (push→main): path-scoped to `landing/**` — a params-only change never fires it.

Cost: one redundant `ci.yml` run on the post-merge push (~2.5 min). Bonus: `publish-rules.yml`'s smoke-check of the published URL now actually runs.

## Tests

Updated `ingestion-scheduled-workflow.test.mjs` to pin the new invariant (params commit must NOT carry `[skip ci]`). Full workflow + hardening suite green (70/70).