### PR TITLE
chore(lib): fix www regex, prune dead DNR recipes, correct stale headers

### DIFF
--- a/src/lib/affiliates.js
+++ b/src/lib/affiliates.js
@@ -168,7 +168,7 @@ _rebuildHostIndex();
 export function getPatternsForHost(hostname) {
   // Rebuild index if AFFILIATE_PATTERNS was modified (e.g. by tests)
   if (AFFILIATE_PATTERNS.length !== _indexedLength) _rebuildHostIndex();
-  const host = hostname.replace(/^www./, "");
+  const host = hostname.replace(/^www\./, "");
   const exact = _hostIndex.get(host);
   if (exact) return exact;
   // Suffix scan: when multiple suffixes match (e.g. "amazon" and "amazon.co.uk"

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -74,8 +74,8 @@ export function getLandingPolicy(hostname, referrer) {
   // merchant.com navigations are treated as same-origin (mirrors the
   // normalization in affiliates.js:getRedirectNetworkForRedirectHost #831).
   if (hostname &&
-      refHost.toLowerCase().replace(/^www./, "") ===
-      String(hostname).toLowerCase().replace(/^www./, "")) {
+      refHost.toLowerCase().replace(/^www\./, "") ===
+      String(hostname).toLowerCase().replace(/^www\./, "")) {
     return EMPTY_LANDING_POLICY;
   }
 

--- a/src/lib/native-shortener-resolver.js
+++ b/src/lib/native-shortener-resolver.js
@@ -4,10 +4,6 @@
 // Performs the same HTTP redirect the browser would perform,
 // reads the `Location` header, and returns the destination — no server hop.
 //
-// This module is PURE resolution logic: it is NOT wired into the service
-// worker (ADR-0004 phase 1). Gating on optional_host_permissions and the
-// dual-path feature flag land in phases 2-3.
-//
 // Behaviour & safety floor — MUGA is a denoise tool, not a security/privacy
 // product, so these are CORRECTNESS guards (don't hand back garbage), not a
 // security posture. Notably http:// destinations are allowed: the user clicked

--- a/src/lib/wrapper-dnr-builder.js
+++ b/src/lib/wrapper-dnr-builder.js
@@ -12,12 +12,16 @@
  * never sends a request to awin1.com / l.facebook.com / etc.
  *
  * SCOPE (slice B6, issue #449):
- *   The seven entries listed in REGEX_PURE_WRAPPER_IDS — the wrappers whose
+ *   The five entries listed in REGEX_PURE_WRAPPER_IDS — the wrappers whose
  *   destination lives in a single, well-known query parameter on a literal
- *   hostname.  All other wrappers (Impact's regex hostPatterns, t.co's
- *   path-only shape, link.medium.com's redirect, the naked-query proxies
- *   href.li / anonym.to, the social outbounds with no extractor) fall back
- *   to the runtime engine — that path is unchanged.
+ *   hostname.  Only two of the five (facebook-l, facebook-lm) currently
+ *   resolve to a rule: the skimlinks-redirectingat, skimlinks-skimresources,
+ *   and shareasale ids reference wrappers retired from WRAPPERS in #907, so
+ *   their RECIPES entries were pruned (buildDnrRules would have silently
+ *   skipped them anyway).  All other wrappers (Impact's regex hostPatterns,
+ *   t.co's path-only shape, link.medium.com's redirect, the naked-query
+ *   proxies href.li / anonym.to, the social outbounds with no extractor)
+ *   fall back to the runtime engine — that path is unchanged.
  *
  * URL-decode caveat:
  *   Chromium's regexSubstitution copies the captured group verbatim into the
@@ -33,10 +37,16 @@
  */
 
 /**
- * The seven wrapper identifiers in scope for DNR rule generation.
+ * The five wrapper identifiers in scope for DNR rule generation.
  * Order is load-bearing for the test suite (it uses index lookup) and for
  * deterministic numeric ID assignment.  Do not reorder without updating the
  * generated wrapper-dnr-rules.json.
+ *
+ * Three of these ids (skimlinks-redirectingat, skimlinks-skimresources,
+ * shareasale) reference wrappers retired from WRAPPERS in #907 and no
+ * longer have a matching RECIPES entry below — they are kept here because
+ * tests/unit/wrapper-dnr-builder.test.mjs still asserts this exact five-id
+ * allowlist. Only facebook-l and facebook-lm currently produce a DNR rule.
  *
  * @type {ReadonlyArray<string>}
  */
@@ -70,6 +80,13 @@ export const REGEX_PURE_WRAPPER_IDS = Object.freeze([
  *   paramName: string,
  * }>}
  */
+// Pruned entries (issue #934): skimlinks-redirectingat, skimlinks-skimresources,
+// and shareasale used to live here, but their sourceId ("skimlinks" /
+// "shareasale") was retired from WRAPPERS in #907 — buildDnrRules() has been
+// silently skipping them ever since (see the isStringOnlyHostPatterns /
+// bySourceId lookup below), so removing the dead entries does not change
+// buildDnrRules(WRAPPERS)'s output. Their ids remain in REGEX_PURE_WRAPPER_IDS
+// above for test compatibility; see that constant's comment.
 const RECIPES = Object.freeze([
   {
     id: "facebook-l",
@@ -84,27 +101,6 @@ const RECIPES = Object.freeze([
     hostRegex: "lm\\.facebook\\.com",
     pathPrefix: "/l\\.php",
     paramName: "u",
-  },
-  {
-    id: "skimlinks-redirectingat",
-    sourceId: "skimlinks",
-    hostRegex: "go\\.redirectingat\\.com",
-    pathPrefix: null,
-    paramName: "url",
-  },
-  {
-    id: "skimlinks-skimresources",
-    sourceId: "skimlinks",
-    hostRegex: "go\\.skimresources\\.com",
-    pathPrefix: null,
-    paramName: "url",
-  },
-  {
-    id: "shareasale",
-    sourceId: "shareasale",
-    hostRegex: "(?:www\\.)?shareasale\\.com",
-    pathPrefix: "/r\\.cfm",
-    paramName: "urllink",
   },
 ]);
 

--- a/tests/unit/get-landing-policy.test.mjs
+++ b/tests/unit/get-landing-policy.test.mjs
@@ -59,6 +59,17 @@ describe("getLandingPolicy — empty policy contract", () => {
     assert.equal(policy.preserve.size, 0);
     assert.equal(policy.network, null);
   });
+
+  test("same-origin check requires a literal 'www.' prefix, not 'www' + any character", () => {
+    // Regression test: the www-strip regex must be /^www\./ (escaped dot), not
+    // /^www./ (unescaped dot matches ANY single character). With the bug,
+    // "www1awin1.com" incorrectly strips to "awin1.com", which then falsely
+    // matches the referrer host and short-circuits to the empty policy,
+    // hiding a real first-touch network match.
+    const policy = getLandingPolicy("www1awin1.com", "awin1.com");
+    assert.equal(policy.network, "awin");
+    assert.ok(policy.preserve.size > 0);
+  });
 });
 
 describe("getLandingPolicy — first-touch from each matrix v1.0 network", () => {

--- a/tests/unit/latent-guards-831.test.mjs
+++ b/tests/unit/latent-guards-831.test.mjs
@@ -46,6 +46,19 @@ describe("Item 1 — getPatternsForHost most-specific suffix match", () => {
     assert.deepEqual(www, bare, "www-stripped lookup must match bare domain");
   });
 
+  // Regression (#934): the www prefix strip must require a LITERAL "www." —
+  // not "www" + any character. Before the fix the regex was /^www./ (unescaped
+  // dot), so "wwwzamazon.com" was mis-stripped to "amazon.com" and falsely
+  // returned Amazon's affiliate patterns. The escaped /^www\./ leaves such a
+  // host intact, so it correctly resolves to no patterns.
+  test("host of the form www + non-dot char must NOT be mis-stripped to a bare domain (#934)", () => {
+    const bare = getPatternsForHost("amazon.com");
+    assert.ok(bare.length > 0, "sanity: amazon.com must have patterns");
+    const misStripped = getPatternsForHost("wwwzamazon.com");
+    assert.deepEqual(misStripped, [],
+      "wwwzamazon.com must NOT be treated as amazon.com after www strip");
+  });
+
   // --- synthetic two-suffix collision ---
   // We add TWO synthetic programs: one for the short suffix "synth-base.io"
   // and one for the more-specific suffix "shop.synth-base.io".


### PR DESCRIPTION
## Summary

Top of the stack: `fix/audit-housekeeping` → `fix/audit-ui` → `fix/audit-options` → `fix/audit-core-gating` (on top of #939 → #938 → #937).

Closes #934.

#938 and #939 already covered the options/popup/onboarding sub-items of #934. This PR completes the remaining `src/lib/` items:

1. **`src/lib/cleaner.js`** — `getLandingPolicy()` used `/^www./` with an unescaped regex dot, which matches `www` + ANY single character, not just a literal dot (e.g. `wwwXexample.com` would be silently mis-stripped). Escaped to `/^www\./` and added a regression test (`tests/unit/get-landing-policy.test.mjs`).
2. **`src/lib/affiliates.js`** — `getPatternsForHost()` had the **identical** unescaped-dot bug (`/^www./`), inconsistent with `_rebuildHostIndex()` on line 154 which already used the escaped form. A host like `wwwzamazon.com` was mis-stripped to `amazon.com` and falsely returned Amazon's affiliate patterns. Escaped to `/^www\./` and added a behavioral regression test in `tests/unit/latent-guards-831.test.mjs` (`www + non-dot char must NOT be mis-stripped to a bare domain`).
3. **`src/lib/wrapper-dnr-builder.js`** — removed the 3 dead `RECIPES` entries (`skimlinks-redirectingat`, `skimlinks-skimresources`, `shareasale`) whose source wrappers were retired from `WRAPPERS` in #907; `buildDnrRules()` was already silently skipping them. Fixed the header's stale "seven entries" count to the correct "five" (matching `REGEX_PURE_WRAPPER_IDS.length`). `REGEX_PURE_WRAPPER_IDS` itself was **left unchanged** — `tests/unit/wrapper-dnr-builder.test.mjs` still actively asserts its exact 5-id contents, so removing it would have broken that suite.
4. **`src/lib/native-shortener-resolver.js`** — removed a stale header paragraph claiming the module is "NOT wired into the service worker" with gating "in phases 2-3". Verified false: `src/background/service-worker.js` imports (`line 21`) and calls (`line 1198`) `resolveShortener`. Comment-only change.

## Verification: generated JSON is byte-identical

Ran `npm run build:dnr` after pruning the dead recipes, then diffed against HEAD:

```
$ npm run build:dnr
[generate-dnr-rules] wrote 2 rules to .../src/rules/wrapper-dnr-rules.json

$ git diff -- src/rules/wrapper-dnr-rules.json
(no output — byte-identical content; only a CRLF/LF line-ending
 working-tree artifact appeared in `git status`, discarded via
 `git checkout -- src/rules/wrapper-dnr-rules.json`)
```

Confirms the pruned recipes never produced rule output — pruning is a pure no-op on the generated artifact.

## Test plan

- [x] `npm test` — 5225 passed, 1 skipped (pre-existing), 0 failed
- [x] `npm run lint:js` — clean
- [x] `npm run build:dnr` + diff proof above
