### PR TITLE
fix(i18n): register ob_shorteners_desc as an HTML key so onboarding renders bold, not literal tags

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -74,7 +74,7 @@ export function t(key, lang) {
 
 // Keys whose values intentionally contain safe HTML (<code>, <br>).
 // All other keys use textContent to prevent any XSS risk.
-const HTML_KEYS = new Set(["bl_hint", "wl_hint", "cp_hint", "ob_affiliate_desc", "ob_tos_label", "creator_allowlist_hint"]);
+const HTML_KEYS = new Set(["bl_hint", "wl_hint", "cp_hint", "ob_affiliate_desc", "ob_tos_label", "creator_allowlist_hint", "ob_shorteners_desc"]);
 
 // Allowed tags and attributes for HTML_KEYS sanitization.
 const ALLOWED_TAGS = new Set(["code", "br", "strong", "em", "a", "small"]);


### PR DESCRIPTION
## Summary

Closes #943

The onboarding "Short links, resolved locally" section (`src/onboarding/onboarding.html:111`) uses `data-i18n-html="ob_shorteners_desc"`, and the locale value for `ob_shorteners_desc` contains `<strong>...</strong>` markup. That key was never added to the `HTML_KEYS` set in `src/lib/i18n.js`, so `applyTranslations()` fell back to `textContent` for the unregistered `data-i18n-html` key — the `<strong>` tags rendered as literal text instead of being parsed as bold HTML.

Fix: register `ob_shorteners_desc` in `HTML_KEYS`, routing it through the existing `sanitizeHTML()` path. `<strong>` was already present in `ALLOWED_TAGS`, so no sanitizer changes were required.

This bug is pre-existing on `main` and is independent of the current `feat/907-wrapper-affiliate-consent` audit stack — this PR targets `main` directly and is not stacked on that branch.

## Verification

- `npm test` — 5150 passed, 0 failed, 1 skipped
- `npm run lint:js` — clean, no errors
- `npm run check:i18n` — `ok: no FIXME markers, stubs, or empty translations in src/lib/locales/*.mjs`

All 7 locale files (`en`, `es`, `pt`, `de`, `fr`, `it`, `ja`) were checked: each `ob_shorteners_desc` value uses only `<strong>...</strong>`, which is already within `ALLOWED_TAGS` (`code`, `br`, `strong`, `em`, `a`, `small`). No sanitizer changes needed.

No test explicitly enumerated `HTML_KEYS` membership or referenced `ob_shorteners_desc`; the existing `HTML_KEYS has <= 10 entries` guard in `tests/unit/sanitize-import.test.mjs` still passes (7 entries after this change).

## Test plan

- [x] `npm test`
- [x] `npm run lint:js`
- [x] `npm run check:i18n`