### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to MUGA will be documented in this file.
 
 ## [Unreleased]
 
-Cleaning now follows same-document navigation, copy/share never leaks a tag, a per-tab badge shows what was stripped, and a settings reorganization plus a July audit wave hardens consent gating, accessibility, and Chrome path cleaning.
+## [2.4.0] - 2026-07-03
+
+Cleaning now follows same-document navigation, copy/share never leaks a tag, a per-tab badge shows what was stripped, and a settings reorganization plus a July audit wave hardens consent gating, accessibility, and Chrome path cleaning. Affiliate composition (remove-theirs then add-ours) now extends to Bookshop's path-based creator wrappers.
 
 ### Features
 
@@ -37,6 +39,7 @@ Cleaning now follows same-document navigation, copy/share never leaks a tag, a p
 ### Changed
 
 - **"Remove all affiliate tags from other sources" now composes with tag injection.** When both that toggle and MUGA's own-tag injection are enabled, a foreign tag is stripped and ours is then injected into the now-tagless URL (remove theirs, then add ours), matching the toggle's label. Previously injection was suppressed whenever remove-all was on. With injection off, remove-all still leaves the link with no affiliate tag. Supersedes the earlier #353 guard; the two settings are independent, explicit opt-ins.
+- **Path-based affiliate composition on Bookshop** (#959). The remove-all + inject composition now also covers Bookshop's path-based `/a/{creator}/` creator wrappers. With remove-all on, the foreign creator wrapper is unwrapped to its destination; if injection is also on and the destination is a product page, MUGA's affiliate is then added. Storefront (`/shop/`) pages are never touched, and Honor Creator Mode still preserves the creator wrapper untouched. Cross-origin embedded destinations are refused (no open redirect).
 - **Copy rebranded around URL-cleaner DNA** (#953). User-facing copy makes the URL-cleaning purpose explicit, Spanish copy is peninsular (Castilian), Allowlist/Blocklist terminology, and em-dashes removed.
 
 ### Ruleset pipeline (infrastructure)
@@ -1039,7 +1042,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chrome.storage.sync` for cross-device sync
 - MIT License, README
 
-[Unreleased]: https://github.com/yocreoquesi/muga/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/yocreoquesi/muga/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/yocreoquesi/muga/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/yocreoquesi/muga/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/yocreoquesi/muga/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/yocreoquesi/muga/compare/v2.0.0...v2.1.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.3.0-blue)](#)
+[![Version](https://img.shields.io/badge/version-2.4.0-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen)](#development)
 [![CAPS](https://img.shields.io/badge/CAPS-Basic%20%2B%20Contextual-2ea44f)](CONFORMANCE.md)
 # MUGA: The URL denoise extension for the web
@@ -17,7 +17,7 @@
 
 > **MUGA?** Maximally Unannoying Garbage Auditor. **MUGA.** Make URLs Quiet Again. **MUGA!** The web, with the noise turned down.
 
-> **2.3.0 shipped.** Self-scaling ruleset pipeline (EPIC C), full consent-gate coverage for all DNR rulesets, Firefox wrapper_unwrap parity, 25-issue June 2026 audit wave. See [CHANGELOG](CHANGELOG.md) for the full release notes.
+> **2.4.0 shipped.** Cleaning follows same-document (SPA) navigation, copy/share never leaks MUGA's own tag, a per-tab badge shows what was stripped, affiliate composition (remove theirs, then add ours) now covers Bookshop's path-based creator wrappers, and a July audit wave hardened consent gating, accessibility, and Chrome path cleaning. See [CHANGELOG](CHANGELOG.md) for the full release notes.
 
 [Privacy policy](https://rules.muga.app/) · [Comparison vs other URL cleaners](https://rules.muga.app/comparison.html) · [FAQ](docs/faq.md) · [Objectives & non-goals](OBJECTIVES.md) · [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) · [ADRs](docs/adr/) · [Maintainer ops docs](docs/ops/README.md)
 

--- a/docs/data_architect.md
+++ b/docs/data_architect.md
@@ -32,7 +32,7 @@ Source of truth: `PREF_DEFAULTS` in `src/lib/storage.js`.
 | `showReportButton` | boolean | `true` | Show "Report a problem" button in popup |
 | `domainStats` | boolean | `true` | Track and display per-domain tracker counts in popup |
 | `showBadge` | boolean | `true` | Show the tab's running count of stripped tracking params as a native toolbar badge (#910) |
-| `remoteRulesEnabled` | boolean | `false` | Opt-in: fetch signed remote parameter updates weekly. Default off (zero network activity on fresh install) |
+| `remoteRulesEnabled` | boolean | `true` | On by default (#888): fetches Ed25519-signed rule updates at most once per 7 days (`credentials: "omit"`, no cookies, no identifiers). A fresh install makes this one outbound GET to rules.muga.app; disable in Settings for zero network activity. Supersedes REQ-OPT-1. |
 | `honorCreatorMode` | boolean | `false` | Opt-in (#435, B12; wired in #452): preserve creator referral chains on trusted social-media and link-shortener redirects (a `detectWrapper()` match) when the referrer is in `creatorAllowlist`. Does not gate affiliate-redirect networks (Awin, Skimlinks, etc.) — those are preserved automatically via unconditional pass-through, independent of this pref (#907). |
 | `creatorAllowlist` | string[] | `[]` | (#445, B13) Per-creator allowlist consumed by Honor Creator Mode. Referrer-domain-shaped strings (e.g. `youtube.com/@LinusTechTips`, `dot-css-news.com`). Capped at 100 entries (storage hygiene). CRUD in `src/lib/creator-allowlist.js`. |
 | `canonicalExtractorEnabled` | boolean | `true` | (#442, B7) When the wrapper engine detects an opaque wrapper (host matched but no destination in URL), consult content-script-supplied `<link rel=canonical>` / JSON-LD `@id` before giving up. Default ON. |
@@ -95,14 +95,18 @@ The core `processUrl(rawUrl, prefs)` function in `src/lib/cleaner.js` returns:
 ```js
 {
   cleanUrl: string,           // The cleaned URL (equals rawUrl if no changes)
-  action: string,             // "untouched" | "blacklisted" | "cleaned" | "error"
+  action: string,             // "untouched" | "cleaned" | "injected" | "detected_foreign" | "blacklisted" | "honored-creator"
   removedTracking: string[],  // Names of tracking params removed
   junkRemoved: number,        // Count of params removed + path segments cleaned
-  detectedAffiliate: {        // null if no foreign affiliate detected
+  detectedAffiliate: {        // null unless a foreign affiliate is detected (notifyForeignAffiliate on)
     param: string,
     value: string,
-    id: string,
-    name: string,
+    pattern: object,          // The matched affiliate pattern
   } | null,
+  preservedAffiliate: object | null,  // A creator/foreign tag deliberately left intact, else null
+  creatorReferralPreserved: boolean,  // true when a path-based creator referral (e.g. Bookshop /a/) was honored
+  // network and creator are present ONLY on the "honored-creator" shape:
+  network?: string,
+  creator?: string,
 }
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,12 +56,15 @@ separate sources and are joined by the cleaner only at strip time.
 
 ### Q: What about parameters that are technically "noise" but live inside a redirect wrapper?
 
-Those are stripped. MUGA categorises Awin / ShareASale / Admitad / Impact
-Radius and similar redirect-based networks as "network-redirect" affiliates
-and refuses to collaborate with them — the click is unwrapped to the
-destination and the wrapper's noise is dropped. The architectural
-rationale is in the README's *How it works* section; the implementation
-lives in `src/lib/wrapper-engine.js` and is invoked from the cleaner.
+MUGA leaves the redirect itself alone. Awin / ShareASale / Admitad / Impact
+Radius and similar redirect-based networks are classified as
+"network-redirect" affiliates and pass through unchanged: the redirect click
+is the attribution event, so unwrapping it would break the payout the creator
+earns. MUGA only strips generic tracking noise (UTM tags, click IDs) from the
+final destination URL once you land there. These networks are listed in
+`MUGA_EXCLUDED_IDS` (`src/lib/wrapper-engine.js`) and in
+`AFFILIATE_REDIRECT_NETWORKS` (`src/lib/opaque-networks.js`), which mark them
+pass-through.
 
 ### Q: How do I verify what MUGA does on my own machine?
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "url": "https://rules.muga.app/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "softwareVersion": "2.3.0"
+    "softwareVersion": "2.4.0"
   }
   </script>
 

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -35,7 +35,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.3.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.4.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,6 +1,6 @@
 # MUGA: Store Listings
 
-> Version: 2.3.0
+> Version: 2.4.0
 > Last updated: 2026-07-03
 > Status: Listing for Chrome Web Store and Firefox AMO under the 2.1 denoise pivot (creator-agnostic positioning, see ADR-0002). Lead headline: "Shorter, cleaner URLs. Fair to every creator". The 2.0-era anti-redirect framing has been removed; MUGA no longer takes a stance against affiliate-redirect networks (their click IS the attribution event and MUGA respects it). Third-party retailer brand names previously enumerated were removed after Chrome Web Store flagged the list as keyword spam (rejection routing ID FZSL, 2026-05). URL Unwrapper section rewritten with honest scope: generic shorteners only (bit.ly, t.co, tinyurl.com, etc.); affiliate redirects pass through unchanged. Privacy claims (no telemetry / no analytics) remain firm but are no longer in the headline.
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -71,7 +71,7 @@
 <body>
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;&middot;&nbsp; Version 2.3.0 &nbsp;&middot;&nbsp; 2026-06-10 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: The web, with the noise turned down &nbsp;&middot;&nbsp; Version 2.4.0 &nbsp;&middot;&nbsp; 2026-07-03 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim: what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -82,7 +82,7 @@
   <div class="at-a-glance">
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">Version</span>
-      <span class="at-a-glance-value">2.3.0</span>
+      <span class="at-a-glance-value">2.4.0</span>
     </div>
     <div class="at-a-glance-row">
       <span class="at-a-glance-label">External server connections</span>
@@ -210,7 +210,7 @@
   <hr>
 
   <div class="footer">
-    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v2.3.0 (2026-06-10) &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
+    <p>This report is updated with each release. &nbsp;&middot;&nbsp; Last updated: v2.4.0 (2026-07-03) &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">github.com/yocreoquesi/muga</a></p>
   </div>
 
 </body>

--- a/landing/index.html
+++ b/landing/index.html
@@ -28,7 +28,7 @@
   "operatingSystem": "Chrome, Firefox",
   "description": "Open-source browser extension that quiets 450+ noise patterns from URLs while preserving creator affiliate referrals.",
   "offers": { "@type": "Offer", "price": "0" },
-  "softwareVersion": "2.3.0",
+  "softwareVersion": "2.4.0",
   "license": "https://www.gnu.org/licenses/gpl-3.0.html"
 }
 </script>
@@ -407,7 +407,7 @@
     <a href="/" class="brand" aria-label="MUGA home">
       <img class="brand-mark" src="https://rules.muga.app/assets/muga-mark.svg" alt="" width="22" height="22">
       <span>muga.app</span>
-      <span class="ver">v2.3.0</span>
+      <span class="ver">v2.4.0</span>
     </a>
     <nav class="nav-links" aria-label="Primary">
       <a href="https://rules.muga.app/transparency.html">Transparency</a>
@@ -420,7 +420,7 @@
 
   <section class="hero">
     <div class="wrap">
-      <div class="eyebrow"><span class="dot"></span> v2.3.0 · Chrome + Firefox · GPL v3</div>
+      <div class="eyebrow"><span class="dot"></span> v2.4.0 · Chrome + Firefox · GPL v3</div>
       <h1>The web,<br><span class="mark">with the noise turned down.</span></h1>
       <p class="lede">
         MUGA quiets <b>450+ noise patterns</b> from every link you open. Locally, in your browser.
@@ -636,7 +636,7 @@
     </div>
     <div class="footer-meta">
       <span>© 2026 muga.app · Released under GPL v3</span>
-      <span>v2.3.0 · published 2026-06-10</span>
+      <span>v2.4.0 · published 2026-07-03</span>
     </div>
   </div>
 </footer>

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "muga",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "The denoise extension for the web. Removes 450+ noise patterns from URLs while honoring creator affiliate referrals. Open source.",
   "type": "module",
   "scripts": {
     "dev:chrome": "npm run build:content && web-ext run --source-dir src/ --target chromium",
     "dev:firefox": "npm run build:content && bash scripts/with-firefox-manifest.sh web-ext run --source-dir src/ --target firefox-desktop",
     "build:content": "node tools/bundle-content.mjs",
-    "build:chrome": "npm run build:content && node tools/strip-test-seams.mjs --source-dir src/ --artifacts-dir dist/chrome/ --overwrite-dest --ignore-files rules/manifest.json manifest.v2.json content/cleaner-bundle-src.mjs _metadata _metadata/** _metadata/**/*",
-    "build:firefox": "npm run build:content && bash scripts/with-firefox-manifest.sh node tools/strip-test-seams.mjs --source-dir src/ --artifacts-dir dist/firefox/ --overwrite-dest --ignore-files rules/manifest.json manifest.v2.json content/cleaner-bundle-src.mjs _metadata _metadata/** _metadata/**/*",
+    "build:chrome": "npm run build:content && node tools/strip-test-seams.mjs --source-dir src/ --artifacts-dir dist/chrome/ --overwrite-dest --ignore-files rules/manifest.json manifest.v2.json content/cleaner-bundle-src.mjs icons/newicon.png _metadata _metadata/** _metadata/**/*",
+    "build:firefox": "npm run build:content && bash scripts/with-firefox-manifest.sh node tools/strip-test-seams.mjs --source-dir src/ --artifacts-dir dist/firefox/ --overwrite-dest --ignore-files rules/manifest.json manifest.v2.json content/cleaner-bundle-src.mjs icons/newicon.png _metadata _metadata/** _metadata/**/*",
     "build": "npm run build:chrome && npm run build:firefox",
     "lint": "bash scripts/with-firefox-manifest.sh npx --no-install web-ext lint --source-dir src/",
     "test": "node --test --test-reporter=spec tests/unit/*.mjs",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "MUGA: The URL denoise extension for the web",
   "short_name": "MUGA",
-  "version": "2.3.0",
-  "version_name": "2.3.0",
+  "version": "2.4.0",
+  "version_name": "2.4.0",
   "description": "Quiet URL noise: 450+ tracking patterns (utm, fbclid, gclid). Honor creator referrals. No analytics, no telemetry. Open source.",
 
   "permissions": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "MUGA: The URL denoise extension for the web",
   "short_name": "MUGA",
-  "version": "2.3.0",
-  "version_name": "2.3.0",
+  "version": "2.4.0",
+  "version_name": "2.4.0",
   "description": "Quiet URL noise: 450+ tracking patterns (utm, fbclid, gclid). Honor creator referrals. No analytics, no telemetry. Open source.",
 
   "permissions": [

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -9,7 +9,7 @@
 <body>
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.3.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 2.4.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.

--- a/tests/unit/shortener-stats-sw.test.mjs
+++ b/tests/unit/shortener-stats-sw.test.mjs
@@ -254,31 +254,31 @@ describe("ADR-0004 phase 5: proxy artifacts removed from service-worker", () => 
 // ── 6. Version integrity ─────────────────────────────────────────────────────
 
 describe("Version integrity — manifest versions match package.json", () => {
-  test("package.json version is 2.3.0", () => {
-    assert.equal(pkg.version, "2.3.0", "package.json must be 2.3.0");
+  test("package.json version is 2.4.0", () => {
+    assert.equal(pkg.version, "2.4.0", "package.json must be 2.4.0");
   });
 
-  test("manifest.json version is 2.3.0", () => {
-    assert.equal(mv3.version, "2.3.0", "src/manifest.json version must be 2.3.0");
+  test("manifest.json version is 2.4.0", () => {
+    assert.equal(mv3.version, "2.4.0", "src/manifest.json version must be 2.4.0");
   });
 
-  test("manifest.v2.json version is 2.3.0", () => {
-    assert.equal(mv2.version, "2.3.0", "src/manifest.v2.json version must be 2.3.0");
+  test("manifest.v2.json version is 2.4.0", () => {
+    assert.equal(mv2.version, "2.4.0", "src/manifest.v2.json version must be 2.4.0");
   });
 
   test("manifest.json version_name matches version (stable release, no beta suffix)", () => {
     assert.equal(
       mv3.version_name,
-      "2.3.0",
-      "MV3 manifest version_name must be '2.3.0'"
+      "2.4.0",
+      "MV3 manifest version_name must be '2.4.0'"
     );
   });
 
   test("manifest.v2.json version_name matches version (stable release, no beta suffix)", () => {
     assert.equal(
       mv2.version_name,
-      "2.3.0",
-      "MV2 manifest version_name must be '2.3.0'"
+      "2.4.0",
+      "MV2 manifest version_name must be '2.4.0'"
     );
   });
 });


### PR DESCRIPTION
Cuts **2.4.0** for Chrome Web Store + Firefox AMO, gated behind a full pre-release audit.

## Release contents
Stamps the CHANGELOG `[Unreleased]` -> `[2.4.0]` (2026-07-03) and bumps `version` + `version_name` to 2.4.0 across all version-stamped surfaces (package.json, both manifests, README, docs, privacy pages, landing site, and the version-integrity test pin). Adds the #959 Bookshop path-unwrap composition entry.

Highlights already merged into main for this release: SPA-navigation re-cleaning (#951), copy-safe URLs (#946), per-tab badge (#910), "Update now" for remote rules (#954), Amazon nav/slug cleaning (#916/#903), settings reorg (#936), strip-all + inject composition for query (#958) and Bookshop path (#960) affiliates.

## Pre-release audit (4 parallel agents, findings verified against HEAD)
| Dimension | Result |
| --- | --- |
| Core / security | 0 blockers. All prior CRITICAL/HIGH already fixed (#921 rule-1001 gate, #922 shortener egress gate, #923 self-heal, #936 gate inversion). New cross-world signaling + path-unwrap surfaces verified: no nonce/state leak, no open-redirect. |
| UI / a11y / CSS | 0 blockers. 11 prior findings fixed. |
| i18n runtime | Clean: 319 keys, exact parity across all 7 locales; placeholders intact; peninsular Spanish; no em-dashes in shipped locale strings. |
| Manifest / permissions / packaging | Least-privilege OK; WAR matches content-script fetches; CSP clean; MV2/MV3 parity confirmed (the flagged "Amazon canonicalization gap on Firefox" is a **false positive** — covered by the content-script path-strip path via #955). |

## Fixes included in this PR (audit blockers)
- **faq.md** false claim that redirect networks are unwrapped -> corrected to pass-through (verified against `MUGA_EXCLUDED_IDS`).
- **data_architect.md** false `remoteRulesEnabled` default (`false` / "zero network activity") -> corrected to `true` (#888), plus stale `processUrl` return shape.
- **Packaging hygiene:** unreferenced `src/icons/newicon.png` (933 KB) excluded from shipped Chrome/Firefox zips (asset kept in-repo).

## Verification
- Full unit suite: **5566 tests, 0 failures**.
- `npm run build` produces clean 2.4.0 Chrome + Firefox zips; verified `newicon.png` absent and icons 16/48/128 + version 2.4.0 present in both packages.

Tag `v2.4.0` (which triggers `release.yml` store submission) should be pushed after this merges.