### PR TITLE
feat(cleaner): strip Amazon internal-nav tracking tags on Chrome via a scoped DNR rule

### DIFF
--- a/src/lib/dnr-ids.js
+++ b/src/lib/dnr-ids.js
@@ -6,7 +6,10 @@
  * A collision would cause one rule to silently overwrite another with no error.
  *
  * ID allocation:
- *   1        — static ruleset (tracking-params.json, managed by the browser)
+ *   1        — static ruleset: global tracking-param strip (tracking-params.json)
+ *   2        — static ruleset: Amazon-scoped internal-nav param strip — params the
+ *              cleaner strips on Amazon that the global rule can't (unsafe to strip
+ *              site-wide), scoped via requestDomains to Amazon marketplaces
  *   1000     — dynamic custom params rule (user-defined params, DNR redirect)
  *   1001     — dynamic remote params rule (signed remote payload, DNR redirect)
  *
@@ -16,6 +19,15 @@
 
 /** ID of the static tracking-params ruleset (tracking-params.json). */
 export const DNR_STATIC_RULE_ID = 1;
+
+/**
+ * ID of the static Amazon-scoped internal-nav param strip rule, emitted into
+ * tracking-params.json alongside the global rule. Scoped via `requestDomains`
+ * to Amazon marketplaces so params that are unsafe to strip site-wide (e.g.
+ * `ref`, `sr`) are still removed on Chrome's DNR-only current-page path —
+ * closing the gap where the in-page cleaner strips them but DNR did not.
+ */
+export const DNR_AMAZON_PARAMS_RULE_ID = 2;
 
 /**
  * ID of the dynamic rule that removes user-defined custom params.

--- a/src/rules/tracking-params.json
+++ b/src/rules/tracking-params.json
@@ -461,5 +461,76 @@
         "main_frame"
       ]
     }
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "queryTransform": {
+            "removeParams": [
+              "aaxitk",
+              "adid",
+              "almbrandid",
+              "aref",
+              "asc_refurl",
+              "asc_source",
+              "camp",
+              "colid",
+              "coliid",
+              "creative",
+              "field-lbr_brands_browse-bin",
+              "fpw",
+              "gid",
+              "hsa_cr_id",
+              "ie",
+              "ld",
+              "mrai",
+              "pagetype",
+              "pd_gw_unk",
+              "pf_rd_i",
+              "pf_rd_m",
+              "pf_rd_t",
+              "qu",
+              "qualifier",
+              "ref",
+              "ref_",
+              "refrid",
+              "reftag",
+              "rnid",
+              "sp_cr",
+              "sp_csd",
+              "sr",
+              "storetype"
+            ]
+          }
+        }
+      }
+    },
+    "condition": {
+      "requestDomains": [
+        "amazon.ca",
+        "amazon.co.jp",
+        "amazon.co.uk",
+        "amazon.com",
+        "amazon.com.au",
+        "amazon.com.br",
+        "amazon.com.mx",
+        "amazon.de",
+        "amazon.es",
+        "amazon.fr",
+        "amazon.in",
+        "amazon.it",
+        "amazon.nl",
+        "amazon.pl",
+        "amazon.se",
+        "amazon.sg"
+      ],
+      "resourceTypes": [
+        "main_frame"
+      ]
+    }
   }
 ]

--- a/tests/unit/dnr-amazon-params.test.mjs
+++ b/tests/unit/dnr-amazon-params.test.mjs
@@ -1,0 +1,152 @@
+/**
+ * MUGA — Amazon-scoped internal-nav param strip rule (#910/#911 follow-up)
+ *
+ * Chrome cleans the CURRENT page via DNR only (the in-page cleaner is skipped
+ * when DNR is present). Amazon internal-nav tracking tags (ref, ref_, pf_rd_*,
+ * sr, …) that the cleaner strips via domain-rules — but that are unsafe to strip
+ * site-wide, so absent from the global DNR rule — therefore survive a direct
+ * navigation on Chrome. tracking-params.json now carries a SECOND rule, scoped
+ * via requestDomains to Amazon marketplaces, that removes exactly those params.
+ *
+ * These tests pin:
+ *   1. the artifact ↔ generator sync (drift guard, like dnr-rules-sync.test.mjs),
+ *   2. that the rule is Amazon-scoped (never global), and
+ *   3. the SAFETY invariant: it never strips a creator-attribution or
+ *      protected nav/search key.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { AFFILIATE_PATTERNS } from "../../src/lib/affiliates.js";
+import { AFFILIATE_PARAM_GUARD, REMOTE_PARAM_DENYLIST } from "../../src/lib/remote-rules.js";
+import { DNR_AMAZON_PARAMS_RULE_ID, DNR_STATIC_RULE_ID } from "../../src/lib/dnr-ids.js";
+import { buildAmazonParamsRule } from "../../tools/generate-rules.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+const RULES = JSON.parse(readFileSync(join(ROOT, "src/rules/tracking-params.json"), "utf8"));
+const DOMAIN_RULES = JSON.parse(readFileSync(join(ROOT, "src/rules/domain-rules.json"), "utf8"));
+
+const AMAZON_HOST_RE = /(^|\.)amazon\./;
+const amazonRule = RULES.find((r) => r.id === DNR_AMAZON_PARAMS_RULE_ID);
+const removeParams = amazonRule?.action?.redirect?.transform?.queryTransform?.removeParams ?? [];
+
+// Amazon domain-rule facts, recomputed independently of the generator.
+const amazonEntries = DOMAIN_RULES.filter(
+  (r) => typeof r.domain === "string" && AMAZON_HOST_RE.test(r.domain),
+);
+const amazonStrip = new Set();
+const amazonPreserve = new Set();
+for (const r of amazonEntries) {
+  for (const p of r.stripParams ?? []) amazonStrip.add(p);
+  for (const p of r.preserveParams ?? []) amazonPreserve.add(p);
+}
+const globalRemove = new Set(
+  RULES[0].action.redirect.transform.queryTransform.removeParams,
+);
+
+describe("Amazon-scoped DNR rule — shape & scope", () => {
+  test("tracking-params.json contains the Amazon rule at DNR_AMAZON_PARAMS_RULE_ID", () => {
+    assert.ok(amazonRule, "a rule with id DNR_AMAZON_PARAMS_RULE_ID must exist");
+    assert.equal(amazonRule.id, DNR_AMAZON_PARAMS_RULE_ID);
+    assert.notEqual(amazonRule.id, DNR_STATIC_RULE_ID);
+    assert.equal(amazonRule.action?.type, "redirect");
+    assert.ok(Array.isArray(removeParams) && removeParams.length > 0);
+  });
+
+  test("is SCOPED to Amazon hosts (requestDomains), never a global urlFilter", () => {
+    assert.ok(Array.isArray(amazonRule.condition.requestDomains));
+    assert.ok(amazonRule.condition.requestDomains.length > 0);
+    for (const d of amazonRule.condition.requestDomains) {
+      assert.ok(AMAZON_HOST_RE.test(d), `requestDomain "${d}" must be an Amazon host`);
+    }
+    assert.equal(amazonRule.condition.urlFilter, undefined,
+      "the Amazon rule must NOT use a global urlFilter — that would strip on every site");
+    assert.deepEqual(amazonRule.condition.resourceTypes, ["main_frame"]);
+  });
+
+  test("covers every Amazon marketplace domain the cleaner knows about", () => {
+    const expected = [...new Set(amazonEntries.map((r) => r.domain))].sort();
+    assert.deepEqual([...amazonRule.condition.requestDomains].sort(), expected);
+  });
+});
+
+describe("Amazon-scoped DNR rule — parity with the cleaner", () => {
+  test("every stripped param is one the cleaner strips on Amazon", () => {
+    for (const p of removeParams) {
+      assert.ok(amazonStrip.has(p), `"${p}" must be in Amazon domain-rules stripParams`);
+    }
+  });
+
+  test("never strips a param Amazon needs (not in preserveParams)", () => {
+    for (const p of removeParams) {
+      assert.ok(!amazonPreserve.has(p), `"${p}" is functional on Amazon (preserveParams) — must not strip`);
+    }
+  });
+
+  test("adds ONLY params the global rule misses (no redundant overlap)", () => {
+    for (const p of removeParams) {
+      assert.ok(!globalRemove.has(p), `"${p}" is already in the global rule — redundant`);
+    }
+  });
+
+  test("closes the reported gap — the known internal nav tags are stripped", () => {
+    for (const p of ["ref", "ref_", "pf_rd_t", "pf_rd_i", "pf_rd_m", "sr"]) {
+      assert.ok(removeParams.includes(p), `internal nav tag "${p}" must be stripped on Amazon`);
+    }
+  });
+});
+
+describe("Amazon-scoped DNR rule — SAFETY (never harm creator attribution)", () => {
+  test("no stripped param is an affiliate-attribution key (AFFILIATE_PARAM_GUARD)", () => {
+    const guard = new Set([...AFFILIATE_PARAM_GUARD].map((s) => s.toLowerCase()));
+    for (const p of removeParams) {
+      assert.ok(!guard.has(p.toLowerCase()),
+        `"${p}" is affiliate-guarded — stripping it could break a creator's referral`);
+    }
+  });
+
+  test("no stripped param is a protected nav/search key (REMOTE_PARAM_DENYLIST)", () => {
+    const deny = new Set([...REMOTE_PARAM_DENYLIST].map((s) => s.toLowerCase()));
+    for (const p of removeParams) {
+      assert.ok(!deny.has(p.toLowerCase()), `"${p}" is a protected nav/search key — must not strip`);
+    }
+  });
+
+  test("the affiliate param 'tag' is NEVER in the strip list", () => {
+    assert.ok(!removeParams.map((p) => p.toLowerCase()).includes("tag"));
+  });
+
+  test("no stripped param is the attribution param of any Amazon-targeting affiliate program", () => {
+    // Scope-aware mirror of dnr-rules.test.mjs's global collision check: a param
+    // like `ref` is fine to strip on Amazon even though it's Vercel's affiliate
+    // param, because Vercel does not operate on amazon.* — but a param that IS an
+    // affiliate key for a program targeting an Amazon domain must never be stripped.
+    const amazonProgramParams = new Set(
+      AFFILIATE_PATTERNS
+        .filter((p) => (p.domains ?? []).some((d) => AMAZON_HOST_RE.test(d)))
+        .map((p) => p.param.toLowerCase()),
+    );
+    for (const p of removeParams) {
+      assert.ok(
+        !amazonProgramParams.has(p.toLowerCase()),
+        `"${p}" is an affiliate param for an Amazon-targeting program — must not strip`,
+      );
+    }
+  });
+});
+
+describe("Amazon-scoped DNR rule — artifact ↔ generator sync (drift guard)", () => {
+  test("the committed rule equals buildAmazonParamsRule(domainRules, globalRemove)", () => {
+    const rebuilt = buildAmazonParamsRule(DOMAIN_RULES, globalRemove);
+    assert.deepEqual(
+      amazonRule,
+      rebuilt,
+      "tracking-params.json is stale — run `npm run compile:rules`",
+    );
+  });
+});

--- a/tests/unit/dnr-rules.test.mjs
+++ b/tests/unit/dnr-rules.test.mjs
@@ -21,6 +21,18 @@ const root = join(__dirname, "../..");
 const rulesPath = join(root, "src", "rules", "tracking-params.json");
 const rules = JSON.parse(readFileSync(rulesPath, "utf8"));
 
+// The GLOBAL strip rule (urlFilter:"*") is sourced from TRACKING_PARAMS and must
+// satisfy the strictest invariants: it strips on EVERY site, so it can never
+// touch an affiliate-attribution or domain-functional param. Domain-SCOPED rules
+// (e.g. the Amazon internal-nav rule, id 2) are sourced from per-domain
+// stripParams and are safe to strip params that would be unsafe site-wide
+// (`ref` is Vercel's affiliate param but Amazon's internal breadcrumb). Those
+// rules get their own scope-aware safety coverage in dnr-amazon-params.test.mjs,
+// so the TRACKING_PARAMS-sourced invariants below target the global rule only.
+const globalRule = rules.find(r => r.condition?.urlFilter === "*") ?? rules[0];
+const globalRemoveParams =
+  globalRule.action?.redirect?.transform?.queryTransform?.removeParams ?? [];
+
 // ---------------------------------------------------------------------------
 // Test 1 — The JSON is an array
 // ---------------------------------------------------------------------------
@@ -101,11 +113,9 @@ test("No removeParams entry collides with AFFILIATE_PATTERNS params", async () =
   const { AFFILIATE_PATTERNS } = await import("../../src/lib/affiliates.js");
 
   const affiliateParams = new Set(AFFILIATE_PATTERNS.map(e => e.param));
-  const allRemoveParams = rules.flatMap(
-    r => r.action?.redirect?.transform?.queryTransform?.removeParams ?? []
-  );
-
-  const collisions = allRemoveParams.filter(p => affiliateParams.has(p));
+  // Global rule only — it strips site-wide, so ANY affiliate-param collision is
+  // unsafe. Scoped rules are checked against their own domains elsewhere.
+  const collisions = globalRemoveParams.filter(p => affiliateParams.has(p));
   assert.equal(
     collisions.length,
     0,
@@ -136,11 +146,9 @@ test("every removeParam (lowercased) exists in TRACKING_PARAMS", async () => {
   const { TRACKING_PARAMS } = await import("../../src/lib/affiliates.js");
 
   const trackingSet = new Set(TRACKING_PARAMS.map(p => p.toLowerCase()));
-  const allRemoveParams = [
-    ...new Set(
-      rules.flatMap(r => r.action?.redirect?.transform?.queryTransform?.removeParams ?? [])
-    ),
-  ];
+  // Global rule only — it is the one sourced from TRACKING_PARAMS. Scoped rules
+  // draw from per-domain stripParams (a different source), verified separately.
+  const allRemoveParams = [...new Set(globalRemoveParams)];
 
   for (const param of allRemoveParams) {
     assert.ok(
@@ -181,16 +189,17 @@ test("every lowercase TRACKING_PARAM has a corresponding removeParam entry (exce
   }
 });
 
-test("DNR-excluded params are NOT in DNR removeParams", () => {
-  const removeParamSet = new Set(
-    rules.flatMap(r => r.action?.redirect?.transform?.queryTransform?.removeParams ?? [])
-      .map(p => p.toLowerCase())
-  );
+test("DNR-excluded params are NOT in the GLOBAL DNR rule", () => {
+  // Scoped to the global rule: a param preserved on domain X must not be stripped
+  // site-wide. A domain-scoped rule MAY strip a param that is preserved on a
+  // DIFFERENT domain (e.g. `ref` is preserved on imdb.com but is Amazon's internal
+  // breadcrumb) — the Amazon rule excludes Amazon's OWN preserveParams instead.
+  const removeParamSet = new Set(globalRemoveParams.map(p => p.toLowerCase()));
 
   for (const param of DNR_EXCLUDED_PARAMS) {
     assert.ok(
       !removeParamSet.has(param),
-      `"${param}" should NOT be in DNR — it conflicts with domain-rules.json preserveParams`
+      `"${param}" should NOT be in the global DNR rule — it conflicts with domain-rules.json preserveParams`
     );
   }
 });

--- a/tools/generate-rules.mjs
+++ b/tools/generate-rules.mjs
@@ -22,7 +22,11 @@ import {
   TRACKING_PARAM_CATEGORIES,
   TRACKING_PREFIXES,
 } from "../src/lib/affiliates.js";
-import { DNR_STATIC_RULE_ID } from "../src/lib/dnr-ids.js";
+import { AFFILIATE_PARAM_GUARD, REMOTE_PARAM_DENYLIST } from "../src/lib/remote-rules.js";
+import { DNR_STATIC_RULE_ID, DNR_AMAZON_PARAMS_RULE_ID } from "../src/lib/dnr-ids.js";
+
+/** Amazon marketplace hosts we scope the internal-nav strip rule to. */
+const AMAZON_HOST_RE = /(^|\.)amazon\./;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -318,7 +322,7 @@ export function buildDnrRules() {
 
   const filtered = TRACKING_PARAMS.filter((p) => !preservedByDomain.has(p));
 
-  const dnrRule = [
+  const rules = [
     {
       id: DNR_STATIC_RULE_ID,
       priority: 1,
@@ -339,7 +343,76 @@ export function buildDnrRules() {
     },
   ];
 
-  return dnrRule;
+  const amazonRule = buildAmazonParamsRule(domainRules, new Set(filtered));
+  if (amazonRule) rules.push(amazonRule);
+
+  return rules;
+}
+
+/**
+ * Builds the Amazon-scoped internal-nav param strip rule (#910/#911 follow-up).
+ *
+ * Chrome cleans the CURRENT page via DNR only (the in-page cleaner is skipped
+ * when DNR is present), so any Amazon internal-nav tracking param that the
+ * cleaner strips via domain-rules — but that is UNSAFE to strip site-wide, so
+ * it's absent from the global rule — survives a direct navigation. This rule
+ * closes that gap by removing exactly those params, scoped to Amazon hosts.
+ *
+ * The param list is DERIVED, never hand-maintained, so it can't drift from the
+ * cleaner:  removeParams = (Amazon stripParams)
+ *                          − (global DNR removeParams)      // already covered
+ *                          − (Amazon preserveParams)        // functional on Amazon
+ *                          − (AFFILIATE_PARAM_GUARD)         // creator attribution — NEVER strip
+ *                          − (REMOTE_PARAM_DENYLIST)         // protected nav/search keys
+ * The last two are safety nets: they currently exclude nothing, but guarantee a
+ * future domain-rules edit can never leak an affiliate/nav key into a DNR strip.
+ *
+ * @param {Array<object>} domainRules - parsed domain-rules.json
+ * @param {Set<string>} globalRemoveParams - the global rule's removeParams
+ * @returns {object|null} the DNR rule, or null when there is nothing to strip
+ */
+export function buildAmazonParamsRule(domainRules, globalRemoveParams) {
+  const amazonEntries = domainRules.filter(
+    (r) => typeof r.domain === "string" && AMAZON_HOST_RE.test(r.domain),
+  );
+  if (amazonEntries.length === 0) return null;
+
+  const requestDomains = [...new Set(amazonEntries.map((r) => r.domain))].sort();
+
+  const strip = new Set();
+  const preserve = new Set();
+  for (const r of amazonEntries) {
+    for (const p of r.stripParams ?? []) strip.add(p);
+    for (const p of r.preserveParams ?? []) preserve.add(p);
+  }
+
+  const guard = new Set([...AFFILIATE_PARAM_GUARD].map((s) => s.toLowerCase()));
+  const deny = new Set([...REMOTE_PARAM_DENYLIST].map((s) => s.toLowerCase()));
+
+  const removeParams = [...strip]
+    .filter(
+      (p) =>
+        !globalRemoveParams.has(p) &&
+        !preserve.has(p) &&
+        !guard.has(p.toLowerCase()) &&
+        !deny.has(p.toLowerCase()),
+    )
+    .sort();
+
+  if (removeParams.length === 0) return null;
+
+  return {
+    id: DNR_AMAZON_PARAMS_RULE_ID,
+    priority: 1,
+    action: {
+      type: "redirect",
+      redirect: { transform: { queryTransform: { removeParams } } },
+    },
+    condition: {
+      requestDomains,
+      resourceTypes: ["main_frame"],
+    },
+  };
 }
 
 /**
@@ -350,12 +423,16 @@ function main() {
   const dnrRules = buildDnrRules();
 
   const excluded = TRACKING_PARAMS.length - dnrRules[0].action.redirect.transform.queryTransform.removeParams.length;
+  const amazonRule = dnrRules.find((r) => r.id === DNR_AMAZON_PARAMS_RULE_ID);
+  const amazonCount = amazonRule
+    ? amazonRule.action.redirect.transform.queryTransform.removeParams.length
+    : 0;
 
   writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n", "utf8");
   writeFileSync(DNR_PATH, JSON.stringify(dnrRules, null, 2) + "\n", "utf8");
 
   console.log(
-    `Generated rules-manifest.json (${manifest.tracking.length} params, ${manifest.prefix_rules.length} prefixes) and tracking-params.json (${dnrRules[0].action.redirect.transform.queryTransform.removeParams.length} DNR params, ${excluded} excluded)`
+    `Generated rules-manifest.json (${manifest.tracking.length} params, ${manifest.prefix_rules.length} prefixes) and tracking-params.json (${dnrRules[0].action.redirect.transform.queryTransform.removeParams.length} global DNR params, ${excluded} excluded; ${amazonCount} Amazon-scoped params)`
   );
 }
 


### PR DESCRIPTION
## Problem

On Chrome the current page is cleaned by **DNR only** (the in-page cleaner is skipped when DNR is present). The global DNR rule (`tracking-params.json` id 1, `urlFilter:"*"`) deliberately omits params that are unsafe to strip site-wide — so Amazon internal-navigation tracking tags that the in-page cleaner *does* strip on Amazon (via `domain-rules.json`) survive a direct navigation on Chrome: `ref`, `ref_`, `pf_rd_t/i/m`, `sr`, and 28 more.

These are pure tracking/session breadcrumbs — **not** creator attribution (`tag` is untouched).

## Change

Emit a **second static DNR rule (id 2)**, scoped via `requestDomains` to the 16 Amazon marketplaces, that removes exactly the internal params the cleaner strips but the global rule misses.

The list is **derived** in `generate-rules.mjs` (`buildAmazonParamsRule`), never hand-maintained, so it can't drift from the cleaner:

```
removeParams = (Amazon stripParams)
             − (global DNR removeParams)   // already covered
             − (Amazon preserveParams)     // functional on Amazon
             − (AFFILIATE_PARAM_GUARD)      // creator attribution — never strip
             − (REMOTE_PARAM_DENYLIST)      // protected nav/search keys
```

The last two exclusions currently remove nothing, but are **safety nets**: a future `domain-rules` edit can never leak an affiliate/nav key into a DNR strip.

## Safety

- Scope-aware tests confirm no stripped param is the attribution key of an **Amazon-targeting** affiliate program. (`ref` collides with Vercel's affiliate param, but Vercel isn't on `amazon.*`, so stripping `ref` on Amazon is safe.)
- `tag` is never in the list.
- Drift guard: `dnr-amazon-params.test.mjs` rebuilds the rule from source and asserts the committed artifact matches (`npm run compile:rules`).

## Scope

Closes the **param** side of the Chrome direct-nav gap. Does **not** address the Amazon SEO-slug **path** (#903) — DNR cannot rewrite paths; that needs a separate mechanism.

Full unit suite green (5132), rule generation idempotent.