### PR TITLE
feat(content): re-clean URLs on same-document SPA navigation (#951 Layer B)

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -401,6 +401,117 @@
   // Eagerly load prefs so they're available synchronously for click/copy handlers
   getContentPrefs();
 
+  // ── Reclean helper (#951 Layer B) ───────────────────────────────────────
+  // Single code path for "re-run the full local cleaning pipeline against a
+  // given URL". Used by:
+  //   1. The document_start self-clean below (initial page load).
+  //   2. history-defuser.js's `muga:history-committed` listener, so a
+  //      same-document SPA navigation (history.pushState/replaceState) gets
+  //      the SAME path-aware + query-aware cleaning as a real navigation —
+  //      DNR only intercepts network requests, so pushState traffic never
+  //      hits the network layer at all.
+  //   3. history-defuser.js's popstate/hashchange listeners (also
+  //      same-document navigations DNR never sees).
+  //
+  // Exposed as a global because history-defuser.js runs as a separate
+  // content script in the SAME isolated world — `window.*` properties are
+  // shared between isolated-world scripts (unlike MAIN-world scripts, which
+  // need a CustomEvent to cross the boundary).
+  let _lastRecleanUrl = null;
+  // Per-URL loop cap for the SPA reclean path (see __mugaReclean below).
+  // Keyed on the resolved input URL so a genuine loop (same dirty URL
+  // re-cleaned repeatedly) trips it while legitimate rapid navigation
+  // (distinct URLs) never does.
+  const _recleanLog = new Map(); // resolved url -> { count, firstTs }
+  function isRecleanLoop(url) {
+    const now = Date.now();
+    if (_recleanLog.size > 100) {
+      for (const [key, val] of _recleanLog) {
+        if (now - val.firstTs > 3000) _recleanLog.delete(key);
+      }
+      if (_recleanLog.size > 300) _recleanLog.clear();
+    }
+    const entry = _recleanLog.get(url);
+    if (!entry || now - entry.firstTs > 3000) {
+      _recleanLog.set(url, { count: 1, firstTs: now });
+      return false;
+    }
+    entry.count++;
+    return entry.count > 5;
+  }
+
+  window.__mugaReclean = function (rawUrl) {
+    if (!_contentPrefs || !_contentPrefs.enabled || !_contentPrefs.onboardingDone) return;
+    // Resolve to an absolute URL before anything else. `rawUrl` here is
+    // frequently RELATIVE — history.pushState()/replaceState() accept
+    // relative URLs (the common case for real SPA routers, e.g. React
+    // Router), and the muga:history-committed event forwards whatever
+    // shape the page originally passed (see cleanUrl()'s "same shape"
+    // comment in history-defuser-mainworld.js). By the time this runs the
+    // native pushState/replaceState call has already committed, so
+    // window.location.href is always a safe resolution base.
+    let url;
+    try {
+      url = new URL(rawUrl || window.location.href, window.location.href).href;
+    } catch {
+      return;
+    }
+    if (!url.startsWith("http")) return;
+    // Loop guard: a successful reclean below calls history.replaceState(),
+    // which re-enters the main-world pushState/replaceState wrap and
+    // re-dispatches `muga:history-committed` with the URL we JUST wrote.
+    // Without this short-circuit that would call back into this function
+    // forever. Terminates because the second call sees
+    // `url === _lastRecleanUrl` and returns before ever calling
+    // replaceState again — the recursion depth is bounded to exactly 1.
+    if (url === _lastRecleanUrl) return;
+    // Loop cap keyed on the RESOLVED INPUT url (not hostname): a genuine
+    // loop is the SAME dirty URL re-cleaned repeatedly (e.g. a page that
+    // re-adds a tracking param after each strip), which trips this cap;
+    // legitimate rapid SPA browsing produces DISTINCT urls and is never
+    // throttled. Keying by hostname (as the click-rewrite path's
+    // isRewriteLoop does) would wrongly drop cleaning on fast same-host
+    // navigation, and sharing that budget would starve either path.
+    if (isRecleanLoop(url)) return;
+    if (!window.__mugaCleaner || typeof window.__mugaCleaner.processUrl !== "function") return;
+    // Perf note: this runs a full processUrl() per pushState/replaceState
+    // on high-frequency SPA routers. The loop guard above prevents runaway
+    // recursion, but bursty routers (e.g. scroll-driven URL updates) could
+    // still call this often. Not coalesced (microtask/rAF) for now — keep
+    // an eye on this if profiling shows it matters; the main-world sync
+    // subset intentionally avoids this cost for the common case.
+    const domainRules = _domainRulesCache || [];
+    const pathRules = _pathRulesCache || { pathStripRules: [], pathAffiliateRules: [] };
+    let result;
+    try {
+      result = window.__mugaCleaner.processUrl(
+        url, _contentPrefs, domainRules,
+        undefined, undefined, undefined,
+        pathRules.pathStripRules, pathRules.pathAffiliateRules,
+      );
+    } catch (err) {
+      console.error("[MUGA] reclean failed:", err);
+      return;
+    }
+    if (!result || !result.cleanUrl || result.cleanUrl === window.location.href) return;
+    _lastRecleanUrl = result.cleanUrl;
+    try {
+      history.replaceState(history.state, "", result.cleanUrl);
+    } catch { /* cross-origin or sandboxed — ignore */ }
+    // Fire-and-forget: tell the SW to update badge + stats. Failure here
+    // doesn't roll back the URL change — the user's address bar already
+    // reflects the cleaned URL.
+    if (result.junkRemoved > 0) {
+      chrome.runtime.sendMessage({
+        type: "BADGE_AND_STATS",
+        junkRemoved: result.junkRemoved,
+        removedTracking: result.removedTracking,
+        cleanUrl: result.cleanUrl,
+        originalUrl: url,
+      }).catch(() => { /* SW dead — badge will catch up next nav */ });
+    }
+  };
+
   // ── Self-clean: clean the current page URL on load ────────────────────────
   // (#356) Cleans locally via the bundled cleaner attached to
   // `window.__mugaCleaner` by content/cleaner-bundle.js (loaded just before
@@ -424,45 +535,17 @@
   // Domain rules are fetched once at IIFE start (see getDomainRulesCached
   // hoisted above). Stats and badge updates fire-and-forget; SW death is
   // not fatal — only the badge lags by one nav.
+  //
+  // Delegates to window.__mugaReclean (#951) so the document_start path and
+  // the SPA-navigation reclean path (history-defuser.js) share one
+  // implementation. By the time the Promise.all below resolves, each
+  // getXCached() has already set its module-level cache as a side effect
+  // (see definitions above), so __mugaReclean can read them synchronously.
 
   const _hasDNR = typeof chrome.declarativeNetRequest !== "undefined";
 
-  if (!_hasDNR) Promise.all([getContentPrefs(), getDomainRulesCached(), getPathRulesCached()]).then(([prefs, domainRules, pathRules]) => {
-    if (!prefs || !prefs.enabled || !prefs.onboardingDone) return;
-    const href = window.location.href;
-    if (!href.startsWith("http")) return;
-    if (!window.__mugaCleaner || typeof window.__mugaCleaner.processUrl !== "function") {
-      // Bundle didn't load — should never happen in production. Silent
-      // degrade: leave the URL alone rather than crash.
-      return;
-    }
-    let result;
-    try {
-      result = window.__mugaCleaner.processUrl(
-        href, prefs, domainRules,
-        undefined, undefined, undefined,
-        pathRules.pathStripRules, pathRules.pathAffiliateRules,
-      );
-    } catch (err) {
-      console.error("[MUGA] local self-clean failed:", err);
-      return;
-    }
-    if (!result || !result.cleanUrl || result.cleanUrl === href) return;
-    try {
-      history.replaceState(history.state, "", result.cleanUrl);
-    } catch { /* cross-origin or sandboxed — ignore */ }
-    // Fire-and-forget: tell the SW to update badge + stats. Failure here
-    // doesn't roll back the URL change — the user's address bar already
-    // reflects the cleaned URL.
-    if (result.junkRemoved > 0) {
-      chrome.runtime.sendMessage({
-        type: "BADGE_AND_STATS",
-        junkRemoved: result.junkRemoved,
-        removedTracking: result.removedTracking,
-        cleanUrl: result.cleanUrl,
-        originalUrl: href,
-      }).catch(() => { /* SW dead — badge will catch up next nav */ });
-    }
+  if (!_hasDNR) Promise.all([getContentPrefs(), getDomainRulesCached(), getPathRulesCached()]).then(() => {
+    window.__mugaReclean(window.location.href);
   });
 
   /**

--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -137,6 +137,36 @@
     return _gateOpen;
   }
 
+  // ── Post-commit signal (#951 Layer B) ────────────────────────────────────
+  //
+  // The subset strip above is a synchronous, defense-in-depth measure only
+  // (see file docblock). It does NOT cover path segments (e.g. Amazon's
+  // trailing `/ref=...`) or the full tracking-param list, because doing the
+  // full clean here would require an async round-trip the page might
+  // observe. Instead, once the native call has committed (so
+  // `window.location` already reflects the new URL), we tell the
+  // isolated-world side to run the FULL pipeline (path + query rules) via
+  // `muga:history-committed`. The isolated-world listener lives in
+  // history-defuser.js; the actual reclean logic lives in cleaner.js
+  // (`window.__mugaReclean`), which is only reachable from the isolated
+  // world.
+  //
+  // SECURITY (#811): this event is dispatched from the MAIN (page) world, so
+  // its CustomEvent detail is fully readable by hostile page scripts. It must
+  // NOT carry the gate nonce — leaking it would hand the page the secret that
+  // guards the `muga:history-gate` handshake, letting it forge a gate event
+  // and force the gate closed to disable cleaning. No nonce is needed here:
+  // the isolated reclean this triggers only ever calls history.replaceState()
+  // on the resulting URL, something page scripts can already do directly, so a
+  // forged committed event grants no capability the page lacks.
+  function dispatchCommitted(finalUrl) {
+    try {
+      document.dispatchEvent(new CustomEvent("muga:history-committed", {
+        detail: { url: finalUrl },
+      }));
+    } catch { /* document detached or CustomEvent unavailable — silent */ }
+  }
+
   const origPush = history.pushState;
   const origReplace = history.replaceState;
 
@@ -145,9 +175,11 @@
     if (arguments.length >= 3 && gateOpen()) {
       try { finalUrl = cleanUrl(url); } catch { finalUrl = url; }
     }
-    return arguments.length >= 3
+    const ret = arguments.length >= 3
       ? origPush.call(this, state, title, finalUrl)
       : origPush.call(this, state, title);
+    if (arguments.length >= 3 && gateOpen()) dispatchCommitted(finalUrl);
+    return ret;
   };
 
   history.replaceState = function replaceState(state, title, url) {
@@ -155,8 +187,10 @@
     if (arguments.length >= 3 && gateOpen()) {
       try { finalUrl = cleanUrl(url); } catch { finalUrl = url; }
     }
-    return arguments.length >= 3
+    const ret = arguments.length >= 3
       ? origReplace.call(this, state, title, finalUrl)
       : origReplace.call(this, state, title);
+    if (arguments.length >= 3 && gateOpen()) dispatchCommitted(finalUrl);
+    return ret;
   };
 })();

--- a/src/content/history-defuser.js
+++ b/src/content/history-defuser.js
@@ -118,6 +118,58 @@
     } catch { /* document detached or CustomEvent unavailable — silent */ }
   }
 
+  // ── SPA reclean on committed history navigation (#951 Layer B) ─────────
+  //
+  // The main-world wrap (history-defuser-mainworld.js) only applies a
+  // synchronous, hard-coded query-param SUBSET before committing a
+  // pushState/replaceState — it has no chrome.* access and can't reach
+  // path rules or the full tracking-param list. After it commits the call,
+  // it dispatches `muga:history-committed` on `document` so this
+  // isolated-world script can trigger the FULL cleaning pipeline
+  // (path-strip + path-affiliate + full query rules) via
+  // `window.__mugaReclean`, which is set by content/cleaner.js — a sibling
+  // isolated-world script sharing the same `window` object.
+  //
+  // No nonce guard here (unlike the gate handshake): `muga:history-committed`
+  // originates in the MAIN world, so its detail is page-readable and cannot
+  // carry a secret without leaking it (see the SECURITY note in
+  // history-defuser-mainworld.js). A forged event is harmless — __mugaReclean
+  // only calls history.replaceState() on the URL, which the page can already
+  // do itself — and is further bounded by the prefs gate + loop guard inside
+  // __mugaReclean.
+  document.addEventListener("muga:history-committed", (e) => {
+    if (!e || !e.detail) return;
+    try {
+      if (typeof window.__mugaReclean === "function") {
+        window.__mugaReclean(e.detail.url);
+      }
+    } catch { /* never let a reclean failure break the page's navigation */ }
+  });
+
+  // ── popstate / hashchange coverage (#951 Layer B, additive) ─────────────
+  //
+  // Back/forward navigation (popstate) and hash-only routing (hashchange)
+  // are ALSO same-document navigations that never hit the network layer,
+  // so DNR never sees them — same gap as pushState/replaceState. These are
+  // genuine browser-dispatched events (not page-triggerable the way a
+  // CustomEvent is), so no nonce handshake is needed here. Gating
+  // (enabled/onboardingDone) happens inside window.__mugaReclean itself.
+  window.addEventListener("popstate", () => {
+    try {
+      if (typeof window.__mugaReclean === "function") {
+        window.__mugaReclean(window.location.href);
+      }
+    } catch { /* never let a reclean failure break the page's navigation */ }
+  });
+
+  window.addEventListener("hashchange", () => {
+    try {
+      if (typeof window.__mugaReclean === "function") {
+        window.__mugaReclean(window.location.href);
+      }
+    } catch { /* never let a reclean failure break the page's navigation */ }
+  });
+
   function readPrefsAndGate() {
     try {
       chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -103,6 +103,17 @@
     "extension_pages": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app; style-src 'self'"
   },
 
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "rules/domain-rules.json",
+        "rules/path-strip-rules.json",
+        "rules/path-affiliate-rules.json"
+      ],
+      "matches": ["<all_urls>"]
+    }
+  ],
+
   "icons": {
     "16": "icons/16.png",
     "48": "icons/48.png",

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -78,7 +78,10 @@
     "privacy/privacy.html",
     "privacy/tos.html",
     "content/history-defuser-mainworld.js",
-    "content/window-name-defuser-mainworld.js"
+    "content/window-name-defuser-mainworld.js",
+    "rules/domain-rules.json",
+    "rules/path-strip-rules.json",
+    "rules/path-affiliate-rules.json"
   ],
 
   "declarative_net_request": {

--- a/tests/e2e/history-defuser-reclean.spec.mjs
+++ b/tests/e2e/history-defuser-reclean.spec.mjs
@@ -1,0 +1,162 @@
+/**
+ * E2E: SPA reclean on same-document navigation (#951 Layer B)
+ *
+ * Layer A (#955) fixed DNR + the document_start self-clean, but a
+ * same-document SPA navigation (e.g. an on-site banner click that calls
+ * `history.pushState`) never hits the network layer, so DNR never sees it,
+ * and the document_start self-clean only runs once at page load. This left
+ * two independent gaps on Amazon-shaped URLs:
+ *   - Path rules ("/ref=..." trailing segment) were never re-applied.
+ *   - The domain-scoped "aref" query param (declared per-domain in
+ *     domain-rules.json, not in the main-world's hard-coded query subset)
+ *     survived a pushState navigation.
+ *
+ * This spec drives a REAL pushState navigation (not a page.goto network
+ * request) against a stubbed Amazon-shaped host and proves the full local
+ * pipeline (domain rules + path rules) gets re-applied via the
+ * muga:history-committed cross-world signal, and that the reclean does not
+ * loop.
+ *
+ * The unit tests in tests/unit/history-defuser.test.mjs cover the pure
+ * processUrl behaviour and the structural wiring; this spec proves the
+ * end-to-end wiring actually fires in a real Chromium with the extension
+ * loaded.
+ *
+ * NOTE: like tests/e2e/history-defuser.spec.mjs, this is NOT run as part of
+ * `npm test` (unit suite). Run via `npm run test:e2e` or equivalent.
+ *
+ * DEPENDS ON THE WAR FIX SHIPPED WITH THIS CHANGE: on Chrome MV3 a content
+ * script's fetch(chrome.runtime.getURL("rules/*.json")) is attributed to the
+ * PAGE's origin and fails with net::ERR_FAILED unless the resource is listed
+ * in web_accessible_resources — so getDomainRulesCached()/getPathRulesCached()
+ * in content/cleaner.js silently fell back to empty arrays on EVERY
+ * content-script execution (not just this reclean path, but also the
+ * document_start self-clean, click handler, and copy handler, meaning #955
+ * Layer A path-strip was dead at runtime on Chrome). This change adds
+ * "rules/domain-rules.json", "rules/path-strip-rules.json", and
+ * "rules/path-affiliate-rules.json" to web_accessible_resources in both
+ * manifests, which is why the full local pipeline now re-applies at runtime.
+ * Empirically confirmed: without the WAR entry this spec times out (/ref=
+ * survives); with it, it passes. web_accessible_resources is NOT a permission,
+ * so no new install/update permission warning.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "www.amazon.com";
+
+async function completeOnboarding(context, extensionId) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(() =>
+    new Promise(resolve => {
+      chrome.storage.sync.set({ enabled: true }, () => {
+        chrome.storage.local.set({
+          mugaConsent: { onboardingDone: true, consentVersion: "1.1", consentDate: Date.now() },
+        }, () => {
+          chrome.storage.sync.set({ onboardingDone: true }, resolve);
+        });
+      });
+    })
+  );
+  await page.close();
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Stubs an Amazon-shaped host. The initial load is a clean, simple page
+ * (no /dp/ pattern, no query) so the amazon_path_canonical DNR rule and the
+ * global tracking-params DNR rule are both no-ops on the FIRST navigation —
+ * the interesting behaviour under test is entirely client-side pushState,
+ * which never generates a network request DNR could intercept anyway.
+ */
+async function stubAmazonHost(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <button id="muga-push-btn">on-site banner link</button>
+        <script>
+          // Count replaceState calls at the page-world level (same world as
+          // history-defuser-mainworld.js, since it runs with world: MAIN).
+          // Bounds the "no rewrite loop" assertion: a runaway reclean loop
+          // would keep calling replaceState indefinitely.
+          window.__mugaReplaceCount = 0;
+          const _origReplace = history.replaceState.bind(history);
+          history.replaceState = function (...args) {
+            window.__mugaReplaceCount++;
+            return _origReplace(...args);
+          };
+
+          // Simulates an on-site banner click driving a client-side router
+          // navigation (no network request) to a dirty Amazon product URL:
+          // an SEO slug + trailing /ref= path marker, plus the domain-scoped
+          // "aref" tracking query param and a functional "th" param.
+          document.getElementById("muga-push-btn").addEventListener("click", () => {
+            history.pushState({ tag: "muga-test" }, "Product",
+              "/Some-Product-Name/dp/B0044R881I/ref=sr_1_1?aref=abc123&th=1");
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("SPA reclean on pushState (#951 Layer B)", () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId);
+  });
+
+  test("Amazon-like banner pushState: /ref= and aref are cleaned, no rewrite loop", async ({ context }) => {
+    const page = await context.newPage();
+    await stubAmazonHost(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the page-world wrap flag set by history-defuser-mainworld.js.
+    await page.waitForFunction(() => window.__mugaHistoryDefused === true, { timeout: 10000 });
+
+    await page.locator("#muga-push-btn").click();
+
+    // The full reclean is async (main-world dispatch -> isolated-world
+    // muga:history-committed listener -> window.__mugaReclean ->
+    // processUrl -> replaceState), unlike the main-world synchronous
+    // query-subset strip. Poll until the path segment is gone.
+    await page.waitForFunction(
+      () => !window.location.pathname.includes("/ref="),
+      { timeout: 10000 }
+    );
+
+    const finalUrl = await page.evaluate(() => window.location.href);
+    const finalPath = await page.evaluate(() => window.location.pathname);
+    const finalSearch = await page.evaluate(() => window.location.search);
+
+    // Path rule: the SEO slug + trailing /ref= marker are gone.
+    expect(finalPath).not.toContain("/ref=");
+    expect(finalPath).toContain("/dp/B0044R881I");
+    // Domain-scoped query strip: aref is gone (not in the main-world's
+    // hard-coded subset — only reachable via the full domainRules pipeline).
+    expect(finalSearch).not.toContain("aref");
+    // Functional param preserved.
+    expect(finalSearch).toContain("th=1");
+
+    // No rewrite loop: give any further (incorrect) recleans a chance to
+    // fire, then assert the replaceState call count stayed bounded. One
+    // call cleans the URL; a second may occur if the committed event for
+    // our own replaceState round-trips before the loop guard catches it;
+    // anything beyond that indicates the guard failed to terminate.
+    // REASON: there is no observable "reclean settled" signal to poll for
+    // (the whole point is proving nothing further happens) — a short fixed
+    // wait is the only way to assert an absence of runaway async activity.
+    await page.waitForTimeout(500);
+    const replaceCount = await page.evaluate(() => window.__mugaReplaceCount);
+    expect(replaceCount).toBeLessThanOrEqual(2);
+
+    // URL stayed stable after settling (no oscillation).
+    const settledUrl = await page.evaluate(() => window.location.href);
+    expect(settledUrl).toBe(finalUrl);
+
+    await page.close();
+  });
+});

--- a/tests/unit/history-defuser.test.mjs
+++ b/tests/unit/history-defuser.test.mjs
@@ -22,6 +22,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { installHistoryDefuser } from "../../src/lib/history-defuser.js";
+import { processUrl } from "../../src/lib/cleaner.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -345,5 +346,236 @@ describe("history-defuser — content-script wiring", () => {
     // Gate listener present.
     assert.ok(/muga:history-gate/.test(src),
       "main-world wrap must listen for muga:history-gate to honor disabled state");
+  });
+});
+
+// ── SPA reclean pipeline (#951 Layer B) ─────────────────────────────────────
+//
+// Layer A (#955) fixed DNR + the document_start self-clean but left a gap:
+// a same-document SPA navigation (history.pushState/replaceState, popstate,
+// hashchange) never re-runs the cleaning pipeline, so path rules (Amazon's
+// trailing "/ref=...") and domain-scoped query params (e.g. "aref") survive
+// an on-site pushState navigation. This section proves:
+//   1. processUrl (the pure function __mugaReclean delegates to) DOES clean
+//      both path segments and domain-scoped query params when given real
+//      domainRules + pathRules — i.e. the underlying pipeline is capable of
+//      the full clean once wired with both rule sets together.
+//   2. content/cleaner.js actually wires window.__mugaReclean to pass both
+//      pathRules.pathStripRules and pathRules.pathAffiliateRules into
+//      processUrl (the exact gap that let Layer A's bug ship — the
+//      pre-#951 self-clean omitted path rules from some call sites).
+//   3. The loop-guard, nonce handling, and dispatch wiring exist in source.
+//
+// content/cleaner.js and content/history-defuser*.js are plain IIFEs with
+// no module exports (chrome.*, window, document side effects at parse
+// time), so — following this repo's established pattern for these files
+// (see the "content-script wiring" describe block above, and
+// tests/unit/content-script.test.mjs) — wiring is verified via structural
+// source assertions, while the actual cleaning LOGIC is verified against
+// the real, exported pure `processUrl` function with the project's real
+// rule data. This matches the "prefer testing pure logic over IIFE side
+// effects" convention.
+
+const cleanerSrc = readFileSync(
+  join(__dirname, "../../src/content/cleaner.js"), "utf8"
+);
+const mainworldSrc = readFileSync(
+  join(__dirname, "../../src/content/history-defuser-mainworld.js"), "utf8"
+);
+const gateSrc = readFileSync(
+  join(__dirname, "../../src/content/history-defuser.js"), "utf8"
+);
+
+// Minimal prefs — mirrors the shape used by other processUrl integration
+// tests (see tests/unit/cleaner-canonical-integration.test.mjs).
+const RECLEAN_PREFS = {
+  enabled: true,
+  onboardingDone: true,
+  injectOwnAffiliate: false,
+  notifyForeignAffiliate: false,
+  blacklist: [],
+  whitelist: [],
+};
+
+const domainRules = JSON.parse(
+  readFileSync(join(__dirname, "../../src/rules/domain-rules.json"), "utf8")
+);
+const pathStripRules = JSON.parse(
+  readFileSync(join(__dirname, "../../src/rules/path-strip-rules.json"), "utf8")
+);
+const pathAffiliateRules = JSON.parse(
+  readFileSync(join(__dirname, "../../src/rules/path-affiliate-rules.json"), "utf8")
+);
+
+describe("processUrl — full reclean on an Amazon-like pushState URL (#951 Layer B)", () => {
+  test("real path-strip-rules.json is non-empty (the exact data Layer A's bug omitted)", () => {
+    assert.ok(Array.isArray(pathStripRules) && pathStripRules.length > 0,
+      "path-strip-rules.json must be non-empty for this regression to mean anything");
+    assert.ok(Array.isArray(pathAffiliateRules),
+      "path-affiliate-rules.json must parse to an array");
+  });
+
+  test("strips the Amazon /ref= path segment AND the domain-scoped aref query param together", () => {
+    // Simulates a same-document pushState navigation (e.g. an on-site
+    // banner click) landing a dirty Amazon URL — no network request is
+    // ever made for this, so DNR never sees it; only the local pipeline
+    // (domainRules + pathRules) can catch it.
+    const dirty = "https://www.amazon.com/Some-Product-Name/dp/B0044R881I/ref=sr_1_1?aref=abc123&th=1";
+    const result = processUrl(
+      dirty, RECLEAN_PREFS, domainRules,
+      undefined, undefined, undefined,
+      pathStripRules, pathAffiliateRules,
+    );
+    assert.ok(result && result.cleanUrl, "processUrl must return a cleanUrl");
+    assert.ok(!result.cleanUrl.includes("/ref="),
+      `path-strip must remove the trailing /ref= segment, got: ${result.cleanUrl}`);
+    assert.ok(!/[?&]aref=/.test(result.cleanUrl),
+      `domain-scoped strip must remove aref, got: ${result.cleanUrl}`);
+    // Functional param preserved (amazon.com preserveParams includes "th").
+    assert.ok(/[?&]th=1/.test(result.cleanUrl),
+      "functional param th must survive the clean");
+  });
+
+  test("WITHOUT pathStripRules, the /ref= segment survives (proves path rules are load-bearing)", () => {
+    const dirty = "https://www.amazon.com/Some-Product-Name/dp/B0044R881I/ref=sr_1_1?aref=abc123&th=1";
+    const result = processUrl(
+      dirty, RECLEAN_PREFS, domainRules,
+      undefined, undefined, undefined,
+      [], [], // <- empty path rules, same shape as the pre-#951 self-clean bug
+    );
+    assert.ok(result.cleanUrl.includes("/ref="),
+      "without path rules, /ref= must NOT be stripped — this is the exact regression #951 Layer B fixes");
+    // Domain-scoped query strip is independent of path rules and still fires.
+    assert.ok(!/[?&]aref=/.test(result.cleanUrl));
+  });
+});
+
+describe("content/cleaner.js — window.__mugaReclean wiring (#951 Layer B)", () => {
+  test("exposes window.__mugaReclean as a global for history-defuser.js to call", () => {
+    assert.ok(/window\.__mugaReclean\s*=\s*function/.test(cleanerSrc),
+      "cleaner.js must assign window.__mugaReclean = function (...) {...}");
+  });
+
+  function recleanBody() {
+    const match = cleanerSrc.match(
+      /window\.__mugaReclean\s*=\s*function[\s\S]*?\n {2}\};/
+    );
+    assert.ok(match, "must be able to isolate the __mugaReclean function body");
+    return match[0];
+  }
+
+  test("__mugaReclean passes pathRules.pathStripRules and pathRules.pathAffiliateRules into processUrl", () => {
+    const body = recleanBody();
+    assert.ok(/processUrl\(/.test(body), "__mugaReclean must call processUrl");
+    assert.ok(body.includes("pathRules.pathStripRules"),
+      "__mugaReclean must forward pathRules.pathStripRules to processUrl");
+    assert.ok(body.includes("pathRules.pathAffiliateRules"),
+      "__mugaReclean must forward pathRules.pathAffiliateRules to processUrl");
+    // Guards against a silent regression back to hardcoded empty arrays —
+    // the exact shape of the pre-#951 bug.
+    assert.equal(/processUrl\([^)]*\[\],\s*\[\]/.test(body), false,
+      "__mugaReclean must not call processUrl with hardcoded empty path-rule arrays");
+  });
+
+  test("__mugaReclean also forwards domainRules (so domain-scoped params like aref are stripped)", () => {
+    const body = recleanBody();
+    assert.ok(body.includes("domainRules"),
+      "__mugaReclean must forward domainRules to processUrl");
+  });
+
+  test("loop guard: __mugaReclean short-circuits when the URL matches the last recleaned URL", () => {
+    const body = recleanBody();
+    assert.ok(/_lastRecleanUrl/.test(body),
+      "__mugaReclean must reference a _lastRecleanUrl guard");
+    // The short-circuit compare must appear BEFORE the processUrl() call so
+    // the guard actually prevents redundant work / recursive re-entry.
+    const guardIdx = body.indexOf("url === _lastRecleanUrl");
+    const processIdx = body.indexOf("processUrl(");
+    assert.ok(guardIdx !== -1, "must compare url === _lastRecleanUrl");
+    assert.ok(guardIdx < processIdx,
+      "the loop-guard check must run before processUrl() is invoked");
+    // _lastRecleanUrl must be updated with the cleaned result so a
+    // subsequent re-entrant call (triggered by our own replaceState) is
+    // recognized and short-circuited.
+    assert.ok(/_lastRecleanUrl\s*=\s*result\.cleanUrl/.test(body),
+      "_lastRecleanUrl must be set to the cleaned URL after a successful clean");
+  });
+
+  test("__mugaReclean bails when prefs are missing/disabled/not onboarded", () => {
+    const body = recleanBody();
+    assert.ok(/!_contentPrefs/.test(body) && /_contentPrefs\.enabled/.test(body),
+      "__mugaReclean must gate on _contentPrefs.enabled");
+    assert.ok(/onboardingDone/.test(body),
+      "__mugaReclean must gate on onboardingDone");
+  });
+
+  test("__mugaReclean uses a URL-keyed loop cap, not the hostname-keyed isRewriteLoop", () => {
+    const body = recleanBody();
+    assert.ok(/isRecleanLoop\(url\)/.test(body),
+      "__mugaReclean must call the URL-keyed isRecleanLoop(url) guard");
+    assert.ok(!/isRewriteLoop\(/.test(body),
+      "__mugaReclean must NOT reuse the hostname-keyed isRewriteLoop() — it throttles legit rapid SPA navs and shares the click-rewrite budget");
+  });
+
+  test("document_start self-clean delegates to window.__mugaReclean (single code path)", () => {
+    assert.ok(/window\.__mugaReclean\(window\.location\.href\)/.test(cleanerSrc),
+      "the document_start self-clean must call window.__mugaReclean, not duplicate the logic");
+  });
+});
+
+describe("content/history-defuser-mainworld.js — post-commit dispatch (#951 Layer B)", () => {
+  test("dispatches muga:history-committed after a committed pushState/replaceState", () => {
+    assert.ok(/muga:history-committed/.test(mainworldSrc),
+      "main-world wrap must dispatch muga:history-committed");
+  });
+
+  test("the commit event must NOT carry the gate nonce (main-world event is page-readable, #811)", () => {
+    const match = mainworldSrc.match(
+      /function dispatchCommitted[\s\S]*?detail:\s*\{([^}]*)\}/
+    );
+    assert.ok(match, "dispatchCommitted must build a muga:history-committed detail");
+    assert.ok(!/nonce/.test(match[1]),
+      "committed detail must not include the nonce — a MAIN-world event leaks it to page scripts, reopening the #811 gate-spoof");
+  });
+
+  test("commit dispatch only fires when the gate is open", () => {
+    // dispatchCommitted(...) call sites must be guarded by gateOpen().
+    const pushSite = mainworldSrc.match(
+      /history\.pushState = function pushState[\s\S]*?\n {2}\};/
+    )[0];
+    const replaceSite = mainworldSrc.match(
+      /history\.replaceState = function replaceState[\s\S]*?\n {2}\};/
+    )[0];
+    assert.ok(/gateOpen\(\)\)\s*dispatchCommitted/.test(pushSite),
+      "pushState wrap must only dispatchCommitted when gateOpen()");
+    assert.ok(/gateOpen\(\)\)\s*dispatchCommitted/.test(replaceSite),
+      "replaceState wrap must only dispatchCommitted when gateOpen()");
+  });
+});
+
+describe("content/history-defuser.js — muga:history-committed + popstate/hashchange (#951 Layer B)", () => {
+  test("listens for muga:history-committed without a nonce gate (forged events are harmless; a nonce would leak)", () => {
+    const match = gateSrc.match(
+      /document\.addEventListener\("muga:history-committed"[\s\S]*?\}\);/
+    );
+    assert.ok(match, "history-defuser.js must listen for muga:history-committed");
+    const handler = match[0];
+    assert.ok(!/e\.detail\.nonce/.test(handler),
+      "handler must NOT gate the committed event on a nonce — the MAIN-world event cannot carry one without leaking it (#811)");
+    assert.ok(/window\.__mugaReclean/.test(handler),
+      "handler must call window.__mugaReclean on a commit event");
+  });
+
+  test("adds popstate and hashchange listeners that call window.__mugaReclean (additive same-document coverage)", () => {
+    assert.ok(/addEventListener\("popstate"/.test(gateSrc),
+      "history-defuser.js must add a popstate listener");
+    assert.ok(/addEventListener\("hashchange"/.test(gateSrc),
+      "history-defuser.js must add a hashchange listener");
+    const popstateBlock = gateSrc.match(/addEventListener\("popstate"[\s\S]*?\}\);/)[0];
+    const hashchangeBlock = gateSrc.match(/addEventListener\("hashchange"[\s\S]*?\}\);/)[0];
+    assert.ok(popstateBlock.includes("window.__mugaReclean"),
+      "popstate listener must call window.__mugaReclean");
+    assert.ok(hashchangeBlock.includes("window.__mugaReclean"),
+      "hashchange listener must call window.__mugaReclean");
   });
 });


### PR DESCRIPTION
Closes #951 (Layer B). Layer A shipped as #955.

## Problem
A same-document navigation (`history.pushState`/`replaceState`, `popstate`, `hashchange`) fires no network request, so DNR never sees it and the `document_start` self-clean runs only once. On on-site SPA navigations (e.g. an Amazon banner click), the path rule `/ref=` and the domain-scoped query param `aref` survived.

## Fix
- **Main world** (`history-defuser-mainworld.js`): after each gated `push`/`replaceState` commits, dispatch `muga:history-committed`.
- **Isolated world** (`history-defuser.js`): listen for it and re-run the full pipeline via `window.__mugaReclean`; `popstate`/`hashchange` covered too.
- **`cleaner.js`**: extracted the `document_start` self-clean into the reusable `window.__mugaReclean(url)` (single code path). Re-entrancy is bounded by a last-cleaned-URL short-circuit plus a **per-URL** loop cap (distinct rapid navs are never throttled; a page re-adding a param in a loop is capped).

## Pre-existing bug fixed here (broader than Layer B)
On **Chrome MV3**, a content-script `fetch(chrome.runtime.getURL("rules/*.json"))` fails with `net::ERR_FAILED` unless the file is in `web_accessible_resources`. Without it, `getDomainRulesCached()`/`getPathRulesCached()` silently fell back to empty arrays on **every** content-script run — so #955 Layer A path-strip was already dead at runtime on Chrome, along with `aref`. This PR declares the 3 rule JSON as web-accessible in both manifests.

`web_accessible_resources` is **not a permission** — no new install/update permission warning. (Empirically confirmed: without the entry the new e2e times out; with it, it passes.)

## Security
`muga:history-committed` originates in the page world, so its `detail` is page-readable. It deliberately carries **no nonce** — carrying the gate nonce would leak the #811 handshake secret and let a page force the gate closed. No guard is needed: the reclean only calls `history.replaceState`, which page scripts can already do. A regression test locks this in.

## Tests
- Unit `tests/unit/history-defuser.test.mjs`: 37/37. Full suite: 5548/5549 (0 fail, 1 pre-existing skip).
- e2e `tests/e2e/history-defuser-reclean.spec.mjs`: real-Chromium `pushState` proving `/ref=` + `aref` cleaned with no rewrite loop — passes.
- eslint clean.

Adversarially reviewed (fresh context); the nonce-leak and hostname-throttle findings were confirmed and fixed before this PR.