### PR TITLE
fix(dnr): strip Amazon SEO path slug on Chrome direct navigation (#903)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muga",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muga",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "devDependencies": {
         "@playwright/test": "^1.52.0",
         "@types/node": "^25.9.2",
@@ -15,6 +15,12 @@
         "playwright": "^1.58.2",
         "typescript": "^6.0.3",
         "web-ext": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.11"
+      },
+      "optionalDependencies": {
+        "re2": "^1.25.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -828,6 +834,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@mdn/browser-compat-data": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-7.1.5.tgz",
@@ -981,6 +1000,16 @@
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/abbrev": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-5.0.0.tgz",
+      "integrity": "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1705,6 +1734,16 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chrome-launcher": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
@@ -2210,6 +2249,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -2507,6 +2556,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2580,6 +2636,24 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -2860,7 +2934,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graceful-readlink": {
@@ -3012,6 +3086,20 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/install-artifact-from-github": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.6.0.tgz",
+      "integrity": "sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "bin": {
+        "install-from-cache": "bin/install-from-cache.js",
+        "save-to-github-cache": "bin/save-to-github-cache.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/is-absolute": {
@@ -3499,6 +3587,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3525,6 +3636,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3542,6 +3660,57 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-gyp": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-13.0.0.tgz",
+      "integrity": "sha512-FYYyBDWdc+kzoyPd5PqHUgM9DGs1C/Z4jxBZAOnA2GRUVXPivKRREq5q+VVPXVr9aGVqGMaMqyFHbviy/yb7Hg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^10.0.0",
+        "proc-log": "^7.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^7.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+      "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/node-notifier": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
@@ -3555,6 +3724,22 @@
         "shellwords": "^0.1.1",
         "uuid": "^8.3.2",
         "which": "^2.0.2"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-10.0.1.tgz",
+      "integrity": "sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "^5.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -3824,6 +4009,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pino": {
       "version": "9.9.5",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
@@ -3904,6 +4102,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+      "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -4035,6 +4243,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/re2": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.25.0.tgz",
+      "integrity": "sha512-mtxKjWS+VYIt2ijgt6ohEdwzNlGPom1whyaEKJD40cBc/wqkO1vJoOyK539Qb8Xa9m4GA6hiPGDIbW/d3egSRQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "install-artifact-from-github": "^1.6.0",
+        "nan": "^2.27.0",
+        "node-gyp": "^13.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
       }
     },
     "node_modules/readable-stream": {
@@ -4218,7 +4445,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4490,6 +4717,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4513,6 +4757,23 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -4569,6 +4830,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -4938,6 +5209,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "playwright": "^1.58.2",
     "typescript": "^6.0.3",
     "web-ext": "^8.0.0"
+  },
+  "optionalDependencies": {
+    "re2": "^1.25.0"
   }
 }

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -477,6 +477,12 @@ async function applyDnrState(prefs) {
     for (const id of declaredIds) {
       if (id === "tracking_params") {
         enableRulesetIds.push(id);
+      } else if (id === "amazon_path_canonical") {
+        // Amazon /dp/ SEO-slug strip (#903) — always-on when the consent
+        // gate is open, same as tracking_params. There is no dedicated
+        // feature pref for this yet; it is a Chrome-only DNR redirect
+        // (Firefox strips the slug via the in-page cleaner instead).
+        enableRulesetIds.push(id);
       } else if (id === "amp_redirect") {
         if (prefs.ampRedirect) {
           enableRulesetIds.push(id);

--- a/src/lib/dnr-ids.js
+++ b/src/lib/dnr-ids.js
@@ -10,6 +10,11 @@
  *   2        — static ruleset: Amazon-scoped internal-nav param strip — params the
  *              cleaner strips on Amazon that the global rule can't (unsafe to strip
  *              site-wide), scoped via requestDomains to Amazon marketplaces
+ *   100-102  — static ruleset: AMP unwrap redirects (amp-redirect.json)
+ *   1-5      — static ruleset: wrapper-link unwrap redirects (wrapper-dnr-rules.json,
+ *              its own file-scoped namespace, distinct from tracking-params.json's 1/2)
+ *   200      — static ruleset: Amazon /dp/ SEO-slug strip, Chrome-only DNR
+ *              regexSubstitution redirect (amazon-path-canonical.json) — #903
  *   1000     — dynamic custom params rule (user-defined params, DNR redirect)
  *   1001     — dynamic remote params rule (signed remote payload, DNR redirect)
  *

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -90,6 +90,11 @@
         "id": "wrapper_unwrap",
         "enabled": true,
         "path": "rules/wrapper-dnr-rules.json"
+      },
+      {
+        "id": "amazon_path_canonical",
+        "enabled": true,
+        "path": "rules/amazon-path-canonical.json"
       }
     ]
   },

--- a/src/rules/amazon-path-canonical.json
+++ b/src/rules/amazon-path-canonical.json
@@ -9,7 +9,7 @@
       }
     },
     "condition": {
-      "regexFilter": "^(https?://(?:[a-z0-9-]+\\.)*amazon\\.[a-z.]+(?:/-/[a-z]{2,3})?)/[^/]+/(dp/[A-Za-z0-9]{10})(.*)$",
+      "regexFilter": "^(https?://(?:[a-z0-9-]+\\.)*amazon\\.[a-z.]+(?:/-/[a-z]{2,3})?)/[^/]+/(dp/[A-Za-z0-9]{10})((?:[/?].*)?)$",
       "resourceTypes": ["main_frame"]
     }
   }

--- a/src/rules/amazon-path-canonical.json
+++ b/src/rules/amazon-path-canonical.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 200,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "regexSubstitution": "\\1/\\2\\3"
+      }
+    },
+    "condition": {
+      "regexFilter": "^(https?://(?:[a-z0-9-]+\\.)*amazon\\.[a-z.]+(?:/-/[a-z]{2,3})?)/[^/]+/(dp/[A-Za-z0-9]{10})(.*)$",
+      "resourceTypes": ["main_frame"]
+    }
+  }
+]

--- a/tests/e2e/amazon-path-canonical.spec.mjs
+++ b/tests/e2e/amazon-path-canonical.spec.mjs
@@ -1,0 +1,82 @@
+/**
+ * E2E: Amazon SEO-slug DNR redirect (#903)
+ *
+ * Verifies that the static DNR rule under
+ * src/rules/amazon-path-canonical.json actually redirects main-frame
+ * navigations from an Amazon /dp/ product URL carrying an SEO slug to the
+ * canonical slug-free URL, before any product page content loads, and that
+ * it does not produce a redirect loop (ERR_TOO_MANY_REDIRECTS) once the URL
+ * is already canonical. The unit suite
+ * (tests/unit/amazon-path-canonical-dnr.test.mjs) validates the regex
+ * shape; this spec proves DNR fires in a real (Chrome) browser.
+ *
+ * Chrome-only: amazon_path_canonical is intentionally absent from
+ * manifest.v2.json (see tests/unit/firefox-mv2.test.mjs — Firefox gets
+ * slug-stripping via the in-page cleaner instead).
+ */
+
+import { test, expect } from "./fixtures.mjs";
+
+async function stubHost(page, hostname) {
+  await page.route(`**://${hostname}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>${hostname} stub</body></html>`,
+    })
+  );
+}
+
+test.describe("Amazon path-canonical DNR redirect (#903)", () => {
+  test("strips the SEO slug from a /dp/ product URL, preserving locale prefix and query", async ({ context }) => {
+    const page = await context.newPage();
+    await stubHost(page, "www.amazon.de");
+
+    await page.goto(
+      "https://www.amazon.de/-/en/Arcos-Serie-Universal-Kochmesser-Polyoxymethylen/dp/B0044R881I/?th=1"
+    );
+    await page.waitForLoadState("domcontentloaded");
+
+    expect(page.url()).toBe("https://www.amazon.de/-/en/dp/B0044R881I/?th=1");
+    await page.close();
+  });
+
+  test("strips the SEO slug on a no-locale /dp/ URL, preserving query", async ({ context }) => {
+    const page = await context.newPage();
+    await stubHost(page, "www.amazon.com");
+
+    await page.goto("https://www.amazon.com/Some-Slug-Here/dp/B0044R881I?psc=1");
+    await page.waitForLoadState("domcontentloaded");
+
+    expect(page.url()).toBe("https://www.amazon.com/dp/B0044R881I?psc=1");
+    await page.close();
+  });
+
+  test("already-canonical URL does not redirect loop (ERR_TOO_MANY_REDIRECTS)", async ({ context }) => {
+    const page = await context.newPage();
+    await stubHost(page, "www.amazon.de");
+
+    let navigationError = null;
+    try {
+      await page.goto("https://www.amazon.de/-/en/dp/B0044R881I/?th=1");
+      await page.waitForLoadState("domcontentloaded");
+    } catch (err) {
+      navigationError = err;
+    }
+
+    expect(navigationError).toBeNull();
+    expect(page.url()).toBe("https://www.amazon.de/-/en/dp/B0044R881I/?th=1");
+    await page.close();
+  });
+
+  test("non-product Amazon pages are NOT redirected", async ({ context }) => {
+    const page = await context.newPage();
+    await stubHost(page, "www.amazon.com");
+
+    await page.goto("https://www.amazon.com/s?k=knife");
+    await page.waitForLoadState("domcontentloaded");
+
+    expect(page.url()).toBe("https://www.amazon.com/s?k=knife");
+    await page.close();
+  });
+});

--- a/tests/e2e/amazon-path-canonical.spec.mjs
+++ b/tests/e2e/amazon-path-canonical.spec.mjs
@@ -45,10 +45,19 @@ test.describe("Amazon path-canonical DNR redirect (#903)", () => {
     const page = await context.newPage();
     await stubHost(page, "www.amazon.com");
 
-    await page.goto("https://www.amazon.com/Some-Slug-Here/dp/B0044R881I?psc=1");
+    // NOTE: this asserts the COMPOSED behaviour of the whole extension, not the
+    // amazon_path_canonical rule alone. The slug rule (id 200) preserves any
+    // query verbatim (see the unit suite), but the always-on global
+    // tracking_params rule (id 1, urlFilter "*") independently strips curated
+    // tracking params. `psc` is one of those (tracking-params.json) — so a URL
+    // carrying `?psc=1` ends up with NO query end to end, regardless of the
+    // slug rule. To prove the slug rule preserves the query on a no-locale,
+    // no-trailing-slash URL we use `th`, a functional param MUGA keeps (this is
+    // the same param the locale test above relies on surviving).
+    await page.goto("https://www.amazon.com/Some-Slug-Here/dp/B0044R881I?th=1");
     await page.waitForLoadState("domcontentloaded");
 
-    expect(page.url()).toBe("https://www.amazon.com/dp/B0044R881I?psc=1");
+    expect(page.url()).toBe("https://www.amazon.com/dp/B0044R881I?th=1");
     await page.close();
   });
 

--- a/tests/e2e/onboarding-regression.spec.mjs
+++ b/tests/e2e/onboarding-regression.spec.mjs
@@ -237,8 +237,9 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
   });
 
   test("DNR tracking_params ruleset is disabled until onboardingDone, enabled after", async ({ context, extensionId }) => {
-    // Pre-onboarding: ALL three rulesets must be disabled (#810 — consent-gate
-    // must cover amp_redirect and wrapper_unwrap, not only tracking_params).
+    // Pre-onboarding: ALL four rulesets must be disabled (#810 — consent-gate
+    // must cover amp_redirect, wrapper_unwrap and amazon_path_canonical, not
+    // only tracking_params).
     // Poll so the result does not race with applyDnrState() after beforeEach clear.
     await expect.poll(
       async () => {
@@ -264,6 +265,14 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
       { timeout: 5000 }
     ).not.toContain("wrapper_unwrap");
 
+    await expect.poll(
+      async () => {
+        const r = await readEnabledRulesets(context, extensionId);
+        return r.ruleIds || [];
+      },
+      { timeout: 5000 }
+    ).not.toContain("amazon_path_canonical");
+
     // Complete onboarding without letting the page self-close — the
     // assertion is on the SW side, but we still want a deterministic
     // visible signal that the click landed.
@@ -273,8 +282,9 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
     await completeOnboardingAndKeepPageOpen(page);
 
     // After acceptance, the storage listener re-applies DNR state.
-    // All three rulesets (with default prefs ampRedirect:true, unwrapRedirects:true)
-    // must be enabled. Poll to absorb the listener latency.
+    // All four rulesets (with default prefs ampRedirect:true, unwrapRedirects:true;
+    // amazon_path_canonical has no feature pref and is always-on) must be
+    // enabled. Poll to absorb the listener latency.
     await expect.poll(
       async () => {
         const r = await readEnabledRulesets(context, extensionId);
@@ -298,6 +308,14 @@ test.describe("Onboarding regression: Firefox close + consent gate", () => {
       },
       { timeout: 5000 }
     ).toContain("wrapper_unwrap");
+
+    await expect.poll(
+      async () => {
+        const r = await readEnabledRulesets(context, extensionId);
+        return r.ruleIds || [];
+      },
+      { timeout: 5000 }
+    ).toContain("amazon_path_canonical");
 
     if (!page.isClosed()) await page.close();
   });

--- a/tests/unit/amazon-path-canonical-dnr.test.mjs
+++ b/tests/unit/amazon-path-canonical-dnr.test.mjs
@@ -76,21 +76,55 @@ describe("amazon-path-canonical.json — ID non-collision (#903)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Behavioural fixtures: apply the regexFilter + regexSubstitution as a pure
-// JS function using RegExp + .replace-style backreference substitution —
-// RE2 capture-group substitution syntax \1/\2/\3 maps directly to JS
-// backreferences. This mirrors the pattern used in amp-redirect-dnr.test.mjs.
+// Engine seam: Chrome DNR compiles regexFilter with RE2, NOT the JS RegExp
+// engine. The two can diverge on the same pattern, so — when the optional
+// `re2` devDependency is installed (see package.json) — we evaluate the rule
+// with RE2, the SAME engine Chrome ships, and additionally assert JS ⇄ RE2
+// agreement (see the "engine parity" describe below). If re2 is unavailable
+// in this environment (e.g. the native module could not be built), we fall
+// back to the JS RegExp approximation.
+//
+// IMPORTANT (test scope): these fixtures exercise the amazon_path_canonical
+// rule (id 200) IN ISOLATION — slug removal + verbatim query pass-through.
+// End to end, MUGA loads more rulesets, and the always-on global
+// tracking_params rule (id 1, urlFilter "*") additionally strips curated
+// tracking params. So a param such as `psc` IS preserved by rule 200 alone
+// (asserted here) but is stripped from the FINAL composed URL by rule 1 — a
+// benign one that stays (e.g. `th`) survives end to end. The e2e spec
+// (tests/e2e/amazon-path-canonical.spec.mjs) is authoritative for the
+// composed, real-Chromium substitution result.
 // ---------------------------------------------------------------------------
 
-function applyRule(rule, url) {
-  const re = new RegExp(rule.condition.regexFilter);
-  const m = url.match(re);
-  if (!m) return null;
-  let sub = rule.action.redirect.regexSubstitution;
+let RE2 = null;
+try {
+  ({ default: RE2 } = await import("re2"));
+} catch {
+  // re2 is an optional native devDependency; fall back to JS RegExp below.
+  RE2 = null;
+}
+const RE2_ACTIVE = RE2 !== null;
+
+// RE2 capture-group substitution syntax \1\2\3 maps directly to JS
+// backreferences, so we implement the substitution the same way for both
+// engines and only swap the matcher.
+function substitute(sub, m) {
+  let out = sub;
   for (let i = 1; i < m.length; i++) {
-    sub = sub.replace(new RegExp("\\\\" + i, "g"), m[i] ?? "");
+    out = out.replace(new RegExp("\\\\" + i, "g"), m[i] ?? "");
   }
-  return sub;
+  return out;
+}
+
+function matchWith(engine, filter, url) {
+  if (engine === "re2") return new RE2(filter).exec(url);
+  return url.match(new RegExp(filter));
+}
+
+// Applies the rule using RE2 when available, else JS RegExp.
+function applyRule(rule, url) {
+  const m = matchWith(RE2_ACTIVE ? "re2" : "js", rule.condition.regexFilter, url);
+  if (!m) return null;
+  return substitute(rule.action.redirect.regexSubstitution, m);
 }
 
 const [RULE] = amazonPathRules;
@@ -104,12 +138,36 @@ describe("amazon-path-canonical.json — slug stripping, locale + query preserve
     assert.equal(result, "https://www.amazon.de/-/en/dp/B0044R881I/?th=1");
   });
 
-  test("no-locale URL: slug stripped, query preserved (no trailing slash before ?)", () => {
+  test("no-locale URL, query begins with '?' right after ASIN: slug stripped, query preserved (regression for #903 e2e drop)", () => {
+    // This is the exact URL the #903 CI e2e used. Under BOTH JS RegExp and RE2
+    // (Chrome's engine), capture group 3 = "?psc=1" and rule 200 IN ISOLATION
+    // preserves it verbatim — there is no trailing slash synthesized before
+    // the query. The end-to-end e2e result differs ONLY because the global
+    // tracking_params rule (id 1) independently strips the curated `psc`
+    // param; that is not a defect of this rule. See the engine-seam note above.
     const result = applyRule(RULE, "https://www.amazon.com/Some-Slug-Here/dp/B0044R881I?psc=1");
-    // The rule does not synthesize a trailing slash before the query string —
-    // it only removes the slug segment and passes the remainder through
-    // verbatim via the third capture group, so "?psc=1" stays exactly as-is.
     assert.equal(result, "https://www.amazon.com/dp/B0044R881I?psc=1");
+  });
+
+  test("no-locale URL, multi-param query (?a=1&b=2) preserved verbatim", () => {
+    const result = applyRule(RULE, "https://www.amazon.com/Some-Slug/dp/B0044R881I?a=1&b=2");
+    assert.equal(result, "https://www.amazon.com/dp/B0044R881I?a=1&b=2");
+  });
+
+  test("no-locale URL, path-suffix tail (/ref=...) preserved verbatim", () => {
+    const result = applyRule(RULE, "https://www.amazon.com/Some-Slug/dp/B0044R881I/ref=sr_1_1");
+    assert.equal(result, "https://www.amazon.com/dp/B0044R881I/ref=sr_1_1");
+  });
+
+  test("no-locale URL, trailing slash and empty tail preserved verbatim", () => {
+    assert.equal(
+      applyRule(RULE, "https://www.amazon.com/Some-Slug/dp/B0044R881I/"),
+      "https://www.amazon.com/dp/B0044R881I/"
+    );
+    assert.equal(
+      applyRule(RULE, "https://www.amazon.com/Some-Slug/dp/B0044R881I"),
+      "https://www.amazon.com/dp/B0044R881I"
+    );
   });
 
   // Addendum: the /-/xx locale prefix is functional (Amazon uses it to pick
@@ -195,17 +253,18 @@ describe("amazon-path-canonical.json — non-product pages are not matched", () 
 describe("amazon-path-canonical.json — moat safety: query string is never touched", () => {
   test("regexFilter never matches on a literal query-string separator ('\\?')", () => {
     // The pattern uses "?" only as regex syntax (non-capturing groups "(?:",
-    // optional quantifiers) — never an escaped literal "\?" that would target
-    // the URL's query-string separator. Everything from "dp/ASIN" onward
-    // (path suffix + "?query") is passed through untouched via the trailing
-    // `(.*)$` capture group instead of being parsed/matched.
+    // optional quantifiers, and the "[/?]" tail-delimiter char class) — never
+    // an escaped literal "\?" that would target the URL's query-string
+    // separator. Everything from "dp/ASIN" onward (path suffix + "?query") is
+    // passed through untouched via the trailing `((?:[/?].*)?)$` capture group
+    // instead of being parsed/matched.
     assert.ok(
       !RULE.condition.regexFilter.includes("\\?"),
       "regexFilter must not contain an escaped literal '\\?' — the query string must never be parsed, only passed through"
     );
     assert.ok(
-      RULE.condition.regexFilter.endsWith("(.*)$"),
-      "regexFilter must end with a catch-all capture group that passes the path suffix + query string through verbatim"
+      RULE.condition.regexFilter.endsWith("((?:[/?].*)?)$"),
+      "regexFilter must end with a tail capture group that is empty OR begins with a '/' or '?' delimiter and then passes the remainder through verbatim"
     );
   });
 
@@ -218,5 +277,63 @@ describe("amazon-path-canonical.json — moat safety: query string is never touc
       applyRule(RULE, "https://www.amazon.com/Slug/dp/B0044R881I?psc=1"),
       "https://www.amazon.com/dp/B0044R881I?psc=1"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine parity (JS RegExp vs RE2): Chrome DNR uses RE2. This guards against
+// the exact class of false confidence that let #903 ship — a pattern that
+// behaves one way under JS RegExp and another under RE2. When the optional
+// `re2` devDependency is installed, we assert both engines agree (match/no-match
+// AND the substituted output) across the full behavioural corpus. If re2 is not
+// installed, the block reports that parity was NOT machine-verified and defers
+// to the e2e spec, which runs in real Chromium.
+// ---------------------------------------------------------------------------
+describe("amazon-path-canonical.json — JS RegExp vs RE2 engine parity (#903)", () => {
+  const CORPUS = [
+    "https://www.amazon.de/-/en/Arcos-Serie/dp/B0044R881I/?th=1",
+    "https://www.amazon.com/Some-Slug-Here/dp/B0044R881I?psc=1",
+    "https://www.amazon.com/Some-Slug/dp/B0044R881I?a=1&b=2",
+    "https://www.amazon.com/Some-Slug/dp/B0044R881I/ref=sr_1_1",
+    "https://www.amazon.com/Some-Slug/dp/B0044R881I/",
+    "https://www.amazon.com/Some-Slug/dp/B0044R881I",
+    "https://www.amazon.es/-/es/Otro/dp/B0044R881I",
+    "https://www.amazon.co.jp/-/ja/Slug/dp/B0044R881I",
+    // idempotency / non-matching
+    "https://www.amazon.com/dp/B0044R881I?psc=1",
+    "https://www.amazon.de/-/en/dp/B0044R881I?th=1",
+    "https://www.amazon.de/-/EN/Slug/dp/B0044R881I",
+    "https://www.amazon.de/-/en-US/Slug/dp/B0044R881I",
+    "https://www.amazon.com/s?k=knife",
+    "https://www.amazon.com/gp/cart/view.html",
+    "https://www.amazon.com/",
+  ];
+
+  test(RE2_ACTIVE ? "RE2 is the active engine and agrees with JS RegExp on every corpus URL" : "re2 not installed — parity NOT machine-verified (e2e in real Chromium is authoritative)", () => {
+    if (!RE2_ACTIVE) {
+      // Not a hard failure: re2 is an optional native module. We still encode
+      // the intended outcomes elsewhere in this file, and the Chrome e2e spec
+      // validates the real RE2 substitution behaviour end to end.
+      assert.ok(true);
+      return;
+    }
+    const sub = RULE.action.redirect.regexSubstitution;
+    const filter = RULE.condition.regexFilter;
+    for (const url of CORPUS) {
+      const jm = matchWith("js", filter, url);
+      const rm = matchWith("re2", filter, url);
+      assert.equal(
+        Boolean(jm),
+        Boolean(rm),
+        `match/no-match diverges between JS and RE2 for ${url}`
+      );
+      if (jm && rm) {
+        assert.equal(
+          substitute(sub, jm),
+          substitute(sub, rm),
+          `substituted output diverges between JS and RE2 for ${url}`
+        );
+      }
+    }
   });
 });

--- a/tests/unit/amazon-path-canonical-dnr.test.mjs
+++ b/tests/unit/amazon-path-canonical-dnr.test.mjs
@@ -1,0 +1,222 @@
+/**
+ * MUGA — Structural validation for amazon-path-canonical.json DNR rules (#903)
+ *
+ * Chrome-only: strips the Amazon SEO path slug on direct navigation to a
+ * /dp/ product page via a standalone DNR regexSubstitution redirect, e.g.
+ *   https://www.amazon.de/-/en/Some-Slug/dp/B0044R881I/?th=1
+ *   → https://www.amazon.de/-/en/dp/B0044R881I/?th=1
+ *
+ * Verifies the rule resource is well-formed, its ID does not collide with
+ * any other static ruleset or dynamic rule ID, the regex preserves the
+ * `/-/xx` locale prefix and query string while stripping only the slug,
+ * and the already-canonical output URL cannot re-match (loop prevention).
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import {
+  DNR_CUSTOM_PARAMS_RULE_ID,
+  DNR_REMOTE_PARAMS_RULE_ID,
+} from "../../src/lib/dnr-ids.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "../..");
+
+const amazonPathRules = JSON.parse(
+  readFileSync(join(ROOT, "src/rules/amazon-path-canonical.json"), "utf8")
+);
+const trackingRules = JSON.parse(readFileSync(join(ROOT, "src/rules/tracking-params.json"), "utf8"));
+const ampRules = JSON.parse(readFileSync(join(ROOT, "src/rules/amp-redirect.json"), "utf8"));
+const wrapperRules = JSON.parse(readFileSync(join(ROOT, "src/rules/wrapper-dnr-rules.json"), "utf8"));
+
+describe("amazon-path-canonical.json — shape", () => {
+  test("is an array", () => {
+    assert.ok(Array.isArray(amazonPathRules));
+  });
+
+  test("contains exactly one rule", () => {
+    assert.equal(amazonPathRules.length, 1);
+  });
+
+  test("rule has id, priority, action.type === redirect, regexSubstitution, condition.regexFilter, resourceTypes ['main_frame']", () => {
+    const [r] = amazonPathRules;
+    assert.equal(typeof r.id, "number");
+    assert.equal(typeof r.priority, "number");
+    assert.equal(r.action?.type, "redirect");
+    assert.equal(typeof r.action?.redirect?.regexSubstitution, "string");
+    assert.equal(typeof r.condition?.regexFilter, "string");
+    assert.deepEqual(r.condition?.resourceTypes, ["main_frame"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ID collision guard — must not collide with any other static ruleset ID
+// (tracking-params.json, amp-redirect.json, wrapper-dnr-rules.json) or any
+// dynamic rule ID declared in src/lib/dnr-ids.js.
+// ---------------------------------------------------------------------------
+describe("amazon-path-canonical.json — ID non-collision (#903)", () => {
+  test("rule ID does not collide with tracking-params.json, amp-redirect.json, wrapper-dnr-rules.json, or dynamic dnr-ids.js IDs", () => {
+    const otherStaticIds = [
+      ...trackingRules.map(r => r.id),
+      ...ampRules.map(r => r.id),
+      ...wrapperRules.map(r => r.id),
+    ];
+    const dynamicIds = [DNR_CUSTOM_PARAMS_RULE_ID, DNR_REMOTE_PARAMS_RULE_ID];
+    const allOtherIds = new Set([...otherStaticIds, ...dynamicIds]);
+
+    for (const r of amazonPathRules) {
+      assert.ok(
+        !allOtherIds.has(r.id),
+        `amazon-path-canonical.json rule ID ${r.id} collides with an existing static or dynamic rule ID`
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavioural fixtures: apply the regexFilter + regexSubstitution as a pure
+// JS function using RegExp + .replace-style backreference substitution —
+// RE2 capture-group substitution syntax \1/\2/\3 maps directly to JS
+// backreferences. This mirrors the pattern used in amp-redirect-dnr.test.mjs.
+// ---------------------------------------------------------------------------
+
+function applyRule(rule, url) {
+  const re = new RegExp(rule.condition.regexFilter);
+  const m = url.match(re);
+  if (!m) return null;
+  let sub = rule.action.redirect.regexSubstitution;
+  for (let i = 1; i < m.length; i++) {
+    sub = sub.replace(new RegExp("\\\\" + i, "g"), m[i] ?? "");
+  }
+  return sub;
+}
+
+const [RULE] = amazonPathRules;
+
+describe("amazon-path-canonical.json — slug stripping, locale + query preserved", () => {
+  test("issue URL: /-/en locale prefix + slug + trailing slash + query", () => {
+    const result = applyRule(
+      RULE,
+      "https://www.amazon.de/-/en/Arcos-Serie-Universal-Kochmesser-Polyoxymethylen/dp/B0044R881I/?th=1"
+    );
+    assert.equal(result, "https://www.amazon.de/-/en/dp/B0044R881I/?th=1");
+  });
+
+  test("no-locale URL: slug stripped, query preserved (no trailing slash before ?)", () => {
+    const result = applyRule(RULE, "https://www.amazon.com/Some-Slug-Here/dp/B0044R881I?psc=1");
+    // The rule does not synthesize a trailing slash before the query string —
+    // it only removes the slug segment and passes the remainder through
+    // verbatim via the third capture group, so "?psc=1" stays exactly as-is.
+    assert.equal(result, "https://www.amazon.com/dp/B0044R881I?psc=1");
+  });
+
+  // Addendum: the /-/xx locale prefix is functional (Amazon uses it to pick
+  // the storefront language) and MUST survive slug removal for every
+  // supported locale, not just /-/en.
+  test("preserves /-/es locale prefix (amazon.es)", () => {
+    const result = applyRule(RULE, "https://www.amazon.es/-/es/Otro-Slug-De-Producto/dp/B0044R881I");
+    assert.equal(result, "https://www.amazon.es/-/es/dp/B0044R881I");
+  });
+
+  test("preserves /-/ja locale prefix (amazon.co.jp, multi-label TLD)", () => {
+    const result = applyRule(RULE, "https://www.amazon.co.jp/-/ja/Slug-Japones-De-Producto/dp/B0044R881I");
+    assert.equal(result, "https://www.amazon.co.jp/-/ja/dp/B0044R881I");
+  });
+});
+
+describe("amazon-path-canonical.json — idempotency (loop prevention)", () => {
+  test("already-canonical URL (no locale) does NOT match regexFilter", () => {
+    const re = new RegExp(RULE.condition.regexFilter);
+    assert.equal(re.test("https://www.amazon.com/dp/B0044R881I?psc=1"), false);
+  });
+
+  test("already-canonical URL WITH /-/en locale does NOT match regexFilter", () => {
+    const re = new RegExp(RULE.condition.regexFilter);
+    assert.equal(re.test("https://www.amazon.de/-/en/dp/B0044R881I?th=1"), false);
+  });
+
+  test("already-canonical URL WITH /-/es locale does NOT match regexFilter", () => {
+    const re = new RegExp(RULE.condition.regexFilter);
+    assert.equal(re.test("https://www.amazon.es/-/es/dp/B0044R881I"), false);
+  });
+
+  test("already-canonical URL WITH /-/ja locale does NOT match regexFilter", () => {
+    const re = new RegExp(RULE.condition.regexFilter);
+    assert.equal(re.test("https://www.amazon.co.jp/-/ja/dp/B0044R881I"), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Safe-fail on unrecognized locale forms: the path-locale capture group is
+// `(?:/-/[a-z]{2,3})?`, matching Amazon's real path-locale codes (two-letter
+// ISO 639-1 language codes such as en/es/de/fr/it/ja; three letters is
+// reserved headroom, no known Amazon path code needs it). A locale segment
+// outside that shape (uppercase, hyphenated region suffix like en-US) must
+// NOT be partially consumed — the rule must simply not match rather than
+// produce a mangled path.
+// ---------------------------------------------------------------------------
+describe("amazon-path-canonical.json — safe-fail on malformed locale prefix", () => {
+  const re = () => new RegExp(RULE.condition.regexFilter);
+
+  test("uppercase locale (/-/EN) does not match — URL left untouched", () => {
+    assert.equal(re().test("https://www.amazon.de/-/EN/Slug/dp/B0044R881I"), false);
+  });
+
+  test("region-suffixed locale (/-/en-US) does not match — URL left untouched", () => {
+    assert.equal(re().test("https://www.amazon.de/-/en-US/Slug/dp/B0044R881I"), false);
+  });
+});
+
+describe("amazon-path-canonical.json — non-product pages are not matched", () => {
+  const re = () => new RegExp(RULE.condition.regexFilter);
+
+  test("search results page", () => {
+    assert.equal(re().test("https://www.amazon.com/s?k=knife"), false);
+  });
+
+  test("cart page", () => {
+    assert.equal(re().test("https://www.amazon.com/gp/cart/view.html"), false);
+  });
+
+  test("homepage", () => {
+    assert.equal(re().test("https://www.amazon.com/"), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Moat safety: the rule must only ever touch the path, never the query
+// string. Any param in domain-rules.json's Amazon preserveParams, or the
+// tracking-params.json Amazon-scoped strip rule, must pass through
+// untouched — the regex only removes the path segment before "dp/ASIN",
+// everything else (including "?...") is captured verbatim and replayed.
+// ---------------------------------------------------------------------------
+describe("amazon-path-canonical.json — moat safety: query string is never touched", () => {
+  test("regexFilter never matches on a literal query-string separator ('\\?')", () => {
+    // The pattern uses "?" only as regex syntax (non-capturing groups "(?:",
+    // optional quantifiers) — never an escaped literal "\?" that would target
+    // the URL's query-string separator. Everything from "dp/ASIN" onward
+    // (path suffix + "?query") is passed through untouched via the trailing
+    // `(.*)$` capture group instead of being parsed/matched.
+    assert.ok(
+      !RULE.condition.regexFilter.includes("\\?"),
+      "regexFilter must not contain an escaped literal '\\?' — the query string must never be parsed, only passed through"
+    );
+    assert.ok(
+      RULE.condition.regexFilter.endsWith("(.*)$"),
+      "regexFilter must end with a catch-all capture group that passes the path suffix + query string through verbatim"
+    );
+  });
+
+  test("functional/affiliate params (tag, th, psc) survive the redirect untouched", () => {
+    assert.equal(
+      applyRule(RULE, "https://www.amazon.de/-/en/Slug/dp/B0044R881I/?th=1&tag=creator-21"),
+      "https://www.amazon.de/-/en/dp/B0044R881I/?th=1&tag=creator-21"
+    );
+    assert.equal(
+      applyRule(RULE, "https://www.amazon.com/Slug/dp/B0044R881I?psc=1"),
+      "https://www.amazon.com/dp/B0044R881I?psc=1"
+    );
+  });
+});

--- a/tests/unit/dnr-consent-gate.test.mjs
+++ b/tests/unit/dnr-consent-gate.test.mjs
@@ -59,6 +59,9 @@ async function applyDnrStateLogic(prefs, declaredIds, dnrApi) {
   for (const id of declaredIds) {
     if (id === "tracking_params") {
       enableRulesetIds.push(id);
+    } else if (id === "amazon_path_canonical") {
+      // Mirrors production: always-on when the gate is open (#903).
+      enableRulesetIds.push(id);
     } else if (id === "amp_redirect") {
       if (prefs.ampRedirect) {
         enableRulesetIds.push(id);
@@ -97,7 +100,7 @@ function makeFakeDnr() {
   };
 }
 
-const MV3_IDS = ["tracking_params", "amp_redirect", "wrapper_unwrap"];
+const MV3_IDS = ["tracking_params", "amp_redirect", "wrapper_unwrap", "amazon_path_canonical"];
 const MV2_IDS = ["tracking_params"];
 
 const BASE_PREFS_OPEN = {
@@ -284,6 +287,47 @@ describe("applyDnrState — gate open with per-feature pref toggles", () => {
   });
 });
 
+describe("applyDnrState — amazon_path_canonical (#903)", () => {
+  test("gate open → amazon_path_canonical is always enabled, like tracking_params", async () => {
+    const dnr = makeFakeDnr();
+    await applyDnrStateLogic(BASE_PREFS_OPEN, MV3_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.ok(
+      call.enableRulesetIds.includes("amazon_path_canonical"),
+      "amazon_path_canonical must be enabled when the consent gate is open"
+    );
+  });
+
+  test("gate open + ampRedirect:false + unwrapRedirects:false → amazon_path_canonical stays enabled", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, ampRedirect: false, unwrapRedirects: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.ok(
+      call.enableRulesetIds.includes("amazon_path_canonical"),
+      "amazon_path_canonical has no per-feature pref (yet) — it must stay enabled regardless of other toggles"
+    );
+    assert.ok(
+      !(call.disableRulesetIds || []).includes("amazon_path_canonical"),
+      "amazon_path_canonical must never be disabled while the gate is open"
+    );
+  });
+
+  test("gate closed (onboardingDone:false) → amazon_path_canonical is disabled with all other rulesets", async () => {
+    const dnr = makeFakeDnr();
+    const prefs = { ...BASE_PREFS_OPEN, onboardingDone: false };
+    await applyDnrStateLogic(prefs, MV3_IDS, dnr);
+
+    const call = dnr.calls[0];
+    assert.ok(
+      call.disableRulesetIds.includes("amazon_path_canonical"),
+      "amazon_path_canonical must be disabled when the consent gate is closed (#810 regression class)"
+    );
+  });
+});
+
 describe("applyDnrState — MV2 parity: only declared IDs are touched", () => {
   test("MV2 manifest (tracking_params only): gate closed disables only tracking_params", async () => {
     const dnr = makeFakeDnr();
@@ -366,8 +410,9 @@ describe("service-worker.js source guards — #810 fix present", () => {
   test("applyDnrState references ampRedirect pref", () => {
     const applyFnStart = swSource.indexOf("async function applyDnrState(");
     assert.ok(applyFnStart !== -1, "applyDnrState must exist in SW");
-    // Use 2000 chars — the function grew with comments after the #810 fix
-    const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2000);
+    // Use 2600 chars — the function grew with comments after the #810 fix
+    // and the #903 amazon_path_canonical branch
+    const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2600);
     assert.ok(
       applyFnBlock.includes("ampRedirect"),
       "applyDnrState must check prefs.ampRedirect to gate amp_redirect ruleset"
@@ -377,8 +422,9 @@ describe("service-worker.js source guards — #810 fix present", () => {
   test("applyDnrState references unwrapRedirects pref", () => {
     const applyFnStart = swSource.indexOf("async function applyDnrState(");
     assert.ok(applyFnStart !== -1, "applyDnrState must exist in SW");
-    // Use 2000 chars — the function grew with comments after the #810 fix
-    const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2000);
+    // Use 2600 chars — the function grew with comments after the #810 fix
+    // and the #903 amazon_path_canonical branch
+    const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2600);
     assert.ok(
       applyFnBlock.includes("unwrapRedirects"),
       "applyDnrState must check prefs.unwrapRedirects to gate wrapper_unwrap ruleset"

--- a/tests/unit/firefox-mv2.test.mjs
+++ b/tests/unit/firefox-mv2.test.mjs
@@ -292,6 +292,12 @@ describe("Firefox MV2 manifest structure", () => {
 //   MV2 is unverified; tracked separately. Do not remove it from this list
 //   without a confirmed live Firefox run.
 //
+//   amazon_path_canonical — Chrome-only DNR regexSubstitution redirect that
+//   strips the Amazon SEO slug from /dp/ URLs on direct navigation (#903).
+//   Firefox already gets equivalent path-strip behavior via the in-page
+//   cleaner (JS-side self-clean), so this static ruleset is intentionally
+//   not declared in manifest.v2.json.
+//
 // All other rulesets must be declared in both manifests. If a new ruleset is
 // added to manifest.json (MV3) without a decision for Firefox, this test will
 // fail loudly so the gap is never silent. (#820)
@@ -299,6 +305,7 @@ describe("Firefox MV2 manifest structure", () => {
 describe("DNR ruleset MV2 parity (#820)", () => {
   const DOCUMENTED_MV2_EXCEPTIONS = new Set([
     "amp_redirect",
+    "amazon_path_canonical",
   ]);
 
   const mv3Ids = new Set(


### PR DESCRIPTION
Closes #903.

## Problem
On Chrome, MUGA did not strip the Amazon SEO path slug on direct navigation. Root cause: Chrome current-page cleaning is DNR-only (query-param removal); the in-page self-clean that applies `path-strip-rules.json` is skipped when DNR is present (`cleaner.js`, since #371). So the path was never canonicalized on any Chrome current-page path.

Example: `https://www.amazon.de/-/en/Arcos-Serie-Universal-Kochmesser-Polyoxymethylen/dp/B0044R881I/?th=1` kept the full slug.

## Fix
New standalone static DNR redirect ruleset `src/rules/amazon-path-canonical.json` (id 200, `main_frame`), scoped to Amazon product URLs, rewriting `.../<slug>/dp/<ASIN>...` → `.../dp/<ASIN>...` via `regexSubstitution`. Independent of #905 (composes via DNR multi-hop). Scope: `/dp/` only — `/gp/product/` and `/ref=` stripping are documented follow-ups.

## Correctness (the load-bearing bits)
- **Query + locale preserved verbatim.** Chrome DNR `regexSubstitution` replaces the *entire* matched URL, so the trailing path/query is captured as `(.*)$` and reproduced (`\1/\2\3`) — same technique as the production `amp-redirect` rule 102. The `/-/xx` locale prefix (`en`/`es`/`ja`/…) and the full query string (`th`, `psc`, and any affiliate `tag`) are never touched. **Path-only rewrite → affiliate moat safe.**
- **Idempotent / no redirect loop.** A canonical `.../dp/<ASIN>` URL structurally cannot re-match (the pattern needs two path segments before `dp/`), so no `ERR_TOO_MANY_REDIRECTS`.
- **Safe-fail.** Unrecognized locale forms (`/-/EN`, `/-/en-US`) and non-product pages (`/s`, `/gp/cart`, home) do not match and are left untouched.

## Consent gate
`applyDnrState()` enables `amazon_path_canonical` only when the consent gate is open (mirrors `tracking_params`), preserving the #810 guarantee. Ruleset-id enumeration tests updated so the new id doesn't bypass the gate.

## Testing
- New `tests/unit/amazon-path-canonical-dnr.test.mjs` — 19 tests: multi-locale (en/es/ja) preservation, no-locale, idempotency with/without locale, safe-fail malformed locales, non-product exclusion, id uniqueness, moat safety.
- New `tests/e2e/amazon-path-canonical.spec.mjs` — real-browser navigation + anti-loop assertion (**not run locally — Playwright; CI e2e is the loop-safety gate, do not merge until green**).
- Full unit suite: **5180 pass / 0 fail / 1 pre-existing skip**. web-ext lint clean.

## Firefox
`manifest.v2.json` untouched — Firefox strips the slug via the in-page cleaner (no DNR-skip there).