### PR TITLE
feat(copy): copy-safe URLs on all copy/share surfaces (#946)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -290,15 +290,24 @@ _hydrateAttributionLedger();
  * @param {string} rawUrl
  * @param {object} result - return value from processUrl
  * @param {object} prefs  - cached prefs (already resolved)
+ * @param {string} [referrer] - navigation referrer (#452/B14), threaded
+ *   through so fromCleanerResult can reprocess an `injected` result with
+ *   the same referrer context when deriving the tagless copy-safe URL (#946).
  */
-function pushAttributionAndPersist(rawUrl, result, prefs) {
+function pushAttributionAndPersist(rawUrl, result, prefs, referrer = "") {
   // Privacy gate: skip both in-memory accumulation AND storage write so
   // a user who flips the toggle off mid-session sees the ring buffer
   // freeze immediately.
   if (prefs?.attributionLedgerEnabled === false) return;
   let event;
   try {
-    event = attributionEventFromCleanerResult(rawUrl, result);
+    // #946: ctx lets fromCleanerResult reprocess `injected` results with
+    // injectOwnAffiliate forced off, so the ledger never stores a
+    // MUGA-tagged URL. domainRules/pathStripRules/pathAffiliateRules are
+    // the same module-level caches handleProcessUrl() itself uses.
+    event = attributionEventFromCleanerResult(rawUrl, result, {
+      prefs, domainRules, pathStripRules, pathAffiliateRules, referrer,
+    });
   } catch (err) {
     console.warn("[MUGA] attribution: fromCleanerResult failed:", err);
     return;
@@ -1535,7 +1544,7 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
   // #460 (A2): mirror the cleaner outcome into the Attribution Ledger
   // so the popup's "Recent activity" section can render. Fire-and-forget
   // so a write hiccup never affects the caller's URL processing.
-  pushAttributionAndPersist(rawUrl, result, prefs);
+  pushAttributionAndPersist(rawUrl, result, prefs, referrer);
 
   return result;
 }

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -250,12 +250,19 @@
 
       const domainRules = _domainRulesCache || [];
       const pathRules = _pathRulesCache || { pathStripRules: [], pathAffiliateRules: [] };
+      // Copy-safe prefs (#946): the user is copying, not navigating, so
+      // MUGA must never inject its own affiliate tag nor surface the
+      // foreign-affiliate toast on a copy action. Mirrors the effectivePrefs
+      // pattern in background/service-worker.js#handleProcessUrl (skipNotify
+      // branch) — third-party attribution tags are still preserved, only
+      // MUGA's own injection + notification are suppressed.
+      const copyPrefs = { ..._contentPrefs, notifyForeignAffiliate: false, injectOwnAffiliate: false };
       const urlMap = new Map();
       for (const url of allUrls) {
         let r;
         try {
           r = window.__mugaCleaner.processUrl(
-            url, _contentPrefs, domainRules,
+            url, copyPrefs, domainRules,
             undefined, undefined, undefined,
             pathRules.pathStripRules, pathRules.pathAffiliateRules,
           );
@@ -350,6 +357,10 @@
       const sortedMatches = [...matches].sort((a, b) => b[0].length - a[0].length);
       const domainRules = _domainRulesCache || [];
       const pathRules = _pathRulesCache || { pathStripRules: [], pathAffiliateRules: [] };
+      // Copy-safe prefs (#946): same rationale as the GET_AND_COPY_CLEAN_SELECTION
+      // handler above — Ctrl+C is a copy action, not a navigation, so MUGA's own
+      // affiliate injection and the foreign-affiliate toast must both be suppressed.
+      const copyPrefs = { ..._contentPrefs, notifyForeignAffiliate: false, injectOwnAffiliate: false };
       let resultText = trimmed;
       let totalJunkRemoved = 0;
       const allRemovedTracking = [];
@@ -359,7 +370,7 @@
         let r;
         try {
           r = window.__mugaCleaner.processUrl(
-            cleanCandidate, _contentPrefs, domainRules,
+            cleanCandidate, copyPrefs, domainRules,
             undefined, undefined, undefined,
             pathRules.pathStripRules, pathRules.pathAffiliateRules,
           );

--- a/src/lib/attribution-ledger.js
+++ b/src/lib/attribution-ledger.js
@@ -22,6 +22,8 @@
  * user switches language without rebuilding event history.
  */
 
+import { processUrl } from "./cleaner.js";
+
 /** Default size of the ledger ring buffer. Caps how many events the popup ever renders. */
 export const DEFAULT_LEDGER_CAPACITY = 10;
 
@@ -122,17 +124,61 @@ export function presentLedger(ledger) {
 }
 
 /**
+ * Re-derives the tag-free destination for an `injected` result (#946).
+ *
+ * `processUrl()` does not produce a tagless value on a normal injecting
+ * call — the tag is added in the same pass that strips tracking params, so
+ * there is no intermediate "clean but not yet tagged" URL to read off the
+ * result object. Rather than regex-stripping MUGA's tag back out of
+ * `result.cleanUrl` (fragile: tag param names/positions vary per pattern),
+ * we reprocess the ORIGINAL raw URL through the same pipeline with
+ * `injectOwnAffiliate` forced off. This is the same principled approach
+ * background/service-worker.js#handleProcessUrl already uses for its
+ * copy-safe `effectivePrefs` (skipNotify branch) — single source of truth
+ * for "what would this URL look like if MUGA never injected its own tag".
+ *
+ * Falls back to `rawUrl` (the pre-injection original — guaranteed free of
+ * MUGA's tag by construction, though not guaranteed to have tracking
+ * params stripped) when `ctx` is missing or reprocessing throws. This only
+ * matters for callers that don't supply a `ctx` (e.g. isolated unit
+ * tests) — the production caller (pushAttributionAndPersist) always does.
+ *
+ * @param {string} rawUrl
+ * @param {{prefs?: object, domainRules?: Array, pathStripRules?: Array, pathAffiliateRules?: Array, referrer?: string}|undefined} ctx
+ * @returns {string}
+ */
+function deriveTaglessUrl(rawUrl, ctx) {
+  if (!ctx || typeof ctx !== "object" || !ctx.prefs) return rawUrl;
+  try {
+    const tagless = processUrl(
+      rawUrl,
+      { ...ctx.prefs, injectOwnAffiliate: false },
+      ctx.domainRules || [],
+      undefined,
+      undefined,
+      ctx.referrer,
+      ctx.pathStripRules || [],
+      ctx.pathAffiliateRules || [],
+    );
+    return tagless?.cleanUrl ?? rawUrl;
+  } catch {
+    return rawUrl;
+  }
+}
+
+/**
  * Adapts a `processUrl()` result object into a presenter event. Returns
  * null when the action is unrecognized so callers can skip without
  * polluting the ledger with garbage entries.
  *
- * Action mapping:
- *   `untouched`        → navigate         (URL passed through unchanged)
- *   `cleaned`          → clean            (tracking params stripped)
- *   `blacklisted`      → clean            (params stripped via blacklist)
- *   `injected`         → inject-affiliate (our tag added; network from preservedAffiliate.group)
- *   `detected_foreign` → preserve-affiliate (third-party tag preserved; network from detectedAffiliate.pattern.group)
- *   `honored-creator`  → honor-creator    (wrapper passed through; network + creator)
+ * Action mapping (#946 — every `url` here is a COPY-SAFE value: tracking
+ * stripped, no MUGA-injected tag, third-party creator attribution intact):
+ *   `untouched`        → navigate         (URL passed through unchanged; rawUrl)
+ *   `cleaned`          → clean            (result.cleanUrl — tracking stripped)
+ *   `blacklisted`      → clean            (result.cleanUrl — params stripped via blacklist)
+ *   `injected`         → inject-affiliate (tagless destination, see deriveTaglessUrl; network from preservedAffiliate.group)
+ *   `detected_foreign` → preserve-affiliate (result.cleanUrl — third-party tag preserved; network from detectedAffiliate.pattern.group)
+ *   `honored-creator`  → honor-creator    (result.cleanUrl — wrapper passed through unchanged; network + creator)
  *
  * `blocked-opaque` has no cleaner action today — it's a future event the
  * popup may emit when an opaque wrapper (t.co etc.) couldn't be resolved.
@@ -140,9 +186,13 @@ export function presentLedger(ledger) {
  *
  * @param {string} rawUrl
  * @param {object|null|undefined} result - return value from processUrl
+ * @param {{prefs?: object, domainRules?: Array, pathStripRules?: Array, pathAffiliateRules?: Array, referrer?: string}} [ctx]
+ *   Optional reprocessing context, only consulted for the `injected` action.
+ *   Production callers (pushAttributionAndPersist) always supply it so the
+ *   ledger never stores a MUGA-tagged URL.
  * @returns {object|null}
  */
-export function fromCleanerResult(rawUrl, result) {
+export function fromCleanerResult(rawUrl, result, ctx) {
   if (!result || typeof result !== "object") return null;
 
   switch (result.action) {
@@ -150,29 +200,31 @@ export function fromCleanerResult(rawUrl, result) {
       return { type: "navigate", url: rawUrl };
     case "cleaned":
     case "blacklisted":
-      return { type: "clean", url: rawUrl };
+      return { type: "clean", url: result.cleanUrl ?? rawUrl };
     case "injected": {
       // Network sourced from the preservedAffiliate descriptor when the
       // cleaner attached one (group is the program family, e.g. "amazon").
       const network = result.preservedAffiliate?.group || result.preservedAffiliate?.store;
-      const ev = { type: "inject-affiliate", url: rawUrl };
+      const ev = { type: "inject-affiliate", url: deriveTaglessUrl(rawUrl, ctx) };
       if (network) ev.network = network;
       return ev;
     }
     case "detected_foreign": {
       // detectedAffiliate carries the matched pattern; group identifies
-      // the program family the foreign tag belongs to.
+      // the program family the foreign tag belongs to. cleanUrl already
+      // carries the third-party tag (honor-creator attribution) — only
+      // MUGA-irrelevant tracking noise was stripped ahead of this point.
       const network =
         result.detectedAffiliate?.pattern?.group ||
         result.detectedAffiliate?.pattern?.name;
-      const ev = { type: "preserve-affiliate", url: rawUrl };
+      const ev = { type: "preserve-affiliate", url: result.cleanUrl ?? rawUrl };
       if (network) ev.network = network;
       return ev;
     }
     case "honored-creator":
       return {
         type: "honor-creator",
-        url: rawUrl,
+        url: result.cleanUrl ?? rawUrl,
         network: result.network,
         creator: result.creator,
       };

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -69,6 +69,43 @@ function copyWithFeedback(text, { onSuccess, onError, onRevert }) {
   });
 }
 
+/**
+ * Reprocesses `originalUrl` through the copy-safe pipeline (#946) instead of
+ * copying the value stored at navigation time. History's "clean" column is
+ * computed with injectOwnAffiliate ON (that's the correct value for what
+ * actually happened at navigation), so copying it verbatim would put MUGA's
+ * own affiliate tag on the clipboard for an `injected` entry. Reusing the
+ * existing PROCESS_URL message with `skipNotify: true` mirrors the same
+ * effectivePrefs branch background/service-worker.js#handleProcessUrl already
+ * applies for keyboard-shortcut/context-menu copy (injectOwnAffiliate +
+ * notifyForeignAffiliate both forced off) — single source of truth instead of
+ * a second nav-time value.
+ *
+ * Degraded fallback (#946): if the service worker is unreachable, return
+ * `originalUrl` — the pre-navigation URL, which by construction NEVER carries
+ * MUGA's own injected tag (injection only happens during cleaning, producing
+ * the nav-time `entry.clean`). We deliberately do NOT fall back to the
+ * nav-time clean value: for an `injected` entry that would put MUGA's own
+ * affiliate tag on the clipboard, the exact leak #946 exists to prevent. The
+ * original may still carry third-party tracking noise in this rare path, but
+ * copy must never leak MUGA's tag — tag-safety wins over noise-freeness here.
+ *
+ * @param {string} originalUrl
+ * @returns {Promise<string>}
+ */
+async function getCopySafeCleanUrl(originalUrl) {
+  try {
+    const response = await chrome.runtime.sendMessage({ type: "PROCESS_URL", url: originalUrl, skipNotify: true });
+    if (response && typeof response.cleanUrl === "string" && response.cleanUrl) {
+      return response.cleanUrl;
+    }
+  } catch {
+    // SW unreachable (e.g. cold-killed mid-popup-session) — degrade to the
+    // tag-free original rather than failing the copy or leaking MUGA's tag.
+  }
+  return originalUrl;
+}
+
 // ── Param breakdown ───────────────────────────────────────────────────────────
 
 /** Builds a reverse index: param name → { category key, label, labelEs, labelPt, labelDe }. Cached as singleton. */
@@ -1314,39 +1351,44 @@ async function showHistory(prefs, lang) {
       }
     });
 
-    // Click to copy clean URL (#87)
+    // Click to copy clean URL (#87). Reprocessed copy-safe (#946) — see
+    // getCopySafeCleanUrl for why this doesn't just copy entry.clean.
     entryDiv.addEventListener("click", (e) => {
       if (e.target === copyOrigBtn || copyCleanBtn.contains(e.target)) return; // handled separately
       const orig = afterDiv.textContent;
-      copyWithFeedback(entry.clean, {
-        onSuccess: () => {
-          entryDiv.classList.add("copied");
-          afterDiv.textContent = t("history_copied", lang);
-        },
-        onError: () => { afterDiv.textContent = "✗"; },
-        onRevert: () => {
-          entryDiv.classList.remove("copied");
-          afterDiv.textContent = orig;
-        },
+      getCopySafeCleanUrl(entry.original).then((safeUrl) => {
+        copyWithFeedback(safeUrl, {
+          onSuccess: () => {
+            entryDiv.classList.add("copied");
+            afterDiv.textContent = t("history_copied", lang);
+          },
+          onError: () => { afterDiv.textContent = "✗"; },
+          onRevert: () => {
+            entryDiv.classList.remove("copied");
+            afterDiv.textContent = orig;
+          },
+        });
       });
     });
 
-    // Copy clean URL icon button
+    // Copy clean URL icon button. Reprocessed copy-safe (#946).
     copyCleanBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      copyWithFeedback(entry.clean, {
-        onSuccess: () => {
-          copyCleanBtn.textContent = "✓";
-          copyCleanBtn.style.fontSize = "11px";
-        },
-        onError: () => {
-          copyCleanBtn.textContent = "✗";
-          copyCleanBtn.style.fontSize = "11px";
-        },
-        onRevert: () => {
-          _setClipboardIcon(copyCleanBtn);
-          copyCleanBtn.style.fontSize = "";
-        },
+      getCopySafeCleanUrl(entry.original).then((safeUrl) => {
+        copyWithFeedback(safeUrl, {
+          onSuccess: () => {
+            copyCleanBtn.textContent = "✓";
+            copyCleanBtn.style.fontSize = "11px";
+          },
+          onError: () => {
+            copyCleanBtn.textContent = "✗";
+            copyCleanBtn.style.fontSize = "11px";
+          },
+          onRevert: () => {
+            _setClipboardIcon(copyCleanBtn);
+            copyCleanBtn.style.fontSize = "";
+          },
+        });
       });
     });
 

--- a/tests/unit/attribution-ledger.test.mjs
+++ b/tests/unit/attribution-ledger.test.mjs
@@ -15,6 +15,7 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import {
   DEFAULT_LEDGER_CAPACITY,
   EVENT_TYPES,
@@ -23,6 +24,10 @@ import {
   presentLedger,
   fromCleanerResult,
 } from "../../src/lib/attribution-ledger.js";
+import { processUrl } from "../../src/lib/cleaner.js";
+
+const require = createRequire(import.meta.url);
+const domainRules = require("../../src/rules/domain-rules.json");
 
 const URL_A = "https://example.com/article";
 const URL_B = "https://shop.example/product?utm_source=x";
@@ -295,5 +300,80 @@ describe("fromCleanerResult", () => {
     assert.equal(entry.decision, "honor-creator");
     assert.equal(entry.network, "skimlinks");
     assert.equal(entry.creatorCredit, "youtube.com/@foo");
+  });
+});
+
+// ── #946: copy-safe action table ─────────────────────────────────────────────
+// Every user-facing COPY/SHARE affordance (including the Recent-activity
+// ledger's per-row "Copy" button, which copies `row.url` sourced straight
+// from these events) must put the cleanest SAFE form of a URL on the
+// clipboard: tracking stripped, third-party creator attribution preserved,
+// and — critically — no MUGA-injected affiliate tag. Before this fix,
+// `cleaned`/`blacklisted` stored the raw pre-clean rawUrl (tracking noise
+// intact) and `injected` stored result.cleanUrl verbatim (MUGA's own tag
+// intact) — both wrong for a copy/share affordance.
+const NAV_PREFS = Object.freeze({
+  enabled: true,
+  onboardingDone: true,
+  injectOwnAffiliate: true,
+  notifyForeignAffiliate: false,
+  stripAllAffiliates: false,
+  blacklist: [],
+  whitelist: [],
+  disabledCategories: [],
+});
+
+describe("fromCleanerResult — #946 copy-safe action table", () => {
+  test("'cleaned' uses result.cleanUrl (tracking-stripped), NOT the raw pre-clean url", () => {
+    const raw = "https://shop.example/product?utm_source=newsletter&id=1";
+    const clean = "https://shop.example/product?id=1";
+    const ev = fromCleanerResult(raw, { action: "cleaned", cleanUrl: clean });
+    assert.equal(ev.url, clean);
+    assert.notEqual(ev.url, raw, "must not store the raw URL carrying tracking noise");
+  });
+
+  test("'blacklisted' uses result.cleanUrl, NOT the raw pre-clean url", () => {
+    const raw = "https://shop.example/product?tag=blocked";
+    const clean = "https://shop.example/product";
+    const ev = fromCleanerResult(raw, { action: "blacklisted", cleanUrl: clean });
+    assert.equal(ev.url, clean);
+    assert.notEqual(ev.url, raw);
+  });
+
+  test("'injected' derives a TAGLESS url via ctx reprocessing (real processUrl, injection re-forced off)", () => {
+    const raw = "https://www.amazon.com/dp/B00X?utm_source=newsletter";
+    const navResult = processUrl(raw, NAV_PREFS, domainRules);
+    assert.equal(navResult.action, "injected", "sanity: this URL really gets MUGA's tag injected at navigation time");
+    assert.ok(navResult.cleanUrl.includes("tag="), "sanity: the real nav result carries our tag");
+
+    const ev = fromCleanerResult(raw, navResult, { prefs: NAV_PREFS, domainRules });
+    assert.equal(ev.type, "inject-affiliate");
+    assert.ok(!ev.url.includes("tag="), "ledger must never store MUGA's own injected tag");
+    assert.ok(!ev.url.includes("utm_source"), "tracking noise must still be stripped from the derived copy-safe url");
+  });
+
+  test("'injected' without ctx falls back to the pre-injection rawUrl (backward compatible, still tag-free)", () => {
+    const ev = fromCleanerResult(URL_A, { action: "injected", preservedAffiliate: { group: "amazon" } });
+    assert.equal(ev.url, URL_A, "no ctx supplied — falls back to rawUrl rather than crashing or using a tagged cleanUrl");
+  });
+
+  test("'detected_foreign' preserves the third-party creator tag via result.cleanUrl", () => {
+    const raw = "https://www.amazon.com/dp/B00X?utm_source=x&tag=creator-21";
+    const foreignResult = processUrl(raw, { ...NAV_PREFS, notifyForeignAffiliate: true }, domainRules);
+    assert.equal(foreignResult.action, "detected_foreign");
+
+    const ev = fromCleanerResult(raw, foreignResult);
+    assert.equal(ev.type, "preserve-affiliate");
+    assert.equal(ev.url, foreignResult.cleanUrl);
+    assert.ok(ev.url.includes("tag=creator-21"), "third-party creator tag must survive");
+    assert.ok(!ev.url.includes("utm_source"), "unrelated tracking noise is still stripped");
+  });
+
+  test("'honored-creator' uses result.cleanUrl — the unmodified wrapper", () => {
+    const wrapper = "https://go.skimresources.com/?id=abc&url=https://dest.example";
+    const ev = fromCleanerResult(wrapper, {
+      action: "honored-creator", cleanUrl: wrapper, network: "skimlinks", creator: "yt/@x",
+    });
+    assert.equal(ev.url, wrapper);
   });
 });

--- a/tests/unit/content-copy-safe-injection.test.mjs
+++ b/tests/unit/content-copy-safe-injection.test.mjs
@@ -1,0 +1,531 @@
+/**
+ * MUGA — #946: copy-safe cleaning for content-script copy paths.
+ *
+ * Every user-facing COPY/SHARE affordance must put the cleanest SAFE form
+ * of a URL on the clipboard: tracking stripped, third-party creator
+ * attribution preserved, and — critically — NO MUGA-injected affiliate tag.
+ * Navigation-time injection is the monetization model and must stay ON;
+ * only copy actions must suppress it.
+ *
+ * background/service-worker.js#handleProcessUrl already had this right for
+ * the keyboard-shortcut / context-menu-on-a-link / selection-fallback paths
+ * (its `effectivePrefs` branch forces `injectOwnAffiliate: false` and
+ * `notifyForeignAffiliate: false` when `skipNotify` is set). This file
+ * covers the two content-script-local copy paths that were missing the
+ * same suppression:
+ *
+ *   1. GET_AND_COPY_CLEAN_SELECTION — the content-script side of the
+ *      right-click "Copy clean selection" context-menu item (cleans an
+ *      entire DOM selection locally, no service-worker round trip per URL).
+ *   2. The `copy` DOM event listener — Ctrl+C / Cmd+C.
+ *
+ * Both call `window.__mugaCleaner.processUrl()` (the bundled cleaner) with
+ * a *live* prefs object (`_contentPrefs`) mirroring whatever the user has
+ * configured for navigation. Before the fix, that included
+ * `injectOwnAffiliate` verbatim — so copying a link on an affiliate store
+ * could put MUGA's own tag on the clipboard, exactly the non-consensual
+ * hijack this ticket exists to prevent.
+ *
+ * ## Why a `vm` harness
+ *
+ * Content scripts cannot be `import`-ed (no ES modules; top-level
+ * `chrome.*` / `window.*` / `document.*` references). Per the #951
+ * precedent in content-cleaner-patterns.test.mjs, we execute the raw
+ * source text inside a fresh `vm` context with minimal browser-global
+ * stand-ins and inspect the REAL arguments passed to
+ * `window.__mugaCleaner.processUrl()`. This is a behavioral test — it
+ * would fail if someone reverted the prefs-copy fix, even if the
+ * surrounding code shape changed — rather than a source-string match.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { createRequire } from "node:module";
+import vm from "node:vm";
+
+import { processUrl } from "../../src/lib/cleaner.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cleanerSource = readFileSync(join(__dirname, "../../src/content/cleaner.js"), "utf8");
+const require = createRequire(import.meta.url);
+const domainRules = require("../../src/rules/domain-rules.json");
+
+function mockFetch(url) {
+  if (url.includes("domain-rules.json")) return Promise.resolve({ json: () => Promise.resolve([]) });
+  if (url.includes("path-strip-rules.json")) return Promise.resolve({ json: () => Promise.resolve([]) });
+  if (url.includes("path-affiliate-rules.json")) return Promise.resolve({ json: () => Promise.resolve([]) });
+  return Promise.reject(new Error("unexpected fetch: " + url));
+}
+
+/**
+ * Runs the content script and dispatches a synthetic Ctrl+C `copy` event
+ * with `selectionText` as the current DOM selection's plain text.
+ *
+ * @returns {Promise<{ processUrlCalls: any[][], clipboardWritten: string|null }>}
+ */
+function runContentScriptCopyEvent({ contentPrefsFixture, selectionText }) {
+  return new Promise((resolve, reject) => {
+    const processUrlCalls = [];
+    const documentListeners = {};
+    let clipboardWritten = null;
+
+    const fakeDocument = {
+      addEventListener: (type, fn) => { documentListeners[type] = fn; },
+      getElementById: () => null,
+      createElement: () => ({
+        style: {}, setAttribute() {}, appendChild() {}, querySelectorAll: () => [], remove() {},
+      }),
+      documentElement: {},
+      body: { appendChild() {} },
+      querySelector: () => null,
+      readyState: "complete",
+      referrer: "",
+    };
+
+    const fakeSelection = { toString: () => selectionText };
+    const fakeLocation = { href: "https://page.example/", hostname: "page.example", pathname: "/" };
+
+    const fakeWindow = {
+      location: fakeLocation,
+      getSelection: () => fakeSelection,
+      open: () => {},
+    };
+    fakeWindow.self = fakeWindow;
+    fakeWindow.top = fakeWindow;
+    fakeWindow.__mugaCleaner = {
+      processUrl: (...args) => {
+        processUrlCalls.push(args);
+        return { cleanUrl: args[0], junkRemoved: 0, removedTracking: [] };
+      },
+      isGenericShortener: () => false,
+    };
+
+    const fakeChrome = {
+      runtime: {
+        id: "test-ext-id",
+        lastError: null,
+        getURL: (path) => path,
+        onMessage: { addListener: () => {} },
+        sendMessage: (msg, cb) => {
+          if (msg && msg.type === "getPrefs" && typeof cb === "function") cb(contentPrefsFixture);
+          return Promise.resolve({ ok: false });
+        },
+      },
+      storage: {
+        sync: { get: (defaults, cb) => cb(defaults) },
+        onChanged: { addListener: () => {} },
+      },
+    };
+
+    const sandbox = {
+      window: fakeWindow,
+      document: fakeDocument,
+      chrome: fakeChrome,
+      navigator: {
+        language: "en",
+        clipboard: { writeText: (text) => { clipboardWritten = text; return Promise.resolve(); } },
+      },
+      location: fakeLocation,
+      history: { state: null, replaceState: () => {} },
+      NodeFilter: { SHOW_TEXT: 4 },
+      URL,
+      console,
+      setTimeout,
+      clearTimeout,
+      fetch: mockFetch,
+    };
+
+    vm.createContext(sandbox);
+    try {
+      vm.runInContext(cleanerSource, sandbox, { filename: "content/cleaner.js" });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    // Let the eager getContentPrefs()/getDomainRulesCached()/getPathRulesCached()
+    // chains settle (they're microtask/fetch-driven) before dispatching.
+    setTimeout(() => {
+      const copyHandler = documentListeners.copy;
+      if (typeof copyHandler !== "function") {
+        reject(new Error("document 'copy' listener was not registered"));
+        return;
+      }
+      copyHandler({ preventDefault: () => {} });
+      setTimeout(() => resolve({ processUrlCalls, clipboardWritten }), 20);
+    }, 20);
+  });
+}
+
+/**
+ * Runs the content script and dispatches a synthetic
+ * GET_AND_COPY_CLEAN_SELECTION message (the context-menu "Copy clean
+ * selection" path), with `selectionText` standing in for the plain-text
+ * content found inside the cloned DOM selection.
+ *
+ * @returns {Promise<{ processUrlCalls: any[][], responseResult: object }>}
+ */
+function runContentScriptSelectionMessage({ contentPrefsFixture, selectionText }) {
+  return new Promise((resolve, reject) => {
+    const processUrlCalls = [];
+    let messageListener;
+    let responseResult;
+
+    const fakeContainer = { appendChild() {}, querySelectorAll: () => [] };
+
+    const fakeDocument = {
+      addEventListener: () => {},
+      getElementById: () => null,
+      createElement: (tag) => (tag === "div" ? fakeContainer : {
+        style: {}, setAttribute() {}, appendChild() {}, querySelectorAll: () => [], remove() {},
+      }),
+      createTreeWalker: () => {
+        let done = false;
+        return {
+          nextNode() {
+            if (done) return null;
+            done = true;
+            return { textContent: selectionText };
+          },
+        };
+      },
+      documentElement: {},
+      body: { appendChild() {} },
+      querySelector: () => null,
+      readyState: "complete",
+      referrer: "",
+    };
+
+    const fakeSelection = {
+      rangeCount: 1,
+      getRangeAt: () => ({ cloneContents: () => ({}) }),
+      toString: () => selectionText,
+    };
+    const fakeLocation = { href: "https://page.example/", hostname: "page.example", pathname: "/" };
+
+    const fakeWindow = {
+      location: fakeLocation,
+      getSelection: () => fakeSelection,
+      open: () => {},
+    };
+    fakeWindow.self = fakeWindow;
+    fakeWindow.top = fakeWindow;
+    fakeWindow.__mugaCleaner = {
+      processUrl: (...args) => {
+        processUrlCalls.push(args);
+        return { cleanUrl: args[0], junkRemoved: 0 };
+      },
+      isGenericShortener: () => false,
+    };
+
+    const fakeChrome = {
+      runtime: {
+        id: "test-ext-id",
+        lastError: null,
+        getURL: (path) => path,
+        onMessage: { addListener: (fn) => { messageListener = fn; } },
+        sendMessage: (msg, cb) => {
+          if (msg && msg.type === "getPrefs" && typeof cb === "function") cb(contentPrefsFixture);
+          return Promise.resolve({ ok: false });
+        },
+      },
+      storage: {
+        sync: { get: (defaults, cb) => cb(defaults) },
+        onChanged: { addListener: () => {} },
+      },
+    };
+
+    const sandbox = {
+      window: fakeWindow,
+      document: fakeDocument,
+      chrome: fakeChrome,
+      navigator: { language: "en", clipboard: { writeText: () => Promise.resolve() } },
+      location: fakeLocation,
+      history: { state: null, replaceState: () => {} },
+      NodeFilter: { SHOW_TEXT: 4 },
+      URL,
+      console,
+      setTimeout,
+      clearTimeout,
+      fetch: mockFetch,
+    };
+
+    vm.createContext(sandbox);
+    try {
+      vm.runInContext(cleanerSource, sandbox, { filename: "content/cleaner.js" });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    setTimeout(() => {
+      if (typeof messageListener !== "function") {
+        reject(new Error("chrome.runtime.onMessage listener was not registered"));
+        return;
+      }
+      messageListener(
+        { type: "GET_AND_COPY_CLEAN_SELECTION" },
+        { id: "test-ext-id" },
+        (resp) => { responseResult = resp; },
+      );
+      setTimeout(() => resolve({ processUrlCalls, responseResult }), 20);
+    }, 20);
+  });
+}
+
+/**
+ * Runs the content script's document_start self-clean branch (NAVIGATION,
+ * not copy) with a caller-supplied prefs fixture. Adapted from the #951
+ * harness in content-cleaner-patterns.test.mjs, parameterized on
+ * `contentPrefsFixture` so this file can prove the navigation path is
+ * NOT touched by the copy-safe-prefs fix (regression guard, AC #6).
+ */
+function runContentScriptSelfClean({ href, contentPrefsFixture }) {
+  return new Promise((resolve, reject) => {
+    const processUrlCalls = [];
+    const parsedHref = new URL(href);
+    const fakeLocation = { href, hostname: parsedHref.hostname, pathname: parsedHref.pathname };
+
+    const fakeWindow = { location: fakeLocation, getSelection: () => null, open: () => {} };
+    fakeWindow.self = fakeWindow;
+    fakeWindow.top = fakeWindow;
+    fakeWindow.__mugaCleaner = {
+      processUrl: (...args) => {
+        processUrlCalls.push(args);
+        return { cleanUrl: href, junkRemoved: 0 };
+      },
+      isGenericShortener: () => false,
+    };
+
+    const fakeDocument = {
+      addEventListener: () => {},
+      getElementById: () => null,
+      createElement: () => ({
+        style: {}, setAttribute() {}, appendChild() {}, querySelectorAll: () => [], remove() {},
+      }),
+      documentElement: {},
+      body: { appendChild() {} },
+      querySelector: () => null,
+      readyState: "complete",
+      referrer: "",
+    };
+
+    const fakeChrome = {
+      runtime: {
+        id: "test-ext-id",
+        lastError: null,
+        getURL: (path) => path,
+        onMessage: { addListener: () => {} },
+        sendMessage: (msg, cb) => {
+          if (msg && msg.type === "getPrefs" && typeof cb === "function") cb(contentPrefsFixture);
+          return Promise.resolve({ ok: false });
+        },
+      },
+      storage: {
+        sync: { get: (defaults, cb) => cb(defaults) },
+        onChanged: { addListener: () => {} },
+      },
+    };
+
+    const sandbox = {
+      window: fakeWindow,
+      document: fakeDocument,
+      chrome: fakeChrome,
+      navigator: { language: "en", clipboard: { writeText: () => Promise.resolve() } },
+      location: fakeLocation,
+      history: { state: null, replaceState: () => {} },
+      fetch: mockFetch,
+      URL,
+      console,
+      setTimeout,
+      clearTimeout,
+    };
+
+    vm.createContext(sandbox);
+    try {
+      vm.runInContext(cleanerSource, sandbox, { filename: "content/cleaner.js" });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    setTimeout(() => resolve({ processUrlCalls }), 50);
+  });
+}
+
+const TAGGED_URL = "https://www.amazon.es/dp/B08N5WRWNW?tag=creator-21&utm_source=newsletter";
+
+// Live prefs mirror what a real user with both toggles ON would have —
+// injection AND the foreign-affiliate toast are both enabled for navigation.
+const CONTENT_PREFS_NAV_INJECTS = Object.freeze({
+  enabled: true,
+  onboardingDone: true,
+  injectOwnAffiliate: true,
+  notifyForeignAffiliate: true,
+  _affiliateDomains: [],
+});
+
+describe("#946 — content-script copy paths suppress MUGA's own injection", () => {
+  test("GET_AND_COPY_CLEAN_SELECTION (context-menu 'Copy clean selection') passes copy-safe prefs to processUrl", async () => {
+    const { processUrlCalls } = await runContentScriptSelectionMessage({
+      contentPrefsFixture: CONTENT_PREFS_NAV_INJECTS,
+      selectionText: `Check this out: ${TAGGED_URL}`,
+    });
+    const call = processUrlCalls.find(([url]) => url === TAGGED_URL);
+    assert.ok(call, "processUrl must be called with the URL found in the selection");
+    const prefsArg = call[1];
+    assert.equal(prefsArg.injectOwnAffiliate, false, "copy must suppress MUGA's own injection even though the live pref is ON");
+    assert.equal(prefsArg.notifyForeignAffiliate, false, "copy must suppress the foreign-affiliate toast");
+  });
+
+  test("Ctrl+C copy event passes copy-safe prefs to processUrl", async () => {
+    const { processUrlCalls } = await runContentScriptCopyEvent({
+      contentPrefsFixture: CONTENT_PREFS_NAV_INJECTS,
+      selectionText: `Look: ${TAGGED_URL}`,
+    });
+    const call = processUrlCalls.find(([url]) => url === TAGGED_URL);
+    assert.ok(call, "processUrl must be called with the URL found in the copied text");
+    const prefsArg = call[1];
+    assert.equal(prefsArg.injectOwnAffiliate, false);
+    assert.equal(prefsArg.notifyForeignAffiliate, false);
+  });
+
+  test("copy-safe prefs are a NEW object — the live _contentPrefs reference is never mutated", async () => {
+    const { processUrlCalls } = await runContentScriptCopyEvent({
+      contentPrefsFixture: CONTENT_PREFS_NAV_INJECTS,
+      selectionText: TAGGED_URL,
+    });
+    const call = processUrlCalls.find(([url]) => url === TAGGED_URL);
+    const prefsArg = call[1];
+    assert.notEqual(prefsArg, CONTENT_PREFS_NAV_INJECTS, "processUrl must receive a copy, not the live prefs object");
+    assert.equal(CONTENT_PREFS_NAV_INJECTS.injectOwnAffiliate, true, "the live prefs object itself must remain untouched after a copy action");
+  });
+});
+
+describe("#946 — regression guard: navigation-path injection is untouched", () => {
+  test("document_start self-clean still passes the real (unsuppressed) prefs through to processUrl", async () => {
+    const href = "https://www.amazon.es/dp/B08N5WRWNW";
+    const { processUrlCalls } = await runContentScriptSelfClean({
+      href,
+      contentPrefsFixture: CONTENT_PREFS_NAV_INJECTS,
+    });
+    assert.equal(processUrlCalls.length, 1, "self-clean must call processUrl exactly once");
+    const prefsArg = processUrlCalls[0][1];
+    assert.equal(prefsArg.injectOwnAffiliate, true, "navigation-path self-clean must NOT suppress injection — only copy paths do");
+    assert.equal(prefsArg, CONTENT_PREFS_NAV_INJECTS, "navigation passes the SAME prefs object, unmodified — no copy-safe override applied");
+  });
+});
+
+// ── Real processUrl(): copy-safe prefs still preserve third-party attribution ──
+// These exercise the actual cleaner pipeline (not the vm-mocked stub above) to
+// prove that suppressing injectOwnAffiliate/notifyForeignAffiliate on copy does
+// NOT strip a third-party creator's own tag, and does not disturb opaque
+// affiliate-redirect-network wrapper handling (constraint: copy inherits the
+// existing isAffiliateRedirectNetwork gate for free).
+describe("#946 — copy-safe prefs preserve third-party attribution (real processUrl)", () => {
+  const COPY_PREFS = {
+    enabled: true,
+    onboardingDone: true,
+    injectOwnAffiliate: false,
+    notifyForeignAffiliate: false,
+    stripAllAffiliates: false,
+    blacklist: [],
+    whitelist: [],
+    disabledCategories: [],
+  };
+
+  test("a third-party (creator) affiliate tag survives copy-safe cleaning untouched", () => {
+    const raw = "https://www.amazon.com/dp/B00X?utm_source=newsletter&tag=someothercreator-21";
+    const r = processUrl(raw, COPY_PREFS, domainRules);
+    assert.ok(r.cleanUrl.includes("tag=someothercreator-21"), "foreign creator tag must survive copy-safe cleaning");
+    assert.ok(!r.cleanUrl.includes("utm_source"), "unrelated tracking noise is still stripped");
+    assert.notEqual(r.action, "injected", "copy-safe prefs must never report our own injection");
+  });
+
+  test("copy-safe prefs never add MUGA's own tag to an untagged affiliate URL", () => {
+    const raw = "https://www.amazon.com/dp/B00X";
+    const r = processUrl(raw, COPY_PREFS, domainRules);
+    assert.notEqual(r.action, "injected");
+    assert.ok(!new URL(r.cleanUrl).searchParams.has("tag"), "no tag param should be added on copy");
+  });
+
+  test("an affiliate-redirect-network wrapper is left intact on copy (unwrap gate inherited, not bypassed)", () => {
+    const wrapped = "https://s.click.aliexpress.com/e/_abcDEF12";
+    const withCopyPrefs = processUrl(wrapped, COPY_PREFS, domainRules);
+    const withNavPrefs = processUrl(wrapped, { ...COPY_PREFS, injectOwnAffiliate: true, notifyForeignAffiliate: true }, domainRules);
+    assert.equal(withCopyPrefs.cleanUrl, wrapped, "opaque wrapper must pass through unmodified on copy");
+    assert.equal(
+      withCopyPrefs.cleanUrl, withNavPrefs.cleanUrl,
+      "copy and navigation share the same unwrap gate — injectOwnAffiliate/notifyForeignAffiliate do not change wrapper handling",
+    );
+  });
+});
+
+// ── background/service-worker.js copy call sites (regression pin) ──────────
+// Per prior triage, the keyboard-shortcut (Alt+Shift+C), context-menu
+// "Copy link", and context-menu "Copy selection" fallback paths already
+// route through handleProcessUrl's `effectivePrefs` branch, which forces
+// injectOwnAffiliate/notifyForeignAffiliate off when `skipNotify` is set.
+// service-worker.js cannot be imported in Node (top-level chrome.* calls at
+// module scope — DNR setup, alarms, etc.), so this is pinned two ways:
+// a source-location check that each call site still passes `skipNotify:
+// true` (source-string is the correct tool here per the ratchet's own
+// documented exemption criteria — the module is not importable), PLUS a
+// behavioral test of the effectivePrefs branch re-expressed as a pure
+// function, following the sw-robustness-833.test.mjs precedent for logic
+// mirrors of un-importable SW code.
+describe("#946 — background copy call sites already suppress injection (regression pin)", () => {
+  const swSrc = readFileSync(join(__dirname, "../../src/background/service-worker.js"), "utf8");
+
+  test("handleProcessUrl's effectivePrefs branch forces both toggles off on skipNotify", () => {
+    const idx = swSrc.indexOf("const effectivePrefs = skipNotify");
+    assert.ok(idx !== -1, "handleProcessUrl must build a copy-safe effectivePrefs branch");
+    const block = swSrc.slice(idx, idx + 200);
+    assert.ok(block.includes("notifyForeignAffiliate: false"));
+    assert.ok(block.includes("injectOwnAffiliate: false"));
+  });
+
+  test("keyboard shortcut (Alt+Shift+C) copy call site passes skipNotify: true", () => {
+    const idx = swSrc.indexOf('source: "shortcut"');
+    assert.ok(idx !== -1, "shortcut copy call site must exist");
+    assert.ok(swSrc.slice(Math.max(0, idx - 200), idx + 50).includes("skipNotify: true"));
+  });
+
+  test("context-menu 'Copy link' call site passes skipNotify: true", () => {
+    const idx = swSrc.indexOf('source: "copy_link"');
+    assert.ok(idx !== -1, "copy_link call site must exist");
+    assert.ok(swSrc.slice(Math.max(0, idx - 200), idx + 50).includes("skipNotify: true"));
+  });
+
+  test("context-menu 'Copy selection' fallback call site passes skipNotify: true", () => {
+    const idx = swSrc.indexOf('source: "copy_selection"');
+    assert.ok(idx !== -1, "copy_selection call site must exist");
+    assert.ok(swSrc.slice(Math.max(0, idx - 200), idx + 50).includes("skipNotify: true"));
+  });
+});
+
+describe("#946 — effectivePrefs copy-safe logic (pure mirror, behavioral)", () => {
+  // Mirrors handleProcessUrl's one-line branch verbatim.
+  function buildEffectivePrefs(prefs, skipNotify) {
+    return skipNotify
+      ? { ...prefs, notifyForeignAffiliate: false, injectOwnAffiliate: false }
+      : prefs;
+  }
+
+  test("skipNotify:true forces both toggles off regardless of the live prefs", () => {
+    const live = { injectOwnAffiliate: true, notifyForeignAffiliate: true, enabled: true };
+    const effective = buildEffectivePrefs(live, true);
+    assert.equal(effective.injectOwnAffiliate, false);
+    assert.equal(effective.notifyForeignAffiliate, false);
+    assert.equal(live.injectOwnAffiliate, true, "the live prefs object must not be mutated");
+  });
+
+  test("skipNotify:false (normal navigation) passes prefs through unmodified", () => {
+    const live = { injectOwnAffiliate: true, notifyForeignAffiliate: true, enabled: true };
+    const effective = buildEffectivePrefs(live, false);
+    assert.equal(effective, live, "navigation must receive the SAME prefs reference — no copy-safe override");
+  });
+});

--- a/tests/unit/popup-copy-safe-history.test.mjs
+++ b/tests/unit/popup-copy-safe-history.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * MUGA — #946: popup History "Copy clean" affordances must be copy-safe.
+ *
+ * Before this fix, the History section's per-entry click-to-copy and the
+ * "copy clean URL" icon button both copied `entry.clean` — the value
+ * stored at NAVIGATION time (computed with `injectOwnAffiliate` ON). For
+ * an `injected` action that value carries MUGA's own affiliate tag, which
+ * must never land on the clipboard from a copy affordance.
+ *
+ * The fix reprocesses `entry.original` through the existing PROCESS_URL
+ * message with `skipNotify: true` — the SAME effectivePrefs branch
+ * background/service-worker.js#handleProcessUrl already uses for the
+ * keyboard-shortcut / context-menu copy paths (injectOwnAffiliate +
+ * notifyForeignAffiliate both forced off) — instead of inventing a new
+ * message type or a second nav-time value.
+ *
+ * popup.js is a plain DOMContentLoaded script with no exports and
+ * top-level `chrome.*`/`document.*` references, so it cannot be
+ * `import`-ed in Node (same constraint documented in
+ * popup-copy-with-feedback.test.mjs, which established the pattern this
+ * file follows). Structural assertions pin the wiring; the extracted
+ * `getCopySafeCleanUrl` helper is additionally exercised BEHAVIORALLY
+ * below by evaluating its real source against a fake `chrome.runtime`.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+const popupSrc = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+
+/** Extracts a top-level `async function <name>(...) { ... }` block via brace matching. */
+function extractFunctionSource(src, name) {
+  const idx = src.indexOf(`async function ${name}`);
+  assert.ok(idx !== -1, `${name} must be defined as an async function`);
+  let depth = 0;
+  let started = false;
+  let i = idx;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") { depth++; started = true; }
+    else if (src[i] === "}") {
+      depth--;
+      if (started && depth === 0) { i++; break; }
+    }
+  }
+  return src.slice(idx, i);
+}
+
+/** Builds a callable getCopySafeCleanUrl bound to a fake `chrome` global. */
+function buildGetCopySafeCleanUrl(fakeChrome) {
+  const fnSrc = extractFunctionSource(popupSrc, "getCopySafeCleanUrl");
+  // Intentional: evaluating the real source (not a re-implementation)
+  // against injected browser-global stand-ins, matching the vm-harness
+  // precedent used for content-script tests (#951).
+  const factory = new Function("chrome", `"use strict";\n${fnSrc}\nreturn getCopySafeCleanUrl;`);
+  return factory(fakeChrome);
+}
+
+describe("#946 — getCopySafeCleanUrl helper (behavioral)", () => {
+  test("reprocesses via PROCESS_URL with skipNotify:true and returns the copy-safe cleanUrl", async () => {
+    let sentMessage;
+    const fakeChrome = {
+      runtime: {
+        sendMessage: (msg) => {
+          sentMessage = msg;
+          return Promise.resolve({ cleanUrl: "https://example.com/clean-no-tag", action: "injected" });
+        },
+      },
+    };
+    const getCopySafeCleanUrl = buildGetCopySafeCleanUrl(fakeChrome);
+    const result = await getCopySafeCleanUrl("https://example.com/raw?tag=x");
+
+    assert.equal(sentMessage.type, "PROCESS_URL");
+    assert.equal(sentMessage.url, "https://example.com/raw?tag=x", "must reprocess the ORIGINAL url, not the stale nav-time clean value");
+    assert.equal(sentMessage.skipNotify, true, "must mirror handleProcessUrl's copy-safe effectivePrefs branch");
+    assert.equal(result, "https://example.com/clean-no-tag");
+  });
+
+  test("falls back to the tag-free original (NOT the nav-time clean) when the service worker is unreachable", async () => {
+    const fakeChrome = { runtime: { sendMessage: () => Promise.reject(new Error("SW unreachable")) } };
+    const getCopySafeCleanUrl = buildGetCopySafeCleanUrl(fakeChrome);
+    const result = await getCopySafeCleanUrl("https://example.com/raw?utm_source=x");
+    // Degraded path must never leak MUGA's tag: it returns the original (which by
+    // construction has no injected tag), not the possibly-tagged nav-time value.
+    assert.equal(result, "https://example.com/raw?utm_source=x");
+  });
+
+  test("falls back to the tag-free original when the response has no usable cleanUrl", async () => {
+    const fakeChrome = { runtime: { sendMessage: () => Promise.resolve({ action: "error", cleanUrl: null }) } };
+    const getCopySafeCleanUrl = buildGetCopySafeCleanUrl(fakeChrome);
+    const result = await getCopySafeCleanUrl("https://example.com/raw");
+    assert.equal(result, "https://example.com/raw");
+  });
+});
+
+describe("#946 — History copy handlers reprocess via getCopySafeCleanUrl instead of entry.clean directly", () => {
+  test("entry-row click-to-copy calls getCopySafeCleanUrl(entry.original)", () => {
+    const idx = popupSrc.indexOf('entryDiv.addEventListener("click"');
+    assert.ok(idx !== -1, "entryDiv click handler must exist");
+    const block = popupSrc.slice(idx, idx + 700);
+    assert.ok(
+      block.includes("getCopySafeCleanUrl(entry.original)"),
+      "must reprocess copy-safe instead of copying entry.clean (the nav-time, possibly-tagged value) directly",
+    );
+  });
+
+  test("copy-clean icon button calls getCopySafeCleanUrl(entry.original)", () => {
+    const idx = popupSrc.indexOf('copyCleanBtn.addEventListener("click"');
+    assert.ok(idx !== -1, "copyCleanBtn click handler must exist");
+    const block = popupSrc.slice(idx, idx + 500);
+    assert.ok(
+      block.includes("getCopySafeCleanUrl(entry.original)"),
+      "must reprocess copy-safe instead of copying entry.clean directly",
+    );
+  });
+
+  test("copy-original button is UNCHANGED — still copies entry.original directly (never carried a tag)", () => {
+    const idx = popupSrc.indexOf('copyOrigBtn.addEventListener("click"');
+    assert.ok(idx !== -1, "copyOrigBtn click handler must exist");
+    const block = popupSrc.slice(idx, idx + 400);
+    assert.ok(
+      block.includes("copyWithFeedback(entry.original,"),
+      "copy-original must keep copying entry.original verbatim — it is the raw pre-clean URL by definition, out of scope for #946",
+    );
+  });
+});

--- a/tests/unit/popup-copy-with-feedback.test.mjs
+++ b/tests/unit/popup-copy-with-feedback.test.mjs
@@ -37,11 +37,24 @@ describe("#935 — copyWithFeedback helper extracted and shared", () => {
   });
 
   test("all three clipboard call sites route through copyWithFeedback", () => {
-    const calls = popupSrc.match(/copyWithFeedback\(\s*entry\.\w+/g) || [];
+    // #946: the history-entry click and copy-clean button no longer copy
+    // `entry.clean` (the value stored at navigation time, computed with
+    // injectOwnAffiliate ON) directly — they reprocess copy-safe via
+    // getCopySafeCleanUrl(entry.original) first and pass the
+    // resolved `safeUrl` into copyWithFeedback. Only copy-original still
+    // copies `entry.original` directly (it was never MUGA-tagged to begin
+    // with, so it needs no reprocessing).
+    const directEntryCalls = popupSrc.match(/copyWithFeedback\(\s*entry\.\w+/g) || [];
     assert.equal(
-      calls.length,
-      3,
-      `expected 3 copyWithFeedback(entry.___, ...) call sites (history-entry click, copy-clean button, copy-original button); found ${calls.length}`,
+      directEntryCalls.length,
+      1,
+      `expected exactly 1 copyWithFeedback(entry.___, ...) call site (copy-original button); found ${directEntryCalls.length}`,
+    );
+    const copySafeCalls = popupSrc.match(/copyWithFeedback\(\s*safeUrl\b/g) || [];
+    assert.equal(
+      copySafeCalls.length,
+      2,
+      `expected exactly 2 copyWithFeedback(safeUrl, ...) call sites (history-entry click, copy-clean button); found ${copySafeCalls.length}`,
     );
   });
 
@@ -72,7 +85,10 @@ describe("#935 — copyWithFeedback helper extracted and shared", () => {
   test("copy-clean icon button preserves the icon-swap + fontSize behavior", () => {
     const idx = popupSrc.indexOf('copyCleanBtn.addEventListener("click"');
     assert.ok(idx !== -1, "copyCleanBtn click handler must exist");
-    const block = popupSrc.slice(idx, idx + 500);
+    // #946: window widened from 500 — the handler now wraps its body in
+    // getCopySafeCleanUrl(...).then(...), pushing the icon-swap/revert
+    // calls further from the listener's opening line.
+    const block = popupSrc.slice(idx, idx + 650);
     assert.ok(block.includes('copyCleanBtn.textContent = "✓"'), "must still show ✓ on success");
     assert.ok(block.includes('copyCleanBtn.textContent = "✗"'), "must still show ✗ on failure");
     assert.ok(block.includes('_setClipboardIcon(copyCleanBtn)'), "must still restore the clipboard icon on revert");


### PR DESCRIPTION
## What

Makes every copy/share surface put a **copy-safe** URL on the clipboard: unwrapped destination (for safe wrappers), tracking stripped, and with **no MUGA-injected affiliate tag** — while preserving third-party creator attribution. Navigation-time affiliate injection (the monetization model) is unchanged. Closes #946.

## The three defects fixed

1. **Content-script copy paths leaked MUGA's own tag.** The service worker's copy path already builds copy-effective-prefs (`injectOwnAffiliate:false`, `notifyForeignAffiliate:false`), but the two content-script copy call sites (selection copy + Ctrl+C copy-event) passed the live content prefs. They now build the same `copyPrefs` and pass it. The two **navigation** call sites (document_start self-clean, affiliate click-intercept) are untouched, so navigation still injects. One `injectOwnAffiliate:false` disables both the query-tag (Amazon) and path-param (Bookshop) injection paths.

2. **Attribution ledger returned non-copy-safe URLs.** `fromCleanerResult` now maps each action to a copy-safe value: `cleaned`/`blacklisted` → `cleanUrl` (not the raw input); `injected` → a **tagless** destination via `deriveTaglessUrl()` (reprocesses the raw URL through the real `processUrl` with `injectOwnAffiliate:false` — a principled reprocess, not a regex tag-stripper); `detected_foreign` → `cleanUrl` with the third-party tag preserved; `honored-creator`/`untouched` → unchanged.

3. **Popup copy buttons copied stale/raw values.** History "Copy clean" now reprocesses at click time via `getCopySafeCleanUrl` (reuses the existing `PROCESS_URL` message with `skipNotify:true` — no new message type). Recent-activity "Copy" reads the now-copy-safe ledger `url`.

## Degraded-path hardening (tag-safety over noise)

If the service worker is unreachable from the popup (rare cold-kill mid-session), `getCopySafeCleanUrl` now falls back to **`entry.original`** — the pre-navigation URL, which by construction never carries MUGA's injected tag — rather than the nav-time `entry.clean` (which for an `injected` entry would carry MUGA's own tag). The original may still hold third-party tracking noise on this rare path, but copy must never leak MUGA's tag: tag-safety wins over noise-freeness. This closes the one gap where a degraded copy could still surface the tag.

## Constraints honored

- Affiliate-redirect networks (opaque wrappers) are left intact on copy (attribution preserved) — copy inherits the existing `shouldHonor`/`isAffiliateRedirectNetwork` unwrap gate.
- Third-party creator tags survive on copy (strip only non-attribution noise).
- Navigation injection unchanged — verified by a regression test asserting the self-clean receives injecting prefs.
- No storage keys or message types changed (the popup reuses `PROCESS_URL` with a backward-compatible `skipNotify`).

## Tests

- Full unit suite: 5530 pass, 0 fail, 1 skip.
- New: `content-copy-safe-injection.test.mjs` (tagless-on-copy for injected, strip-only for cleaned, foreign-tag preserved, affiliate-redirect intact — asserts tag ABSENCE against real `processUrl`), `popup-copy-safe-history.test.mjs` (behavioral `getCopySafeCleanUrl` incl. the tag-free degraded fallback).
- Updated: `attribution-ledger.test.mjs` (`injected` derives a tagless url), `popup-copy-with-feedback.test.mjs`.
- Fresh adversarial review: SHIP, no must-fix (all five copy surfaces verified tag-free; navigation injection verified intact; foreign tag preserved).

## Not touched

`src/content/cleaner-bundle.js` (generated), the navigation `processUrl` call sites, honor-creator/`detected_foreign` semantics beyond noise-stripping.
