### PR TITLE
refactor(options): surface remote-rules section outside advanced mode

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -103,6 +103,47 @@
     </div>
   </section>
 
+  <!-- Remote rule updates: visible by default (follow-up to #936 IA reorg —
+       moved back out of the Advanced card so it's on by default and visible).
+       Feature-detected + un-hidden by initRemoteRules at runtime. -->
+  <section id="remote-rules-section" hidden>
+    <h2 class="mt-16" data-i18n="optionsRemoteRulesTitle"></h2>
+    <div class="card">
+      <div class="row">
+        <div class="row-label">
+          <p data-i18n="optionsRemoteRulesDesc"></p>
+        </div>
+      </div>
+      <div class="row">
+        <label class="toggle">
+          <input type="checkbox" id="remote-rules-toggle" data-i18n-aria-label="aria_remote_rules_toggle">
+          <span class="slider"></span>
+        </label>
+        <span data-i18n="optionsRemoteRulesToggle"></span>
+      </div>
+      <div id="remote-rules-status" hidden>
+        <div class="row">
+          <div class="row-label">
+            <span data-i18n="optionsRemoteRulesLastFetch"></span>
+            <span id="remote-rules-last-fetch"></span>
+          </div>
+        </div>
+        <div class="row">
+          <div class="row-label">
+            <span data-i18n="optionsRemoteRulesParamCount"></span>
+            <span id="remote-rules-param-count"></span>
+          </div>
+        </div>
+        <div class="row">
+          <div class="row-label">
+            <a id="remote-rules-source" target="_blank" rel="noopener noreferrer" data-i18n="optionsRemoteRulesSource"></a>
+          </div>
+        </div>
+      </div>
+      <p id="remote-rules-error" class="error" hidden data-i18n="optionsRemoteRulesError"></p>
+    </div>
+  </section>
+
   <!-- ═══ TIER 2 & 3 — Advanced (dev-mode gated) ═══ -->
   <section id="section-dev">
     <h2 data-i18n="section_advanced">Advanced</h2>
@@ -260,46 +301,6 @@
           <label class="toggle"><input type="checkbox" id="domain-stats" data-i18n-aria-label="aria_domain_stats"><span class="slider"></span></label>
         </div>
       </div>
-
-      <!-- Advanced: Remote rule updates (#936 — moved into the gated card).
-           Feature-detected + un-hidden by initRemoteRules at runtime. -->
-      <section id="remote-rules-section" hidden>
-        <h2 class="mt-16" data-i18n="optionsRemoteRulesTitle"></h2>
-        <div class="card">
-          <div class="row">
-            <div class="row-label">
-              <p data-i18n="optionsRemoteRulesDesc"></p>
-            </div>
-          </div>
-          <div class="row">
-            <label class="toggle">
-              <input type="checkbox" id="remote-rules-toggle" data-i18n-aria-label="aria_remote_rules_toggle">
-              <span class="slider"></span>
-            </label>
-            <span data-i18n="optionsRemoteRulesToggle"></span>
-          </div>
-          <div id="remote-rules-status" hidden>
-            <div class="row">
-              <div class="row-label">
-                <span data-i18n="optionsRemoteRulesLastFetch"></span>
-                <span id="remote-rules-last-fetch"></span>
-              </div>
-            </div>
-            <div class="row">
-              <div class="row-label">
-                <span data-i18n="optionsRemoteRulesParamCount"></span>
-                <span id="remote-rules-param-count"></span>
-              </div>
-            </div>
-            <div class="row">
-              <div class="row-label">
-                <a id="remote-rules-source" target="_blank" rel="noopener noreferrer" data-i18n="optionsRemoteRulesSource"></a>
-              </div>
-            </div>
-          </div>
-          <p id="remote-rules-error" class="error" hidden data-i18n="optionsRemoteRulesError"></p>
-        </div>
-      </section>
 
       <!-- Advanced: Follow shortener redirects (#936 — moved into the gated card) -->
       <section id="follow-shorteners">

--- a/tests/e2e/remote-rules.spec.mjs
+++ b/tests/e2e/remote-rules.spec.mjs
@@ -160,13 +160,6 @@ test.describe("Remote rules — E2E", () => {
 
   test("SC-02: enable → fetch → verify → UI shows timestamp and correct param count",
     async ({ context: _context, optionsPage: page, extensionId: _extensionId }) => {
-      // #936 reorg: the remote-rules section now lives inside the advanced
-      // (dev-mode-gated) dev-tools card. Enable advanced mode first — the click
-      // persists devMode to chrome.storage.local, so the card stays visible
-      // across the page.reload() further down.
-      await page.evaluate(() => document.getElementById("dev-mode").click());
-      await expect(page.locator("#dev-tools-card")).toBeVisible();
-
       // Remote-rules section must be visible on Chrome (supports alarms + DNR)
       await expect(page.locator("#remote-rules-section")).not.toBeHidden();
 

--- a/tests/unit/options-patterns.test.mjs
+++ b/tests/unit/options-patterns.test.mjs
@@ -152,15 +152,15 @@ describe("T3.1 remote-rules section in options.html", () => {
     );
   });
 
-  test("section lives inside the Advanced (dev-mode-gated) block", () => {
-    // #936 IA reorg: remote-rules moved INTO the dev-mode-gated Advanced card
-    // (#dev-tools-card, inside #section-dev) so it is only visible with
-    // "Show advanced settings" on. It therefore now appears AFTER the
-    // #section-dev opening tag and inside the #dev-tools-card container, but
-    // still above the version-info / footer. The Advanced section as a whole
-    // still sits above Support + version-info.
+  test("section is visible by default, outside the Advanced (dev-mode-gated) block", () => {
+    // Follow-up to #936: remote-rules was moved back OUT of the dev-mode-gated
+    // Advanced card so it is visible by default (it's an ON-by-default weekly
+    // network fetch feature, not an opt-in advanced setting). It is now a
+    // top-level section that appears BEFORE the #section-dev (Advanced)
+    // opening tag, and therefore is not nested inside #dev-tools-card either.
     const devIdx   = optionsHtml.indexOf('id="section-dev"');
     const cardIdx  = optionsHtml.indexOf('id="dev-tools-card"');
+    const cardEndIdx = optionsHtml.indexOf("</div>", cardIdx);
     const rrIdx    = optionsHtml.indexOf('id="remote-rules-section"');
     const verIdx   = optionsHtml.indexOf('version-info');
 
@@ -170,12 +170,12 @@ describe("T3.1 remote-rules section in options.html", () => {
     assert.ok(verIdx !== -1,  "version-info must still be in the page");
 
     assert.ok(
-      rrIdx > cardIdx,
-      "remote-rules section must now live INSIDE the dev-mode-gated #dev-tools-card (#936)"
+      rrIdx < devIdx,
+      "remote-rules section must now live BEFORE #section-dev, outside the dev-mode-gated Advanced block"
     );
     assert.ok(
-      devIdx < rrIdx && rrIdx < verIdx,
-      "remote-rules must sit inside the Advanced block, which stays above the version-info / footer"
+      rrIdx < cardIdx || rrIdx > cardEndIdx,
+      "remote-rules section must not be nested inside the #dev-tools-card gated container"
     );
   });
 });


### PR DESCRIPTION
## What

Move `#remote-rules-section` out of the dev-mode-gated `#dev-tools-card` (where #936's IA reorg had placed it) to a **top-level, visible-by-default** position in the options page — directly after the "General" section and before the Advanced (`#section-dev`) section.

## Why (transparency)

Remote rules is an **ON-by-default weekly network fetch**. Burying its toggle and status behind "Show advanced settings" hurt transparency: users couldn't easily see or control a feature that reaches the network on their behalf. Surfacing it as its own top-level section restores that visibility.

`#follow-shorteners` is unchanged — it stays inside the advanced card because it is **opt-in / OFF by default**, which is the appropriate place for it.

## Implementation note

The moved section keeps **all ids, the `hidden` attribute, and every inner child exactly as-is**. The Chrome feature-detect reveal and `initRemoteRules` rely on those ids — only the DOM position changed.

## Test updates

- `tests/unit/options-patterns.test.mjs` (T3.1): assertion + comment rewritten. It now asserts `#remote-rules-section` appears **before** `#section-dev` and is **not nested** inside `#dev-tools-card`. Existence / `hidden` / id checks kept intact.
- `tests/e2e/remote-rules.spec.mjs` (SC-02): reverted the #936 patch that enabled advanced mode first. SC-02 now asserts `#remote-rules-section` visibility **directly**, since it is visible without advanced mode.

## Verification — all gates green

| # | Gate | Result |
|---|------|--------|
| 1 | `npm run typecheck` | exit 0, no errors |
| 2 | `npm run lint:js` | exit 0, no errors |
| 3 | `compile:rules && build:dnr` + `git diff --exit-code -- src/rules/` | clean (no content diff) |
| 4 | `build:content` + `git diff --exit-code -- src/content/cleaner-bundle.js` | clean (no content diff) |
| 5 | `npm run check:i18n` | ok — no FIXME markers, stubs, or empty translations |
| 6 | `npm test` (unit) | 5394 pass / 0 fail / 1 skipped |
| 7 | `npm run test:integration:stub` | 233 pass / 0 fail |
| 8 | `npm run conformance:contextual` | 12 pass / 0 fail |
| 9 | `npm run lint` (web-ext) | 0 errors (2 pre-existing unrelated innerHTML warnings) |
| 10 | `npx playwright test` (full e2e) | **93 passed, 3 skipped** (pre-existing Firefox-only skips), 0 failed |

Confirmed specifically: `remote-rules.spec.mjs` SC-02 passes directly, and all 11 `options.spec.mjs` tests pass (advanced-mode gating for `#dev-tools-card` / `#follow-shorteners` still verified, untouched).

The `src/rules/*.json` and `src/content/cleaner-bundle.js` files show as modified locally only due to a Windows CRLF working-copy artifact (git blob is LF); their content is byte-identical after regeneration, so they are **not** part of this PR.
