### PR TITLE
fix(popup,onboarding): a11y aria-labels, i18n gaps, missing CSS, contrast, copy helper

### DIFF
--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -93,6 +93,7 @@ export default Object.freeze({
   support_link: "Unterstützen ♥",
   consent_gate_msg: "Bitte akzeptiere die Nutzungsbedingungen und Datenschutzrichtlinie, bevor du MUGA verwendest.",
   consent_gate_btn: "Bedingungen akzeptieren und fortfahren",
+  aria_consent_gate: "MUGA-Zustimmung erforderlich",
   rate_nudge_btn_short: "Gefällt dir MUGA? Bewerte es",
   bl_placeholder: "mysite.com  oder  amazon.de::tag::youtuber-21",
   wl_placeholder: "mysite.com  oder  amazon.de::tag::creator-21",
@@ -291,4 +292,7 @@ export default Object.freeze({
   aria_toast_duration: "Benachrichtigungsdauer",
   aria_cp_entry: "Eigener Tracking-Parameter",
   aria_dev_url_input: "Test-URL",
+  aria_onboarding_affiliate_check: "Affiliate-Unterstützung aktivieren",
+  aria_onboarding_remote_rules_check: "Remote-Regelaktualisierungen auf diesem Gerät aktivieren",
+  aria_onboarding_tos_check: "Nutzungsbedingungen akzeptieren",
 });

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -93,6 +93,7 @@ export default Object.freeze({
   support_link: "Support ♥",
   consent_gate_msg: "Please accept the Terms of Use and Privacy Policy before using MUGA.",
   consent_gate_btn: "Accept terms to continue",
+  aria_consent_gate: "MUGA consent required",
   rate_nudge_btn_short: "Enjoying MUGA? Rate it",
   bl_placeholder: "mysite.com  or  amazon.es::tag::youtuber-21",
   wl_placeholder: "mysite.com  or  amazon.es::tag::creator-21",
@@ -291,4 +292,7 @@ export default Object.freeze({
   aria_toast_duration: "Notification duration",
   aria_cp_entry: "Custom tracking parameter",
   aria_dev_url_input: "URL to test",
+  aria_onboarding_affiliate_check: "Enable affiliate support",
+  aria_onboarding_remote_rules_check: "Enable remote rule updates on this device",
+  aria_onboarding_tos_check: "Accept terms of use",
 });

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -93,6 +93,7 @@ export default Object.freeze({
   support_link: "Apoyar ♥",
   consent_gate_msg: "Acepta los Términos de uso y la Política de privacidad antes de usar MUGA.",
   consent_gate_btn: "Aceptar condiciones para continuar",
+  aria_consent_gate: "Se requiere el consentimiento de MUGA",
   rate_nudge_btn_short: "¿Te gusta MUGA? Valóralo",
   bl_placeholder: "mysite.com  o  amazon.es::tag::youtuber-21",
   wl_placeholder: "mysite.com  o  amazon.es::tag::creador-21",
@@ -291,4 +292,7 @@ export default Object.freeze({
   aria_toast_duration: "Duración de la notificación",
   aria_cp_entry: "Parámetro de rastreo personalizado",
   aria_dev_url_input: "URL para probar",
+  aria_onboarding_affiliate_check: "Activar el soporte de afiliados",
+  aria_onboarding_remote_rules_check: "Activar las actualizaciones remotas de reglas en este dispositivo",
+  aria_onboarding_tos_check: "Aceptar los términos de uso",
 });

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -93,6 +93,7 @@ export default Object.freeze({
   support_link: "Soutenir ♥",
   consent_gate_msg: "Veuillez accepter les Conditions d'utilisation et la Politique de confidentialité avant d'utiliser MUGA.",
   consent_gate_btn: "Accepter les conditions pour continuer",
+  aria_consent_gate: "Consentement MUGA requis",
   rate_nudge_btn_short: "MUGA vous plaît ? Évaluez-le",
   bl_placeholder: "mysite.com  ou  amazon.fr::tag::youtuber-21",
   wl_placeholder: "mysite.com  ou  amazon.fr::tag::createur-21",
@@ -291,4 +292,7 @@ export default Object.freeze({
   aria_toast_duration: "Durée de la notification",
   aria_cp_entry: "Paramètre de pistage personnalisé",
   aria_dev_url_input: "URL à tester",
+  aria_onboarding_affiliate_check: "Activer le support d'affiliation",
+  aria_onboarding_remote_rules_check: "Activer les mises à jour de règles à distance sur cet appareil",
+  aria_onboarding_tos_check: "Accepter les conditions d'utilisation",
 });

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -93,6 +93,7 @@ export default Object.freeze({
   support_link: "Sostieni ♥",
   consent_gate_msg: "Accetta i Termini di utilizzo e l'Informativa sulla privacy prima di usare MUGA.",
   consent_gate_btn: "Accetta i termini per continuare",
+  aria_consent_gate: "Consenso MUGA richiesto",
   rate_nudge_btn_short: "Ti piace MUGA? Valutalo",
   bl_placeholder: "mysite.com  o  amazon.it::tag::youtuber-21",
   wl_placeholder: "mysite.com  o  amazon.it::tag::creator-21",
@@ -291,4 +292,7 @@ export default Object.freeze({
   aria_toast_duration: "Durata della notifica",
   aria_cp_entry: "Parametro di tracciamento personalizzato",
   aria_dev_url_input: "URL da testare",
+  aria_onboarding_affiliate_check: "Attiva il supporto affiliati",
+  aria_onboarding_remote_rules_check: "Attiva gli aggiornamenti remoti delle regole su questo dispositivo",
+  aria_onboarding_tos_check: "Accetta i termini di utilizzo",
 });

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -93,6 +93,7 @@ export default Object.freeze({
   support_link: "支援する ♥",
   consent_gate_msg: "MUGAを使用する前に利用規約とプライバシーポリシーに同意してください。",
   consent_gate_btn: "規約に同意して続行",
+  aria_consent_gate: "MUGAの同意が必要です",
   rate_nudge_btn_short: "MUGAがお気に入りですか? 評価してください",
   bl_placeholder: "mysite.com  または  amazon.co.jp::tag::youtuber-21",
   wl_placeholder: "mysite.com  または  amazon.co.jp::tag::creator-21",
@@ -291,4 +292,7 @@ export default Object.freeze({
   aria_toast_duration: "通知の表示時間",
   aria_cp_entry: "カスタムトラッキングパラメータ",
   aria_dev_url_input: "テスト用URL",
+  aria_onboarding_affiliate_check: "アフィリエイトサポートを有効にする",
+  aria_onboarding_remote_rules_check: "このデバイスでルールのリモート更新を有効にする",
+  aria_onboarding_tos_check: "利用規約に同意する",
 });

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -93,6 +93,7 @@ export default Object.freeze({
   support_link: "Apoiar ♥",
   consent_gate_msg: "Aceite os Termos de Uso e a Política de Privacidade antes de usar o MUGA.",
   consent_gate_btn: "Aceitar termos para continuar",
+  aria_consent_gate: "É necessário o consentimento do MUGA",
   rate_nudge_btn_short: "Curtindo o MUGA? Avalie-o",
   bl_placeholder: "mysite.com  ou  amazon.com.br::tag::youtuber-21",
   wl_placeholder: "mysite.com  ou  amazon.com.br::tag::criador-21",
@@ -291,4 +292,7 @@ export default Object.freeze({
   aria_toast_duration: "Duração da notificação",
   aria_cp_entry: "Parâmetro de rastreamento personalizado",
   aria_dev_url_input: "URL para testar",
+  aria_onboarding_affiliate_check: "Ativar o suporte de afiliados",
+  aria_onboarding_remote_rules_check: "Ativar atualizações remotas de regras neste dispositivo",
+  aria_onboarding_tos_check: "Aceitar os termos de uso",
 });

--- a/src/onboarding/onboarding.css
+++ b/src/onboarding/onboarding.css
@@ -104,6 +104,13 @@
     }
     .affiliate-body strong { color: var(--text-1); font-weight: 500; }
 
+    /* #932: browser-sync clarification note. Mirrors .affiliate-body p's
+       muted-text treatment at a slightly smaller size, since it reads as a
+       footnote rather than section body copy. */
+    .sync-note {
+      font-size: 12.5px; color: var(--text-2); line-height: 1.55;
+    }
+
     /* Consent checkboxes */
     .consent-check {
       display: flex; align-items: flex-start; gap: 12px;

--- a/src/onboarding/onboarding.html
+++ b/src/onboarding/onboarding.html
@@ -11,7 +11,7 @@
   <div class="container">
     <div class="logo">
       <span class="logo-mark" aria-hidden="true">
-        <svg viewBox="0 0 104 68" fill="none" aria-label="MUGA">
+        <svg viewBox="0 0 104 68" fill="none">
           <path d="M 12 56 C 12 8, 46 8, 52 46 L 62 22 L 72 50 L 84 50" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
           <path d="M 80 37 L 98 50 L 80 63 Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
         </svg>
@@ -94,11 +94,11 @@
           Whoever earned the click keeps it.
         </p>
         <label class="consent-check" id="affiliate-label">
-          <input type="checkbox" id="affiliate-check" aria-label="Enable affiliate support">
+          <input type="checkbox" id="affiliate-check" data-i18n-aria-label="aria_onboarding_affiliate_check">
           <div class="consent-check-label">
             <strong data-i18n="ob_affiliate_check_label">Allow MUGA's affiliate tag on links that have none</strong>
             <small data-i18n="ob_affiliate_check_hint">Same price, always. If a link already has a tag, MUGA never touches it. Verify in our source code.</small>
-            <small id="affiliate-synced-note" class="synced-note" data-i18n="ob_synced_from_other_device" hidden>This setting was enabled on another device. Confirm it for this device, or uncheck to keep it off here.</small>
+            <small id="affiliate-synced-note" data-i18n="ob_synced_from_other_device" hidden>This setting was enabled on another device. Confirm it for this device, or uncheck to keep it off here.</small>
           </div>
         </label>
       </div>
@@ -125,7 +125,7 @@
           Your other device has remote rule updates enabled. With this on, MUGA performs a weekly fetch of a signed tracking-param list from a public GitHub Pages endpoint to keep your protection fresh. No user data is sent.
         </p>
         <label class="consent-check" id="remote-rules-label">
-          <input type="checkbox" id="remote-rules-check" aria-label="Enable remote rule updates on this device">
+          <input type="checkbox" id="remote-rules-check" data-i18n-aria-label="aria_onboarding_remote_rules_check">
           <div class="consent-check-label">
             <strong data-i18n="ob_remote_rules_check_label">Enable remote rule updates on this device</strong>
             <small data-i18n="ob_synced_from_other_device">This setting was enabled on another device. Confirm it for this device, or uncheck to keep it off here.</small>
@@ -146,7 +146,7 @@
     <!-- ToS acceptance -->
     <div class="tos-section">
       <label class="tos-check" id="tos-label">
-        <input type="checkbox" id="tos-check" aria-label="Accept terms of use">
+        <input type="checkbox" id="tos-check" data-i18n-aria-label="aria_onboarding_tos_check">
         <div class="tos-check-label" data-i18n-html="ob_tos_label">
           I have read and accept the
           <a href="../privacy/tos.html" target="_blank" rel="noopener noreferrer">Terms of use</a>

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -32,7 +32,7 @@
   --info:    #2A5880;
   --info-soft: #DCE7F1;
 
-  --diff-strip: #C94A2A;
+  --diff-strip: #A83D22;
   --diff-strip-bg: rgba(201, 74, 42, .10);
   --diff-keep: #2F6B3A;
 
@@ -365,6 +365,21 @@ header {
   color: var(--text-2);
   font-size: 10.5px;
   line-height: 1.45;
+}
+
+/* #932: honored-creator badge (B14). Mirrors .preview-preserved's shape —
+   same padding/border-left/font-size — with the info accent instead of
+   success, since "honored" (wrapper passed through untouched) is a distinct
+   outcome from "preserved" (an affiliate tag was kept on a cleaned URL). */
+.preview-honored {
+  margin-top: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: var(--info-soft);
+  border-left: 2px solid var(--info);
+  color: var(--info);
+  font-size: 11px;
+  line-height: 1.35;
 }
 
 .report-link {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,7 +10,7 @@
   <header>
     <div class="brand">
       <span class="brand-mark" aria-hidden="true">
-        <svg viewBox="0 0 104 68" fill="none" aria-label="MUGA">
+        <svg viewBox="0 0 104 68" fill="none">
           <path d="M 12 56 C 12 8, 46 8, 52 46 L 62 22 L 72 50 L 84 50" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
           <path d="M 80 37 L 98 50 L 80 63 Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
         </svg>
@@ -19,8 +19,8 @@
     </div>
     <div class="toggle-wrap">
       <span class="toggle-label sr-only" data-i18n="toggle_enabled">Enable MUGA</span>
-      <label class="toggle" title="Enable / disable MUGA">
-        <input type="checkbox" id="enabled-toggle" aria-label="Enable MUGA">
+      <label class="toggle" data-i18n-title="toggle_title">
+        <input type="checkbox" id="enabled-toggle" data-i18n-aria-label="toggle_enabled">
         <span class="slider"></span>
       </label>
     </div>
@@ -32,7 +32,7 @@
   <section class="migration-banner" id="migration-banner" hidden role="region" aria-live="polite">
     <div class="migration-banner-header">
       <strong id="migration-banner-title"></strong>
-      <button type="button" id="migration-banner-dismiss" class="migration-banner-dismiss" aria-label="Dismiss"><span aria-hidden="true">×</span></button>
+      <button type="button" id="migration-banner-dismiss" class="migration-banner-dismiss" data-i18n-aria-label="toast_dismiss"><span aria-hidden="true">×</span></button>
     </div>
     <p id="migration-banner-body"></p>
     <div class="migration-banner-actions">
@@ -123,7 +123,7 @@
   <footer>
     <button id="open-options" data-i18n="link_advanced" class="footer-link-btn">Settings →</button>
     <a href="#" id="popup-rate-link" data-i18n="rate_muga_link">Rate MUGA</a>
-    <a href="https://github.com/sponsors/yocreoquesi" target="_blank" rel="noopener noreferrer" id="popup-support-link" class="popup-support-link" data-i18n="support_link">Support ♥</a>
+    <a href="https://github.com/sponsors/yocreoquesi" target="_blank" rel="noopener noreferrer" id="popup-support-link" data-i18n="support_link">Support ♥</a>
   </footer>
 
   <script src="../lib/browser-polyfill.min.js"></script>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -44,6 +44,31 @@ function _setClipboardIcon(el) {
   el.appendChild(_createClipboardSvg());
 }
 
+/**
+ * Writes `text` to the clipboard, then shows one-shot visual feedback that
+ * reverts after 1200ms. Centralizes the try/writeText/timeout pattern shared
+ * by the history-entry click-to-copy, the copy-clean icon button, and the
+ * copy-original button (#935) — each call site plugs in its own success/error
+ * rendering via the callbacks since they differ (label swap, icon swap,
+ * classList toggle) while the clipboard write + revert-after-1200ms plumbing
+ * stays identical.
+ *
+ * @param {string}   text       Text to write to the clipboard.
+ * @param {object}   handlers
+ * @param {Function} handlers.onSuccess Called after a successful write; render the "copied" feedback state.
+ * @param {Function} handlers.onError   Called after a failed write; render the "✗" failure state.
+ * @param {Function} handlers.onRevert  Called 1200ms after either outcome; restore the pre-copy state.
+ */
+function copyWithFeedback(text, { onSuccess, onError, onRevert }) {
+  navigator.clipboard.writeText(text).then(() => {
+    onSuccess();
+    setTimeout(onRevert, 1200);
+  }).catch(() => {
+    onError();
+    setTimeout(onRevert, 1200);
+  });
+}
+
 // ── Param breakdown ───────────────────────────────────────────────────────────
 
 /** Builds a reverse index: param name → { category key, label, labelEs, labelPt, labelDe }. Cached as singleton. */
@@ -1296,36 +1321,35 @@ async function showHistory(prefs, lang) {
     entryDiv.addEventListener("click", (e) => {
       if (e.target === copyOrigBtn || copyCleanBtn.contains(e.target)) return; // handled separately
       const orig = afterDiv.textContent;
-      navigator.clipboard.writeText(entry.clean).then(() => {
-        entryDiv.classList.add("copied");
-        afterDiv.textContent = t("history_copied", lang);
-        setTimeout(() => {
+      copyWithFeedback(entry.clean, {
+        onSuccess: () => {
+          entryDiv.classList.add("copied");
+          afterDiv.textContent = t("history_copied", lang);
+        },
+        onError: () => { afterDiv.textContent = "✗"; },
+        onRevert: () => {
           entryDiv.classList.remove("copied");
           afterDiv.textContent = orig;
-        }, 1200);
-      }).catch(() => {
-        afterDiv.textContent = "✗";
-        setTimeout(() => { afterDiv.textContent = orig; }, 1200);
+        },
       });
     });
 
     // Copy clean URL icon button
     copyCleanBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      navigator.clipboard.writeText(entry.clean).then(() => {
-        copyCleanBtn.textContent = "✓";
-        copyCleanBtn.style.fontSize = "11px";
-        setTimeout(() => {
+      copyWithFeedback(entry.clean, {
+        onSuccess: () => {
+          copyCleanBtn.textContent = "✓";
+          copyCleanBtn.style.fontSize = "11px";
+        },
+        onError: () => {
+          copyCleanBtn.textContent = "✗";
+          copyCleanBtn.style.fontSize = "11px";
+        },
+        onRevert: () => {
           _setClipboardIcon(copyCleanBtn);
           copyCleanBtn.style.fontSize = "";
-        }, 1200);
-      }).catch(() => {
-        copyCleanBtn.textContent = "✗";
-        copyCleanBtn.style.fontSize = "11px";
-        setTimeout(() => {
-          _setClipboardIcon(copyCleanBtn);
-          copyCleanBtn.style.fontSize = "";
-        }, 1200);
+        },
       });
     });
 
@@ -1333,12 +1357,10 @@ async function showHistory(prefs, lang) {
     copyOrigBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       const origText = copyOrigBtn.textContent;
-      navigator.clipboard.writeText(entry.original).then(() => {
-        copyOrigBtn.textContent = t("history_copied", lang);
-        setTimeout(() => { copyOrigBtn.textContent = origText; }, 1200);
-      }).catch(() => {
-        copyOrigBtn.textContent = "✗";
-        setTimeout(() => { copyOrigBtn.textContent = origText; }, 1200);
+      copyWithFeedback(entry.original, {
+        onSuccess: () => { copyOrigBtn.textContent = t("history_copied", lang); },
+        onError: () => { copyOrigBtn.textContent = "✗"; },
+        onRevert: () => { copyOrigBtn.textContent = origText; },
       });
     });
   });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -140,7 +140,7 @@ async function init() {
     const gate = document.createElement("div");
     gate.className = "consent-gate";
     gate.setAttribute("role", "alertdialog");
-    gate.setAttribute("aria-label", "MUGA consent required");
+    gate.setAttribute("aria-label", t("aria_consent_gate", lang));
     gate.setAttribute("aria-describedby", "consent-gate-msg");
     const logo = document.createElement("div");
     logo.className = "consent-gate-logo";
@@ -184,9 +184,6 @@ async function init() {
     formatStat(local.stats?.referralsSpotted ?? 0);
 
   const enabledToggle = document.getElementById("enabled-toggle");
-  enabledToggle.setAttribute("aria-label", t("toggle_enabled", lang));
-  enabledToggle.closest(".toggle").setAttribute("title", t("toggle_title", lang));
-
   enabledToggle.checked = prefs.enabled;
 
   enabledToggle.addEventListener("change", async () => {

--- a/tests/unit/onboarding-aria-i18n.test.mjs
+++ b/tests/unit/onboarding-aria-i18n.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * MUGA — Regression tests for the #930 onboarding consent-gate checkbox
+ * aria-label i18n cleanup.
+ *
+ * Mirrors the #707 options-page guard (tests/unit/options-aria-i18n.test.mjs):
+ *
+ * 1. No hardcoded `aria-label="..."` attributes remain in
+ *    `src/onboarding/onboarding.html`. Every aria-label must come from
+ *    `data-i18n-aria-label="<key>"` so screen-reader users on every
+ *    supported locale hear the label in their own language.
+ *
+ * 2. Every `data-i18n-aria-label` key resolves to a real TRANSLATIONS entry
+ *    in `src/lib/i18n.js` and covers all SUPPORTED_LANGS.
+ *
+ * 3. The three consent-gate checkboxes (#affiliate-check, #remote-rules-check,
+ *    #tos-check) specifically carry `data-i18n-aria-label`.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import { TRANSLATIONS, SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ONBOARDING_HTML = readFileSync(
+  join(__dirname, "../../src/onboarding/onboarding.html"),
+  "utf8",
+);
+
+describe("#930 — onboarding consent-gate checkbox aria-labels are i18n-driven", () => {
+  test("no hardcoded aria-label= attributes remain in onboarding.html", () => {
+    // Negative lookbehind avoids matching the `aria-label` substring inside
+    // `data-i18n-aria-label="..."`. We only flag bare `aria-label="..."`.
+    const hardcoded = ONBOARDING_HTML.match(/(?<!data-i18n-)aria-label="[^"]*"/g) || [];
+    assert.equal(
+      hardcoded.length,
+      0,
+      `onboarding.html still contains ${hardcoded.length} hardcoded aria-label attributes: ${hardcoded.join(", ")}.\n` +
+        "Every aria-label must use data-i18n-aria-label=\"<key>\" so non-EN screen-reader users hear the translated label.",
+    );
+  });
+
+  test("every data-i18n-aria-label key resolves to a TRANSLATIONS entry", () => {
+    const keyRe = /data-i18n-aria-label="([^"]+)"/g;
+    const keys = [];
+    let m;
+    while ((m = keyRe.exec(ONBOARDING_HTML)) !== null) keys.push(m[1]);
+    assert.ok(keys.length > 0, "expected at least one data-i18n-aria-label in onboarding.html");
+    for (const key of keys) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(TRANSLATIONS, key),
+        `data-i18n-aria-label="${key}" but TRANSLATIONS["${key}"] is missing in src/lib/i18n.js`,
+      );
+    }
+  });
+
+  test("every data-i18n-aria-label entry covers all SUPPORTED_LANGS", () => {
+    const keyRe = /data-i18n-aria-label="([^"]+)"/g;
+    const keys = new Set();
+    let m;
+    while ((m = keyRe.exec(ONBOARDING_HTML)) !== null) keys.add(m[1]);
+    for (const key of keys) {
+      const entry = TRANSLATIONS[key];
+      for (const { code } of SUPPORTED_LANGS) {
+        assert.ok(
+          typeof entry?.[code] === "string" && entry[code].length > 0,
+          `TRANSLATIONS["${key}"] is missing a non-empty "${code}" value — screen-reader users in ${code} would hear a blank label`,
+        );
+      }
+    }
+  });
+
+  const checkboxes = [
+    { id: "affiliate-check", key: "aria_onboarding_affiliate_check" },
+    { id: "remote-rules-check", key: "aria_onboarding_remote_rules_check" },
+    { id: "tos-check", key: "aria_onboarding_tos_check" },
+  ];
+
+  for (const { id, key } of checkboxes) {
+    test(`#${id} carries data-i18n-aria-label="${key}" and no literal aria-label`, () => {
+      const inputRe = new RegExp(`<input[^>]*id="${id}"[^>]*>`);
+      const m = ONBOARDING_HTML.match(inputRe);
+      assert.ok(m, `#${id} checkbox must exist in onboarding.html`);
+      const tag = m[0];
+      assert.ok(
+        tag.includes(`data-i18n-aria-label="${key}"`),
+        `#${id} must carry data-i18n-aria-label="${key}"`,
+      );
+      assert.ok(
+        !/(?<!data-i18n-)aria-label="/.test(tag),
+        `#${id} must not carry a literal hardcoded aria-label`,
+      );
+    });
+  }
+});

--- a/tests/unit/popup-aria-i18n.test.mjs
+++ b/tests/unit/popup-aria-i18n.test.mjs
@@ -1,0 +1,209 @@
+/**
+ * MUGA — Regression tests for #931 (popup i18n/aria gaps), #932 (missing CSS),
+ * #933 (contrast), and the #934 housekeeping items landed alongside them.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import { TRANSLATIONS, SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "../..");
+const POPUP_HTML = readFileSync(join(ROOT, "src/popup/popup.html"), "utf8");
+const POPUP_JS = readFileSync(join(ROOT, "src/popup/popup.js"), "utf8");
+const POPUP_CSS = readFileSync(join(ROOT, "src/popup/popup.css"), "utf8");
+const ONBOARD_HTML = readFileSync(join(ROOT, "src/onboarding/onboarding.html"), "utf8");
+const ONBOARD_CSS = readFileSync(join(ROOT, "src/onboarding/onboarding.css"), "utf8");
+
+// ── #931.1 — consent-gate modal aria-label is i18n ─────────────────────────
+
+describe("#931 — consent-gate modal aria-label is i18n-driven", () => {
+  test("popup.js no longer hardcodes the English consent-gate aria-label", () => {
+    assert.ok(
+      !POPUP_JS.includes('gate.setAttribute("aria-label", "MUGA consent required")'),
+      "popup.js must not hardcode the consent-gate aria-label string",
+    );
+  });
+
+  test('popup.js sets the consent-gate aria-label via t("aria_consent_gate")', () => {
+    assert.ok(
+      /gate\.setAttribute\(\s*["']aria-label["']\s*,\s*t\(\s*["']aria_consent_gate["']/.test(POPUP_JS),
+      "popup.js must resolve the consent-gate aria-label through t(\"aria_consent_gate\", lang)",
+    );
+  });
+
+  test("aria_consent_gate key exists and covers all SUPPORTED_LANGS", () => {
+    const entry = TRANSLATIONS.aria_consent_gate;
+    assert.ok(entry, "TRANSLATIONS.aria_consent_gate must exist");
+    for (const { code } of SUPPORTED_LANGS) {
+      assert.ok(
+        typeof entry[code] === "string" && entry[code].length > 0,
+        `aria_consent_gate is missing a non-empty "${code}" value`,
+      );
+    }
+  });
+});
+
+// ── #931.2 — migration-banner-dismiss reuses toast_dismiss ────────────────
+
+describe("#931 — migration-banner-dismiss aria-label is i18n-driven", () => {
+  test("popup.html: #migration-banner-dismiss has no literal aria-label", () => {
+    const m = POPUP_HTML.match(/<button[^>]*id="migration-banner-dismiss"[^>]*>/);
+    assert.ok(m, "#migration-banner-dismiss must exist");
+    assert.ok(
+      !/(?<!data-i18n-)aria-label="/.test(m[0]),
+      "#migration-banner-dismiss must not carry a literal hardcoded aria-label",
+    );
+    assert.ok(
+      m[0].includes('data-i18n-aria-label="toast_dismiss"'),
+      "#migration-banner-dismiss must reuse the existing toast_dismiss key via data-i18n-aria-label",
+    );
+  });
+});
+
+// ── #931.3 — master toggle is declarative, no JS flash ─────────────────────
+
+describe("#931 — master toggle title/aria-label are declarative (no JS flash)", () => {
+  test("popup.html: .toggle label carries data-i18n-title, no literal title", () => {
+    const m = POPUP_HTML.match(/<label class="toggle"[^>]*>/);
+    assert.ok(m, ".toggle label must exist");
+    assert.ok(
+      m[0].includes('data-i18n-title="toggle_title"'),
+      ".toggle label must carry data-i18n-title=\"toggle_title\"",
+    );
+    assert.ok(!/(?<!data-i18n-)title="/.test(m[0]), ".toggle label must not carry a literal title attribute");
+  });
+
+  test("popup.html: #enabled-toggle carries data-i18n-aria-label, no literal aria-label", () => {
+    const m = POPUP_HTML.match(/<input[^>]*id="enabled-toggle"[^>]*>/);
+    assert.ok(m, "#enabled-toggle must exist");
+    assert.ok(
+      m[0].includes('data-i18n-aria-label="toggle_enabled"'),
+      "#enabled-toggle must carry data-i18n-aria-label=\"toggle_enabled\"",
+    );
+    assert.ok(
+      !/(?<!data-i18n-)aria-label="/.test(m[0]),
+      "#enabled-toggle must not carry a literal hardcoded aria-label",
+    );
+  });
+
+  test("popup.js no longer imperatively sets title/aria-label on the master toggle", () => {
+    assert.ok(
+      !/enabledToggle\.setAttribute\(\s*["']aria-label["']/.test(POPUP_JS),
+      "popup.js must not imperatively set aria-label on enabledToggle — it's now declarative via data-i18n-aria-label",
+    );
+    assert.ok(
+      !/\.closest\(\s*["']\.toggle["']\s*\)\.setAttribute\(\s*["']title["']/.test(POPUP_JS),
+      "popup.js must not imperatively set title on the .toggle wrapper — it's now declarative via data-i18n-title",
+    );
+  });
+});
+
+// ── #934 — decorative brand SVG has no redundant aria-label ────────────────
+
+describe("#934 — decorative brand mark SVG has no redundant aria-label", () => {
+  test("popup.html: brand-mark svg has no aria-label (parent is aria-hidden)", () => {
+    const m = POPUP_HTML.match(/<span class="brand-mark" aria-hidden="true">\s*<svg[^>]*>/);
+    assert.ok(m, "brand-mark svg must exist inside an aria-hidden parent");
+    assert.ok(!m[0].includes("aria-label"), "brand-mark svg must not carry a redundant aria-label");
+  });
+
+  test("onboarding.html: logo-mark svg has no aria-label (parent is aria-hidden)", () => {
+    const m = ONBOARD_HTML.match(/<span class="logo-mark" aria-hidden="true">\s*<svg[^>]*>/);
+    assert.ok(m, "logo-mark svg must exist inside an aria-hidden parent");
+    assert.ok(!m[0].includes("aria-label"), "logo-mark svg must not carry a redundant aria-label");
+  });
+});
+
+// ── #934 — dead classes removed ─────────────────────────────────────────────
+
+describe("#934 — dead CSS classes removed from markup", () => {
+  test("popup.html: #popup-support-link no longer carries the unused popup-support-link class", () => {
+    const m = POPUP_HTML.match(/<a[^>]*id="popup-support-link"[^>]*>/);
+    assert.ok(m, "#popup-support-link must still exist");
+    assert.ok(
+      !/class="popup-support-link"/.test(m[0]),
+      "#popup-support-link must not carry the dead .popup-support-link class",
+    );
+  });
+
+  test("onboarding.html: #affiliate-synced-note no longer carries the dead synced-note class", () => {
+    const m = ONBOARD_HTML.match(/<small[^>]*id="affiliate-synced-note"[^>]*>/);
+    assert.ok(m, "#affiliate-synced-note must still exist");
+    assert.ok(
+      !/class="synced-note"/.test(m[0]),
+      "#affiliate-synced-note must not carry the dead .synced-note class",
+    );
+  });
+});
+
+// ── #932 — missing CSS rules added ──────────────────────────────────────────
+
+describe("#932 — missing CSS rules added", () => {
+  test("popup.css defines a .preview-honored rule", () => {
+    assert.ok(
+      /\.preview-honored\s*\{/.test(POPUP_CSS),
+      "popup.css must define a .preview-honored rule for the #preview-honored badge",
+    );
+  });
+
+  test("onboarding.css defines a .sync-note rule", () => {
+    assert.ok(
+      /\.sync-note\s*\{/.test(ONBOARD_CSS),
+      "onboarding.css must define a .sync-note rule for the browser-sync clarification note",
+    );
+  });
+});
+
+// ── #933 — contrast fix ─────────────────────────────────────────────────────
+
+describe("#933 — .preview-url.before contrast fix", () => {
+  test("popup.css light-mode --diff-strip is no longer the low-contrast #C94A2A", () => {
+    assert.ok(
+      !POPUP_CSS.includes("--diff-strip: #C94A2A;"),
+      "the original #C94A2A value (~4.08:1 contrast) must be replaced with a darker, AA-compliant value",
+    );
+  });
+
+  test("popup.css light-mode --diff-strip clears WCAG AA (>= 4.5:1) against --diff-strip-bg", () => {
+    const m = POPUP_CSS.match(/--diff-strip:\s*(#[0-9A-Fa-f]{6});/);
+    assert.ok(m, "--diff-strip must be defined as a hex value");
+    const hex = m[1];
+
+    function hexToRgb(h) {
+      h = h.replace("#", "");
+      return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+    }
+    function srgbToLin(c) {
+      c = c / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    }
+    function relLum(rgb) {
+      const [r, g, b] = rgb.map(srgbToLin);
+      return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    }
+    function flatten(rgb, alpha, bgRgb) {
+      return rgb.map((c, i) => c * alpha + bgRgb[i] * (1 - alpha));
+    }
+    function contrastRgb(rgb1, rgb2) {
+      const L1 = relLum(rgb1);
+      const L2 = relLum(rgb2);
+      const lighter = Math.max(L1, L2);
+      const darker = Math.min(L1, L2);
+      return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    // --diff-strip-bg: rgba(201, 74, 42, .10) flattened over the light-mode
+    // --surface-1 (#FFFFFF), which is the effective background .preview-url.before renders on.
+    const flattenedBg = flatten([201, 74, 42], 0.10, [255, 255, 255]);
+    const ratio = contrastRgb(hexToRgb(hex), flattenedBg);
+    assert.ok(
+      ratio >= 4.5,
+      `--diff-strip (${hex}) contrast against --diff-strip-bg is ${ratio.toFixed(2)}:1 — below WCAG AA (4.5:1)`,
+    );
+  });
+});

--- a/tests/unit/popup-copy-with-feedback.test.mjs
+++ b/tests/unit/popup-copy-with-feedback.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * MUGA — #935: shared copyWithFeedback() helper for the popup's three
+ * clipboard flows (history-entry click, copy-clean icon button,
+ * copy-original button).
+ *
+ * Follows the source-grep convention used across the popup-*.test.mjs
+ * family (popup.js is a plain DOMContentLoaded script with no exports, so
+ * these tests pin structure/behavior at the source level rather than
+ * importing + executing the module).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+
+describe("#935 — copyWithFeedback helper extracted and shared", () => {
+  test("popup.js declares a copyWithFeedback(text, handlers) helper", () => {
+    assert.ok(
+      /function\s+copyWithFeedback\s*\(\s*text\s*,\s*\{\s*onSuccess\s*,\s*onError\s*,\s*onRevert\s*\}\s*\)/.test(popupSrc),
+      "popup.js must declare copyWithFeedback(text, { onSuccess, onError, onRevert })",
+    );
+  });
+
+  test("copyWithFeedback writes to the clipboard and reverts after exactly 1200ms on both outcomes", () => {
+    const fnIdx = popupSrc.indexOf("function copyWithFeedback");
+    assert.ok(fnIdx !== -1, "copyWithFeedback must be defined");
+    const body = popupSrc.slice(fnIdx, fnIdx + 500);
+    assert.ok(/navigator\.clipboard\.writeText\(\s*text\s*\)/.test(body), "must call navigator.clipboard.writeText(text)");
+    const revertCalls = body.match(/setTimeout\(\s*onRevert\s*,\s*1200\s*\)/g) || [];
+    assert.equal(revertCalls.length, 2, "onRevert must be scheduled via setTimeout(onRevert, 1200) on both the success and error paths");
+  });
+
+  test("all three clipboard call sites route through copyWithFeedback", () => {
+    const calls = popupSrc.match(/copyWithFeedback\(\s*entry\.\w+/g) || [];
+    assert.equal(
+      calls.length,
+      3,
+      `expected 3 copyWithFeedback(entry.___, ...) call sites (history-entry click, copy-clean button, copy-original button); found ${calls.length}`,
+    );
+  });
+
+  test("no call site still hand-rolls its own navigator.clipboard.writeText(...).then/.catch pattern", () => {
+    // Only the copyWithFeedback definition itself may call writeText directly.
+    const writeTextCalls = [...popupSrc.matchAll(/navigator\.clipboard\.writeText\(/g)];
+    // The showRecentActivity per-row copy button (#460) uses its own await/try-catch
+    // flow (different shape entirely — no revert-to-previous-label semantics), so it
+    // is intentionally out of scope for #935 and still calls writeText directly.
+    // Expected surviving direct call sites: copyWithFeedback's own body (1) +
+    // showRecentActivity's per-row copy button (1).
+    assert.equal(
+      writeTextCalls.length,
+      2,
+      `expected exactly 2 direct navigator.clipboard.writeText(...) call sites after the #935 extraction (copyWithFeedback itself + the unrelated showRecentActivity row-copy flow); found ${writeTextCalls.length}`,
+    );
+  });
+
+  test("history-entry click preserves the 'copied' classList toggle behavior", () => {
+    const idx = popupSrc.indexOf('entryDiv.addEventListener("click"');
+    assert.ok(idx !== -1, "entryDiv click handler must exist");
+    const block = popupSrc.slice(idx, idx + 700);
+    assert.ok(block.includes('entryDiv.classList.add("copied")'), "must still add the copied class on success");
+    assert.ok(block.includes('entryDiv.classList.remove("copied")'), "must still remove the copied class on revert");
+    assert.ok(block.includes('t("history_copied", lang)'), "must still show the translated copied label on success");
+  });
+
+  test("copy-clean icon button preserves the icon-swap + fontSize behavior", () => {
+    const idx = popupSrc.indexOf('copyCleanBtn.addEventListener("click"');
+    assert.ok(idx !== -1, "copyCleanBtn click handler must exist");
+    const block = popupSrc.slice(idx, idx + 500);
+    assert.ok(block.includes('copyCleanBtn.textContent = "✓"'), "must still show ✓ on success");
+    assert.ok(block.includes('copyCleanBtn.textContent = "✗"'), "must still show ✗ on failure");
+    assert.ok(block.includes('_setClipboardIcon(copyCleanBtn)'), "must still restore the clipboard icon on revert");
+  });
+
+  test("copy-original button preserves the label-swap-and-restore behavior", () => {
+    const idx = popupSrc.indexOf('copyOrigBtn.addEventListener("click"');
+    assert.ok(idx !== -1, "copyOrigBtn click handler must exist");
+    const block = popupSrc.slice(idx, idx + 400);
+    assert.ok(block.includes("const origText = copyOrigBtn.textContent"), "must still capture the original label before writing");
+    assert.ok(block.includes('t("history_copied", lang)'), "must still show the translated copied label on success");
+    assert.ok(block.includes('copyOrigBtn.textContent = "✗"'), "must still show ✗ on failure");
+    assert.ok(block.includes("copyOrigBtn.textContent = origText"), "must still restore the original label on revert");
+  });
+});


### PR DESCRIPTION
## Stacked PR

This is **PR #3** in a linear stack:

- base: `fix/audit-options` (#938) — itself stacked on `fix/audit-core-gating` (#937)
- head: `fix/audit-ui`

Review/merge the stack in order (#937 → #938 → this).

## Scope

Popup and onboarding UI / a11y / i18n / CSS audit fixes.

### a11y + i18n aria-labels
- **#930** — Onboarding consent-gate checkboxes (affiliate / remote-rules / tos) no longer carry hardcoded English `aria-label`; they use `data-i18n-aria-label` with 3 new keys (`aria_onboarding_affiliate_check`, `aria_onboarding_remote_rules_check`, `aria_onboarding_tos_check`) added to all 7 locales. Processed by the shared `applyTranslations()` pass already run by `onboarding.js`.
- **#931** — Popup consent-gate modal aria-label now resolves via `t("aria_consent_gate")` (new key, 7 locales); `#migration-banner-dismiss` reuses the existing `toast_dismiss` key; master toggle `title`/`aria-label` are now declarative (`data-i18n-title`/`data-i18n-aria-label`), removing the imperative `setAttribute` English flash before init.

### Missing CSS
- **#932** — Added `.preview-honored` badge rule in `popup.css` (info accent, mirrors `.preview-preserved`) and `.sync-note` rule in `onboarding.css` (muted footnote, mirrors `.affiliate-body p`).

### Contrast
- **#933** — Darkened `--diff-strip` `#C94A2A` → `#A83D22` so `.preview-url.before` clears WCAG AA (~4.08:1 → ~5.46:1 against `--diff-strip-bg`). Dark-mode value was already compliant and left untouched.

### Refactor
- **#935** — Extracted `copyWithFeedback(text, { onSuccess, onError, onRevert })`; the three clipboard flows (history-entry click, copy-clean icon, copy-original) route through it. Pure refactor — behavior/timing/strings preserved.

### Housekeeping (Refs #934, not closing)
- Removed redundant `aria-label` on decorative brand SVGs (parent is `aria-hidden="true"`) in popup and onboarding.
- Removed dead `.popup-support-link` and `.synced-note` classes.

## Tests
- `tests/unit/onboarding-aria-i18n.test.mjs` — guards #930 (no hardcoded aria-label, keys resolve across all locales).
- `tests/unit/popup-aria-i18n.test.mjs` — guards #931/#932/#933/#934 (declarative attrs, dead classes gone, new CSS rules present, computed WCAG contrast >= 4.5:1).
- `tests/unit/popup-copy-with-feedback.test.mjs` — guards #935 (helper signature, 1200ms revert on both outcomes, all 3 call sites routed).

No existing tests needed changing. `npm test` → 5223 pass / 0 fail / 1 pre-existing skip. `npm run lint:js` and `npm run check:i18n` clean.

Closes #930
Closes #931
Closes #932
Closes #933
Closes #935
Refs #934
