### PR TITLE
copy(text): legal em-dash cleanup, localized Settings tab title, faq citation fixes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,15 +26,15 @@ MUGA's design point is narrower and more opinionated:
 
 1. **Remove the same noise parameters those tools remove** — `utm_*`,
    `fbclid`, `gclid`, `msclkid`, `mc_cid`, `igshid`, the rest of the usual
-   set ([`src/lib/affiliates.js:33-100`](../src/lib/affiliates.js#L33-L100)).
+   set ([`src/lib/affiliates-data.js:18`](../src/lib/affiliates-data.js#L18)).
 2. **Preserve affiliate parameters that belong to a creator** — even on
    programs MUGA itself has no commercial relationship with (Booking,
    Vercel, DigitalOcean, etc.). The preservation table is sourced from
    MUGA's documented affiliate-program rules
-   ([`src/lib/affiliates.js:852-861`](../src/lib/affiliates.js#L852-L861)).
+   ([`src/lib/affiliates.js:136`](../src/lib/affiliates.js#L136)).
 3. **Be explicit about the one case where MUGA itself benefits** — affiliate
    injection — and gate it behind an opt-in checkbox during onboarding
-   ([`src/lib/storage.js:84-86`](../src/lib/storage.js#L84-L86)).
+   ([`src/lib/prefs.js:25`](../src/lib/prefs.js#L25)).
 
 If you only want noise removed and don't care about creator attribution,
 a generic cleaner is fine. If you want the YouTuber who recommended you
@@ -49,9 +49,9 @@ identifies **the recommender**, not you. A tracking parameter like
 strips the second and preserves the first.
 
 You can verify the distinction in the code: the `TRACKING_PARAMS` list
-([`src/lib/affiliates.js:33`](../src/lib/affiliates.js#L33)) and the
+([`src/lib/affiliates-data.js:18`](../src/lib/affiliates-data.js#L18)) and the
 `AFFILIATE_PATTERNS` table
-([`src/lib/affiliates.js:852`](../src/lib/affiliates.js#L852)) are
+([`src/lib/affiliates.js:136`](../src/lib/affiliates.js#L136)) are
 separate sources and are joined by the cleaner only at strip time.
 
 ### Q: What about parameters that are technically "noise" but live inside a redirect wrapper?
@@ -87,7 +87,7 @@ Yes. On a small set of supported stores, **if and only if the user opted in
 during onboarding**, MUGA can inject its own affiliate tag into URLs that
 arrive **without any affiliate tag at all**. The set of programs MUGA has
 its own tag for is hardcoded in
-[`src/lib/affiliates.js:790-814`](../src/lib/affiliates.js#L790-L814)
+[`src/lib/affiliates.js:74`](../src/lib/affiliates.js#L74)
 (Amazon and eBay marketplaces; a handful of programs pending account
 approval; everything else is preservation-only).
 
@@ -96,13 +96,13 @@ approval; everything else is preservation-only).
 No. The default for `injectOwnAffiliate` is `false`:
 
 ```js
-// src/lib/storage.js:86
+// src/lib/prefs.js:25
 injectOwnAffiliate: false,  // set to true only if user opts in during onboarding (#224)
 ```
 
 The user is asked explicitly during onboarding via a checkbox that ships
 unchecked unless the preference was already enabled on another device they
-own ([`src/onboarding/onboarding.html:333`](../src/onboarding/onboarding.html#L333),
+own ([`src/onboarding/onboarding.html:96`](../src/onboarding/onboarding.html#L96),
 [`src/onboarding/onboarding.js:183-184`](../src/onboarding/onboarding.js#L183-L184)).
 On a per-device basis, the user can decline even if a sibling device opted
 in — the decline is stored as a local override and does not propagate back
@@ -144,12 +144,12 @@ the URL at injection time is never overwritten in place.
 It is preserved anyway. The `ourTag` map is allowed to be empty for a
 program — preservation does not require MUGA to have its own tag for that
 program. The detection loop at
-[`src/lib/cleaner.js:467-480`](../src/lib/cleaner.js#L467-L480) iterates
+[`src/lib/cleaner.js:679`](../src/lib/cleaner.js#L679) iterates
 every pattern that matches the host, not just patterns where
 `OUR_TAGS[prog.id]` is populated. Programs like Booking, Vercel,
 DigitalOcean, Humble Bundle, and Lemon Squeezy ride this path
-([`src/lib/affiliates.js:811-813`](../src/lib/affiliates.js#L811-L813),
-and the comment block at lines 462-466 in `cleaner.js`).
+(the `AFFILIATE_PATTERNS` table,
+[`src/lib/affiliates.js:136`](../src/lib/affiliates.js#L136)).
 
 ### Q: Does my price change when MUGA injects its tag?
 
@@ -237,7 +237,7 @@ to keep the project small enough to audit.
 
 Affiliate revenue from the injection feature described above, on the
 small set of programs in
-[`src/lib/affiliates.js:790-814`](../src/lib/affiliates.js#L790-L814).
+[`src/lib/affiliates.js:74`](../src/lib/affiliates.js#L74).
 The cost base is intentionally low:
 
 - The cleaner is a local computation; there is no per-user server cost.
@@ -257,10 +257,10 @@ forces user clicks through external tracking servers (the "network-redirect"
 class — Awin, ShareASale, Admitad, Impact Radius, and similar). The
 extension still **strips** their noise parameters when encountered;
 it just will not **inject** them on MUGA's behalf. The rationale is in
-the onboarding copy
-([`src/onboarding/onboarding.html:329-330`](../src/onboarding/onboarding.html#L329-L330))
+the `MUGA_EXCLUDED_IDS` set
+([`src/lib/wrapper-engine.js:226`](../src/lib/wrapper-engine.js#L226))
 and the comment at
-[`src/lib/affiliates.js:815-825`](../src/lib/affiliates.js#L815-L825):
+[`src/lib/affiliates.js:105`](../src/lib/affiliates.js#L105):
 deprecated Booking / Humble Bundle entries are removed, and Apple's PHG
 is intentionally not in `OUR_TAGS` because the program is closed to
 small publishers.

--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -66,6 +66,7 @@ export default Object.freeze({
   milestone_100: "MUGA: Rauschpegel: niedrig",
   milestone_10: "MUGA: Erste Schritte zu sauberen URLs",
   opts_title: "Einstellungen",
+  opts_page_title: "MUGA: Einstellungen",
   opts_subtitle: "Entrausche die URLs, die du besuchst und teilst.",
   section_affiliate_settings: "Affiliate & Creator",
   row_inject_label: "Unser Affiliate-Tag einfügen, wenn ein Link keinen hat",

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -66,6 +66,7 @@ export default Object.freeze({
   milestone_100: "MUGA: Noise level: low",
   milestone_10: "MUGA: First steps to clean URLs",
   opts_title: "Settings",
+  opts_page_title: "MUGA: Settings",
   opts_subtitle: "Denoise the URLs you visit and share.",
   section_affiliate_settings: "Affiliate & creators",
   row_inject_label: "Inject our affiliate tag when a link has none",

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -66,6 +66,7 @@ export default Object.freeze({
   milestone_100: "MUGA: Nivel de ruido: bajo",
   milestone_10: "MUGA: Primeros pasos hacia URLs limpias",
   opts_title: "Ajustes",
+  opts_page_title: "MUGA: Ajustes",
   opts_subtitle: "Limpia el ruido de las URLs que visitas y compartes.",
   section_affiliate_settings: "Afiliados y creadores",
   row_inject_label: "Inyectar nuestro afiliado cuando no hay ninguno",

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -66,6 +66,7 @@ export default Object.freeze({
   milestone_100: "MUGA : Niveau de bruit : faible",
   milestone_10: "MUGA : Premiers pas vers des URL propres",
   opts_title: "Paramètres",
+  opts_page_title: "MUGA: Paramètres",
   opts_subtitle: "Débruitez les URL que vous visitez et partagez.",
   section_affiliate_settings: "Affiliation et créateurs",
   row_inject_label: "Injecter notre tag d'affiliation lorsqu'un lien n'en a aucun",

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -66,6 +66,7 @@ export default Object.freeze({
   milestone_100: "MUGA: Livello di rumore: basso",
   milestone_10: "MUGA: Primi passi verso URL pulite",
   opts_title: "Impostazioni",
+  opts_page_title: "MUGA: Impostazioni",
   opts_subtitle: "Togli il rumore dalle URL che visiti e condividi.",
   section_affiliate_settings: "Affiliazione e creator",
   row_inject_label: "Inserisci il nostro tag di affiliazione quando un link non ne ha nessuno",

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -66,6 +66,7 @@ export default Object.freeze({
   milestone_100: "MUGA: ノイズレベル: 低",
   milestone_10: "MUGA: クリーンURLへの第一歩",
   opts_title: "設定",
+  opts_page_title: "MUGA: 設定",
   opts_subtitle: "訪問・共有するURLのノイズを除去します。",
   section_affiliate_settings: "アフィリエイトとクリエイター",
   row_inject_label: "リンクにアフィリエイトタグがない場合は当方のタグを挿入",

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -66,6 +66,7 @@ export default Object.freeze({
   milestone_100: "MUGA: Nível de ruído: baixo",
   milestone_10: "MUGA: Primeiros passos para URLs limpas",
   opts_title: "Configurações",
+  opts_page_title: "MUGA: Configurações",
   opts_subtitle: "Tire o ruído das URLs que você visita e compartilha.",
   section_affiliate_settings: "Afiliados e criadores",
   row_inject_label: "Inserir nossa tag de afiliado quando o link não tem nenhuma",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MUGA: Settings</title>
+  <title data-i18n="opts_page_title">MUGA: Settings</title>
   <link rel="stylesheet" href="options.css">
 </head>
 <body>

--- a/src/privacy/privacy.html
+++ b/src/privacy/privacy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MUGA Privacy Policy — The denoise extension for the web</title>
+  <title>MUGA Privacy Policy: The denoise extension for the web</title>
   <link rel="stylesheet" href="privacy.css">
 </head>
 <body>
@@ -15,7 +15,7 @@
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.
     MUGA never acts behind your back. Nothing happens without your action.
     The code is open source. You can read every line at the link above.
-    For the questions a skeptic would ask — affiliate model, network behaviour, sustainability — see the <a href="https://github.com/yocreoquesi/muga/blob/main/docs/faq.md" target="_blank" rel="noopener noreferrer">FAQ</a>.
+    For the questions a skeptic would ask (affiliate model, network behaviour, sustainability), see the <a href="https://github.com/yocreoquesi/muga/blob/main/docs/faq.md" target="_blank" rel="noopener noreferrer">FAQ</a>.
   </div>
 
   <h2>What data does MUGA handle?</h2>
@@ -23,8 +23,8 @@
 
   <p>MUGA's data lives in two places, deliberately separated:</p>
   <ul>
-    <li><strong>Per-device, on this machine only</strong> (<code>chrome.storage.local</code>): your acceptance of these terms and the version of the policy you agreed to (<code>onboardingDone</code>, <code>consentVersion</code>, <code>consentDate</code>); per-device decisions you made about behaviours your other devices may have enabled (<code>injectOwnAffiliate</code>, <code>remoteRulesEnabled</code> overrides — see <strong>Per-device consent</strong> below); usage counters (URLs cleaned, parameters removed, referrals spotted); and short-lived session data (debug logs, per-tab badge counts, recently cleaned URLs).</li>
-    <li><strong>Across your own devices, via your browser account</strong> (<code>chrome.storage.sync</code>): behavioural preferences you would expect to follow you between devices — language, blacklist, whitelist, custom tracking parameters, the affiliate toggles' default values, the remote-rule-updates default value. Sync happens through your browser, never through MUGA.</li>
+    <li><strong>Per-device, on this machine only</strong> (<code>chrome.storage.local</code>): your acceptance of these terms and the version of the policy you agreed to (<code>onboardingDone</code>, <code>consentVersion</code>, <code>consentDate</code>); per-device decisions you made about behaviours your other devices may have enabled (<code>injectOwnAffiliate</code>, <code>remoteRulesEnabled</code> overrides; see <strong>Per-device consent</strong> below); usage counters (URLs cleaned, parameters removed, referrals spotted); and short-lived session data (debug logs, per-tab badge counts, recently cleaned URLs).</li>
+    <li><strong>Across your own devices, via your browser account</strong> (<code>chrome.storage.sync</code>): behavioural preferences you would expect to follow you between devices: language, blacklist, whitelist, custom tracking parameters, the affiliate toggles' default values, the remote-rule-updates default value. Sync happens through your browser, never through MUGA.</li>
   </ul>
   <p>Neither bucket is ever visible to MUGA. Session data (<code>chrome.storage.session</code>) is automatically cleared when the browser restarts. Usage counters are never transmitted anywhere.</p>
 
@@ -44,7 +44,7 @@
   <ul>
     <li><strong>AMP redirect:</strong> Redirects AMP pages to the original canonical URL. On Chrome, this happens at the network layer via the browser's built-in declarativeNetRequest engine, before the AMP page is loaded. On Firefox, it happens locally via the content script.</li>
     <li><strong>Ping blocking:</strong> Removes <code>&lt;a ping&gt;</code> attributes from links so the browser does not send tracking beacons when you click.</li>
-    <li><strong>Link-share unwrapping:</strong> Detects link-share wrappers where the destination URL is embedded directly in the redirect URL's query string (Facebook's <code>l.facebook.com/?u=</code>, Instagram's <code>l.instagram.com/?u=</code>, Twitter's <code>t.co</code> in some templates) and navigates straight to the embedded destination. This is not an affiliate-attribution event — these wrappers are share-link tracking, not commission-bearing redirects. Affiliate-redirect networks (Awin, CJ, AliExpress Portals, etc.) are deliberately NOT unwrapped — see "Affiliate networks" below.</li>
+    <li><strong>Link-share unwrapping:</strong> Detects link-share wrappers where the destination URL is embedded directly in the redirect URL's query string (Facebook's <code>l.facebook.com/?u=</code>, Instagram's <code>l.instagram.com/?u=</code>, Twitter's <code>t.co</code> in some templates) and navigates straight to the embedded destination. This is not an affiliate-attribution event; these wrappers are share-link tracking, not commission-bearing redirects. Affiliate-redirect networks (Awin, CJ, AliExpress Portals, etc.) are deliberately NOT unwrapped; see "Affiliate networks" below.</li>
     <li><strong>Right-click "Copy clean link":</strong> Cleans URLs when you copy them via context menu. Also available via keyboard shortcut (Alt+Shift+C).</li>
   </ul>
   <p>All of these operate entirely within your browser. No external requests are made.</p>
@@ -57,18 +57,18 @@
 
   <h2>What MUGA never does</h2>
   <ul>
-    <li>Does not silently send your URLs or browsing data to any server. Every external request is gated on an explicit Settings toggle (Remote rule updates is on by default and sends no user data — see Permissions below; Follow shortener redirects remains off by default).</li>
+    <li>Does not silently send your URLs or browsing data to any server. Every external request is gated on an explicit Settings toggle (Remote rule updates is on by default and sends no user data; see Permissions below; Follow shortener redirects remains off by default).</li>
     <li>Does not collect your browsing history.</li>
     <li>Does not silently replace other people's affiliate tags. The default is always "keep the original".</li>
-    <li>Does not strip affiliate-redirect networks (Awin, CJ Affiliate, AliExpress Portals, Impact, Partnerize, Admitad, A8.net, Rakuten, TradeTracker) from URLs. Their redirect IS the attribution event and MUGA respects it — the creator's commission survives.</li>
+    <li>Does not strip affiliate-redirect networks (Awin, CJ Affiliate, AliExpress Portals, Impact, Partnerize, Admitad, A8.net, Rakuten, TradeTracker) from URLs. Their redirect IS the attribution event and MUGA respects it; the creator's commission survives.</li>
     <li>Does not collect, store, or transmit any personally identifiable information.</li>
     <li>Does not use analytics, telemetry, or crash reporting services.</li>
   </ul>
 
   <h2>Affiliate networks: redirect-tolerant</h2>
   <p>MUGA recognises both styles of affiliate attribution and respects both. Some programs (Amazon, eBay, Vercel, DigitalOcean, Lemon Squeezy, Apple Performance Partners, Bookshop.org, Steam Curator) carry the creator's referral as a query parameter or path segment on the merchant's own URL. Other programs (Awin, CJ Affiliate, AliExpress Portals, Impact, Partnerize, Admitad, A8.net, Rakuten, TradeTracker) carry it as a redirect through the network's own servers, where the network's 30x sets a first-party cookie on the merchant's domain at landing. MUGA does not pick winners by attribution model.</p>
-  <p>Practically: when MUGA sees an affiliate-redirect URL, the redirect passes through your browser unchanged. The network's servers see your click (that's the entire point — without it the creator's commission cannot be paid) and the merchant's first-party cookie gets populated normally. MUGA does not interpose, does not log the redirect anywhere outside your device, and does not rewrite the URL beyond removing well-known tracking parameters (utm_*, fbclid, gclid, and the rest) from the merchant's landing page once you arrive. The matrix that drives this is published in <a href="https://github.com/yocreoquesi/muga/blob/main/docs/affiliate-networks-matrix.md" target="_blank" rel="noopener noreferrer">docs/affiliate-networks-matrix.md</a> on each release.</p>
-  <p>Independently of any affiliate model, MUGA offers an optional "Follow shortener redirects" feature that resolves generic URL shorteners (bit.ly, tinyurl.com, t.co, link.medium.com, lnkd.in, fb.me, ebay.to) directly in your browser so you can see where a short link actually leads before clicking. This feature is off by default and requires you to grant optional host permissions for the eight shortener domains. MUGA does not send these URLs to any server — the redirect is resolved entirely in-browser via a standard HTTP fetch. Affiliate-redirect networks are never sent anywhere; they pass through unchanged.</p>
+  <p>Practically: when MUGA sees an affiliate-redirect URL, the redirect passes through your browser unchanged. The network's servers see your click (that's the entire point; without it the creator's commission cannot be paid) and the merchant's first-party cookie gets populated normally. MUGA does not interpose, does not log the redirect anywhere outside your device, and does not rewrite the URL beyond removing well-known tracking parameters (utm_*, fbclid, gclid, and the rest) from the merchant's landing page once you arrive. The matrix that drives this is published in <a href="https://github.com/yocreoquesi/muga/blob/main/docs/affiliate-networks-matrix.md" target="_blank" rel="noopener noreferrer">docs/affiliate-networks-matrix.md</a> on each release.</p>
+  <p>Independently of any affiliate model, MUGA offers an optional "Follow shortener redirects" feature that resolves generic URL shorteners (bit.ly, tinyurl.com, t.co, link.medium.com, lnkd.in, fb.me, ebay.to) directly in your browser so you can see where a short link actually leads before clicking. This feature is off by default and requires you to grant optional host permissions for the eight shortener domains. MUGA does not send these URLs to any server; the redirect is resolved entirely in-browser via a standard HTTP fetch. Affiliate-redirect networks are never sent anywhere; they pass through unchanged.</p>
 
   <h2>Third-party affiliate programs</h2>
   <p>When you navigate to a store via a MUGA-modified URL, the store's own analytics may record the visit as originating from an affiliate link. This is standard affiliate behaviour and is governed by the store's own privacy policy, not MUGA's.</p>
@@ -86,8 +86,8 @@
   </ul>
   <p>Optional host permissions (revocable from browser settings at any time):</p>
   <ul>
-    <li><strong>rules.muga.app/*</strong> — "Remote rule updates". On by default (#888): a single HTTPS GET at most once per 7 days, piggybacked on natural service-worker wake events. The response is an Ed25519-signed payload verified against a public key shipped with the extension. Credentials-omit; no user data transmitted. Disable it any time in Settings.</li>
-    <li><strong>bit.ly/*, tinyurl.com/*, t.co/*, link.medium.com/*, lnkd.in/*, fb.me/*, ebay.to/*, amzn.to/*</strong> — "Follow shortener redirects". Off by default. Used ONLY to resolve the destination of these eight generic URL shortener domains in-browser via a standard HTTP HEAD/GET with <code>redirect: "manual"</code>. No shortened URL is sent to any MUGA server or any other third party. The HTTP request goes directly from your browser to the shortener's own server — the same request your browser would make when you click the link — and MUGA reads the <code>Location</code> header from the response. Affiliate-redirect networks are NEVER included.</li>
+    <li><strong>rules.muga.app/*</strong>: "Remote rule updates". On by default (#888): a single HTTPS GET at most once per 7 days, piggybacked on natural service-worker wake events. The response is an Ed25519-signed payload verified against a public key shipped with the extension. Credentials-omit; no user data transmitted. Disable it any time in Settings.</li>
+    <li><strong>bit.ly/*, tinyurl.com/*, t.co/*, link.medium.com/*, lnkd.in/*, fb.me/*, ebay.to/*, amzn.to/*</strong>: "Follow shortener redirects". Off by default. Used ONLY to resolve the destination of these eight generic URL shortener domains in-browser via a standard HTTP HEAD/GET with <code>redirect: "manual"</code>. No shortened URL is sent to any MUGA server or any other third party. The HTTP request goes directly from your browser to the shortener's own server, the same request your browser would make when you click the link, and MUGA reads the <code>Location</code> header from the response. Affiliate-redirect networks are NEVER included.</li>
   </ul>
 
   <h2>Open source</h2>

--- a/src/privacy/tos.html
+++ b/src/privacy/tos.html
@@ -9,7 +9,7 @@
 <body>
 
   <h1>Terms of Use</h1>
-  <p class="meta">MUGA: Shorter, cleaner URLs — fair to every creator &nbsp;&middot;&nbsp; Version 1.3 &nbsp;&middot;&nbsp; Last updated: 2026-07-01</p>
+  <p class="meta">MUGA: Shorter, cleaner URLs, fair to every creator &nbsp;&middot;&nbsp; Version 1.3 &nbsp;&middot;&nbsp; Last updated: 2026-07-01</p>
 
   <div class="highlight">
     MUGA is free and open-source software licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank" rel="noopener noreferrer">GNU General Public License v3</a>. You control what MUGA does. MUGA never acts behind your back. Nothing happens without your action.
@@ -25,9 +25,9 @@
     <li>Strips tracking parameters (UTMs, click IDs, and similar) from URLs before pages load</li>
     <li>Redirects AMP pages to their canonical article URLs</li>
     <li>Blocks <code>&lt;a ping&gt;</code> tracking beacons on link clicks</li>
-    <li>Unwraps link-share wrappers where the destination is embedded in the URL's query string (Facebook, Instagram, certain Twitter templates). Affiliate-redirect networks are deliberately preserved so the creator's commission survives the click — see the Privacy Policy for the full list and rationale</li>
-    <li>Optionally resolves generic URL shorteners (bit.ly, tinyurl.com, t.co, link.medium.com, lnkd.in, fb.me, ebay.to) directly in your browser via a standard HTTP fetch — no URL is sent to any MUGA server. Off by default; requires optional host permissions for the eight shortener domains. Affiliate-redirect networks are NEVER resolved this way</li>
-    <li>Fetches weekly rule updates <strong>by default</strong>: about once a week, MUGA downloads an updated tracking-parameter list from <code>rules.muga.app</code> over HTTPS. The request is Ed25519-signed and sent with credentials omitted — no browsing history, no cookies, no identifiers, no request body. You can turn it off at any time in Settings, which returns the Extension to making no outbound requests</li>
+    <li>Unwraps link-share wrappers where the destination is embedded in the URL's query string (Facebook, Instagram, certain Twitter templates). Affiliate-redirect networks are deliberately preserved so the creator's commission survives the click; see the Privacy Policy for the full list and rationale</li>
+    <li>Optionally resolves generic URL shorteners (bit.ly, tinyurl.com, t.co, link.medium.com, lnkd.in, fb.me, ebay.to) directly in your browser via a standard HTTP fetch; no URL is sent to any MUGA server. Off by default; requires optional host permissions for the eight shortener domains. Affiliate-redirect networks are NEVER resolved this way</li>
+    <li>Fetches weekly rule updates <strong>by default</strong>: about once a week, MUGA downloads an updated tracking-parameter list from <code>rules.muga.app</code> over HTTPS. The request is Ed25519-signed and sent with credentials omitted: no browsing history, no cookies, no identifiers, no request body. You can turn it off at any time in Settings, which returns the Extension to making no outbound requests</li>
     <li>Optionally adds our affiliate tag to links that carry no affiliate tag, if you have opted in</li>
   </ul>
   <p>You have full control over every feature. MUGA never collects, sells, or shares your browsing data. Any feature that contacts an external service requires your explicit action.</p>
@@ -39,13 +39,13 @@
     <li>By default, MUGA <strong>does not replace</strong> an affiliate tag that is already present in a URL. Replacing requires a separate, deliberate opt-in by the user</li>
     <li>Affiliate tag injection only applies to the supported stores explicitly listed in the <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">source code</a></li>
     <li>You can disable affiliate tag injection at any time in the Extension's Settings, no questions asked</li>
-    <li>The "Remove all affiliate tags from other sources" option strips third-party tags. MUGA's own tag is preserved <strong>only when you also have affiliate injection enabled on this device</strong>. If you have injection off, MUGA's tag is treated like any other and removed too — symmetric with your stated preference</li>
+    <li>The "Remove all affiliate tags from other sources" option strips third-party tags. MUGA's own tag is preserved <strong>only when you also have affiliate injection enabled on this device</strong>. If you have injection off, MUGA's tag is treated like any other and removed too, symmetric with your stated preference</li>
     <li>The developer may earn commissions from qualifying purchases through supported affiliate programs. This disclosure is required by the operating agreements of those programs</li>
   </ul>
 
   <h2>4. No data collection</h2>
   <p>MUGA does not collect, transmit, or store your browsing data. Every feature is transparent and configurable. MUGA has no analytics, no telemetry, and no crash-reporting services. Optional features that contact an external service (such as rule updates) never send your browsing history and require your explicit action.</p>
-  <p>Your data lives in two places, neither of which is visible to the developer: behavioural preferences (language, blacklist, whitelist, the affiliate toggles' default values) are stored in <code>chrome.storage.sync</code> and follow you across your own devices via your browser account; consent metadata and per-device decisions are stored in <code>chrome.storage.local</code> on each device individually. Acceptance of these Terms is recorded per device, not per browser account — the rationale is captured in our architectural decision record <a href="https://github.com/yocreoquesi/muga/blob/main/docs/adr/0001-per-device-consent.md" target="_blank" rel="noopener noreferrer">ADR-0001</a>.</p>
+  <p>Your data lives in two places, neither of which is visible to the developer: behavioural preferences (language, blacklist, whitelist, the affiliate toggles' default values) are stored in <code>chrome.storage.sync</code> and follow you across your own devices via your browser account; consent metadata and per-device decisions are stored in <code>chrome.storage.local</code> on each device individually. Acceptance of these Terms is recorded per device, not per browser account; the rationale is captured in our architectural decision record <a href="https://github.com/yocreoquesi/muga/blob/main/docs/adr/0001-per-device-consent.md" target="_blank" rel="noopener noreferrer">ADR-0001</a>.</p>
   <p>For full details, see the <a href="privacy.html">Privacy Policy</a>.</p>
 
   <h2>5. Third-party services</h2>


### PR DESCRIPTION
Remaining pending text cleanup from the release audit. **Copy/docs only, no version bump, no store resubmission** (rides the next release; only privacy/options are packaged, faq is docs-only).

## Changes
1. **Em-dashes removed from user-facing legal pages** (`privacy.html` 13, `tos.html` 6). Replaced with meaning-preserving punctuation (`;`, `:`, comma, parentheses). No legal meaning changed. (The em-dashes in `options.html`/`onboarding.html` are inside HTML comments, not user-facing, so left as-is.)
2. **Localized Settings tab title** — `options.html` `<title>` was hardcoded `MUGA: Settings` in every locale. Bound to a new `opts_page_title` key (`MUGA: Settings` localized: Ajustes/Einstellungen/Paramètres/Impostazioni/設定/Configurações). Key added to all 7 locales (parity kept).
3. **FAQ source-citation rot fixed** — the "audit us" FAQ had drifted line references. Remapped all stale/past-EOF citations to current locations: PREF_DEFAULTS -> `prefs.js:25`, TRACKING_PARAMS -> `affiliates-data.js:18`, OUR_TAGS -> `affiliates.js:74`, AFFILIATE_PATTERNS -> `affiliates.js:136`, network-redirect rationale -> `wrapper-engine.js:226` (MUGA_EXCLUDED_IDS), affiliate checkbox -> `onboarding.html:96`. All 21 citations now resolve within file bounds; no behavioral claim changed.

## Verification
- Full unit suite: **5575 tests, 0 failures** (i18n key-parity + fallback-sync green after adding `opts_page_title`).
- Citation validator: all 21 FAQ source links within file bounds.