### PR TITLE
fix(options): Settings display + write-path for guarded privacy prefs

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1277,8 +1277,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         // per-device overrides), so the Settings toggle matches what the
         // extension actually does. A raw sync.get with a hardcoded default
         // contradicted PREF_DEFAULTS.remoteRulesEnabled=true and rendered the
-        // toggle OFF on fresh installs while the weekly fetch was running
-        // (#888 follow-up). buildRemoteRulesStatus routes through getPrefs().
+        // toggle OFF on fresh installs even though the pref DEFAULTS to enabled
+        // (the weekly signed fetch only starts once the rules.muga.app optional
+        // host permission is granted via the toggle, #888 follow-up).
+        // buildRemoteRulesStatus routes through getPrefs().
         const status = await buildRemoteRulesStatus({
           getPrefs,
           local: chrome.storage.local,

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -18,6 +18,7 @@ import {
   buildRemoteDnrRule,
 } from "../lib/remote-rules.js";
 import { TRUSTED_PUBLIC_KEYS } from "../lib/remote-rules-keys.js";
+import { buildRemoteRulesStatus } from "../lib/remote-rules-status.js";
 import { resolveShortener } from "../lib/native-shortener-resolver.js";
 import { isGenericShortener } from "../lib/opaque-networks.js";
 import { createToolbarEventBus } from "../lib/toolbar-event-bus.js";
@@ -1263,26 +1264,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "GET_REMOTE_RULES_STATUS") {
     (async () => {
       try {
-        // Read enabled from sync (authoritative)
-        const syncData = await chrome.storage.sync.get({ remoteRulesEnabled: false });
-        const enabled = !!syncData.remoteRulesEnabled;
-        // Read meta from local
-        const localData = await chrome.storage.local.get({
-          remoteParams: [],
-          remoteRulesMeta: { version: 0, fetchedAt: null, paramCount: 0, lastError: null, published: null },
+        // `enabled` MUST be the CANONICAL effective value (sync + consent +
+        // per-device overrides), so the Settings toggle matches what the
+        // extension actually does. A raw sync.get with a hardcoded default
+        // contradicted PREF_DEFAULTS.remoteRulesEnabled=true and rendered the
+        // toggle OFF on fresh installs while the weekly fetch was running
+        // (#888 follow-up). buildRemoteRulesStatus routes through getPrefs().
+        const status = await buildRemoteRulesStatus({
+          getPrefs,
+          local: chrome.storage.local,
+          hasDNR,
         });
-        // Feature-detect flags (REQ-UI-5). Since v1.10.1 the feature no
-        // longer requires chrome.alarms — the only remaining runtime gate
-        // is DNR availability.
-        const supportsDNR = hasDNR;
         try {
-          sendResponse({
-            ok: true,
-            enabled,
-            meta: localData.remoteRulesMeta,
-            remoteParams: localData.remoteParams,
-            supportsDNR,
-          });
+          sendResponse(status);
         } catch { /* channel closed */ }
       } catch (err) {
         console.error("[MUGA] GET_REMOTE_RULES_STATUS handler failed:", err);

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -19,6 +19,7 @@ import {
 } from "../lib/remote-rules.js";
 import { TRUSTED_PUBLIC_KEYS } from "../lib/remote-rules-keys.js";
 import { buildRemoteRulesStatus } from "../lib/remote-rules-status.js";
+import { reconcileOverrideForExplicitChoice } from "../lib/per-device-prefs.js";
 import { resolveShortener } from "../lib/native-shortener-resolver.js";
 import { isGenericShortener } from "../lib/opaque-networks.js";
 import { createToolbarEventBus } from "../lib/toolbar-event-bus.js";
@@ -1224,6 +1225,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     (async () => {
       try {
         await setPrefs({ remoteRulesEnabled: true });
+        // Explicit Settings action → reconcile the per-device override so the
+        // choice sticks. getPrefs() overlays overrides LAST, so a stale
+        // onboarding-decline override would otherwise keep the effective value
+        // OFF despite the sync write (#888 follow-up, write path).
+        await reconcileOverrideForExplicitChoice("remoteRulesEnabled", true);
         _invalidatePrefsCache();
         // Immediate first fetch (REQ-OPT-3, SC-02). Subsequent fetches happen
         // opportunistically via maybeFetchRemoteRules on any SW wake once the
@@ -1242,6 +1248,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     (async () => {
       try {
         await setPrefs({ remoteRulesEnabled: false });
+        // Explicit Settings action → reconcile the per-device override so the
+        // OFF choice sticks against any pre-existing override (#888 follow-up).
+        await reconcileOverrideForExplicitChoice("remoteRulesEnabled", false);
         _invalidatePrefsCache();
         // Clear remote params + DNR rule 1001. Rule 1000 (custom) is NOT touched. (REQ-OPT-5, SC-03)
         await clearRemoteCache({

--- a/src/lib/per-device-prefs.js
+++ b/src/lib/per-device-prefs.js
@@ -76,6 +76,33 @@ export async function setOverrides(partial) {
 }
 
 /**
+ * Reconciles a per-device override after an EXPLICIT Settings toggle of a
+ * guarded pref (#888 follow-up, write path).
+ *
+ * An explicit toggle in Settings is this device's authoritative current choice.
+ * Because getPrefs() overlays per-device overrides LAST, a stale override
+ * (e.g. a `false` recorded when the user declined a sync-inherited onboarding
+ * prompt) would keep winning over the fresh setPrefs() write — the toggle would
+ * silently revert on reload and the behaviour would never change. Recording the
+ * override to match the chosen value makes getPrefs() return it, so the choice
+ * sticks. Precedence note: this deliberately pins the pref to the device-local
+ * choice, consistent with the guard's intent (#364) that these privacy-
+ * sensitive prefs must not silently flip from sync without explicit local
+ * confirmation.
+ *
+ * No-op for non-guarded keys — only GUARDED_PREFS carry per-device overrides,
+ * so a blanket clear/write is neither needed nor allowed for other toggles.
+ *
+ * @param {string} key - Pref key from an explicit Settings action.
+ * @param {boolean} value - The chosen value.
+ * @returns {Promise<void>}
+ */
+export async function reconcileOverrideForExplicitChoice(key, value) {
+  if (!GUARDED_PREFS.includes(key)) return;
+  await setOverrides({ [key]: !!value });
+}
+
+/**
  * Removes all per-device overrides. Intended for testing and devMode reset.
  * @returns {Promise<void>}
  */

--- a/src/lib/remote-rules-status.js
+++ b/src/lib/remote-rules-status.js
@@ -1,0 +1,46 @@
+/**
+ * MUGA: Remote-rules status builder (#888 follow-up)
+ *
+ * Single source of truth for the `GET_REMOTE_RULES_STATUS` message reply.
+ *
+ * The `enabled` flag MUST reflect the CANONICAL effective preference, i.e.
+ * the same value the rest of the extension acts on. That value comes from
+ * `getPrefs()` (src/lib/prefs.js), which overlays sync + consent + per-device
+ * overrides — NOT from a raw `chrome.storage.sync.get` with a hardcoded
+ * default. On a fresh install the `remoteRulesEnabled` key is never written
+ * (the onboarding accept path relies on `PREF_DEFAULTS.remoteRulesEnabled =
+ * true`), so a hardcoded `false` default would report the toggle as OFF while
+ * the weekly fetch is actually running. Routing through `getPrefs()` keeps the
+ * Settings toggle in lockstep with the effective behaviour, including any
+ * per-device override written when a user declines a sync-inherited prompt.
+ *
+ * Dependency-injected (matching runRemoteRulesFetch's shape) so it is unit
+ * testable without importing the whole service worker.
+ *
+ * @param {object} deps
+ * @param {() => Promise<object>} deps.getPrefs - Canonical merged-prefs reader.
+ * @param {{ get: (defaults: object) => Promise<object> }} deps.local - chrome.storage.local (or a fake).
+ * @param {boolean} deps.hasDNR - Whether declarativeNetRequest is available.
+ * @returns {Promise<{ok: true, enabled: boolean, meta: object, remoteParams: string[], supportsDNR: boolean}>}
+ */
+export async function buildRemoteRulesStatus({ getPrefs, local, hasDNR }) {
+  // Canonical effective value (sync + consent + per-device overrides).
+  const prefs = await getPrefs();
+  const enabled = !!prefs.remoteRulesEnabled;
+
+  // Meta + params live in chrome.storage.local (device-local fetch state).
+  const localData = await local.get({
+    remoteParams: [],
+    remoteRulesMeta: { version: 0, fetchedAt: null, paramCount: 0, lastError: null, published: null },
+  });
+
+  return {
+    ok: true,
+    enabled,
+    meta: localData.remoteRulesMeta,
+    remoteParams: localData.remoteParams,
+    // Feature-detect flag (REQ-UI-5). Since v1.10.1 the only remaining runtime
+    // gate is DNR availability (chrome.alarms dependency was removed).
+    supportsDNR: !!hasDNR,
+  };
+}

--- a/src/lib/remote-rules-status.js
+++ b/src/lib/remote-rules-status.js
@@ -9,10 +9,13 @@
  * overrides — NOT from a raw `chrome.storage.sync.get` with a hardcoded
  * default. On a fresh install the `remoteRulesEnabled` key is never written
  * (the onboarding accept path relies on `PREF_DEFAULTS.remoteRulesEnabled =
- * true`), so a hardcoded `false` default would report the toggle as OFF while
- * the weekly fetch is actually running. Routing through `getPrefs()` keeps the
- * Settings toggle in lockstep with the effective behaviour, including any
- * per-device override written when a user declines a sync-inherited prompt.
+ * true`), so a hardcoded `false` default would report the toggle as OFF even
+ * though the pref DEFAULTS to enabled. The toggle must reflect that default.
+ * (The weekly signed fetch itself only begins once the user grants the
+ * `rules.muga.app` optional host permission via the Settings toggle — it is
+ * not running pre-grant.) Routing through `getPrefs()` keeps the Settings
+ * toggle in lockstep with the effective preference, including any per-device
+ * override written when a user declines a sync-inherited prompt.
  *
  * Dependency-injected (matching runRemoteRulesFetch's shape) so it is unit
  * testable without importing the whole service worker.

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -14,6 +14,8 @@ import {
   removeEntry as removeCreatorAllowlistEntry,
 } from "../lib/creator-allowlist.js";
 import { GENERIC_SHORTENERS } from "../lib/native-shortener-resolver.js";
+import { GUARDED_PREFS } from "../lib/synced-affiliate-pref-guard.js";
+import { reconcileOverrideForExplicitChoice } from "../lib/per-device-prefs.js";
 import { createMutex, withSyncMutation } from "./sync-mutation.js";
 
 let _currentLang = "en";
@@ -225,7 +227,19 @@ function bindToggle(id, key, prefs) {
   if (!el) return;
   el.checked = prefs[key];
   el.addEventListener("change", () => {
-    try { setPrefs({ [key]: el.checked }); } catch (err) { console.error("[MUGA] save toggle:", err); }
+    try {
+      setPrefs({ [key]: el.checked });
+      // Guarded prefs (injectOwnAffiliate, remoteRulesEnabled) may carry a
+      // per-device override that getPrefs() overlays LAST. An explicit Settings
+      // toggle is this device's authoritative choice, so reconcile the override
+      // to match — otherwise a stale onboarding-decline override keeps winning
+      // and the toggle silently reverts on reload (#888 follow-up). Membership-
+      // gated so non-guarded toggles never touch the override map.
+      if (GUARDED_PREFS.includes(key)) {
+        reconcileOverrideForExplicitChoice(key, el.checked)
+          .catch(err => console.error("[MUGA] reconcile override:", err));
+      }
+    } catch (err) { console.error("[MUGA] save toggle:", err); }
   });
 }
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -4,7 +4,7 @@
 
 import { applyTranslations, getStoredLang, t, SUPPORTED_LANGS } from "../lib/i18n.js";
 import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates.js";
-import { PREF_DEFAULTS, setPrefs, getDevMode, setDevMode, getShortenerStats } from "../lib/storage.js";
+import { PREF_DEFAULTS, getPrefs, setPrefs, getDevMode, setDevMode, getShortenerStats } from "../lib/storage.js";
 import { getConsent } from "../lib/consent-storage.js";
 import { isFirefox as detectFirefox } from "../lib/browser-detect.js";
 import { isValidListEntry, isValidCustomParam, capImportedLists, IMPORT_LIST_CAPS } from "../lib/validation.js";
@@ -98,8 +98,14 @@ async function init() {
   _currentLang = await getStoredLang();
   applyTranslations(_currentLang);
 
+  // Initial toggle state MUST come from the canonical merged prefs (sync +
+  // consent + per-device overrides), NOT a raw sync read. A raw sync read
+  // ignores per-device overrides (per-device-prefs), so a toggle like
+  // injectOwnAffiliate or remoteRulesEnabled could DISPLAY a value that
+  // disagrees with the effective value getPrefs() gives the rest of the
+  // extension (#888 follow-up).
   let prefs;
-  try { prefs = await chrome.storage.sync.get(PREF_DEFAULTS); } catch (err) { console.error("[MUGA] load prefs:", err); prefs = { ...PREF_DEFAULTS }; }
+  try { prefs = await getPrefs(); } catch (err) { console.error("[MUGA] load prefs:", err); prefs = { ...PREF_DEFAULTS }; }
 
   // --- Consent gate: redirect to onboarding if user hasn't accepted ToS ---
   // Consent fields moved out of chrome.storage.sync into chrome.storage.local

--- a/tests/e2e/remote-rules.spec.mjs
+++ b/tests/e2e/remote-rules.spec.mjs
@@ -163,8 +163,13 @@ test.describe("Remote rules — E2E", () => {
       // Remote-rules section must be visible on Chrome (supports alarms + DNR)
       await expect(page.locator("#remote-rules-section")).not.toBeHidden();
 
-      // Status block starts hidden (toggle is off by default)
-      await expect(page.locator("#remote-rules-status")).toBeHidden();
+      // Remote rule updates default ON (#888): the toggle renders CHECKED and
+      // the status block is visible from load (showing "never fetched" until
+      // the first fetch runs). This asserts the display matches the effective
+      // getPrefs() value — the #888 follow-up fix. Previously the handler read
+      // sync with a hardcoded `false` default and rendered the toggle OFF here.
+      await expect(page.locator("#remote-rules-toggle")).toBeChecked();
+      await expect(page.locator("#remote-rules-status")).not.toBeHidden();
 
       // Grant host permission from the options page (avoids interactive dialog)
       await grantHostPermission(page);

--- a/tests/unit/options-display-prefs.test.mjs
+++ b/tests/unit/options-display-prefs.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * MUGA — Settings initial toggle state == effective getPrefs() value (#888 follow-up)
+ *
+ * Secondary defect (same architectural root as the remote-rules one): the
+ * options page read its initial toggle state from a RAW
+ *   chrome.storage.sync.get(PREF_DEFAULTS)
+ * which never overlays per-device overrides (per-device-prefs.getOverrides()),
+ * unlike the canonical getPrefs(). So a toggle with a per-device override —
+ * injectOwnAffiliate or remoteRulesEnabled — could DISPLAY a value that
+ * disagrees with the effective value the rest of the extension uses.
+ *
+ * The fix makes init() read from getPrefs(). These tests:
+ *   1. Pin the canonical merge behaviour (getPrefs overlays per-device
+ *      overrides for both injectOwnAffiliate and remoteRulesEnabled), so the
+ *      value the fixed Settings read renders is the effective one.
+ *   2. Source-guard options.js so the initial read cannot regress back to the
+ *      raw sync read that ignored overrides.
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dir, "../..");
+
+function installChromeStub() {
+  const localStore = new Map();
+  const syncStore = new Map();
+
+  const makeArea = (store) => ({
+    get: (defaults, cb) => {
+      const result = {};
+      if (typeof defaults === "string") {
+        result[defaults] = store.has(defaults) ? store.get(defaults) : undefined;
+      } else if (defaults && typeof defaults === "object") {
+        for (const [k, v] of Object.entries(defaults)) {
+          result[k] = store.has(k) ? store.get(k) : v;
+        }
+      }
+      if (cb) { cb(result); return; }
+      return Promise.resolve(result);
+    },
+    set: (data, cb) => {
+      for (const [k, v] of Object.entries(data)) store.set(k, v);
+      if (cb) cb();
+      return Promise.resolve();
+    },
+    remove: (keys, cb) => {
+      const arr = Array.isArray(keys) ? keys : [keys];
+      for (const k of arr) store.delete(k);
+      if (cb) cb();
+      return Promise.resolve();
+    },
+  });
+
+  globalThis.chrome = {
+    storage: { local: makeArea(localStore), sync: makeArea(syncStore) },
+    runtime: { lastError: null },
+  };
+  return { localStore, syncStore };
+}
+
+async function freshGetPrefs() {
+  const mod = await import("../../src/lib/prefs.js?cb=" + Math.random());
+  return mod.getPrefs;
+}
+async function freshPerDevice() {
+  return await import("../../src/lib/per-device-prefs.js?cb=" + Math.random());
+}
+
+describe("canonical merged prefs — the value Settings must display", () => {
+  let stores;
+  beforeEach(() => { stores = installChromeStub(); });
+
+  test("injectOwnAffiliate: per-device override false wins over an absent/true sync value", async () => {
+    // Device B: user declined a sync-inherited injectOwnAffiliate prompt.
+    const perDevice = await freshPerDevice();
+    await perDevice.setOverrides({ injectOwnAffiliate: false });
+    stores.syncStore.set("injectOwnAffiliate", true); // sync says ON
+
+    const getPrefs = await freshGetPrefs();
+    const prefs = await getPrefs();
+    assert.strictEqual(
+      prefs.injectOwnAffiliate, false,
+      "getPrefs must reflect the per-device override; Settings must render OFF to match"
+    );
+  });
+
+  test("remoteRulesEnabled: per-device override false wins over the true default", async () => {
+    const perDevice = await freshPerDevice();
+    await perDevice.setOverrides({ remoteRulesEnabled: false });
+    // sync absent → default true; override must still win.
+
+    const getPrefs = await freshGetPrefs();
+    const prefs = await getPrefs();
+    assert.strictEqual(prefs.remoteRulesEnabled, false);
+  });
+
+  test("no override → getPrefs returns the sync/default value unchanged", async () => {
+    const getPrefs = await freshGetPrefs();
+    const prefs = await getPrefs();
+    assert.strictEqual(prefs.injectOwnAffiliate, false, "default");
+    assert.strictEqual(prefs.remoteRulesEnabled, true, "default");
+  });
+});
+
+describe("options.js source guard — initial toggle read uses canonical getPrefs()", () => {
+  const optionsJs = readFileSync(join(ROOT, "src/options/options.js"), "utf8");
+
+  test("init() reads initial prefs via getPrefs(), not a raw sync.get(PREF_DEFAULTS)", () => {
+    // Isolate the init() body: from `async function init()` to the next top-level function.
+    const initStart = optionsJs.indexOf("async function init()");
+    assert.ok(initStart !== -1, "init() must exist");
+    const initEnd = optionsJs.indexOf("\nfunction bindToggle(", initStart);
+    const initBody = optionsJs.slice(initStart, initEnd === -1 ? undefined : initEnd);
+
+    assert.ok(
+      /await getPrefs\(\)/.test(initBody),
+      "init() must load the initial toggle state from getPrefs() (merges per-device overrides)"
+    );
+    assert.ok(
+      !/chrome\.storage\.sync\.get\(PREF_DEFAULTS\)/.test(initBody),
+      "init() must NOT read the initial toggle state from a raw chrome.storage.sync.get(PREF_DEFAULTS)"
+    );
+  });
+
+  test("options.js imports getPrefs", () => {
+    assert.ok(
+      /import\s*\{[^}]*\bgetPrefs\b[^}]*\}\s*from\s*["']\.\.\/lib\/storage\.js["']/.test(optionsJs),
+      "options.js must import getPrefs from storage.js"
+    );
+  });
+});

--- a/tests/unit/options-display-prefs.test.mjs
+++ b/tests/unit/options-display-prefs.test.mjs
@@ -99,6 +99,33 @@ describe("canonical merged prefs — the value Settings must display", () => {
     assert.strictEqual(prefs.remoteRulesEnabled, false);
   });
 
+  test("injectOwnAffiliate display: the value init() renders equals getPrefs(), not the raw sync value", async () => {
+    // Device declined the sync-inherited injectOwnAffiliate prompt (override=false)
+    // while sync says ON. init() renders the toggle from `prefs[key]` where
+    // `prefs = await getPrefs()` (see options.js init + bindToggle). The OLD
+    // buggy read used a raw chrome.storage.sync.get(PREF_DEFAULTS), which would
+    // have rendered ON. This proves the two disagree and the fix must pick the
+    // merged (override-honored) value.
+    const perDevice = await freshPerDevice();
+    await perDevice.setOverrides({ injectOwnAffiliate: false });
+    stores.syncStore.set("injectOwnAffiliate", true);
+
+    // What the OLD code read (raw sync, ignoring overrides).
+    const rawSync = await new Promise((resolve) =>
+      globalThis.chrome.storage.sync.get({ injectOwnAffiliate: false }, resolve));
+
+    // What init() now renders: the effective getPrefs() value.
+    const getPrefs = await freshGetPrefs();
+    const rendered = (await getPrefs()).injectOwnAffiliate;
+
+    assert.strictEqual(rawSync.injectOwnAffiliate, true, "raw sync read (old path) says ON");
+    assert.strictEqual(rendered, false, "getPrefs (new path) honors the per-device override → renders OFF");
+    assert.notStrictEqual(
+      rendered, rawSync.injectOwnAffiliate,
+      "the fix matters: the effective value the toggle renders must differ from the raw sync value"
+    );
+  });
+
   test("no override → getPrefs returns the sync/default value unchanged", async () => {
     const getPrefs = await freshGetPrefs();
     const prefs = await getPrefs();

--- a/tests/unit/options-write-path-override.test.mjs
+++ b/tests/unit/options-write-path-override.test.mjs
@@ -1,0 +1,171 @@
+/**
+ * MUGA — Explicit Settings toggle of a guarded pref must clear its per-device
+ * override so the choice STICKS (#888 follow-up, write path).
+ *
+ * Root cause: the Settings write paths write only chrome.storage.sync (via
+ * setPrefs) and never touch the per-device override (mugaPerDevicePrefs,
+ * chrome.storage.local). getPrefs() overlays per-device overrides LAST
+ * (prefs.js `{...sync, ...overlay, ...overrides}`), so a user who declined a
+ * sync-inherited prompt during onboarding (override=false) sees the toggle
+ * correctly OFF, flips it ON in Settings, setPrefs writes sync=true, but
+ * getPrefs still returns false (the stale override wins) — the toggle reverts
+ * on reload and the behaviour never changes.
+ *
+ * Fix: an explicit Settings toggle is this device's authoritative choice, so
+ * reconcileOverrideForExplicitChoice() records the override to match the chosen
+ * value for GUARDED_PREFS only. These are genuine behavioural tests: they drive
+ * the real reconcile helper + getPrefs merge and assert the effective value.
+ *
+ * The two wiring sites (options.js bindToggle for injectOwnAffiliate;
+ * service-worker.js ENABLE/DISABLE_REMOTE_RULES) are browser-only and covered
+ * by source guards below, matching the codebase's established pattern.
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dir, "../..");
+
+function installChromeStub() {
+  const localStore = new Map();
+  const syncStore = new Map();
+
+  const makeArea = (store) => ({
+    get: (defaults, cb) => {
+      const result = {};
+      if (typeof defaults === "string") {
+        result[defaults] = store.has(defaults) ? store.get(defaults) : undefined;
+      } else if (defaults && typeof defaults === "object") {
+        for (const [k, v] of Object.entries(defaults)) {
+          result[k] = store.has(k) ? store.get(k) : v;
+        }
+      }
+      if (cb) { cb(result); return; }
+      return Promise.resolve(result);
+    },
+    set: (data, cb) => {
+      for (const [k, v] of Object.entries(data)) store.set(k, v);
+      if (cb) cb();
+      return Promise.resolve();
+    },
+    remove: (keys, cb) => {
+      const arr = Array.isArray(keys) ? keys : [keys];
+      for (const k of arr) store.delete(k);
+      if (cb) cb();
+      return Promise.resolve();
+    },
+  });
+
+  globalThis.chrome = {
+    storage: { local: makeArea(localStore), sync: makeArea(syncStore) },
+    runtime: { lastError: null },
+  };
+  return { localStore, syncStore };
+}
+
+async function freshPrefs() {
+  return await import("../../src/lib/prefs.js?cb=" + Math.random());
+}
+async function freshPerDevice() {
+  return await import("../../src/lib/per-device-prefs.js?cb=" + Math.random());
+}
+
+describe("write path — explicit Settings toggle reconciles the per-device override", () => {
+  beforeEach(() => { installChromeStub(); });
+
+  test("injectOwnAffiliate: enabling ON with a pre-existing override=false makes getPrefs() return true (sticks)", async () => {
+    const perDevice = await freshPerDevice();
+    // Device declined the sync-inherited prompt during onboarding.
+    await perDevice.setOverrides({ injectOwnAffiliate: false });
+
+    // Simulate the Settings write path: setPrefs writes sync ...
+    const prefs = await freshPrefs();
+    await prefs.setPrefs({ injectOwnAffiliate: true });
+
+    // ... and (the fix) the explicit choice reconciles the per-device override.
+    await perDevice.reconcileOverrideForExplicitChoice("injectOwnAffiliate", true);
+
+    const effective = await prefs.getPrefs();
+    assert.strictEqual(
+      effective.injectOwnAffiliate, true,
+      "after an explicit Settings enable, getPrefs must return true — the stale override must not win"
+    );
+  });
+
+  test("remoteRulesEnabled: enabling ON with a pre-existing override=false makes getPrefs() return true (sticks)", async () => {
+    const perDevice = await freshPerDevice();
+    await perDevice.setOverrides({ remoteRulesEnabled: false });
+
+    const prefs = await freshPrefs();
+    await prefs.setPrefs({ remoteRulesEnabled: true });
+    await perDevice.reconcileOverrideForExplicitChoice("remoteRulesEnabled", true);
+
+    const effective = await prefs.getPrefs();
+    assert.strictEqual(effective.remoteRulesEnabled, true);
+  });
+
+  test("remoteRulesEnabled: disabling OFF with a pre-existing override=true makes getPrefs() return false (sticks)", async () => {
+    const perDevice = await freshPerDevice();
+    await perDevice.setOverrides({ remoteRulesEnabled: true });
+
+    const prefs = await freshPrefs();
+    await prefs.setPrefs({ remoteRulesEnabled: false });
+    await perDevice.reconcileOverrideForExplicitChoice("remoteRulesEnabled", false);
+
+    const effective = await prefs.getPrefs();
+    assert.strictEqual(effective.remoteRulesEnabled, false);
+  });
+
+  test("non-guarded key is a no-op — no per-device override is written, no throw", async () => {
+    const perDevice = await freshPerDevice();
+    // dnrEnabled is a normal synced pref, NOT in GUARDED_PREFS.
+    await perDevice.reconcileOverrideForExplicitChoice("dnrEnabled", true);
+
+    const overrides = await perDevice.getOverrides();
+    assert.deepStrictEqual(
+      overrides, {},
+      "reconcile must not smuggle non-guarded keys into the per-device override map"
+    );
+  });
+});
+
+describe("write path — source guards for the browser-only wiring sites", () => {
+  const optionsJs = readFileSync(join(ROOT, "src/options/options.js"), "utf8");
+  const swSource = readFileSync(join(ROOT, "src/background/service-worker.js"), "utf8");
+
+  test("options.js bindToggle reconciles guarded prefs (membership-gated, not blanket)", () => {
+    const start = optionsJs.indexOf("function bindToggle(");
+    assert.ok(start !== -1, "bindToggle must exist");
+    const end = optionsJs.indexOf("\nfunction ", start + 1);
+    const body = optionsJs.slice(start, end === -1 ? undefined : end);
+
+    assert.ok(
+      /GUARDED_PREFS/.test(body),
+      "bindToggle must gate the reconcile on GUARDED_PREFS membership (not blanket-clear every toggle)"
+    );
+    assert.ok(
+      /reconcileOverrideForExplicitChoice/.test(body),
+      "bindToggle must reconcile the per-device override for guarded prefs so the choice sticks"
+    );
+  });
+
+  test("service-worker ENABLE_REMOTE_RULES reconciles the remoteRulesEnabled override to true", () => {
+    const body = swSource.match(/"ENABLE_REMOTE_RULES"[\s\S]*?"DISABLE_REMOTE_RULES"/)?.[0] || "";
+    assert.ok(
+      /reconcileOverrideForExplicitChoice\(\s*["']remoteRulesEnabled["']\s*,\s*true/.test(body),
+      "ENABLE_REMOTE_RULES must reconcile the per-device override to true"
+    );
+  });
+
+  test("service-worker DISABLE_REMOTE_RULES reconciles the remoteRulesEnabled override to false", () => {
+    const body = swSource.match(/"DISABLE_REMOTE_RULES"[\s\S]*?"GET_REMOTE_RULES_STATUS"/)?.[0] || "";
+    assert.ok(
+      /reconcileOverrideForExplicitChoice\(\s*["']remoteRulesEnabled["']\s*,\s*false/.test(body),
+      "DISABLE_REMOTE_RULES must reconcile the per-device override to false"
+    );
+  });
+});

--- a/tests/unit/remote-rules-status.test.mjs
+++ b/tests/unit/remote-rules-status.test.mjs
@@ -1,0 +1,159 @@
+/**
+ * MUGA — GET_REMOTE_RULES_STATUS reports the CANONICAL effective value (#888 follow-up)
+ *
+ * Regression for the bug where the Settings "remote rule updates" toggle showed
+ * OFF even though the user had it ON (default) and the weekly fetch was running.
+ *
+ * Root cause: the service-worker handler read
+ *   chrome.storage.sync.get({ remoteRulesEnabled: false })
+ * with a hardcoded `false` default that contradicts
+ *   PREF_DEFAULTS.remoteRulesEnabled === true.
+ * On a fresh install the key is never written, so the handler reported `false`
+ * while getPrefs() (the value the extension actually uses) reported `true`.
+ *
+ * The fix routes the handler through buildRemoteRulesStatus({ getPrefs, ... }),
+ * so `enabled` always equals the effective getPrefs() value — including any
+ * per-device override.
+ *
+ * These tests exercise the extracted helper against the REAL getPrefs() with an
+ * in-memory chrome stub, plus a source guard on the service worker so the
+ * hardcoded-default anti-pattern cannot silently return.
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dir, "../..");
+
+import { buildRemoteRulesStatus } from "../../src/lib/remote-rules-status.js";
+import { PREF_DEFAULTS } from "../../src/lib/prefs.js";
+
+// In-memory chrome stub. `get` supports BOTH callback style (used by getPrefs /
+// getConsent / getOverrides / getTestFixtures internally) AND promise style
+// (used by buildRemoteRulesStatus's `await local.get(...)`).
+function installChromeStub() {
+  const localStore = new Map();
+  const syncStore = new Map();
+
+  const makeArea = (store) => ({
+    get: (defaults, cb) => {
+      const result = {};
+      if (typeof defaults === "string") {
+        result[defaults] = store.has(defaults) ? store.get(defaults) : undefined;
+      } else if (defaults && typeof defaults === "object") {
+        for (const [k, v] of Object.entries(defaults)) {
+          result[k] = store.has(k) ? store.get(k) : v;
+        }
+      }
+      if (cb) { cb(result); return; }
+      return Promise.resolve(result);
+    },
+    set: (data, cb) => {
+      for (const [k, v] of Object.entries(data)) store.set(k, v);
+      if (cb) cb();
+      return Promise.resolve();
+    },
+    remove: (keys, cb) => {
+      const arr = Array.isArray(keys) ? keys : [keys];
+      for (const k of arr) store.delete(k);
+      if (cb) cb();
+      return Promise.resolve();
+    },
+  });
+
+  globalThis.chrome = {
+    storage: { local: makeArea(localStore), sync: makeArea(syncStore) },
+    runtime: { lastError: null },
+  };
+  return { localStore, syncStore, local: makeArea(localStore) };
+}
+
+// Fresh module graph per test so per-device-prefs / consent modules re-bind to
+// the freshly installed chrome stub.
+async function freshGetPrefs() {
+  const mod = await import("../../src/lib/prefs.js?cb=" + Math.random());
+  return mod.getPrefs;
+}
+
+describe("buildRemoteRulesStatus — enabled equals the effective getPrefs() value", () => {
+  let stores;
+
+  beforeEach(() => {
+    stores = installChromeStub();
+  });
+
+  test("PREF_DEFAULTS.remoteRulesEnabled is true (guards the whole premise)", () => {
+    assert.strictEqual(PREF_DEFAULTS.remoteRulesEnabled, true);
+  });
+
+  test("fresh install (no remoteRulesEnabled key in sync) reports enabled: true", async () => {
+    // Nothing written to sync — the fresh-install condition that triggered the bug.
+    const getPrefs = await freshGetPrefs();
+    const status = await buildRemoteRulesStatus({
+      getPrefs,
+      local: stores.local,
+      hasDNR: true,
+    });
+    assert.strictEqual(
+      status.enabled, true,
+      "on a fresh install the toggle must render ON, matching the true default and the running fetch"
+    );
+    // And it must equal the canonical effective value.
+    const effective = (await getPrefs()).remoteRulesEnabled;
+    assert.strictEqual(status.enabled, effective, "reported enabled must equal getPrefs().remoteRulesEnabled");
+  });
+
+  test("per-device override remoteRulesEnabled=false reports enabled: false", async () => {
+    // A user declined the sync-inherited prompt on this device: local override wins.
+    const perDevice = await import("../../src/lib/per-device-prefs.js?cb=" + Math.random());
+    await perDevice.setOverrides({ remoteRulesEnabled: false });
+    // Sync still says absent/true — the pre-fix raw read would ignore the override.
+    stores.syncStore.set("remoteRulesEnabled", true);
+
+    const getPrefs = await freshGetPrefs();
+    const status = await buildRemoteRulesStatus({
+      getPrefs,
+      local: stores.local,
+      hasDNR: true,
+    });
+    assert.strictEqual(
+      status.enabled, false,
+      "a per-device override must win — display must match getPrefs()"
+    );
+    assert.strictEqual(status.enabled, (await getPrefs()).remoteRulesEnabled);
+  });
+
+  test("passes through local meta / remoteParams and supportsDNR", async () => {
+    stores.localStore.set("remoteParams", ["remote_x"]);
+    stores.localStore.set("remoteRulesMeta", { version: 3, fetchedAt: "2026-07-01T00:00:00Z", paramCount: 1, lastError: null, published: "2026-06-30T00:00:00Z" });
+
+    const getPrefs = await freshGetPrefs();
+    const status = await buildRemoteRulesStatus({ getPrefs, local: stores.local, hasDNR: false });
+    assert.deepEqual(status.remoteParams, ["remote_x"]);
+    assert.strictEqual(status.meta.version, 3);
+    assert.strictEqual(status.supportsDNR, false);
+    assert.strictEqual(status.ok, true);
+  });
+});
+
+describe("service-worker source guard — no hardcoded remote-rules default", () => {
+  const swSrc = readFileSync(join(ROOT, "src/background/service-worker.js"), "utf8");
+
+  test("GET_REMOTE_RULES_STATUS no longer reads sync with a hardcoded false default", () => {
+    assert.ok(
+      !/sync\.get\(\{\s*remoteRulesEnabled:\s*false\s*\}\)/.test(swSrc),
+      "the hardcoded { remoteRulesEnabled: false } sync read must be gone (it contradicted PREF_DEFAULTS)"
+    );
+  });
+
+  test("the handler builds its reply via buildRemoteRulesStatus", () => {
+    assert.ok(
+      swSrc.includes("buildRemoteRulesStatus"),
+      "the SW must route GET_REMOTE_RULES_STATUS through buildRemoteRulesStatus (canonical getPrefs value)"
+    );
+  });
+});

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -620,17 +620,27 @@ describe("T2.3 — Message handler source patterns", () => {
     );
   });
 
-  test("GET_REMOTE_RULES_STATUS responds with enabled, meta, supportsDNR", () => {
-    // supportsAlarms was retired in #706 — zero consumers across the codebase.
-    // The field had been kept "for backwards compat with any cached UI bundle"
-    // but no such bundle existed; the assertion that pinned it was zombie code.
+  test("GET_REMOTE_RULES_STATUS delegates to buildRemoteRulesStatus (canonical getPrefs value)", () => {
+    // #888 follow-up: the reply (enabled/meta/remoteParams/supportsDNR) is now
+    // built by src/lib/remote-rules-status.js so `enabled` reflects the
+    // CANONICAL effective value via getPrefs() instead of a hardcoded sync
+    // default. The field-level shape is pinned in remote-rules-status.test.mjs.
+    // supportsAlarms was retired in #706 — zero consumers; it must not return.
     const statusPos = swSource.indexOf('"GET_REMOTE_RULES_STATUS"');
     const statusBlock = swSource.slice(statusPos, statusPos + 1500);
-    assert.ok(statusBlock.includes("supportsDNR"), "status must include supportsDNR (REQ-UI-5)");
-    assert.ok(statusBlock.includes("enabled"), "status must include enabled flag");
+    assert.ok(
+      statusBlock.includes("buildRemoteRulesStatus"),
+      "handler must delegate to buildRemoteRulesStatus (single source of truth via getPrefs)"
+    );
+    assert.ok(statusBlock.includes("getPrefs"), "handler must pass getPrefs so enabled is the effective value");
+    assert.ok(statusBlock.includes("hasDNR"), "handler must pass hasDNR for the supportsDNR feature-detect (REQ-UI-5)");
     assert.ok(
       !statusBlock.includes("supportsAlarms"),
       "supportsAlarms must NOT be reintroduced — retired in #706 (zero consumers)"
+    );
+    assert.ok(
+      !/sync\.get\(\{\s*remoteRulesEnabled:\s*false\s*\}\)/.test(statusBlock),
+      "the hardcoded { remoteRulesEnabled: false } sync default must be gone"
     );
   });
 

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -613,7 +613,9 @@ describe("T2.3 — Message handler source patterns", () => {
 
   test("ENABLE_REMOTE_RULES handler triggers immediate runRemoteRulesFetch", () => {
     const enablePos = swSource.indexOf('"ENABLE_REMOTE_RULES"');
-    const enableBlock = swSource.slice(enablePos, enablePos + 600);
+    // Window widened (600 → 1200) after the handler grew a per-device override
+    // reconcile step + comment ahead of the immediate fetch (#888 write path).
+    const enableBlock = swSource.slice(enablePos, enablePos + 1200);
     assert.ok(
       enableBlock.includes("runRemoteRulesFetch"),
       "ENABLE handler must call runRemoteRulesFetch for immediate first fetch (REQ-OPT-3)"

--- a/tests/unit/source-grep-ratchet.test.mjs
+++ b/tests/unit/source-grep-ratchet.test.mjs
@@ -138,6 +138,7 @@ const BASELINE = {
   "docs-prefs-table.test.mjs": 1,          // reads storage source to verify docs table (#824)
   "shortener-stats-race.test.mjs": 1,      // reads SW source for regression guard (#824)
   "shortener-stats.test.mjs": 1,           // reads SW source for regression guard (#824)
+  "options-write-path-override.test.mjs": 2, // SW ENABLE/DISABLE_REMOTE_RULES handlers not importable in Node; 2 guards pin the reconcile wiring (#888 write-path follow-up, #824)
 };
 
 // ── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Fixes a Settings display + write-path bug for the guarded privacy prefs (`remoteRulesEnabled`, `injectOwnAffiliate`).

**Reported symptom:** a user enabled "remote rule updates" during onboarding, but the Settings toggle showed OFF.

## Root cause

Settings read initial toggle state via raw `chrome.storage.sync` with an ad-hoc default, bypassing the canonical `getPrefs()` merge (sync + consent overlay + per-device overrides):

- `GET_REMOTE_RULES_STATUS` used `chrome.storage.sync.get({ remoteRulesEnabled: false })` — a hardcoded `false` contradicting `PREF_DEFAULTS.remoteRulesEnabled = true`. On a fresh install the key is never written (the accept path relies on the default), so the read returned `false` and the toggle rendered OFF while the pref was effectively `true` everywhere else. Missed spot from the #888 default flip.
- `options.js init()` read raw sync and never merged per-device overrides, so both `remoteRulesEnabled` and `injectOwnAffiliate` could display a value disagreeing with the effective `getPrefs()` value.

## Fix

1. **Display** — route Settings reads through the canonical `getPrefs()`. New `src/lib/remote-rules-status.js` (`buildRemoteRulesStatus`) is the single source of truth for the status handler; `options.js init()` derives initial toggle state from `getPrefs()`. Now Settings shows the effective value, including per-device overrides. (`187f525`, `d26a86d`)
2. **Write-path** — an explicit Settings toggle of a guarded pref now reconciles its per-device override to the chosen value (`reconcileOverrideForExplicitChoice`, GUARDED_PREFS-gated). Previously the toggle reverted on reload for onboarding-decliner users, because `getPrefs()` overlays per-device overrides last, so a `setPrefs` sync write alone was masked. Semantics: reconcile/pin the choice per-device, consistent with the #364 privacy guard (these prefs must not silently flip from another device's sync). (`0ab9b11`)
3. Behavioral coverage for the `injectOwnAffiliate` display path, and corrected two comments that overstated the fresh-install fetch (the signed fetch only starts once the `rules.muga.app` optional host permission is granted via the toggle). (`7a1b894`, `c87331c`)

## Tests

- Unit: 5484 pass, 0 fail
- e2e: 107 pass, 3 skip, 0 fail
- eslint / web-ext lint / typecheck / i18n check: clean
- Fail-without-fix proven for both the display and write-path regressions.
- Reviewed by a fresh adversarial pass: SHIP, no must-fix.

No user-facing copy changed.
