### PR TITLE
fix(core): gate remote-params DNR + shortener egress; harden remote-rules ingestion

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -10,11 +10,12 @@ import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLo
 import { migrateConsentToLocal } from "../lib/sync-migration.js";
 import { evaluate as evaluateConsent } from "../lib/consent-policy.js";
 import { isValidListEntry } from "../lib/validation.js";
-import { DNR_CUSTOM_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
+import { DNR_CUSTOM_PARAMS_RULE_ID, DNR_REMOTE_PARAMS_RULE_ID } from "../lib/dnr-ids.js";
 import { t } from "../lib/i18n.js";
 import {
   runRemoteRulesFetch,
   clearRemoteCache,
+  buildRemoteDnrRule,
 } from "../lib/remote-rules.js";
 import { TRUSTED_PUBLIC_KEYS } from "../lib/remote-rules-keys.js";
 import { resolveShortener } from "../lib/native-shortener-resolver.js";
@@ -510,6 +511,11 @@ async function applyDnrState(prefs) {
       disableRulesetIds,
     }).catch(err => console.warn("[MUGA] applyDnrState enable:", err));
     await syncCustomParamsDNR(prefs.customParams);
+    // Re-arm the dynamic remote-params rule (id 1001). The gate-closed branch
+    // removes it (#921), so a close→open cycle — or a wake where the weekly
+    // signed fetch is time-gated and skips re-adding it — would otherwise leave
+    // remote cleaning silently off. Rebuild it here from the cached payload.
+    await reconcileRemoteDnrRule(prefs);
   } else {
     // Gate closed: disable ALL declared rulesets so that AMP redirects
     // and wrapper-unwrapping cannot fire before the user has accepted
@@ -520,6 +526,45 @@ async function applyDnrState(prefs) {
       }).catch(err => console.warn("[MUGA] applyDnrState disable:", err));
     }
     await syncCustomParamsDNR([]);
+    // Disabling the static rulesets and clearing rule 1000 is NOT enough: the
+    // remote-params rule (dynamic id 1001) is a DNR redirect that keeps
+    // stripping params for a disabled or non-consented extension. Remove it so
+    // the consent gate holds across the dynamic cleaning path too. (#921)
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: [DNR_REMOTE_PARAMS_RULE_ID],
+    }).catch(err => console.warn("[MUGA] applyDnrState remote-params clear:", err));
+  }
+}
+
+// Reconciles the dynamic remote-params rule (id 1001) with current prefs +
+// cached payload. Used on gate-open so rule 1001 is restored after the
+// gate-closed branch removed it, without waiting for the next weekly fetch.
+// buildRemoteDnrRule rejects an empty removeParams transform, so an empty or
+// missing cache resolves to "no rule" (removal only). (#921)
+//
+// Named distinctly from the SW-local syncRemoteParamsDNR retired in #706: that
+// helper duplicated the write that runRemoteRulesFetch already performs, whereas
+// this one restores rule 1001 from the CACHE on gate-open, which the time-gated
+// weekly fetch does not do.
+async function reconcileRemoteDnrRule(prefs) {
+  if (!hasDNR) return;
+  try {
+    const params = prefs.remoteRulesEnabled
+      ? (await getRemoteParams()).remoteParams
+      : [];
+    const list = Array.isArray(params) ? params : [];
+    if (list.length === 0) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: [DNR_REMOTE_PARAMS_RULE_ID],
+      });
+      return;
+    }
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: [DNR_REMOTE_PARAMS_RULE_ID],
+      addRules: [buildRemoteDnrRule(list)],
+    });
+  } catch (err) {
+    console.warn("[MUGA] reconcileRemoteDnrRule failed:", err);
   }
 }
 
@@ -1113,6 +1158,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     (async () => {
       try {
         const prefs = await getPrefsWithCache();
+        // Consent gate (#922): a disabled or non-onboarded extension MUST NOT
+        // perform the live shortener-resolution egress. This mirrors the DNR
+        // consent gate — no network activity until the user has enabled the
+        // extension AND accepted the ToS. Checked before followShortenersEnabled
+        // and before any fetch so the gate cannot be bypassed by the feature toggle.
+        if (!prefs.enabled || !prefs.onboardingDone) {
+          try { sendResponse({ ok: false, reason: "disabled" }); } catch { /* channel closed */ }
+          return;
+        }
         if (!prefs.followShortenersEnabled) {
           try { sendResponse({ ok: false, reason: "disabled" }); } catch { /* channel closed */ }
           return;

--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -151,6 +151,7 @@ export default Object.freeze({
   optionsRemoteRulesErrOverCap: "Aktualisierung war zu groß. Ignoriert.",
   optionsRemoteRulesErrVersion: "Aktualisierung war älter als die aktuelle. Ignoriert.",
   optionsRemoteRulesErrStale: "Aktualisierungsdatei war zu alt. Ignoriert.",
+  optionsRemoteRulesErrDnr: "Aktualisierung konnte im Browser nicht angewendet werden. Vorherige Liste bleibt aktiv.",
   optionsRemoteRulesErrUnknown: "Aktualisierung fehlgeschlagen. Details in der Konsole.",
   muga_disabled_for_domain: "MUGA ist auf dieser Seite deaktiviert",
   section_advanced: "Erweitert",

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -151,6 +151,7 @@ export default Object.freeze({
   optionsRemoteRulesErrOverCap: "Update was too large. Ignored.",
   optionsRemoteRulesErrVersion: "Update was older than current. Ignored.",
   optionsRemoteRulesErrStale: "Update file was too old. Ignored.",
+  optionsRemoteRulesErrDnr: "Update could not be applied to the browser. Previous list still in use.",
   optionsRemoteRulesErrUnknown: "Update failed. Check the console for details.",
   muga_disabled_for_domain: "MUGA is disabled on this site",
   section_advanced: "Advanced",

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -151,6 +151,7 @@ export default Object.freeze({
   optionsRemoteRulesErrOverCap: "La actualización era demasiado grande. Ignorada.",
   optionsRemoteRulesErrVersion: "La actualización era más antigua que la actual. Ignorada.",
   optionsRemoteRulesErrStale: "El archivo de actualización era demasiado antiguo. Ignorado.",
+  optionsRemoteRulesErrDnr: "No se pudo aplicar la actualización en el navegador. Se mantiene la lista anterior.",
   optionsRemoteRulesErrUnknown: "La actualización falló. Consulta la consola para más detalles.",
   muga_disabled_for_domain: "MUGA está desactivado en este sitio",
   section_advanced: "Avanzado",

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -151,6 +151,7 @@ export default Object.freeze({
   optionsRemoteRulesErrOverCap: "La mise à jour était trop volumineuse. Ignorée.",
   optionsRemoteRulesErrVersion: "La mise à jour était plus ancienne que la version actuelle. Ignorée.",
   optionsRemoteRulesErrStale: "Le fichier de mise à jour était trop ancien. Ignoré.",
+  optionsRemoteRulesErrDnr: "La mise à jour n'a pas pu être appliquée au navigateur. Liste précédente conservée.",
   optionsRemoteRulesErrUnknown: "Échec de la mise à jour. Consultez la console pour plus de détails.",
   muga_disabled_for_domain: "MUGA est désactivé sur ce site",
   section_advanced: "Avancé",

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -151,6 +151,7 @@ export default Object.freeze({
   optionsRemoteRulesErrOverCap: "L'aggiornamento era troppo grande. Ignorato.",
   optionsRemoteRulesErrVersion: "L'aggiornamento era più vecchio di quello attuale. Ignorato.",
   optionsRemoteRulesErrStale: "Il file di aggiornamento era troppo vecchio. Ignorato.",
+  optionsRemoteRulesErrDnr: "Impossibile applicare l'aggiornamento al browser. Elenco precedente ancora in uso.",
   optionsRemoteRulesErrUnknown: "Aggiornamento fallito. Controlla la console per i dettagli.",
   muga_disabled_for_domain: "MUGA è disattivato su questo sito",
   section_advanced: "Avanzate",

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -151,6 +151,7 @@ export default Object.freeze({
   optionsRemoteRulesErrOverCap: "更新が大きすぎました。無視しました。",
   optionsRemoteRulesErrVersion: "更新が現在のバージョンより古いものでした。無視しました。",
   optionsRemoteRulesErrStale: "更新ファイルが古すぎました。無視しました。",
+  optionsRemoteRulesErrDnr: "更新をブラウザに適用できませんでした。以前のリストを引き続き使用します。",
   optionsRemoteRulesErrUnknown: "更新に失敗しました。詳細はコンソールを確認してください。",
   muga_disabled_for_domain: "MUGAはこのサイトで無効です",
   section_advanced: "詳細設定",

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -151,6 +151,7 @@ export default Object.freeze({
   optionsRemoteRulesErrOverCap: "Atualização era grande demais. Ignorada.",
   optionsRemoteRulesErrVersion: "Atualização era mais antiga que a atual. Ignorada.",
   optionsRemoteRulesErrStale: "Arquivo de atualização era muito antigo. Ignorado.",
+  optionsRemoteRulesErrDnr: "Não foi possível aplicar a atualização no navegador. Lista anterior ainda em uso.",
   optionsRemoteRulesErrUnknown: "Atualização falhou. Verifique o console para detalhes.",
   muga_disabled_for_domain: "MUGA está desativado neste site",
   section_advanced: "Avançado",

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -71,6 +71,7 @@ export const ERR = Object.freeze({
   OVER_CAP:           "OVER_CAP",
   VERSION_REGRESSION: "VERSION_REGRESSION",
   STALE_PAYLOAD:      "STALE_PAYLOAD",
+  DNR_ERROR:          "DNR_ERROR",
 });
 
 // ── Denylist + affiliate guard sets ──────────────────────────────────────────
@@ -532,13 +533,32 @@ export async function mergeIntoCache(accepted, meta, { storage, dnr }) {
       `mergeIntoCache: accepted param count ${Array.isArray(accepted) ? accepted.length : "(not-array)"} exceeds MAX_PARAM_COUNT (${MAX_PARAM_COUNT})`,
     );
   }
+
+  // An empty accepted set (a valid signed payload whose params all dedupe
+  // against the built-ins) must NOT produce a rule with an empty removeParams
+  // transform — the DNR API rejects that, which used to throw AFTER the version
+  // had already been persisted, poisoning the cache so the next payload at the
+  // same version failed VERSION_REGRESSION forever. Emit a remove-only update
+  // instead so any stale rule 1001 is cleared and nothing invalid is added. (#923)
+  const dnrUpdate = accepted.length === 0
+    ? { removeRuleIds: [REMOTE_RULE_ID] }
+    : { removeRuleIds: [REMOTE_RULE_ID], addRules: [buildRemoteDnrRule(accepted)] };
+
+  // Apply the DNR change BEFORE persisting the new version. If the update
+  // throws, the version is never advanced and lastError is recorded on the
+  // existing meta, so a later payload at the same version is not rejected as
+  // VERSION_REGRESSION — the pipeline self-heals on the next fetch. (#923)
+  try {
+    await dnr.updateDynamicRules(dnrUpdate);
+  } catch (err) {
+    await _writeError(ERR.DNR_ERROR, storage);
+    console.error("[MUGA] remote-rules:", ERR.DNR_ERROR, err?.message ?? err);
+    return;
+  }
+
   await storage.set({
     remoteParams: accepted,
     remoteRulesMeta: meta,
-  });
-  await dnr.updateDynamicRules({
-    removeRuleIds: [REMOTE_RULE_ID],
-    addRules: [buildRemoteDnrRule(accepted)],
   });
 }
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1272,6 +1272,7 @@ const REMOTE_ERR_KEYS = Object.freeze({
   OVER_CAP:           "optionsRemoteRulesErrOverCap",
   VERSION_REGRESSION: "optionsRemoteRulesErrVersion",
   STALE_PAYLOAD:      "optionsRemoteRulesErrStale",
+  DNR_ERROR:          "optionsRemoteRulesErrDnr",
 });
 
 /**

--- a/tests/unit/dnr-consent-gate.test.mjs
+++ b/tests/unit/dnr-consent-gate.test.mjs
@@ -453,3 +453,48 @@ describe("service-worker.js source guards — #810 fix present", () => {
     );
   });
 });
+
+// ── #921: gate-closed branch must also clear the dynamic remote-params rule ──
+//
+// The service worker has no behavioral unit harness (Chrome API bindings at
+// module scope), so this is a source guard. It genuinely fails against the
+// pre-fix source: before #921 the gate-closed branch disabled the static
+// rulesets and cleared rule 1000 but never removed dynamic rule 1001, so a
+// disabled / non-consented extension kept stripping params via rule 1001.
+//
+// Single source read (regex match) to stay within the #824 source-grep ratchet;
+// all further assertions run against the extracted region, not the raw source.
+
+describe("service-worker.js source guard — #921 remote-params rule (1001) gated", () => {
+  // Extract applyDnrState + the reconcile helper defined immediately after it.
+  const applyRegion =
+    swSource.match(/async function applyDnrState\([\s\S]{0,4500}/)?.[0] ?? "";
+  const gateClosed = applyRegion.slice(applyRegion.indexOf("Gate closed:"));
+
+  test("applyDnrState region was located", () => {
+    assert.ok(applyRegion.length > 0, "applyDnrState must exist in the service worker");
+    assert.ok(applyRegion.includes("Gate closed:"), "applyDnrState must have a gate-closed branch");
+  });
+
+  test("gate-closed branch removes rule 1001 (DNR_REMOTE_PARAMS_RULE_ID) via removeRuleIds", () => {
+    assert.ok(
+      gateClosed.includes("updateDynamicRules") &&
+        gateClosed.includes("DNR_REMOTE_PARAMS_RULE_ID") &&
+        gateClosed.includes("removeRuleIds"),
+      "gate-closed branch must clear dynamic rule 1001 so a disabled/non-consented extension stops stripping params (#921)"
+    );
+  });
+
+  test("gate-open path re-applies rule 1001 from the cached payload", () => {
+    // A close→open cycle (or a time-gated weekly fetch) must restore rule 1001;
+    // the gate-open branch calls a helper that rebuilds it from cached params.
+    assert.ok(
+      applyRegion.includes("reconcileRemoteDnrRule"),
+      "gate-open branch must reconcile rule 1001 via reconcileRemoteDnrRule"
+    );
+    assert.ok(
+      applyRegion.includes("buildRemoteDnrRule"),
+      "gate-open reconciliation must rebuild rule 1001 from cached params via buildRemoteDnrRule"
+    );
+  });
+});

--- a/tests/unit/remote-rules.test.mjs
+++ b/tests/unit/remote-rules.test.mjs
@@ -894,15 +894,57 @@ describe("mergeIntoCache — writes params + meta to storage", () => {
     assert.deepEqual(call.removeRuleIds, [REMOTE_RULE_ID]);
   });
 
-  test("empty params list → DNR rule still updated with empty removeParams", async () => {
+  test("empty params list → remove-only DNR update, no empty removeParams rule (#923)", async () => {
+    // A valid signed payload whose params all dedupe against the built-ins must
+    // NOT build a rule with an empty removeParams transform — the DNR API
+    // rejects that. mergeIntoCache emits a remove-only update instead.
     const storage = makeStorageFake();
     const dnr = makeDnrFake();
     await mergeIntoCache([], { version: 1, fetchedAt: null, paramCount: 0, lastError: null, published: null }, { storage, dnr });
     assert.strictEqual(dnr._calls.length, 1);
-    assert.deepEqual(
-      dnr._calls[0].addRules[0].action.redirect.transform.queryTransform.removeParams,
-      []
+    const call = dnr._calls[0];
+    assert.deepEqual(call.removeRuleIds, [REMOTE_RULE_ID], "stale rule 1001 must still be removed");
+    assert.ok(
+      !call.addRules || call.addRules.length === 0,
+      "no rule may be added for an all-dedupe payload (empty removeParams is rejected by the DNR API)"
     );
+  });
+
+  test("all-dedupe payload persists its version cleanly (no throw poisoning) — #923", async () => {
+    // Regression: the old path wrote meta{version:N} then threw on the empty
+    // removeParams rule, leaving version N persisted so the next payload at N
+    // failed VERSION_REGRESSION. With the fix the empty case never throws.
+    const storage = makeStorageFake();
+    const dnr = makeDnrFake();
+    await mergeIntoCache([], { version: 5, fetchedAt: null, paramCount: 0, lastError: null, published: null }, { storage, dnr });
+    const stored = await storage.get({ remoteRulesMeta: {} });
+    assert.strictEqual(stored.remoteRulesMeta.version, 5, "version must persist for a clean all-dedupe merge");
+  });
+
+  test("DNR update failure does NOT advance the persisted version and records lastError — #923", async () => {
+    // If updateDynamicRules throws, the version must stay put so a later payload
+    // at the same version is not rejected as VERSION_REGRESSION — the pipeline
+    // self-heals on the next fetch instead of being permanently poisoned.
+    const storage = makeStorageFake({
+      remoteParams: ["old_param"],
+      remoteRulesMeta: { version: 4, fetchedAt: "2026-01-01T00:00:00Z", paramCount: 1, lastError: null, published: null },
+    });
+    const throwingDnr = {
+      updateDynamicRules() { return Promise.reject(new Error("DNR rejected update")); },
+    };
+
+    await mergeIntoCache(["utm_new"], { version: 5, fetchedAt: null, paramCount: 1, lastError: null, published: null }, { storage, dnr: throwingDnr });
+
+    const stored = await storage.get({ remoteParams: [], remoteRulesMeta: {} });
+    assert.strictEqual(stored.remoteRulesMeta.version, 4, "version must NOT advance when the DNR update fails");
+    assert.strictEqual(stored.remoteRulesMeta.lastError, ERR.DNR_ERROR, "lastError must record the DNR failure");
+    assert.deepEqual(stored.remoteParams, ["old_param"], "previous remoteParams must be left untouched on failure");
+
+    // Self-heal: a subsequent merge at version 5 with a working DNR now succeeds.
+    const workingDnr = makeDnrFake();
+    await mergeIntoCache(["utm_new"], { version: 5, fetchedAt: null, paramCount: 1, lastError: null, published: null }, { storage, dnr: workingDnr });
+    const healed = await storage.get({ remoteRulesMeta: {} });
+    assert.strictEqual(healed.remoteRulesMeta.version, 5, "a later valid payload at the same version must succeed after self-heal");
   });
 });
 

--- a/tests/unit/shortener-stats-sw.test.mjs
+++ b/tests/unit/shortener-stats-sw.test.mjs
@@ -126,7 +126,7 @@ describe("ADR-0004 phase 5: service-worker uses RESOLVE_SHORTENER (native-only)"
   test("RESOLVE_SHORTENER handler gates on followShortenersEnabled (not privacyProxyEnabled)", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
     assert.ok(handlerStart !== -1, "RESOLVE_SHORTENER handler must be present");
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("followShortenersEnabled"),
       "RESOLVE_SHORTENER handler must check followShortenersEnabled"
@@ -139,7 +139,7 @@ describe("ADR-0004 phase 5: service-worker uses RESOLVE_SHORTENER (native-only)"
 
   test("RESOLVE_SHORTENER handler calls resolveShortener (native path only)", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("resolveShortener"),
       "RESOLVE_SHORTENER handler must call resolveShortener (native resolver)"
@@ -148,7 +148,7 @@ describe("ADR-0004 phase 5: service-worker uses RESOLVE_SHORTENER (native-only)"
 
   test("RESOLVE_SHORTENER handler calls incrementShortenerStat", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("incrementShortenerStat"),
       "RESOLVE_SHORTENER handler must call incrementShortenerStat for pass/fail tracking"
@@ -157,7 +157,7 @@ describe("ADR-0004 phase 5: service-worker uses RESOLVE_SHORTENER (native-only)"
 
   test("RESOLVE_SHORTENER handler validates URL scheme is http or https", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("invalid_url") || handlerSlice.includes("http:"),
       "RESOLVE_SHORTENER handler must validate URL scheme"
@@ -166,7 +166,7 @@ describe("ADR-0004 phase 5: service-worker uses RESOLVE_SHORTENER (native-only)"
 
   test("RESOLVE_SHORTENER handler validates hostname is a generic shortener", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("isGenericShortener"),
       "RESOLVE_SHORTENER handler must check isGenericShortener"
@@ -175,7 +175,7 @@ describe("ADR-0004 phase 5: service-worker uses RESOLVE_SHORTENER (native-only)"
 
   test("RESOLVE_SHORTENER handler returns true for async response", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("return true"),
       "RESOLVE_SHORTENER handler must return true to keep message channel open"
@@ -332,7 +332,7 @@ describe("ADR-0004 phase 4+5: shortener stat increments in native-only handler",
   test("increments pass counter on successful native resolution", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
     assert.ok(handlerStart !== -1, "RESOLVE_SHORTENER handler must be present");
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("incrementShortenerStat") && handlerSlice.includes('"pass"'),
       "RESOLVE_SHORTENER handler must call incrementShortenerStat(..., 'pass') on success"
@@ -341,10 +341,46 @@ describe("ADR-0004 phase 4+5: shortener stat increments in native-only handler",
 
   test("increments fail counter on failed native resolution", () => {
     const handlerStart = swSource.indexOf('"RESOLVE_SHORTENER"');
-    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2000);
+    const handlerSlice = swSource.slice(handlerStart, handlerStart + 2600);
     assert.ok(
       handlerSlice.includes("incrementShortenerStat") && handlerSlice.includes('"fail"'),
       "RESOLVE_SHORTENER handler must call incrementShortenerStat(..., 'fail') on failure"
+    );
+  });
+});
+
+// ── #922: shortener egress gated on enabled + onboardingDone ─────────────────
+//
+// Source guards (the service worker has no behavioral unit harness). Before the
+// fix the handler only checked followShortenersEnabled, so a disabled or
+// non-onboarded extension still performed the live shortener-resolution egress.
+
+// Single source read (regex match) to stay within the #824 source-grep ratchet;
+// all further assertions run against the extracted handler region.
+describe("#922: RESOLVE_SHORTENER egress gated on enabled + onboarding", () => {
+  const handler = swSource.match(/"RESOLVE_SHORTENER"[\s\S]{0,2200}/)?.[0] ?? "";
+  const enabledIdx = handler.indexOf("prefs.enabled");
+  const onboardingIdx = handler.indexOf("prefs.onboardingDone");
+  const resolveIdx = handler.indexOf("resolveShortener");
+
+  test("handler checks prefs.enabled and prefs.onboardingDone", () => {
+    assert.ok(enabledIdx !== -1, "handler must check prefs.enabled (extension toggle) before egress");
+    assert.ok(onboardingIdx !== -1, "handler must check prefs.onboardingDone (consent gate) before egress");
+  });
+
+  test("enabled + onboarding gate is evaluated before resolveShortener (no fetch when gate closed)", () => {
+    assert.ok(resolveIdx !== -1, "handler must call resolveShortener");
+    assert.ok(
+      enabledIdx < resolveIdx && onboardingIdx < resolveIdx,
+      "the enabled/onboarding gate must be checked BEFORE resolveShortener so no network egress happens when the gate is closed"
+    );
+  });
+
+  test("gate-closed early return uses the disabled reason shape", () => {
+    const afterGate = handler.slice(enabledIdx, enabledIdx + 220);
+    assert.ok(
+      afterGate.includes('reason: "disabled"'),
+      'the enabled/onboarding gate must early-return { ok: false, reason: "disabled" }'
     );
   });
 });

--- a/tests/unit/source-grep-ratchet.test.mjs
+++ b/tests/unit/source-grep-ratchet.test.mjs
@@ -123,12 +123,12 @@ const BASELINE = {
   // Files with SW/content-script source that cannot be imported in Node —
   // migration requires extracting pure functions or an integration harness.
   "service-worker-patterns.test.mjs": 76,   // SW not importable; behavioral migration is long arc (#824)
-  "shortener-stats-sw.test.mjs": 39,        // SW + storage; behavioral migration deferred (#824)
+  "shortener-stats-sw.test.mjs": 40,        // SW + storage; behavioral migration deferred (#824). +1 for #922 egress-gate guard (SW not importable)
   "misc-regression.test.mjs": 29,           // mixed bag; partial migration possible (#824)
   "content-cleaner-patterns.test.mjs": 27,  // content script not importable (#824)
   "content-script.test.mjs": 19,            // content script not importable (#824)
   "dnr-ids.test.mjs": 8,                    // verifies SW + remote-rules import the ids module (#824)
-  "dnr-consent-gate.test.mjs": 7,           // SW not importable; mixed with behavioral tests (#824)
+  "dnr-consent-gate.test.mjs": 8,           // SW not importable; mixed with behavioral tests (#824). +1 for #921 rule-1001 gate guard
   "verify-warnings-regression.test.mjs": 6, // regression guards; some migratable (#824)
   "i18n-orphan.test.mjs": 5,               // reads HTML/JS to find orphaned i18n keys (#824)
   "browser-detect.test.mjs": 4,            // verifies popup/options import the module (#824)


### PR DESCRIPTION
## Summary

Three release-critical consent/ingestion fixes surfaced by the 2026-07 audit.

- **Closes #921** — `applyDnrState` never removed dynamic rule 1001 (remote params) when the consent gate closed, so a disabled/non-consented extension kept stripping params via the remote DNR redirect. The gate-closed branch now removes rule 1001; the gate-open branch re-arms it from the cached payload via a new `reconcileRemoteDnrRule` helper (needed because the weekly signed fetch is time-gated and would not re-add it after a close→open cycle).
- **Closes #922** — the `RESOLVE_SHORTENER` handler only checked `followShortenersEnabled`, so a disabled or non-onboarded extension still performed live shortener-resolution egress. It now early-returns `{ ok: false, reason: "disabled" }` when `!prefs.enabled || !prefs.onboardingDone`, before any network call.
- **Closes #923** — `mergeIntoCache` wrote `meta{version:N}` then called `updateDynamicRules` with an empty `removeParams` transform for all-dedupe payloads (`accepted.length === 0`). The DNR API rejects that; the throw left version N persisted, poisoning the cache so the next payload at N failed `VERSION_REGRESSION` forever. Now the empty case emits a remove-only update, and the DNR update runs *before* the version is persisted — on failure a new `DNR_ERROR` is recorded and the version is left untouched, so the pipeline self-heals.

## Test notes

- `#923`: real behavioral regression tests via the injectable `mergeIntoCache` (empty-params → remove-only, no version poisoning; DNR failure does not advance version + self-heal). The pre-fix `empty params → empty removeParams` test was updated to the corrected behavior.
- `#921` / `#922`: the service worker has no behavioral unit harness (Chrome APIs at module scope), so these use source guards consistent with the existing SW tests. Two `#824` source-grep baselines were raised by exactly 1 each with rationale.
- New `DNR_ERROR` code wired into `REMOTE_ERR_KEYS` and all 7 locale files (i18n completeness/parity enforced by existing tests).
- Full suite: **5162 passing, 0 failing**. `npm run lint:js` clean.