### PR TITLE
test(content): cover direct-nav affiliate injection; fix #371 self-clean comment

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -352,12 +352,18 @@
   // on every page load, which previously meant a 3s timeout fall-through if
   // the SW was cold-killed.
   //
-  // (#371) Skipped on Chrome MV3 — DNR strips tracking params at the network
-  // layer BEFORE document_start fires, so by the time this code runs,
-  // window.location.href is already clean and processUrl() returns it
-  // unchanged. The self-clean is only meaningful on Firefox MV2 (no DNR).
-  // We feature-detect rather than hardcode-target so a future browser that
-  // ships DNR also skips automatically.
+  // (#371 / #905) `chrome.declarativeNetRequest` is a background-only API and
+  // is NOT exposed to content scripts, so `_hasDNR` below is ALWAYS false here
+  // — even on Chrome (verified empirically). This branch therefore runs on
+  // BOTH Chrome and Firefox. On Chrome it is a practical no-op for STRIPPING
+  // (DNR already cleaned tracking params at the network layer before
+  // document_start, so processUrl returns the URL unchanged), but it STILL
+  // performs Step 6 affiliate-tag injection when injectOwnAffiliate is on —
+  // DNR cannot inject — which is how our tag lands on direct Amazon
+  // navigations (address bar / bookmark) on Chrome. The `!_hasDNR` guard was
+  // originally meant to skip this on a DNR-capable browser; since the API is
+  // unavailable to content scripts it never actually skips. Left as-is
+  // (harmless: the stripping path is idempotent) — do not rely on it to gate.
   //
   // Domain rules are fetched once at IIFE start (see getDomainRulesCached
   // hoisted above). Stats and badge updates fire-and-forget; SW death is

--- a/tests/e2e/inject-affiliate-direct-nav.spec.mjs
+++ b/tests/e2e/inject-affiliate-direct-nav.spec.mjs
@@ -1,0 +1,136 @@
+/**
+ * E2E: direct-navigation affiliate injection on Chrome (#905)
+ *
+ * Proves — in a real Chrome browser — that a DIRECT navigation (address bar /
+ * bookmark / external app) to an Amazon product URL already gets MUGA's own
+ * tag injected today, with no new feature code. The content-script self-clean
+ * runs on every load (its `!_hasDNR` guard never skips on Chrome, because
+ * `chrome.declarativeNetRequest` is not exposed to content scripts) and its
+ * `processUrl` Step 6 injects our tag via history.replaceState when
+ * `injectOwnAffiliate` is on and the URL carries no tag.
+ *
+ * These are regression guards for behavior that was previously untested (and
+ * widely misunderstood as "skipped on Chrome"): they prove the injection
+ * fires, that it does NOT overwrite a creator's existing tag, that it does NOT
+ * loop, and — critically — that DNR still strips tracking params on already-
+ * tagged URLs. The unit suite pins the processUrl action contract this relies
+ * on; this spec proves the end-to-end result in the browser.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { seedStorage, waitForDnrPropagation } from "./helpers/index.mjs";
+
+// OUR_TAGS["amazon-associates"]["amazon.com"] — the tag MUGA injects.
+const OUR_TAG = "muga0b-20";
+
+async function enableInjection(context, extensionId) {
+  // Accept consent (local, ADR-0001) AND opt into injection (sync). Seeding
+  // storage directly bypasses the onboarding/options UI and the per-device
+  // confirmation dialog, matching a user who has opted in.
+  await seedStorage(context, extensionId, {
+    sync: {
+      injectOwnAffiliate: true,
+      notifyForeignAffiliate: false,
+      stripAllAffiliates: false,
+      language: "en",
+    },
+    local: {
+      mugaConsent: {
+        onboardingDone: true,
+        consentVersion: "1.1",
+        consentDate: Date.now(),
+      },
+    },
+  });
+  await waitForDnrPropagation(context, extensionId);
+}
+
+async function stubHost(page, hostname) {
+  await page.route(`**://${hostname}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>${hostname} stub</body></html>`,
+    }),
+  );
+}
+
+test.describe("Chrome direct-nav affiliate self-inject (#905)", () => {
+  test("injects our tag on an untagged Amazon product URL via replaceState", async ({ context, extensionId }) => {
+    await enableInjection(context, extensionId);
+    const page = await context.newPage();
+    await stubHost(page, "www.amazon.com");
+
+    await page.goto("https://www.amazon.com/dp/B0044R881I");
+    // Injection is applied by the content script shortly after load.
+    await page.waitForFunction(
+      (tag) => new URL(location.href).searchParams.get("tag") !== null && location.href.includes(tag),
+      OUR_TAG,
+      { timeout: 5000 },
+    );
+
+    expect(new URL(page.url()).searchParams.get("tag")).toBe(OUR_TAG);
+    await page.close();
+  });
+
+  test("preserves a creator's tag AND still strips tracking junk on an already-tagged URL", async ({ context, extensionId }) => {
+    // Load-bearing guard: on an already-tagged URL the creator's tag must
+    // survive (no overwrite by injection) WHILE DNR still strips tracking
+    // params. This is exactly the combination a network-layer inject-via-DNR
+    // design would have broken (a high-priority `allow` rule to skip tagged
+    // URLs would also shadow the strip rules); the content-script path keeps
+    // injection and DNR stripping fully independent, so both hold.
+    await enableInjection(context, extensionId);
+    const page = await context.newPage();
+    await stubHost(page, "www.amazon.com");
+
+    await page.goto("https://www.amazon.com/dp/B0044R881I?tag=creator-21&utm_source=spam&fbclid=abc");
+    await page.waitForLoadState("domcontentloaded");
+    // REASON: negative assertion (tag must NOT be overwritten) — there is no
+    // positive "content script finished without acting" signal to await, so we
+    // settle briefly to let the injection branch run, then assert it did not.
+    await page.waitForTimeout(750);
+
+    const params = new URL(page.url()).searchParams;
+    expect(params.get("tag")).toBe("creator-21"); // creator attribution untouched
+    expect(params.has("utm_source")).toBe(false); // DNR strip NOT suppressed
+    expect(params.has("fbclid")).toBe(false);
+    await page.close();
+  });
+
+  test("URL already carrying our tag is left unchanged (idempotent, no loop)", async ({ context, extensionId }) => {
+    await enableInjection(context, extensionId);
+    const page = await context.newPage();
+    await stubHost(page, "www.amazon.com");
+
+    let navigationError = null;
+    try {
+      await page.goto(`https://www.amazon.com/dp/B0044R881I?tag=${OUR_TAG}`);
+      await page.waitForLoadState("domcontentloaded");
+    } catch (err) {
+      navigationError = err;
+    }
+    // REASON: negative assertion (no redirect loop / no re-injection) — settle
+    // to let any erroneous replaceState fire before asserting the URL is stable.
+    await page.waitForTimeout(500);
+
+    expect(navigationError).toBeNull();
+    expect(new URL(page.url()).searchParams.get("tag")).toBe(OUR_TAG);
+    await page.close();
+  });
+
+  test("does NOT inject on a non-affiliate domain", async ({ context, extensionId }) => {
+    await enableInjection(context, extensionId);
+    const page = await context.newPage();
+    await stubHost(page, "example.com");
+
+    await page.goto("https://example.com/product?id=1");
+    await page.waitForLoadState("domcontentloaded");
+    // REASON: negative assertion (non-affiliate domain must never be injected) —
+    // settle to let the content script run before asserting no tag was added.
+    await page.waitForTimeout(500);
+
+    expect(new URL(page.url()).searchParams.has("tag")).toBe(false);
+    await page.close();
+  });
+});

--- a/tests/unit/inject-affiliate-direct-nav.test.mjs
+++ b/tests/unit/inject-affiliate-direct-nav.test.mjs
@@ -1,0 +1,107 @@
+/**
+ * MUGA — Contract tests for direct-navigation affiliate injection (#905).
+ *
+ * Direct navigations (address bar / bookmark / external app) to an Amazon
+ * product URL already get MUGA's own tag injected on Chrome today: the
+ * content-script self-clean in `src/content/cleaner.js` runs on every load
+ * (its `!_hasDNR` guard never skips, because `chrome.declarativeNetRequest`
+ * is not exposed to content scripts) and calls `processUrl()`, whose Step 6
+ * injects our tag when `injectOwnAffiliate` is on and the URL carries no tag.
+ *
+ * The self-clean applies its result via `history.replaceState` only when
+ * `processUrl` reports it changed the URL, and Step 6 reports
+ * `action === "injected"`. So this suite pins the `processUrl` action + tag
+ * contract that direct-nav injection depends on — a future change to Step 6's
+ * `action` value or its honor-creator guard would silently break injection
+ * (or, worse, start clobbering a creator's existing tag) and this catches it.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+import { processUrl } from "../../src/lib/cleaner.js";
+
+const require = createRequire(import.meta.url);
+const domainRules = require("../../src/rules/domain-rules.json");
+
+// Injection enabled — mirrors the content-script gate (injectOwnAffiliate on,
+// stripAllAffiliates off). onboardingDone/enabled true so nothing short-circuits.
+const INJECT_PREFS = {
+  enabled: true,
+  onboardingDone: true,
+  injectOwnAffiliate: true,
+  notifyForeignAffiliate: false,
+  stripAllAffiliates: false,
+  blacklist: [],
+  whitelist: [],
+  disabledCategories: [],
+};
+
+// The tag MUGA injects for amazon.com (OUR_TAGS["amazon-associates"]["amazon.com"]).
+const OUR_AMAZON_COM_TAG = "muga0b-20";
+
+describe("#905 direct-nav injection — processUrl action contract", () => {
+  test('untagged Amazon product URL => action "injected", our tag added', () => {
+    const r = processUrl("https://www.amazon.com/dp/B00X", INJECT_PREFS, domainRules);
+    assert.equal(r.action, "injected", "untagged affiliate URL must inject");
+    const url = new URL(r.cleanUrl);
+    assert.equal(url.searchParams.get("tag"), OUR_AMAZON_COM_TAG);
+  });
+
+  test('untagged Amazon URL with junk => action "injected" (junk-stripping does not suppress the inject gate)', () => {
+    const r = processUrl(
+      "https://www.amazon.com/dp/B00X?utm_source=x&ref=y",
+      INJECT_PREFS,
+      domainRules,
+    );
+    // On Chrome the junk is already gone (DNR) before this runs; even when it
+    // is present, the combined strip+inject outcome must still surface as
+    // "injected" so the content-script gate fires.
+    assert.equal(r.action, "injected");
+    assert.equal(new URL(r.cleanUrl).searchParams.get("tag"), OUR_AMAZON_COM_TAG);
+  });
+
+  test("foreign (creator) tag is preserved and NOT reported as injected — honor-creator", () => {
+    const r = processUrl(
+      "https://www.amazon.com/dp/B00X?tag=creator-21",
+      INJECT_PREFS,
+      domainRules,
+    );
+    assert.notEqual(
+      r.action,
+      "injected",
+      "a URL already carrying a tag must never be reported as injected",
+    );
+    assert.equal(
+      new URL(r.cleanUrl).searchParams.get("tag"),
+      "creator-21",
+      "the creator's tag must survive untouched",
+    );
+  });
+
+  test("our own tag already present => not injected (idempotent, replaceState no-op)", () => {
+    const url = `https://www.amazon.com/dp/B00X?tag=${OUR_AMAZON_COM_TAG}`;
+    const r = processUrl(url, INJECT_PREFS, domainRules);
+    assert.notEqual(r.action, "injected");
+    assert.equal(new URL(r.cleanUrl).searchParams.get("tag"), OUR_AMAZON_COM_TAG);
+  });
+
+  test("injection is suppressed when stripAllAffiliates is on", () => {
+    const r = processUrl(
+      "https://www.amazon.com/dp/B00X",
+      { ...INJECT_PREFS, stripAllAffiliates: true },
+      domainRules,
+    );
+    assert.notEqual(r.action, "injected");
+  });
+
+  test("injection is suppressed when injectOwnAffiliate is off", () => {
+    const r = processUrl(
+      "https://www.amazon.com/dp/B00X",
+      { ...INJECT_PREFS, injectOwnAffiliate: false },
+      domainRules,
+    );
+    assert.notEqual(r.action, "injected");
+  });
+});


### PR DESCRIPTION
## What

Adds test coverage proving that direct navigations (address bar / bookmark / external app) to an Amazon product URL **already** inject MUGA's own affiliate tag on Chrome — and corrects the misleading #371 comment. **No behavior change.**

- `tests/unit/inject-affiliate-direct-nav.test.mjs` — pins the `processUrl` action + tag contract (untagged → `injected`; any existing tag → left untouched, honor-creator; our own tag → idempotent).
- `tests/e2e/inject-affiliate-direct-nav.spec.mjs` — real-Chrome proof of direct-nav injection, creator-tag preservation, no redirect loop, and that DNR still strips tracking params on already-tagged URLs.
- `src/content/cleaner.js` — corrects the #371 self-clean comment.

## Why

#905 asked to inject our tag on direct Amazon navigation, on the premise that Chrome's self-clean is *"skipped when `_hasDNR`"*. That premise is false: `chrome.declarativeNetRequest` is a background-only API and is **not exposed to content scripts**, so `_hasDNR` is always `false` there and the self-clean branch runs on every load — already injecting via `processUrl` Step 6 when `injectOwnAffiliate` is on. The feature works today; it was just untested and misdocumented.

Verified empirically (a content-script probe returned `_hasDNR = false` on Chrome) and by reverting all candidate feature code — the e2e still passes, proving the injection comes from the existing branch.

## Test plan

- [x] `node --test tests/unit/inject-affiliate-direct-nav.test.mjs` → 6/6
- [x] `npx playwright test tests/e2e/inject-affiliate-direct-nav.spec.mjs` → 4/4 (real Chrome)
- [x] Full unit suite: 5404 pass / 0 fail

Closes #905
