### PR TITLE
feat(toolbar): per-tab tracking-param badge on the icon (#910)

### DIFF
--- a/docs/data_architect.md
+++ b/docs/data_architect.md
@@ -31,6 +31,7 @@ Source of truth: `PREF_DEFAULTS` in `src/lib/storage.js`.
 | `paramBreakdown` | boolean | `true` | Show per-category param breakdown in popup cleaned-URL receipt |
 | `showReportButton` | boolean | `true` | Show "Report a problem" button in popup |
 | `domainStats` | boolean | `true` | Track and display per-domain tracker counts in popup |
+| `showBadge` | boolean | `true` | Show the tab's running count of stripped tracking params as a native toolbar badge (#910) |
 | `remoteRulesEnabled` | boolean | `false` | Opt-in: fetch signed remote parameter updates weekly. Default off (zero network activity on fresh install) |
 | `honorCreatorMode` | boolean | `false` | Opt-in (#435, B12; wired in #452): preserve creator referral chains on trusted social-media and link-shortener redirects (a `detectWrapper()` match) when the referrer is in `creatorAllowlist`. Does not gate affiliate-redirect networks (Awin, Skimlinks, etc.) — those are preserved automatically via unconditional pass-through, independent of this pref (#907). |
 | `creatorAllowlist` | string[] | `[]` | (#445, B13) Per-creator allowlist consumed by Honor Creator Mode. Referrer-domain-shaped strings (e.g. `youtube.com/@LinusTechTips`, `dot-css-news.com`). Capped at 100 entries (storage hygiene). CRUD in `src/lib/creator-allowlist.js`. |
@@ -82,7 +83,8 @@ Cleared when the browser closes. No quota concerns.
 | Key | Type | Description |
 |---|---|---|
 | `history` | Array<{original, clean}> | Recent URL clean events (shown in popup history section) |
-| `tab_{tabId}` | number | Count of URLs cleaned for a specific tab (shown as tab badge in popup) |
+| `tab_{tabId}` | number | Count of URLs cleaned for a specific tab, reset on navigation (shown as tab badge in popup) |
+| `tab_badge_{tabId}` | number | Running total of tracking params stripped for a specific tab, reset ONLY on tab close (#910). Drives the native toolbar badge via `setBadgeText`; survives navigation AND service-worker restarts, unlike `tab_{tabId}` above |
 
 ---
 

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -146,7 +146,12 @@ const _rawActionApi = globalThis.chrome?.action || globalThis.chrome?.browserAct
 // the resolved state hasn't changed). Reset / read via __TEST__ handlers
 // (see below) gated on the test-mode sentinel. Production never reads
 // these counts; the cost is one integer increment per action call.
-let _testActionCalls = { setTitle: 0, setBadgeText: 0 };
+// setIcon is tracked here PURELY as an e2e regression guard (#910): the
+// toolbar presenter must NEVER call it (the prior icon-variant swap raced
+// navigation resets and caused the Firefox MV2 icon to flash/disappear —
+// f6a6e2b). Production code never calls actionApi.setIcon; if this counter
+// is ever non-zero in a test run, that is itself the regression.
+let _testActionCalls = { setTitle: 0, setBadgeText: 0, setIcon: 0 };
 const actionApi = new Proxy(_rawActionApi, {
   get(target, prop) {
     const orig = target[prop];
@@ -161,10 +166,11 @@ const actionApi = new Proxy(_rawActionApi, {
   },
 });
 
-// --- Toolbar presenter (#358) ---
-// All toolbar surface mutations (tooltip, badge text, badge color, icon) flow
-// through this presenter via the event bus. No code outside the presenter calls
-// chrome.action.set* directly.
+// --- Toolbar presenter (#358, badge re-introduced #910) ---
+// All toolbar surface mutations (tooltip, badge text) flow through this
+// presenter via the event bus. No code outside the presenter calls
+// chrome.action.set* directly. setIcon is never called — see
+// toolbar-presenter.js module doc for why (f6a6e2b regression).
 const toolbarBus   = createToolbarEventBus();
 const toolbarState = createTabPresenterState();
 createToolbarPresenter({
@@ -176,6 +182,13 @@ createToolbarPresenter({
   // before the cache is warm, which is fine — tooltip update fires after
   // URL processing, by which point prefs are loaded.
   t: (key) => t(key, cachedPrefs?.language || "en"),
+  // Same call-time-resolution pattern as `t` above. Defaults (cachedPrefs
+  // still null) resolve to showBadge:true / onboardingDone:false — the
+  // latter is the SAFE default: never paint a per-tab badge before we
+  // actually know consent is complete, since that would mask the global
+  // "!" badge for that tab.
+  getShowBadge: () => cachedPrefs?.showBadge !== false,
+  isOnboardingDone: () => cachedPrefs?.onboardingDone === true,
 });
 
 // Run migrations once on startup (no-ops if already done).
@@ -626,29 +639,46 @@ async function syncContextMenus(enabled) {
 
 // --- Badge helpers ---
 //
-// The badge text and tooltip are now driven by the ToolbarPresenter (#358).
-// updateTabBadge emits a urlCleaned event; the presenter accumulates the
-// count and writes the badge text. Session storage is still used so the
-// count survives service-worker termination across the same tab lifecycle.
-
+// The badge text and tooltip are driven by the ToolbarPresenter (#358,
+// badge counter re-introduced #910). updateTabBadge emits a urlCleaned
+// event; the presenter writes the tooltip AND (when showBadge is on and
+// onboarding is done) the native toolbar badge text.
+//
+// TWO session-storage keys, two different reset semantics — do not merge
+// them:
+//   - `tab_{tabId}`       — per-PAGE count, cleared on every navigation.
+//     Feeds the popup's "This page" preview badge (src/popup/popup.js).
+//     Unchanged by #910.
+//   - `tab_badge_{tabId}` — per-TAB running total, cleared ONLY on tab
+//     close. Feeds the toolbar badge (#910's requirement: accumulates
+//     across every navigation in the tab, including SPA). Passed to the
+//     presenter as event.total so the badge stays correct even if the
+//     presenter's in-memory map was wiped by a service-worker restart.
 async function updateTabBadge(tabId, junkRemoved) {
   if (!tabId || junkRemoved <= 0) return;
   const key = `tab_${tabId}`;
   const data = await sessionStorage.get({ [key]: 0 });
   const newCount = data[key] + junkRemoved;
   await sessionStorage.set({ [key]: newCount });
-  toolbarBus.emit({ type: "urlCleaned", tabId, paramsRemoved: junkRemoved });
+
+  const badgeKey = `tab_badge_${tabId}`;
+  const badgeData = await sessionStorage.get({ [badgeKey]: 0 });
+  const badgeTotal = badgeData[badgeKey] + junkRemoved;
+  await sessionStorage.set({ [badgeKey]: badgeTotal });
+
+  toolbarBus.emit({ type: "urlCleaned", tabId, paramsRemoved: junkRemoved, total: badgeTotal });
 }
 
-// Clear badge when a tab starts navigating to a new page.
-// While onboarding is pending we deliberately skip the toolbar bus
-// emit: the presenter responds to navigationStarted by writing a
-// per-tab badge "" via setBadgeText({tabId, text:""}), which in
-// Firefox (and Chrome) overrides the global "!" badge for that tab.
-// The result was that the consent-required cue silently disappeared
-// from any tab the user navigated. Since the cleaner is gated on
-// onboardingDone, there are no per-tab counts to clear in this state,
-// so skipping the emit is safe.
+// Reset the per-PAGE popup preview count and the tooltip on every
+// navigation start. Deliberately does NOT touch `tab_badge_{tabId}` or
+// emit anything badge-related — the toolbar badge is a per-TAB running
+// total that must survive navigation (#910).
+//
+// While onboarding is pending we deliberately skip the toolbar bus emit:
+// the cleaner is gated on onboardingDone, so there is no per-page state to
+// reset in this state, and emitting would still update the tooltip for a
+// tab the user has not consented on. Skipping is safe and matches the
+// pre-#910 behavior.
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
   if (changeInfo.status !== "loading") return;
   sessionStorage.remove(`tab_${tabId}`);
@@ -659,9 +689,12 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
   toolbarBus.emit({ type: "navigationStarted", tabId });
 });
 
-// Clean up session data when a tab closes
+// Clean up session data when a tab closes. Both the per-page popup
+// counter AND the per-tab badge running total are tab-scoped and must be
+// evicted here — this is the ONLY place the badge total resets (#910).
 chrome.tabs.onRemoved.addListener((tabId) => {
   sessionStorage.remove(`tab_${tabId}`);
+  sessionStorage.remove(`tab_badge_${tabId}`);
   toolbarBus.emit({ type: "tabClosed", tabId });
 });
 
@@ -727,6 +760,12 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
       ? changes.contextMenuEnabled.newValue !== false
       : (await getPrefsWithCache()).contextMenuEnabled !== false;
     await syncContextMenus(enabled);
+  }
+  // showBadge toggled (#910). Tell the presenter immediately so it clears
+  // (or repaints) every currently-tracked tab's badge — "stops updates"
+  // alone would leave stale numbers visible until each tab's next clean.
+  if (changes.showBadge) {
+    toolbarBus.emit({ type: "showBadgePrefChanged", value: changes.showBadge.newValue !== false });
   }
 });
 
@@ -797,9 +836,24 @@ async function handleTestMessage(message, _sender) {
       // navigation that would otherwise generate the event.
       // The inner event lives under `message.event` so its `type` does
       // not collide with the dispatch `type`.
+      //
+      // #910: warm the prefs cache before emitting. Production code always
+      // emits urlCleaned downstream of a getPrefsWithCache() call (inside
+      // handleProcessUrl), so the presenter's getShowBadge()/isOnboardingDone()
+      // accessors never observe a null cachedPrefs when a REAL urlCleaned
+      // event fires. This synthetic test path bypasses that call entirely —
+      // without warming the cache here, a cold/evicted SW would read
+      // cachedPrefs as null and the presenter would (correctly, but
+      // misleadingly for a test) skip the badge write, producing a flaky
+      // false negative that has nothing to do with presenter logic.
+      await getPrefsWithCache();
       const inner = message.event;
       if (!inner || typeof inner.type !== "string") {
         return { ok: false, error: "missing event.type" };
+      }
+      if (inner.type === "showBadgePrefChanged") {
+        toolbarBus.emit({ type: "showBadgePrefChanged", value: inner.value === true });
+        return { ok: true };
       }
       const tabIdNum = Number(inner.tabId);
       if (!Number.isFinite(tabIdNum) || tabIdNum < 0) {
@@ -808,6 +862,7 @@ async function handleTestMessage(message, _sender) {
       const event = { type: inner.type, tabId: tabIdNum };
       if (inner.type === "urlCleaned") {
         event.paramsRemoved = Number(inner.paramsRemoved) || 0;
+        if (Number.isFinite(inner.total)) event.total = Number(inner.total);
       }
       toolbarBus.emit(event);
       return { ok: true };
@@ -827,7 +882,7 @@ async function handleTestMessage(message, _sender) {
       return { ok: true, tabId: tab.id };
     }
     case "__TEST__resetActionApiCounts": {
-      _testActionCalls = { setTitle: 0, setBadgeText: 0 };
+      _testActionCalls = { setTitle: 0, setBadgeText: 0, setIcon: 0 };
       return { ok: true };
     }
     case "__TEST__readActionApiCounts": {

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -173,7 +173,7 @@ const actionApi = new Proxy(_rawActionApi, {
 // toolbar-presenter.js module doc for why (f6a6e2b regression).
 const toolbarBus   = createToolbarEventBus();
 const toolbarState = createTabPresenterState();
-createToolbarPresenter({
+const toolbarPresenter = createToolbarPresenter({
   bus: toolbarBus,
   state: toolbarState,
   actionApi,
@@ -681,6 +681,30 @@ async function updateTabBadge(tabId, junkRemoved) {
   toolbarBus.emit({ type: "urlCleaned", tabId, paramsRemoved: junkRemoved, total: badgeTotal });
 }
 
+// Enumerate every tab's DURABLE running badge total from the
+// `tab_badge_{tabId}` session keys. The presenter's in-memory badgeTotals
+// map does NOT survive service-worker eviction, but these session keys do
+// (and so do the browser-rendered per-tab badges). When the showBadge pref
+// flips we pass this authoritative list to the presenter as event.tabs so
+// it can clear/repaint EVERY tab — including tabs whose badge was painted
+// before a restart wiped the in-memory map (#910 OFF-path map blind spot).
+async function collectBadgeTotals() {
+  try {
+    const all = await sessionStorage.get(null);
+    const prefix = "tab_badge_";
+    const tabs = [];
+    for (const [key, value] of Object.entries(all || {})) {
+      if (!key.startsWith(prefix)) continue;
+      const tabId = Number(key.slice(prefix.length));
+      if (!Number.isFinite(tabId) || tabId < 0) continue;
+      tabs.push({ tabId, total: Math.max(0, Number(value) || 0) });
+    }
+    return tabs;
+  } catch {
+    return [];
+  }
+}
+
 // Reset the per-PAGE popup preview count and the tooltip on every
 // navigation start. Deliberately does NOT touch `tab_badge_{tabId}` or
 // emit anything badge-related — the toolbar badge is a per-TAB running
@@ -777,7 +801,8 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
   // (or repaints) every currently-tracked tab's badge — "stops updates"
   // alone would leave stale numbers visible until each tab's next clean.
   if (changes.showBadge) {
-    toolbarBus.emit({ type: "showBadgePrefChanged", value: changes.showBadge.newValue !== false });
+    const tabs = await collectBadgeTotals();
+    toolbarBus.emit({ type: "showBadgePrefChanged", value: changes.showBadge.newValue !== false, tabs });
   }
 });
 
@@ -866,7 +891,11 @@ async function handleTestMessage(message, _sender) {
         return { ok: false, error: "missing event.type" };
       }
       if (inner.type === "showBadgePrefChanged") {
-        toolbarBus.emit({ type: "showBadgePrefChanged", value: inner.value === true });
+        // Mirror the production emit path: carry the DURABLE per-tab totals
+        // so the presenter can clear/repaint every tab even when its
+        // in-memory map was wiped by a SW restart (#910 OFF-path fix).
+        const tabs = await collectBadgeTotals();
+        toolbarBus.emit({ type: "showBadgePrefChanged", value: inner.value === true, tabs });
         return { ok: true };
       }
       const tabIdNum = Number(inner.tabId);
@@ -897,6 +926,15 @@ async function handleTestMessage(message, _sender) {
     }
     case "__TEST__resetActionApiCounts": {
       _testActionCalls = { setTitle: 0, setBadgeText: 0, setIcon: 0 };
+      return { ok: true };
+    }
+    case "__TEST__resetPresenterBadgeMap": {
+      // Simulate a service-worker restart WITHOUT touching chrome.storage.session:
+      // wipe the presenter's in-memory badgeTotals map while the durable
+      // `tab_badge_{tabId}` session keys (and the browser-rendered per-tab
+      // badges) survive. Lets the OFF-path regression spec prove the badge
+      // clear no longer depends on the in-memory map (#910).
+      toolbarPresenter._resetInMemoryTotals();
       return { ok: true };
     }
     case "__TEST__updateTabBadge": {

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -722,7 +722,21 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
     const prefs = await getPrefsWithCache();
     if (!prefs.onboardingDone) return;
   } catch { /* fall through and emit — toolbar reset is the safer default */ }
-  toolbarBus.emit({ type: "navigationStarted", tabId });
+  // The browser CLEARS the per-tab badge TEXT on every navigation (MDN
+  // action.setBadgeText, `tabId`: "reset when the user navigates this tab to
+  // a new page"). Read the DURABLE running total so the presenter can
+  // re-paint the badge the browser just wiped — otherwise the count vanishes
+  // after any navigation that does not itself trigger a urlCleaned (#910
+  // flicker). Cold-SW safe: this session key survives SW eviction even when
+  // the presenter's in-memory map does not. Best-effort — on a read failure
+  // the presenter falls back to its in-memory total.
+  let total = 0;
+  try {
+    const badgeKey = `tab_badge_${tabId}`;
+    const badgeData = await sessionStorage.get({ [badgeKey]: 0 });
+    total = Math.max(0, Number(badgeData[badgeKey]) || 0);
+  } catch { /* best-effort; presenter falls back to its in-memory total */ }
+  toolbarBus.emit({ type: "navigationStarted", tabId, total });
 });
 
 // Clean up session data when a tab closes. Both the per-page popup

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -666,6 +666,18 @@ async function updateTabBadge(tabId, junkRemoved) {
   const badgeTotal = badgeData[badgeKey] + junkRemoved;
   await sessionStorage.set({ [badgeKey]: badgeTotal });
 
+  // Warm the prefs cache BEFORE emitting so the presenter's live accessors
+  // (getShowBadge / isOnboardingDone, which read cachedPrefs at call time)
+  // never observe a null cache on a cold/evicted MV3 service worker (#910
+  // cold-SW race). The PROCESS_URL path is safe only because
+  // handleProcessUrl() awaits getPrefsWithCache() before calling us — but
+  // the BADGE_AND_STATS fire-and-forget path calls updateTabBadge with no
+  // prior prefs read. Without this await, a cold SW would emit urlCleaned
+  // while cachedPrefs is null, isOnboardingDone() would default to false,
+  // and writeBadge() would silently skip the write — the badge would never
+  // appear for that clean and only self-heal on the next one.
+  await getPrefsWithCache();
+
   toolbarBus.emit({ type: "urlCleaned", tabId, paramsRemoved: junkRemoved, total: badgeTotal });
 }
 
@@ -837,15 +849,17 @@ async function handleTestMessage(message, _sender) {
       // The inner event lives under `message.event` so its `type` does
       // not collide with the dispatch `type`.
       //
-      // #910: warm the prefs cache before emitting. Production code always
-      // emits urlCleaned downstream of a getPrefsWithCache() call (inside
-      // handleProcessUrl), so the presenter's getShowBadge()/isOnboardingDone()
-      // accessors never observe a null cachedPrefs when a REAL urlCleaned
-      // event fires. This synthetic test path bypasses that call entirely —
-      // without warming the cache here, a cold/evicted SW would read
-      // cachedPrefs as null and the presenter would (correctly, but
-      // misleadingly for a test) skip the badge write, producing a flaky
-      // false negative that has nothing to do with presenter logic.
+      // #910: warm the prefs cache before emitting. The production emit
+      // paths warm the cache themselves — handleProcessUrl() for PROCESS_URL,
+      // and updateTabBadge() (which now awaits getPrefsWithCache() before
+      // emitting) for BADGE_AND_STATS — so the presenter's getShowBadge()/
+      // isOnboardingDone() accessors never observe a null cachedPrefs when a
+      // REAL urlCleaned event fires. This SYNTHETIC test path bypasses both
+      // of those functions and emits straight onto the bus, so it must warm
+      // the cache itself; otherwise a cold/evicted SW would read cachedPrefs
+      // as null and the presenter would (correctly, but misleadingly for a
+      // test) skip the badge write — a flaky false negative unrelated to
+      // presenter logic.
       await getPrefsWithCache();
       const inner = message.event;
       if (!inner || typeof inner.type !== "string") {
@@ -883,6 +897,32 @@ async function handleTestMessage(message, _sender) {
     }
     case "__TEST__resetActionApiCounts": {
       _testActionCalls = { setTitle: 0, setBadgeText: 0, setIcon: 0 };
+      return { ok: true };
+    }
+    case "__TEST__updateTabBadge": {
+      // Drive the REAL production updateTabBadge() path — the same function
+      // the BADGE_AND_STATS fire-and-forget handler calls. Deliberately does
+      // NOT go through __TEST__emitToolbarEvent (which warms the prefs cache),
+      // so it exercises updateTabBadge's OWN cache handling and writes the
+      // durable `tab_badge_{tabId}` session key just like production.
+      //
+      // With `coldCache: true` it invalidates the prefs cache immediately
+      // before calling updateTabBadge and does NOT re-warm it here — mirroring
+      // a cold/evicted MV3 service worker (#910 cold-SW race). If updateTabBadge
+      // fails to await getPrefsWithCache() before emitting, the presenter reads
+      // a null cachedPrefs, isOnboardingDone() defaults to false, and the badge
+      // write is silently skipped — which this handler makes observable.
+      const tabId = Number(message.tabId);
+      if (!Number.isFinite(tabId) || tabId < 0) {
+        return { ok: false, error: "invalid tabId" };
+      }
+      const junkRemoved = Number(message.junkRemoved) || 0;
+      // Deterministic starting total for this tab.
+      await sessionStorage.remove(`tab_badge_${tabId}`);
+      if (message.coldCache === true) {
+        _invalidatePrefsCache();
+      }
+      await updateTabBadge(tabId, junkRemoved);
       return { ok: true };
     }
     case "__TEST__readActionApiCounts": {

--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -311,10 +311,13 @@ export default Object.freeze({
   row_show_report_button_hint: "Fügt eine Schaltfläche hinzu, um eine URL zu melden, die MUGA falsch bereinigt hat.",
   row_domain_stats_label: "Statistiken pro Domain erfassen",
   row_domain_stats_hint: "Zählt bereinigte URLs und entfernte Parameter pro Website, damit das Popup zeigen kann, woher der meiste Lärm kommt. Wird nur auf diesem Gerät gespeichert.",
+  row_show_badge_label: "Laufenden Zähler im Symbolleisten-Icon anzeigen",
+  row_show_badge_hint: "Zeigt als Badge auf dem Symbolleisten-Icon die Anzahl der Tracking-Parameter an, die MUGA in diesem Tab entfernt hat. Wird erst beim Schließen des Tabs zurückgesetzt.",
   aria_canonical_extractor: "Extraktion des kanonischen Ziels",
   aria_cross_site_frequency: "Erkennung seitenübergreifender Kennungen",
   aria_attribution_ledger: "Speicherung der letzten Aktivität",
   aria_param_breakdown: "Aufschlüsselung der entfernten Parameter anzeigen",
   aria_show_report_button: "Melde-Schaltfläche im Popup anzeigen",
   aria_domain_stats: "Statistiken pro Domain erfassen",
+  aria_show_badge: "Tab-Zähler-Badge im Symbolleisten-Icon anzeigen",
 });

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -311,10 +311,13 @@ export default Object.freeze({
   row_show_report_button_hint: "Adds a button to report a URL that MUGA cleaned incorrectly.",
   row_domain_stats_label: "Record per-domain statistics",
   row_domain_stats_hint: "Counts cleaned URLs and stripped parameters per site so the popup can show where the most noise comes from. Stored on this device only.",
+  row_show_badge_label: "Show a running count on the toolbar icon",
+  row_show_badge_hint: "Displays a badge on the toolbar icon with the number of tracking parameters MUGA has stripped in the current tab. Resets only when you close the tab.",
   aria_canonical_extractor: "Canonical destination extraction",
   aria_cross_site_frequency: "Cross-site identifier detection",
   aria_attribution_ledger: "Recent activity persistence",
   aria_param_breakdown: "Show removed-parameter breakdown",
   aria_show_report_button: "Show report button in popup",
   aria_domain_stats: "Record per-domain statistics",
+  aria_show_badge: "Show tab badge count on the toolbar icon",
 });

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -311,10 +311,13 @@ export default Object.freeze({
   row_show_report_button_hint: "Añade un botón para reportar una URL que MUGA limpió incorrectamente.",
   row_domain_stats_label: "Registrar estadísticas por dominio",
   row_domain_stats_hint: "Cuenta las URL limpiadas y los parámetros eliminados por sitio para que la ventana emergente pueda mostrar de dónde viene más ruido. Se almacena solo en este dispositivo.",
+  row_show_badge_label: "Mostrar un contador en el icono de la barra de herramientas",
+  row_show_badge_hint: "Muestra en el icono de la barra de herramientas una insignia con el número de parámetros de seguimiento que MUGA ha eliminado en la pestaña actual. Solo se reinicia al cerrar la pestaña.",
   aria_canonical_extractor: "Extracción del destino canónico",
   aria_cross_site_frequency: "Detección de identificadores entre sitios",
   aria_attribution_ledger: "Persistencia de la actividad reciente",
   aria_param_breakdown: "Mostrar el desglose de parámetros eliminados",
   aria_show_report_button: "Mostrar el botón de reporte en la ventana emergente",
   aria_domain_stats: "Registrar estadísticas por dominio",
+  aria_show_badge: "Mostrar el contador de la pestaña en el icono de la barra de herramientas",
 });

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -311,10 +311,13 @@ export default Object.freeze({
   row_show_report_button_hint: "Ajoute un bouton pour signaler une URL que MUGA a mal nettoyée.",
   row_domain_stats_label: "Enregistrer les statistiques par domaine",
   row_domain_stats_hint: "Compte les URL nettoyées et les paramètres supprimés par site pour que la fenêtre contextuelle puisse montrer d'où vient le plus de bruit. Stocké uniquement sur cet appareil.",
+  row_show_badge_label: "Afficher un compteur cumulé sur l'icône de la barre d'outils",
+  row_show_badge_hint: "Affiche sur l'icône de la barre d'outils un badge indiquant le nombre de paramètres de suivi que MUGA a supprimés dans cet onglet. Réinitialisé uniquement à la fermeture de l'onglet.",
   aria_canonical_extractor: "Extraction de la destination canonique",
   aria_cross_site_frequency: "Détection d'identifiants intersites",
   aria_attribution_ledger: "Conservation de l'activité récente",
   aria_param_breakdown: "Afficher le détail des paramètres supprimés",
   aria_show_report_button: "Afficher le bouton de signalement dans la fenêtre contextuelle",
   aria_domain_stats: "Enregistrer les statistiques par domaine",
+  aria_show_badge: "Afficher le badge de comptage de l'onglet sur l'icône de la barre d'outils",
 });

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -311,10 +311,13 @@ export default Object.freeze({
   row_show_report_button_hint: "Aggiunge un pulsante per segnalare una URL che MUGA ha ripulito in modo errato.",
   row_domain_stats_label: "Registra le statistiche per dominio",
   row_domain_stats_hint: "Conta le URL ripulite e i parametri rimossi per sito affinché la finestra popup possa mostrare da dove proviene più rumore. Memorizzato solo su questo dispositivo.",
+  row_show_badge_label: "Mostra un conteggio continuo sull'icona della barra degli strumenti",
+  row_show_badge_hint: "Mostra sull'icona della barra degli strumenti un badge con il numero di parametri di tracciamento che MUGA ha rimosso in questa scheda. Si azzera solo alla chiusura della scheda.",
   aria_canonical_extractor: "Estrazione della destinazione canonica",
   aria_cross_site_frequency: "Rilevamento di identificatori tra siti",
   aria_attribution_ledger: "Conservazione dell'attività recente",
   aria_param_breakdown: "Mostra il dettaglio dei parametri rimossi",
   aria_show_report_button: "Mostra il pulsante di segnalazione nella finestra popup",
   aria_domain_stats: "Registra le statistiche per dominio",
+  aria_show_badge: "Mostra il badge del conteggio della scheda sull'icona della barra degli strumenti",
 });

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -311,10 +311,13 @@ export default Object.freeze({
   row_show_report_button_hint: "MUGA が誤ってクリーニングした URL を報告するボタンを追加します。",
   row_domain_stats_label: "ドメインごとの統計を記録",
   row_domain_stats_hint: "サイトごとにクリーニングした URL と削除したパラメータを数え、ポップアップでノイズの発生元を表示できるようにします。この端末にのみ保存されます。",
+  row_show_badge_label: "ツールバーアイコンに累計件数を表示",
+  row_show_badge_hint: "MUGA がこのタブで削除したトラッキングパラメータの数を、ツールバーアイコンのバッジとして表示します。タブを閉じたときのみリセットされます。",
   aria_canonical_extractor: "正規リンク先の抽出",
   aria_cross_site_frequency: "サイト横断識別子の検出",
   aria_attribution_ledger: "最近のアクティビティの保存",
   aria_param_breakdown: "削除したパラメータの内訳を表示",
   aria_show_report_button: "ポップアップにレポートボタンを表示",
   aria_domain_stats: "ドメインごとの統計を記録",
+  aria_show_badge: "ツールバーアイコンにタブのバッジ件数を表示",
 });

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -311,10 +311,13 @@ export default Object.freeze({
   row_show_report_button_hint: "Adiciona um botão para reportar uma URL que o MUGA limpou incorretamente.",
   row_domain_stats_label: "Registrar estatísticas por domínio",
   row_domain_stats_hint: "Conta as URLs limpas e os parâmetros removidos por site para que a janela pop-up possa mostrar de onde vem mais ruído. Armazenado somente neste dispositivo.",
+  row_show_badge_label: "Mostrar uma contagem acumulada no ícone da barra de ferramentas",
+  row_show_badge_hint: "Exibe no ícone da barra de ferramentas um emblema com o número de parâmetros de rastreamento que o MUGA removeu nesta aba. Só é reiniciada ao fechar a aba.",
   aria_canonical_extractor: "Extração do destino canônico",
   aria_cross_site_frequency: "Detecção de identificadores entre sites",
   aria_attribution_ledger: "Persistência da atividade recente",
   aria_param_breakdown: "Mostrar o detalhamento de parâmetros removidos",
   aria_show_report_button: "Mostrar o botão de reporte na janela pop-up",
   aria_domain_stats: "Registrar estatísticas por domínio",
+  aria_show_badge: "Mostrar a contagem da aba no ícone da barra de ferramentas",
 });

--- a/src/lib/prefs.js
+++ b/src/lib/prefs.js
@@ -42,6 +42,12 @@ export const PREF_DEFAULTS = {
   paramBreakdown: true,
   showReportButton: true,
   domainStats: true,
+  // Toolbar badge toggle (#910). Default ON: shows the tab's running count
+  // of tracking params stripped as a native browser badge (setBadgeText)
+  // on the toolbar icon, mirroring uBlock Origin. Deliberately NOT an
+  // icon-variant swap — see toolbar-presenter.js module doc for why a
+  // prior setIcon-based badge attempt (f6a6e2b) was reverted.
+  showBadge: true,
   // Remote rules toggle — lives in sync so the preference follows the user
   // across devices. Default true (#888): the weekly Ed25519-signed GET to
   // rules.muga.app carries no user data (credentials: "omit", no cookies, no

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -340,6 +340,12 @@ const _hasSessionStorage = (() => {
 export const sessionStorage = {
   get: (keys) => {
     if (_hasSessionStorage) return chrome.storage.session.get(keys);
+    // null/undefined → return the entire store (matches chrome.storage.session.get(null)).
+    if (keys === null || keys === undefined) {
+      const all = {};
+      for (const [k, v] of _memStore) all[k] = v;
+      return Promise.resolve(all);
+    }
     const result = {};
     const ks = Array.isArray(keys)
       ? keys

--- a/src/lib/toolbar-event-bus.js
+++ b/src/lib/toolbar-event-bus.js
@@ -3,8 +3,8 @@
  *
  * Thin internal pub/sub. The URL-processing path emits semantic events
  * (urlCleaned, creatorReferralPreserved, foreignAffiliateDetected,
- * navigationStarted, tabClosed); the toolbar presenter subscribes and
- * translates them into chrome.action.* calls.
+ * navigationStarted, tabClosed, showBadgePrefChanged); the toolbar
+ * presenter subscribes and translates them into chrome.action.* calls.
  *
  * Decoupling matters: the URL pipeline does not call browser APIs
  * directly, and the presenter does not know about URL cleaning. This is
@@ -12,11 +12,18 @@
  * presentation concerns.
  *
  * Event shapes:
- *   { type: "urlCleaned",                tabId: number, paramsRemoved: number }
+ *   { type: "urlCleaned",                tabId: number, paramsRemoved: number, total?: number }
  *   { type: "creatorReferralPreserved",  tabId: number }
  *   { type: "foreignAffiliateDetected",  tabId: number }
  *   { type: "navigationStarted",         tabId: number }
  *   { type: "tabClosed",                 tabId: number }
+ *   { type: "showBadgePrefChanged",      value: boolean }  // no tabId — global
+ *
+ * `urlCleaned.total`, when present, is the tab's authoritative running
+ * badge total (persisted in chrome.storage.session by the SW so it
+ * survives service-worker restarts — see updateTabBadge() in
+ * service-worker.js). The presenter falls back to in-memory accumulation
+ * when it is absent (#910).
  */
 
 export function createToolbarEventBus() {

--- a/src/lib/toolbar-presenter.js
+++ b/src/lib/toolbar-presenter.js
@@ -162,9 +162,32 @@ export function createToolbarPresenter({ bus, state, actionApi, t, getShowBadge,
         return;
       }
       case "navigationStarted": {
-        // Tooltip only — the badge total is a running tab total and must
-        // NOT reset here, including for SPA/in-page navigations (#910).
+        // Two independent jobs, deliberately kept apart:
+        //
+        //  1. Tooltip — this is per-PAGE state, so reset it to default.
+        //  2. Badge — the running tab total must NOT reset (it accumulates
+        //     across every navigation, including SPA/in-page — #910). BUT
+        //     the browser CLEARS the per-tab badge TEXT on every navigation
+        //     commit (MDN action.setBadgeText, `tabId`: "The text is reset
+        //     when the user navigates this tab to a new page."). So after a
+        //     navigation the badge the user briefly saw is gone — and unless
+        //     the next page happens to trigger a urlCleaned, nothing ever
+        //     re-writes it. We therefore RE-PAINT the durable total here,
+        //     exactly as uBlock Origin repaints from its stored per-tab
+        //     counter (pageStore.counts.blocked.any) on every tabCommitted
+        //     rather than only when a block occurs.
+        //
+        // Cold-SW safe: prefer the caller-supplied durable total (the SW
+        // reads tab_badge_{tabId} from chrome.storage.session and passes it
+        // as event.total) over the in-memory map, which does not survive a
+        // service-worker restart. Only positive totals are painted — a fresh
+        // tab that has cleaned nothing must never get a per-tab override.
         clearTab(tabId);
+        const total = Number.isFinite(event.total)
+          ? Math.max(0, event.total)
+          : (badgeTotals.get(tabId) || 0);
+        badgeTotals.set(tabId, total);
+        if (total > 0) writeBadge(tabId, total);
         return;
       }
       case "tabClosed": {

--- a/src/lib/toolbar-presenter.js
+++ b/src/lib/toolbar-presenter.js
@@ -100,13 +100,34 @@ export function createToolbarPresenter({ bus, state, actionApi, t, getShowBadge,
     if (!event || typeof event !== "object" || !event.type) return;
 
     // Global (non-tab-scoped) event: the showBadge preference flipped.
-    // Repaints or clears every currently-tracked tab's badge immediately
-    // — "stops updates" alone is not enough, existing badges must go too.
+    // Repaints or clears every tab's badge immediately — "stops updates"
+    // alone is not enough, existing badges must go too.
+    //
+    // Source of truth for WHICH tabs have a badge: the DURABLE per-tab
+    // totals the SW enumerates from chrome.storage.session (tab_badge_*)
+    // and passes as event.tabs. The in-memory `badgeTotals` map does NOT
+    // survive service-worker eviction, so iterating it alone would leave
+    // stale browser-rendered badges on every tab after a restart — the OFF
+    // toggle would clear nothing (#910 OFF-path map blind spot). We MERGE
+    // the durable list over the in-memory map so every known tab is touched
+    // even when the map is empty.
     if (event.type === "showBadgePrefChanged") {
-      if (!onboardingDone()) return; // no per-tab badge exists to touch
+      if (!onboardingDone()) return; // "!" onboarding badge wins; no per-tab badge exists to touch
       const enabled = event.value === true;
-      for (const [tabId, total] of badgeTotals) {
+      const totals = new Map(badgeTotals);
+      if (Array.isArray(event.tabs)) {
+        for (const entry of event.tabs) {
+          const tabId = Number(entry?.tabId);
+          if (!Number.isFinite(tabId) || tabId < 0) continue;
+          totals.set(tabId, Math.max(0, Number(entry.total) || 0));
+        }
+      }
+      for (const [tabId, total] of totals) {
         actionApi.setBadgeText?.({ tabId, text: enabled && total > 0 ? String(total) : "" });
+        // Keep the in-memory map in sync with the durable totals so
+        // subsequent urlCleaned accumulation continues correctly after a
+        // restart-driven repaint rehydrated the tab set.
+        badgeTotals.set(tabId, total);
       }
       return;
     }
@@ -159,5 +180,10 @@ export function createToolbarPresenter({ bus, state, actionApi, t, getShowBadge,
   return {
     _tooltipFor: tooltipFor,
     _badgeTotal: (tabId) => badgeTotals.get(tabId) || 0,
+    // Test-only: wipe the in-memory running totals to simulate a
+    // service-worker restart (the durable tab_badge_* session keys and the
+    // browser-rendered badges survive; this map does not). Used by the
+    // #910 OFF-path regression to prove the clear no longer depends on it.
+    _resetInMemoryTotals: () => { badgeTotals.clear(); },
   };
 }

--- a/src/lib/toolbar-presenter.js
+++ b/src/lib/toolbar-presenter.js
@@ -1,18 +1,39 @@
 /**
  * MUGA: Toolbar Presenter
  *
- * Single point of design control over the browser-action toolbar surface.
- * Currently manages only the dynamic per-tab tooltip via setTitle.
+ * Single point of design control over the browser-action toolbar surface:
+ * the dynamic per-tab tooltip (setTitle) and the per-tab numeric badge
+ * (setBadgeText). No code outside this module may call chrome.action.set*
+ * for either surface.
  *
- * Subscribes to a ToolbarEventBus, tracks per-tab semantic state (cleaned,
- * creator-referral preserved, foreign affiliate detected) and translates
- * it into the right tooltip string. State is cached in TabPresenterState
- * so the same setTitle call is not issued twice for the same value.
+ * Subscribes to a ToolbarEventBus and tracks two SEPARATE pieces of
+ * per-tab state, deliberately kept apart because their reset semantics
+ * differ:
  *
- * The badge text/color and icon variant surfaces were removed: the per-tab
- * count was confusing and the icon swap to the *-preserved.png variant
- * caused the toolbar icon to flash and disappear in Firefox MV2. The
- * extension now ships a single static icon declared in the manifest.
+ *   - Tooltip state (`state`, a TabPresenterState) — cleaned / creator-
+ *     referral-preserved / foreign-affiliate-detected flags for the
+ *     CURRENT page. Reset on every `navigationStarted` (per-page).
+ *   - Badge total (`badgeTotals`, owned by this module) — the tab's
+ *     running count of tracking params stripped, accumulated across
+ *     EVERY navigation in the tab's lifetime, including SPA/in-page
+ *     navigations. Reset ONLY on `tabClosed` (#910).
+ *
+ * Icon-variant swapping (setIcon) stays permanently removed: the swap to
+ * the *-preserved.png variant raced navigationStarted's icon reset and
+ * made the toolbar icon flash/disappear in Firefox MV2 (f6a6e2b). The
+ * extension ships a single static icon declared in the manifest; the
+ * badge (#910) is a NATIVE browser badge overlay on top of that icon —
+ * never a re-rendered/composited icon (no OffscreenCanvas/ImageData).
+ *
+ * Badge visibility is gated on two live accessors (mirroring how `t`
+ * resolves the current language from cachedPrefs at call time):
+ *   - `getShowBadge()`     — the user's `showBadge` preference.
+ *   - `isOnboardingDone()` — whether consent/onboarding is complete.
+ * The global "!" onboarding badge (src/background/service-worker.js,
+ * applyOnboardingBadge) has NO tabId; a per-tab setBadgeText call —
+ * even with an empty string — creates a per-tab override that masks
+ * that global badge for that tab. So while onboarding is incomplete,
+ * this presenter must never call setBadgeText with a tabId at all.
  */
 
 /**
@@ -26,9 +47,24 @@
  * @param {object} args.actionApi - chrome.action / browserAction shim.
  * @param {(key: string) => string} args.t - i18n lookup. Returns the
  *   localized string for the user's current language.
+ * @param {() => boolean} [args.getShowBadge] - Returns the current
+ *   `showBadge` preference. Defaults to always-true.
+ * @param {() => boolean} [args.isOnboardingDone] - Returns whether
+ *   onboarding/consent is complete. Defaults to always-true.
  * @returns {object} Presenter with introspection helpers.
  */
-export function createToolbarPresenter({ bus, state, actionApi, t }) {
+export function createToolbarPresenter({ bus, state, actionApi, t, getShowBadge, isOnboardingDone }) {
+  const showBadgeEnabled = typeof getShowBadge === "function" ? getShowBadge : () => true;
+  const onboardingDone   = typeof isOnboardingDone === "function" ? isOnboardingDone : () => true;
+
+  // Per-tab running total of tracking params stripped, accumulated across
+  // the tab's whole lifetime. See module doc comment above for why this is
+  // a separate map from `state`. In-memory only — the SW re-hydrates a
+  // tab's authoritative total from chrome.storage.session (survives
+  // service-worker restarts) and passes it as event.total on urlCleaned;
+  // see updateTabBadge() in service-worker.js.
+  const badgeTotals = new Map();
+
   function tooltipFor(s) {
     const cleaned   = s.paramsRemoved > 0;
     const preserved = s.creatorReferralPreserved;
@@ -51,8 +87,30 @@ export function createToolbarPresenter({ bus, state, actionApi, t }) {
     actionApi.setTitle?.({ tabId, title: t("tooltip_default") });
   }
 
+  // Writes the badge for one tab. Never touches the action surface while
+  // onboarding is pending (see module doc comment) or while showBadge is
+  // off. Empty string when the total is zero — no digit is ever shown for
+  // a fresh tab because this is only called with a positive total.
+  function writeBadge(tabId, total) {
+    if (!onboardingDone() || !showBadgeEnabled()) return;
+    actionApi.setBadgeText?.({ tabId, text: total > 0 ? String(total) : "" });
+  }
+
   bus.subscribe((event) => {
     if (!event || typeof event !== "object" || !event.type) return;
+
+    // Global (non-tab-scoped) event: the showBadge preference flipped.
+    // Repaints or clears every currently-tracked tab's badge immediately
+    // — "stops updates" alone is not enough, existing badges must go too.
+    if (event.type === "showBadgePrefChanged") {
+      if (!onboardingDone()) return; // no per-tab badge exists to touch
+      const enabled = event.value === true;
+      for (const [tabId, total] of badgeTotals) {
+        actionApi.setBadgeText?.({ tabId, text: enabled && total > 0 ? String(total) : "" });
+      }
+      return;
+    }
+
     const tabId = event.tabId;
     if (typeof tabId !== "number" || tabId < 0) return;
 
@@ -62,6 +120,14 @@ export function createToolbarPresenter({ bus, state, actionApi, t }) {
         if (count === 0) return;
         const { prev, next } = state.update(tabId, { paramsRemoved: count });
         applyTab(tabId, prev, next);
+
+        // Prefer the caller-supplied authoritative running total (survives
+        // SW restarts) over in-memory accumulation.
+        const total = Number.isFinite(event.total)
+          ? Math.max(0, event.total)
+          : (badgeTotals.get(tabId) || 0) + count;
+        badgeTotals.set(tabId, total);
+        writeBadge(tabId, total);
         return;
       }
       case "creatorReferralPreserved": {
@@ -75,11 +141,14 @@ export function createToolbarPresenter({ bus, state, actionApi, t }) {
         return;
       }
       case "navigationStarted": {
+        // Tooltip only — the badge total is a running tab total and must
+        // NOT reset here, including for SPA/in-page navigations (#910).
         clearTab(tabId);
         return;
       }
       case "tabClosed": {
         state.evict(tabId);
+        badgeTotals.delete(tabId);
         return;
       }
       default:
@@ -89,5 +158,6 @@ export function createToolbarPresenter({ bus, state, actionApi, t }) {
 
   return {
     _tooltipFor: tooltipFor,
+    _badgeTotal: (tabId) => badgeTotals.get(tabId) || 0,
   };
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -300,6 +300,13 @@
           </div>
           <label class="toggle"><input type="checkbox" id="domain-stats" data-i18n-aria-label="aria_domain_stats"><span class="slider"></span></label>
         </div>
+        <div class="row">
+          <div class="row-label">
+            <strong data-i18n="row_show_badge_label">Show a running count on the toolbar icon</strong>
+            <small data-i18n="row_show_badge_hint">Displays a badge on the toolbar icon with the number of tracking parameters MUGA has stripped in the current tab. Resets only when you close the tab.</small>
+          </div>
+          <label class="toggle"><input type="checkbox" id="show-badge" data-i18n-aria-label="aria_show_badge"><span class="slider"></span></label>
+        </div>
       </div>
 
       <!-- Advanced: Follow shortener redirects (#936 — moved into the gated card) -->

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -144,6 +144,9 @@ async function init() {
   bindToggle("param-breakdown", "paramBreakdown", prefs);
   bindToggle("show-report-button", "showReportButton", prefs);
   bindToggle("domain-stats", "domainStats", prefs);
+  // Toolbar badge toggle (#910). Default ON; controls the native
+  // setBadgeText running-count overlay on the toolbar icon.
+  bindToggle("show-badge", "showBadge", prefs);
 
   // Per-creator allowlist editor (#445, B13). Lives in the Advanced card
   // (dev-mode gated after the #936 reorg), alongside the honor-creator-mode toggle.
@@ -773,6 +776,7 @@ function initExportImport() {
       paramBreakdown: prefs.paramBreakdown,
       showReportButton: prefs.showReportButton,
       domainStats: prefs.domainStats,
+      showBadge: prefs.showBadge,
       followShortenersEnabled: prefs.followShortenersEnabled,
       // #925: privacy booleans are now user-controllable, so round-trip them.
       canonicalExtractorEnabled: prefs.canonicalExtractorEnabled,
@@ -824,7 +828,7 @@ function initExportImport() {
       const { blacklist, whitelist, customParams, droppedBlacklist, droppedWhitelist, skippedParams } = capImportedLists(data);
       const skipped = skippedParams + droppedBlacklist + droppedWhitelist;
       // devMode is device-local — exclude from sync BOOL_KEYS and handle separately
-      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled", "paramBreakdown", "showReportButton", "domainStats", "followShortenersEnabled", "canonicalExtractorEnabled", "crossSiteFrequencyEnabled", "attributionLedgerEnabled"];
+      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled", "paramBreakdown", "showReportButton", "domainStats", "showBadge", "followShortenersEnabled", "canonicalExtractorEnabled", "crossSiteFrequencyEnabled", "attributionLedgerEnabled"];
       const toSave = { blacklist, whitelist, customParams };
       for (const key of BOOL_KEYS) {
         if (typeof data[key] === "boolean") toSave[key] = data[key];
@@ -874,6 +878,7 @@ function initExportImport() {
       document.getElementById("param-breakdown").checked = newPrefs.paramBreakdown;
       document.getElementById("show-report-button").checked = newPrefs.showReportButton;
       document.getElementById("domain-stats").checked = newPrefs.domainStats;
+      document.getElementById("show-badge").checked = newPrefs.showBadge;
       // devMode is device-local — re-read from local storage after import
       document.getElementById("dev-mode").checked = await getDevMode();
       document.getElementById("toast-duration-select").value = String(newPrefs.toastDuration || 15);

--- a/tests/e2e/toolbar-badge.spec.mjs
+++ b/tests/e2e/toolbar-badge.spec.mjs
@@ -1,0 +1,290 @@
+/**
+ * E2E: Toolbar badge — per-tab running count (#910)
+ *
+ * Re-introduces a per-tab toolbar badge: a running count of tracking
+ * params MUGA has stripped in a tab, rendered via the browser's NATIVE
+ * badge API (chrome.action.setBadgeText/setBadgeBackgroundColor) — the
+ * same mechanism uBlock Origin uses. This spec proves the real
+ * chrome.action surface in an actual Chrome instance, exactly the same
+ * way tests/e2e/toolbar-visibility.spec.mjs proves the tooltip surface:
+ * synthetic events driven onto the production toolbar bus via
+ * __TEST__emitToolbarEvent, then read back through
+ * __TEST__readActionSurface (a real chrome.action.getBadgeText call).
+ *
+ * The unit suite (tests/unit/toolbar-presenter.test.mjs) exercises the
+ * presenter's pure accumulation/gating logic exhaustively. This spec
+ * proves the four HARD CONSTRAINTS from #910 hold in a real browser:
+ *   1. The count is readable via the native chrome.action.getBadgeText.
+ *   2. It is genuinely per-tab (two tabs never see each other's count).
+ *   3. It resets on tab close.
+ *   4. setIcon is NEVER called (the f6a6e2b regression this feature
+ *      must not repeat) and the static manifest icon ships unchanged.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import {
+  installTestModeSentinel,
+  clearTestModeSentinel,
+  readActionSurface,
+  seedStorage,
+  waitForDnrPropagation,
+} from "./helpers/index.mjs";
+
+// The badge is gated on onboarding being complete (the global "!" consent
+// badge must win over the count while onboarding is pending — #910). The
+// bare `context` fixture does NOT complete onboarding (unlike popupPage /
+// optionsPage), so every test here must seed consent directly, mirroring
+// enableInjection() in inject-affiliate-direct-nav.spec.mjs.
+//
+// The SW's prefs cache refresh (storage.onChanged → getPrefsWithCache())
+// is async with no observable completion signal — waitForDnrPropagation
+// is the established, documented wait for exactly this race (#824), but
+// its fixed 500ms floor is occasionally too short for onboardingDone
+// specifically (observed flake in the full-suite run, where the SW is
+// busier). Poll the actual "getPrefs" response — which reads through
+// getPrefsWithCache(), the same cache the presenter's isOnboardingDone()
+// accessor reads — until onboardingDone is confirmed true, so this wait
+// is a real condition, not a guess.
+async function completeOnboarding(context, extensionId) {
+  await seedStorage(context, extensionId, {
+    local: {
+      mugaConsent: {
+        onboardingDone: true,
+        consentVersion: "1.1",
+        consentDate: Date.now(),
+      },
+    },
+  });
+  await waitForDnrPropagation(context, extensionId);
+
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  await page.waitForFunction(() =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "getPrefs" }, (r) => resolve(!!r?.onboardingDone));
+    }), { timeout: 5000 }
+  );
+  if (opened) await page.close();
+}
+
+async function emitToolbarEvent(context, extensionId, event) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const result = await page.evaluate((ev) =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage(
+        { type: "__TEST__emitToolbarEvent", event: ev },
+        resolve
+      );
+    }), event
+  );
+  if (opened) await page.close();
+  return result;
+}
+
+/** Opens a fresh extension page (becomes the active tab) and returns its real tabId. */
+async function openHostPageWithTabId(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  const page = await context.newPage();
+  await page.goto(`${extOrigin}/popup/popup.html`);
+  const result = await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "__TEST__getActiveTabId" }, resolve);
+    })
+  );
+  if (!result?.ok) {
+    await page.close();
+    throw new Error(`getActiveTabId failed: ${result?.error}`);
+  }
+  return { page, tabId: result.tabId };
+}
+
+async function readActionApiCounts(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const result = await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "__TEST__readActionApiCounts" }, resolve);
+    })
+  );
+  if (opened) await page.close();
+  return result.counts;
+}
+
+async function resetActionApiCounts(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "__TEST__resetActionApiCounts" }, resolve);
+    })
+  );
+  if (opened) await page.close();
+}
+
+test.describe("Toolbar badge — per-tab running count (#910)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await installTestModeSentinel(context, extensionId);
+    await completeOnboarding(context, extensionId);
+    await resetActionApiCounts(context, extensionId);
+  });
+
+  test.afterEach(async ({ context, extensionId }) => {
+    await clearTestModeSentinel(context, extensionId);
+  });
+
+  test("badge shows the running count via the native chrome.action badge API", async ({ context, extensionId }) => {
+    const { page: hostPage, tabId } = await openHostPageWithTabId(context, extensionId);
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId });
+
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 3 });
+    let surface = await readActionSurface(context, extensionId, tabId);
+    expect(surface.ok).toBe(true);
+    expect(surface.badgeText).toBe("3");
+
+    // Accumulates — a second strip on the same tab adds to the running total.
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 2 });
+    surface = await readActionSurface(context, extensionId, tabId);
+    expect(surface.badgeText).toBe("5");
+
+    await hostPage.close();
+  });
+
+  test("badge survives navigationStarted — running tab total, not per-page", async ({ context, extensionId }) => {
+    const { page: hostPage, tabId } = await openHostPageWithTabId(context, extensionId);
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId });
+
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 4 });
+    await emitToolbarEvent(context, extensionId, { type: "navigationStarted", tabId });
+    let surface = await readActionSurface(context, extensionId, tabId);
+    // The tooltip resets on navigation, but the badge total must not.
+    expect(surface.badgeText).toBe("4");
+
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 1 });
+    surface = await readActionSurface(context, extensionId, tabId);
+    expect(surface.badgeText).toBe("5");
+
+    await hostPage.close();
+  });
+
+  test("per-tab isolation: two tabs show independent counts", async ({ context, extensionId }) => {
+    const { page: pageA, tabId: tabIdA } = await openHostPageWithTabId(context, extensionId);
+    const { page: pageB, tabId: tabIdB } = await openHostPageWithTabId(context, extensionId);
+    expect(tabIdA).not.toBe(tabIdB);
+
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId: tabIdA });
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId: tabIdB });
+
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId: tabIdA, paramsRemoved: 3 });
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId: tabIdB, paramsRemoved: 9 });
+
+    const surfaceA = await readActionSurface(context, extensionId, tabIdA);
+    const surfaceB = await readActionSurface(context, extensionId, tabIdB);
+    expect(surfaceA.badgeText).toBe("3");
+    expect(surfaceB.badgeText).toBe("9");
+
+    // Switching "attention" between tabs (reading either at any point) must
+    // never show a stale value carried over from the other tab.
+    const surfaceAAgain = await readActionSurface(context, extensionId, tabIdA);
+    expect(surfaceAAgain.badgeText).toBe("3");
+
+    await pageA.close();
+    await pageB.close();
+  });
+
+  test("tab close resets the running total; a reused tabId starts fresh", async ({ context, extensionId }) => {
+    const { page: hostPage, tabId } = await openHostPageWithTabId(context, extensionId);
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId });
+
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 8 });
+    let surface = await readActionSurface(context, extensionId, tabId);
+    expect(surface.badgeText).toBe("8");
+
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId });
+
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 1 });
+    surface = await readActionSurface(context, extensionId, tabId);
+    expect(surface.badgeText).toBe("1");
+
+    await hostPage.close();
+  });
+
+  test("no digit is shown for a fresh tab that has cleaned nothing", async ({ context, extensionId }) => {
+    const { page: hostPage, tabId } = await openHostPageWithTabId(context, extensionId);
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId });
+
+    const surface = await readActionSurface(context, extensionId, tabId);
+    expect(surface.badgeText).toBe("");
+
+    await hostPage.close();
+  });
+
+  test("setIcon is NEVER called — the badge is a native overlay, not a composited icon (f6a6e2b regression guard)", async ({ context, extensionId }) => {
+    const { page: hostPage, tabId } = await openHostPageWithTabId(context, extensionId);
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId });
+
+    await resetActionApiCounts(context, extensionId);
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 3 });
+    await emitToolbarEvent(context, extensionId, { type: "creatorReferralPreserved", tabId });
+    await emitToolbarEvent(context, extensionId, { type: "navigationStarted", tabId });
+    await emitToolbarEvent(context, extensionId, { type: "urlCleaned", tabId, paramsRemoved: 2 });
+    await emitToolbarEvent(context, extensionId, { type: "tabClosed", tabId });
+
+    const counts = await readActionApiCounts(context, extensionId);
+    expect(counts.setIcon).toBe(0);
+    // Sanity: the badge surface DID fire (otherwise the setIcon===0
+    // assertion above would pass vacuously because nothing ran at all).
+    expect(counts.setBadgeText).toBeGreaterThan(0);
+
+    await hostPage.close();
+  });
+
+  test("the static manifest icon ships unchanged and is reachable", async ({ context, extensionId }) => {
+    const extOrigin = `chrome-extension://${extensionId}`;
+    const page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+
+    const manifest = await page.evaluate(() => chrome.runtime.getManifest());
+    // No icon-variant entries (e.g. "16-preserved.png") — a single static
+    // icon set declared in the manifest, per the #910 hard constraint.
+    const actionIcons = manifest.action?.default_icon || manifest.browser_action?.default_icon || {};
+    const iconPaths = Object.values(actionIcons);
+    expect(iconPaths.length).toBeGreaterThan(0);
+    for (const p of iconPaths) {
+      expect(p).not.toMatch(/preserved/i);
+    }
+
+    for (const p of iconPaths) {
+      const status = await page.evaluate((path) =>
+        fetch(chrome.runtime.getURL(path)).then(r => r.status).catch(() => 0), p
+      );
+      expect(status).toBe(200);
+    }
+
+    await page.close();
+  });
+});

--- a/tests/e2e/toolbar-badge.spec.mjs
+++ b/tests/e2e/toolbar-badge.spec.mjs
@@ -190,6 +190,17 @@ async function resetPresenterBadgeMap(context, extensionId) {
   return result;
 }
 
+/** Serves a tiny stub for a real https host so navigation hits no network. */
+async function stubHost(page, hostname) {
+  await page.route(`**://${hostname}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>${hostname} stub</body></html>`,
+    }),
+  );
+}
+
 test.describe("Toolbar badge — per-tab running count (#910)", () => {
   test.beforeEach(async ({ context, extensionId }) => {
     await installTestModeSentinel(context, extensionId);
@@ -353,6 +364,41 @@ test.describe("Toolbar badge — per-tab running count (#910)", () => {
 
     await pageA.close();
     await pageB.close();
+  });
+
+  test("badge survives a REAL in-tab navigation — browser clears per-tab badge on navigate; MUGA re-paints the durable total (#950 flicker regression)", async ({ context, extensionId }) => {
+    // The synthetic-event tests above prove the presenter's LOGIC, but they
+    // never trigger the browser's own per-tab badge reset (MDN
+    // action.setBadgeText tabId: "reset when the user navigates this tab to a
+    // new page"). This test drives a REAL navigation so the browser actually
+    // wipes the badge, then asserts MUGA re-paints the running total from the
+    // durable tab_badge_{tabId} session key via the production
+    // chrome.tabs.onUpdated -> navigationStarted path.
+    //
+    // BEFORE the fix, navigationStarted reset only the tooltip, so after the
+    // real navigation the badge stayed BLANK — the exact flicker the user saw.
+    const { page: hostPage, tabId } = await openHostPageWithTabId(context, extensionId);
+
+    // Paint a durable per-tab badge via the REAL updateTabBadge path (writes
+    // the tab_badge_{tabId} session key the onUpdated handler reads back).
+    await updateTabBadge(context, extensionId, { tabId, junkRemoved: 3 });
+    expect((await readActionSurface(context, extensionId, tabId)).badgeText).toBe("3");
+
+    // Perform a REAL in-tab navigation to a stubbed host (no network). This
+    // fires the production onUpdated(status:"loading") handler for this tabId
+    // and makes the browser reset the per-tab badge text.
+    await stubHost(hostPage, "example.com");
+    await hostPage.goto("https://example.com/second");
+
+    // The onUpdated -> bus -> presenter re-paint is async; poll the real
+    // chrome.action badge surface until it settles. It must return to the
+    // accumulated total, NOT stay blank.
+    await expect.poll(
+      async () => (await readActionSurface(context, extensionId, tabId)).badgeText,
+      { timeout: 5000, message: "badge must be re-painted after the navigation reset" },
+    ).toBe("3");
+
+    await hostPage.close();
   });
 
   test("the static manifest icon ships unchanged and is reachable", async ({ context, extensionId }) => {

--- a/tests/e2e/toolbar-badge.spec.mjs
+++ b/tests/e2e/toolbar-badge.spec.mjs
@@ -171,6 +171,25 @@ async function updateTabBadge(context, extensionId, opts) {
   return result;
 }
 
+/** Wipes the presenter's in-memory badgeTotals map — simulates a SW restart. */
+async function resetPresenterBadgeMap(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const result = await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "__TEST__resetPresenterBadgeMap" }, resolve);
+    })
+  );
+  if (opened) await page.close();
+  return result;
+}
+
 test.describe("Toolbar badge — per-tab running count (#910)", () => {
   test.beforeEach(async ({ context, extensionId }) => {
     await installTestModeSentinel(context, extensionId);
@@ -305,6 +324,35 @@ test.describe("Toolbar badge — per-tab running count (#910)", () => {
     expect(surface.badgeText).toBe("3");
 
     await hostPage.close();
+  });
+
+  test("showBadge OFF clears every tab's badge after a SW restart — durable session keys, empty in-memory map (#910 OFF-path)", async ({ context, extensionId }) => {
+    const { page: pageA, tabId: tabIdA } = await openHostPageWithTabId(context, extensionId);
+    const { page: pageB, tabId: tabIdB } = await openHostPageWithTabId(context, extensionId);
+    expect(tabIdA).not.toBe(tabIdB);
+
+    // Paint durable per-tab badges via the REAL updateTabBadge (writes the
+    // tab_badge_* session keys that survive SW eviction).
+    await updateTabBadge(context, extensionId, { tabId: tabIdA, junkRemoved: 4 });
+    await updateTabBadge(context, extensionId, { tabId: tabIdB, junkRemoved: 6 });
+    expect((await readActionSurface(context, extensionId, tabIdA)).badgeText).toBe("4");
+    expect((await readActionSurface(context, extensionId, tabIdB)).badgeText).toBe("6");
+
+    // Simulate a service-worker restart: the presenter's in-memory badge map
+    // is wiped, but the durable session keys AND the browser-rendered badges
+    // survive. Before the fix, the OFF handler iterated only the (now empty)
+    // in-memory map and cleared nothing.
+    const reset = await resetPresenterBadgeMap(context, extensionId);
+    expect(reset.ok).toBe(true);
+
+    // Toggle showBadge OFF. Must clear BOTH tabs from the durable list.
+    await emitToolbarEvent(context, extensionId, { type: "showBadgePrefChanged", value: false });
+
+    expect((await readActionSurface(context, extensionId, tabIdA)).badgeText).toBe("");
+    expect((await readActionSurface(context, extensionId, tabIdB)).badgeText).toBe("");
+
+    await pageA.close();
+    await pageB.close();
   });
 
   test("the static manifest icon ships unchanged and is reachable", async ({ context, extensionId }) => {

--- a/tests/e2e/toolbar-badge.spec.mjs
+++ b/tests/e2e/toolbar-badge.spec.mjs
@@ -146,6 +146,31 @@ async function resetActionApiCounts(context, extensionId) {
   if (opened) await page.close();
 }
 
+/**
+ * Drives the REAL production updateTabBadge() path (not the synthetic
+ * toolbar-bus emit). Writes the durable `tab_badge_{tabId}` session key and
+ * emits urlCleaned exactly like the BADGE_AND_STATS handler.
+ * @param {{ tabId: number, junkRemoved: number, coldCache?: boolean }} opts
+ *   coldCache:true invalidates the prefs cache first, mirroring an evicted SW.
+ */
+async function updateTabBadge(context, extensionId, opts) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let page = context.pages().find(p => p.url().startsWith(extOrigin));
+  let opened = false;
+  if (!page) {
+    page = await context.newPage();
+    await page.goto(`${extOrigin}/popup/popup.html`);
+    opened = true;
+  }
+  const result = await page.evaluate((o) =>
+    new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: "__TEST__updateTabBadge", ...o }, resolve);
+    }), opts
+  );
+  if (opened) await page.close();
+  return result;
+}
+
 test.describe("Toolbar badge — per-tab running count (#910)", () => {
   test.beforeEach(async ({ context, extensionId }) => {
     await installTestModeSentinel(context, extensionId);
@@ -259,6 +284,25 @@ test.describe("Toolbar badge — per-tab running count (#910)", () => {
     // Sanity: the badge surface DID fire (otherwise the setIcon===0
     // assertion above would pass vacuously because nothing ran at all).
     expect(counts.setBadgeText).toBeGreaterThan(0);
+
+    await hostPage.close();
+  });
+
+  test("cold/evicted SW still paints the badge — updateTabBadge warms prefs before emitting (#910 cold-SW race)", async ({ context, extensionId }) => {
+    // The BADGE_AND_STATS path calls updateTabBadge fire-and-forget on a SW
+    // that may be cold. If updateTabBadge emits urlCleaned before warming the
+    // prefs cache, the presenter's isOnboardingDone() reads a null cachedPrefs,
+    // defaults to false, and silently drops the badge write — the count would
+    // never appear for that clean. This drives the REAL updateTabBadge() with
+    // an invalidated cache and asserts the badge STILL paints.
+    const { page: hostPage, tabId } = await openHostPageWithTabId(context, extensionId);
+
+    const res = await updateTabBadge(context, extensionId, { tabId, junkRemoved: 3, coldCache: true });
+    expect(res.ok).toBe(true);
+
+    const surface = await readActionSurface(context, extensionId, tabId);
+    expect(surface.ok).toBe(true);
+    expect(surface.badgeText).toBe("3");
 
     await hostPage.close();
   });

--- a/tests/unit/options-show-badge-toggle.test.mjs
+++ b/tests/unit/options-show-badge-toggle.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * MUGA — options UI wiring for showBadge (#910).
+ *
+ * Pins the source surface for the toolbar-badge toggle the same way
+ * options-surfaced-prefs.test.mjs pins the #925 controls: the HTML row +
+ * aria-label, the bindToggle wiring, and the export/import round-trip.
+ * Source-string-inspection pattern (options.js is browser-only, no DOM
+ * available under node:test).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { PREF_DEFAULTS } from "../../src/lib/prefs.js";
+import { TRANSLATIONS, SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dir, "../..");
+
+const optionsHtml = readFileSync(join(ROOT, "src/options/options.html"), "utf8");
+const optionsJs = readFileSync(join(ROOT, "src/options/options.js"), "utf8");
+
+describe("#910 — showBadge defaults to true", () => {
+  test("PREF_DEFAULTS.showBadge is true", () => {
+    assert.strictEqual(PREF_DEFAULTS.showBadge, true);
+  });
+});
+
+describe("#910 — the toggle has an HTML row and a bindToggle wiring", () => {
+  test('#show-badge checkbox exists with data-i18n-aria-label="aria_show_badge"', () => {
+    assert.ok(optionsHtml.includes('id="show-badge"'), 'options.html must contain a checkbox with id="show-badge"');
+    assert.ok(
+      optionsHtml.includes('data-i18n-aria-label="aria_show_badge"'),
+      'the #show-badge row must carry data-i18n-aria-label="aria_show_badge"'
+    );
+  });
+
+  test('options.js binds #show-badge to "showBadge"', () => {
+    assert.ok(
+      optionsJs.includes('bindToggle("show-badge", "showBadge", prefs)'),
+      'options.js must call bindToggle("show-badge", "showBadge", prefs)'
+    );
+  });
+
+  test("#show-badge lives inside the dev-mode-gated Advanced card (Display group)", () => {
+    const cardIdx = optionsHtml.indexOf('id="dev-tools-card"');
+    const verIdx = optionsHtml.indexOf("version-info");
+    const idx = optionsHtml.indexOf('id="show-badge"');
+    assert.ok(idx > cardIdx && idx < verIdx, "#show-badge must be inside the gated Advanced card");
+  });
+});
+
+describe("#910 — export/import round-trips showBadge", () => {
+  test("export payload includes showBadge", () => {
+    assert.ok(optionsJs.includes("showBadge: prefs.showBadge"), "export payload must include showBadge");
+  });
+
+  test("import BOOL_KEYS includes showBadge", () => {
+    const boolKeysMatch = optionsJs.match(/const BOOL_KEYS = \[([^\]]*)\]/);
+    assert.ok(boolKeysMatch, "import handler must define BOOL_KEYS");
+    assert.ok(boolKeysMatch[1].includes('"showBadge"'), "BOOL_KEYS must include showBadge so import applies it");
+  });
+
+  test("import handler refreshes the #show-badge checkbox after import", () => {
+    assert.ok(
+      optionsJs.includes('document.getElementById("show-badge").checked = newPrefs.showBadge'),
+      "the post-import UI refresh must update #show-badge"
+    );
+  });
+});
+
+describe("#910 — new i18n keys are complete across all locales", () => {
+  const newKeys = ["row_show_badge_label", "row_show_badge_hint", "aria_show_badge"];
+
+  for (const key of newKeys) {
+    test(`"${key}" exists and is non-empty for every supported locale`, () => {
+      const entry = TRANSLATIONS[key];
+      assert.ok(entry, `TRANSLATIONS is missing new key "${key}"`);
+      for (const { code } of SUPPORTED_LANGS) {
+        assert.ok(
+          typeof entry[code] === "string" && entry[code].trim().length > 0,
+          `TRANSLATIONS["${key}"]["${code}"] must be a non-empty string`
+        );
+      }
+    });
+  }
+
+  test("es translations differ from en (peninsular Spanish, not a copy)", () => {
+    for (const key of newKeys) {
+      assert.notEqual(TRANSLATIONS[key].es, TRANSLATIONS[key].en, `"${key}" es must not equal en`);
+    }
+  });
+});

--- a/tests/unit/storage-show-badge-pref.test.mjs
+++ b/tests/unit/storage-show-badge-pref.test.mjs
@@ -1,0 +1,58 @@
+/**
+ * MUGA — PREF_DEFAULTS + docs surface for showBadge (#910).
+ *
+ * Re-introduces a per-tab toolbar badge (running count of tracking params
+ * stripped in the tab) gated behind `showBadge` (default true). See
+ * src/lib/toolbar-presenter.js for the badge logic and
+ * src/background/service-worker.js:updateTabBadge for the persistent
+ * per-tab running total (chrome.storage.session key `tab_badge_{tabId}`).
+ *
+ * These tests pin both the code surface (PREF_DEFAULTS in prefs.js) AND
+ * the documentation surface (docs/data_architect.md) so the schema stays
+ * a single source of truth (docs-prefs-table.test.mjs also enforces 1:1
+ * key coverage for the sync-prefs table generically).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+
+import { makeChromeMock } from "./helpers/chrome-stub.mjs";
+globalThis.chrome = makeChromeMock({ hasSession: false, promiseShape: true });
+
+const { PREF_DEFAULTS } = await import("../../src/lib/storage.js");
+
+test("PREF_DEFAULTS includes showBadge: true", () => {
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(PREF_DEFAULTS, "showBadge"),
+    "PREF_DEFAULTS must include showBadge",
+  );
+  assert.equal(
+    PREF_DEFAULTS.showBadge,
+    true,
+    "showBadge must default to true so users see the toolbar badge unless they opt out",
+  );
+});
+
+test("docs/data_architect.md documents showBadge (sync prefs row)", () => {
+  const md = readFileSync(resolve(root, "docs/data_architect.md"), "utf8");
+  assert.match(
+    md,
+    /\|\s*`showBadge`\s*\|/,
+    "docs/data_architect.md must contain a sync-prefs row for showBadge",
+  );
+});
+
+test("docs/data_architect.md documents tab_badge_{tabId} (chrome.storage.session row)", () => {
+  const md = readFileSync(resolve(root, "docs/data_architect.md"), "utf8");
+  assert.match(
+    md,
+    /\|\s*`tab_badge_\{tabId\}`\s*\|/,
+    "docs/data_architect.md must contain a session-storage row for tab_badge_{tabId}",
+  );
+});

--- a/tests/unit/toolbar-presenter.test.mjs
+++ b/tests/unit/toolbar-presenter.test.mjs
@@ -195,6 +195,52 @@ describe("toolbar-presenter — badge (#910)", () => {
     assert.deepEqual(badgeCallsFor(actionApi, 2).at(-1)[1], { tabId: 2, text: "9" });
   });
 
+  test("navigationStarted RE-PAINTS the badge — the browser clears per-tab badge text on navigation (#950 flicker)", () => {
+    // The browser resets the per-tab badge on every navigation (MDN
+    // action.setBadgeText tabId). navigationStarted must re-write the running
+    // total so the count does not vanish after a navigation that produces no
+    // urlCleaned of its own. Without the re-paint the badge stays blank until
+    // the next clean — the flicker the user reported.
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 4 });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "navigationStarted", tabId: 7 });
+    assert.deepEqual(badgeCallsFor(actionApi, 7).at(-1)?.[1], { tabId: 7, text: "4" });
+  });
+
+  test("navigationStarted re-paints from the caller-supplied durable total when the in-memory map was wiped (cold SW)", () => {
+    // Mirrors production: the SW passes event.total (read from the durable
+    // tab_badge_{tabId} session key). After a service-worker restart the
+    // in-memory map is empty, so the durable total is the only source.
+    const { bus, actionApi, presenter } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 4 });
+    presenter._resetInMemoryTotals();
+    actionApi.calls.length = 0;
+    bus.emit({ type: "navigationStarted", tabId: 7, total: 4 });
+    assert.deepEqual(badgeCallsFor(actionApi, 7).at(-1)?.[1], { tabId: 7, text: "4" });
+  });
+
+  test("navigationStarted does NOT paint a per-tab badge for a fresh tab that has cleaned nothing", () => {
+    // A fresh tab has no running total, so re-painting must not create a
+    // per-tab override (which would mask the global badge and violate the
+    // "no digit on a fresh tab" contract).
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "navigationStarted", tabId: 7 });
+    assert.equal(badgeCallsFor(actionApi, 7).length, 0);
+  });
+
+  test("navigationStarted re-paint respects showBadge OFF (no badge written)", () => {
+    const { bus, actionApi } = setup({ showBadge: false });
+    bus.emit({ type: "navigationStarted", tabId: 7, total: 5 });
+    assert.equal(badgeCallsFor(actionApi, 7).length, 0);
+  });
+
+  test("navigationStarted re-paint is gated on onboarding (must not mask the global \"!\" badge)", () => {
+    const { bus, actionApi } = setup({ onboardingDone: false });
+    bus.emit({ type: "navigationStarted", tabId: 7, total: 5 });
+    assert.equal(badgeCallsFor(actionApi, 7).length, 0);
+  });
+
   test("tabClosed resets the running total; reused tabId starts fresh", () => {
     const { bus, actionApi } = setup();
     bus.emit({ type: "urlCleaned", tabId: 5, paramsRemoved: 8 });

--- a/tests/unit/toolbar-presenter.test.mjs
+++ b/tests/unit/toolbar-presenter.test.mjs
@@ -2,14 +2,15 @@
  * MUGA — toolbar presenter
  *
  * Verifies the contract: given an event sequence, the presenter writes
- * the right per-tab tooltip. Tests assert the API calls the presenter
- * would make against a recording stub — not screenshots, not real
- * chrome APIs.
+ * the right per-tab tooltip AND the right per-tab badge text. Tests
+ * assert the API calls the presenter would make against a recording
+ * stub — not screenshots, not real chrome APIs.
  *
- * Badge text/color and icon variant surfaces were removed (the icon
- * swap caused a flash-and-disappear regression in Firefox MV2 and the
- * per-tab counter was confusing). The tooltip is the only dynamic
- * surface the presenter currently writes.
+ * Icon-variant swapping stays removed (the setIcon swap caused a
+ * flash-and-disappear regression in Firefox MV2 — see f6a6e2b). The
+ * badge (#910) is re-introduced as a NATIVE browser badge overlay
+ * (setBadgeText only) on top of the single static manifest icon —
+ * never a re-rendered/composited icon.
  */
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
@@ -22,6 +23,7 @@ function makeRecordingActionApi() {
   return {
     calls,
     setTitle(arg) { calls.push(["setTitle", arg]); },
+    setBadgeText(arg) { calls.push(["setBadgeText", arg]); },
   };
 }
 
@@ -33,12 +35,35 @@ const STRINGS = {
 };
 const t = (key) => STRINGS[key] ?? key;
 
-function setup() {
+/**
+ * @param {{ showBadge?: boolean, onboardingDone?: boolean }} [opts]
+ * @returns {object} test rig, plus setShowBadge/setOnboardingDone mutators
+ *   so tests can flip the live pref/consent state mid-sequence (mirrors how
+ *   the SW's cachedPrefs-backed accessors behave in production).
+ */
+function setup({ showBadge = true, onboardingDone = true } = {}) {
   const bus = createToolbarEventBus();
   const state = createTabPresenterState();
   const actionApi = makeRecordingActionApi();
-  const presenter = createToolbarPresenter({ bus, state, actionApi, t });
-  return { bus, state, actionApi, presenter };
+  let _showBadge = showBadge;
+  let _onboardingDone = onboardingDone;
+  const presenter = createToolbarPresenter({
+    bus,
+    state,
+    actionApi,
+    t,
+    getShowBadge: () => _showBadge,
+    isOnboardingDone: () => _onboardingDone,
+  });
+  return {
+    bus, state, actionApi, presenter,
+    setShowBadge: (v) => { _showBadge = v; },
+    setOnboardingDone: (v) => { _onboardingDone = v; },
+  };
+}
+
+function badgeCallsFor(actionApi, tabId) {
+  return actionApi.calls.filter(([k, arg]) => k === "setBadgeText" && arg.tabId === tabId);
 }
 
 describe("toolbar-presenter — startup", () => {
@@ -119,6 +144,144 @@ describe("toolbar-presenter — tabClosed", () => {
     bus.emit({ type: "tabClosed", tabId: 11 });
     assert.equal(state.get(11).paramsRemoved, 0);
     assert.equal(state.get(11).creatorReferralPreserved, false);
+  });
+});
+
+describe("toolbar-presenter — badge (#910)", () => {
+  test("does not write a badge at construction", () => {
+    const { actionApi } = setup();
+    assert.equal(badgeCallsFor(actionApi, 7).length, 0);
+  });
+
+  test("first cleaning writes the count as native badge text", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    assert.deepEqual(badgeCallsFor(actionApi, 7).at(-1)[1], { tabId: 7, text: "3" });
+  });
+
+  test("accumulates across multiple urlCleaned events on the same tab", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 2 });
+    assert.deepEqual(badgeCallsFor(actionApi, 7).at(-1)[1], { tabId: 7, text: "5" });
+  });
+
+  test("uses the caller-supplied running total when present (survives SW restarts)", () => {
+    // updateTabBadge() in the SW persists the running total in
+    // chrome.storage.session and passes it as event.total so the badge
+    // stays correct even if the presenter's in-memory map was reset by a
+    // service-worker restart mid-tab-lifetime.
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 2, total: 99 });
+    assert.deepEqual(badgeCallsFor(actionApi, 7).at(-1)[1], { tabId: 7, text: "99" });
+  });
+
+  test("accumulates across navigationStarted — badge total survives in-tab navigation (including SPA)", () => {
+    const { bus, actionApi, state } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    bus.emit({ type: "navigationStarted", tabId: 7 });
+    // The per-page tooltip state resets on navigation...
+    assert.equal(state.get(7).paramsRemoved, 0);
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 2 });
+    // ...but the badge total does not: it's the tab's running total.
+    assert.deepEqual(badgeCallsFor(actionApi, 7).at(-1)[1], { tabId: 7, text: "5" });
+  });
+
+  test("per-tab isolation: two tabs accumulate independently", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 3 });
+    bus.emit({ type: "urlCleaned", tabId: 2, paramsRemoved: 9 });
+    assert.deepEqual(badgeCallsFor(actionApi, 1).at(-1)[1], { tabId: 1, text: "3" });
+    assert.deepEqual(badgeCallsFor(actionApi, 2).at(-1)[1], { tabId: 2, text: "9" });
+  });
+
+  test("tabClosed resets the running total; reused tabId starts fresh", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 5, paramsRemoved: 8 });
+    bus.emit({ type: "tabClosed", tabId: 5 });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "urlCleaned", tabId: 5, paramsRemoved: 1 });
+    assert.deepEqual(badgeCallsFor(actionApi, 5).at(-1)[1], { tabId: 5, text: "1" });
+  });
+
+  test("zero or negative paramsRemoved does not write a badge", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 0 });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: -3 });
+    assert.equal(badgeCallsFor(actionApi, 7).length, 0);
+  });
+
+  test("no digit is shown for a fresh tab (no per-tab override ever written)", () => {
+    const { actionApi } = setup();
+    assert.equal(badgeCallsFor(actionApi, 42).length, 0);
+  });
+});
+
+describe("toolbar-presenter — badge + onboarding precedence (#910)", () => {
+  test("badge is not written while onboarding is incomplete — the global \"!\" badge must win", () => {
+    const { bus, actionApi } = setup({ onboardingDone: false });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    assert.equal(badgeCallsFor(actionApi, 7).length, 0);
+  });
+
+  test("the tooltip is unaffected by onboarding state — only the badge is gated", () => {
+    const { bus, actionApi } = setup({ onboardingDone: false });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    assert.ok(actionApi.calls.find(([k]) => k === "setTitle"));
+  });
+
+  test("badge resumes once onboarding completes; the tracked total is preserved meanwhile", () => {
+    const { bus, actionApi, setOnboardingDone } = setup({ onboardingDone: false });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    setOnboardingDone(true);
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 2 });
+    assert.deepEqual(badgeCallsFor(actionApi, 7).at(-1)[1], { tabId: 7, text: "5" });
+  });
+});
+
+describe("toolbar-presenter — showBadge pref (#910)", () => {
+  test("badge is not written while showBadge is off", () => {
+    const { bus, actionApi } = setup({ showBadge: false });
+    bus.emit({ type: "urlCleaned", tabId: 7, paramsRemoved: 3 });
+    assert.equal(badgeCallsFor(actionApi, 7).length, 0);
+  });
+
+  test("showBadgePrefChanged(false) clears the badge on every tracked tab", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 4 });
+    bus.emit({ type: "urlCleaned", tabId: 2, paramsRemoved: 6 });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "showBadgePrefChanged", value: false });
+    assert.deepEqual(badgeCallsFor(actionApi, 1).at(-1)[1], { tabId: 1, text: "" });
+    assert.deepEqual(badgeCallsFor(actionApi, 2).at(-1)[1], { tabId: 2, text: "" });
+  });
+
+  test("showBadgePrefChanged(true) repaints the accumulated totals", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 4 });
+    bus.emit({ type: "showBadgePrefChanged", value: false });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "showBadgePrefChanged", value: true });
+    assert.deepEqual(badgeCallsFor(actionApi, 1).at(-1)[1], { tabId: 1, text: "4" });
+  });
+
+  test("further urlCleaned events stop updating the badge once showBadge is off", () => {
+    const { bus, actionApi, setShowBadge } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 4 });
+    setShowBadge(false);
+    bus.emit({ type: "showBadgePrefChanged", value: false });
+    actionApi.calls.length = 0;
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 10 });
+    assert.equal(badgeCallsFor(actionApi, 1).length, 0);
+  });
+
+  test("showBadgePrefChanged does not touch the action surface while onboarding is incomplete (does not disturb the \"!\" badge)", () => {
+    const { bus, actionApi, setOnboardingDone } = setup();
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 4 });
+    setOnboardingDone(false);
+    actionApi.calls.length = 0;
+    bus.emit({ type: "showBadgePrefChanged", value: false });
+    assert.equal(actionApi.calls.length, 0);
   });
 });
 

--- a/tests/unit/toolbar-presenter.test.mjs
+++ b/tests/unit/toolbar-presenter.test.mjs
@@ -275,6 +275,46 @@ describe("toolbar-presenter — showBadge pref (#910)", () => {
     assert.equal(badgeCallsFor(actionApi, 1).length, 0);
   });
 
+  test("showBadgePrefChanged(false) clears badges from the DURABLE tab list even when the in-memory map is empty (SW-restart map blind spot #910)", () => {
+    // A fresh presenter after a service-worker restart: no urlCleaned has
+    // been replayed, so badgeTotals is empty — yet the browser still shows
+    // per-tab badges and the durable tab_badge_* session keys survive. The
+    // SW enumerates those keys and passes them as event.tabs. The OFF toggle
+    // MUST clear every one, not just whatever happens to be in memory.
+    const { bus, actionApi } = setup();
+    bus.emit({
+      type: "showBadgePrefChanged",
+      value: false,
+      tabs: [{ tabId: 1, total: 4 }, { tabId: 2, total: 6 }],
+    });
+    assert.deepEqual(badgeCallsFor(actionApi, 1).at(-1)?.[1], { tabId: 1, text: "" });
+    assert.deepEqual(badgeCallsFor(actionApi, 2).at(-1)?.[1], { tabId: 2, text: "" });
+  });
+
+  test("showBadgePrefChanged(true) repaints from the DURABLE tab list when the in-memory map is empty", () => {
+    const { bus, actionApi } = setup();
+    bus.emit({
+      type: "showBadgePrefChanged",
+      value: true,
+      tabs: [{ tabId: 3, total: 7 }],
+    });
+    assert.deepEqual(badgeCallsFor(actionApi, 3).at(-1)?.[1], { tabId: 3, text: "7" });
+  });
+
+  test("showBadgePrefChanged merges the durable tab list with the in-memory map (union of both is cleared)", () => {
+    const { bus, actionApi } = setup();
+    // tab 1 is tracked in-memory; tab 2 exists only in the durable list.
+    bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 4 });
+    actionApi.calls.length = 0;
+    bus.emit({
+      type: "showBadgePrefChanged",
+      value: false,
+      tabs: [{ tabId: 2, total: 6 }],
+    });
+    assert.deepEqual(badgeCallsFor(actionApi, 1).at(-1)?.[1], { tabId: 1, text: "" });
+    assert.deepEqual(badgeCallsFor(actionApi, 2).at(-1)?.[1], { tabId: 2, text: "" });
+  });
+
   test("showBadgePrefChanged does not touch the action surface while onboarding is incomplete (does not disturb the \"!\" badge)", () => {
     const { bus, actionApi, setOnboardingDone } = setup();
     bus.emit({ type: "urlCleaned", tabId: 1, paramsRemoved: 4 });


### PR DESCRIPTION
## What

Re-introduces a per-tab toolbar badge showing the running count of tracking parameters MUGA has stripped in that tab — the feature requested in #910, in the style of uBlock Origin's per-tab badge.

Closes #910.

## Approach

- **Native badge only.** The number is rendered exclusively through the browser's native badge API (`chrome.action.setBadgeText`), the same mechanism uBlock uses — a browser-drawn overlay on the existing static icon. **No** `setIcon` swap and **no** icon compositing (OffscreenCanvas/ImageData). This is deliberate: the feature previously shipped and was removed in `f6a6e2b` because a `setIcon` icon-variant swap raced navigation resets and made the Firefox MV2 icon flash/disappear. The static manifest icon is untouched.
- **No new permissions.** `setBadgeText` is part of the base `action` API; `manifest.json` is unchanged.
- **Semantics:** running per-tab total, accumulates across all in-tab navigations (incl. SPA), resets only on tab close, per-`tabId` (each tab independent). Persisted in `chrome.storage.session` under `tab_badge_{tabId}` so it survives service-worker eviction.
- **New pref `showBadge`** (default ON) with an options-UI toggle; OFF clears every tab's badge and stops updates without disturbing the onboarding `"!"` badge.
- **i18n:** 3 new keys across all 7 locales; the Spanish copy is peninsular Castilian.

## Two production bugs caught in fresh-context review (and fixed)

A green test suite initially hid both — surfaced by adversarial review and locked down with regression tests proven to fail without their fix:

1. **Cold-SW race (`faf7641`).** `updateTabBadge` (the `BADGE_AND_STATS` fire-and-forget path) emitted the badge event without first awaiting `getPrefsWithCache()`. On a cold/evicted MV3 service worker `cachedPrefs` was `null`, `isOnboardingDone()` defaulted to `false`, and the badge write was silently skipped — the count never appeared for that clean. Fixed by awaiting the prefs cache in production before emitting. Regression drives the **real** `updateTabBadge` with a cold cache (not the warmed test handler).
2. **`showBadge` OFF didn't clear after SW restart (`8f21e93`).** The OFF path iterated the in-memory `badgeTotals` map (wiped on eviction) while the browser-rendered badges and session keys persisted, leaving stale badges. Fixed by enumerating the durable `tab_badge_*` session keys and merging that authoritative list in the presenter.

## Tests

- Unit: 5457 pass / 0 fail
- e2e (real Chrome): 106 pass / 0 fail (3 pre-existing skips)
- eslint / web-ext lint / typecheck / i18n check: all clean

## How to validate visually

Load `dist/chrome/` (from `npm run build:chrome`, test seams stripped) via `chrome://extensions` → Load unpacked. Navigate to a URL with tracking params; the count appears on the toolbar icon and accumulates as you browse the tab. Toggle **Settings → Advanced → Display → Show badge** off to confirm it clears.
