### PR TITLE
fix(options): harden Settings import/export against gate bypass and desync

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -42,6 +42,8 @@
           <option value="10">10s</option>
           <option value="15" selected>15s</option>
           <option value="30">30s</option>
+          <option value="45">45s</option>
+          <option value="60">60s</option>
         </select>
       </div>
       <div class="row">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -95,6 +95,38 @@ function showConfirm(msg) {
   });
 }
 
+// Discrete toast-duration values offered by the UI. The persisted pref is
+// snapped to the nearest of these so the pref and the <select> can never
+// disagree — an imported/legacy value like 22 or 45 always maps to a real
+// <option> instead of leaving the control blank (#968). The set spans the
+// full 5..60 range the control accepts, so the ceiling is reachable via UI.
+const TOAST_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60];
+
+/** Snaps an arbitrary duration to the nearest offered <option> value. */
+function snapToastDuration(n) {
+  const v = Number.isFinite(n) ? n : 15;
+  return TOAST_DURATION_OPTIONS.reduce((a, b) =>
+    Math.abs(b - v) < Math.abs(a - v) ? b : a);
+}
+
+/**
+ * Reports whether the eight shortener host permissions are currently granted.
+ * Used by the import path so a config file can never silently ENABLE the
+ * permission-gated shortener resolver without the host grant the normal
+ * toggle enforces (#964).
+ *
+ * @returns {Promise<boolean>}
+ */
+async function hasShortenerPermissions() {
+  try {
+    return await chrome.permissions.contains({
+      origins: GENERIC_SHORTENERS.map((host) => `https://${host}/*`),
+    });
+  } catch {
+    return false;
+  }
+}
+
 /** Initializes the options page: loads prefs, binds controls, renders lists. */
 async function init() {
   _currentLang = await getStoredLang();
@@ -162,9 +194,9 @@ async function init() {
 
   // Toast duration select
   const durationSelect = document.getElementById("toast-duration-select");
-  durationSelect.value = String(prefs.toastDuration || 15);
+  durationSelect.value = String(snapToastDuration(prefs.toastDuration));
   durationSelect.addEventListener("change", () => {
-    const val = Math.max(5, Math.min(60, parseInt(durationSelect.value, 10) || 15));
+    const val = snapToastDuration(parseInt(durationSelect.value, 10));
     try { setPrefs({ toastDuration: val }); } catch (err) { console.error("[MUGA] save duration:", err); }
   });
 
@@ -305,6 +337,11 @@ function bindListButtons() {
 
 // ── Creator allowlist editor (#445, B13) ────────────────────────────────────
 
+// Lets the import path refresh the creator-allowlist editor's in-memory list
+// and re-render it WITHOUT rebinding its event listeners (#968). Set by
+// initCreatorAllowlist; null until the editor is initialised.
+let _refreshCreatorAllowlist = null;
+
 /**
  * Initialises the per-creator allowlist editor. Renders the current list,
  * binds the add button + Enter key, and wires per-row remove buttons.
@@ -428,6 +465,14 @@ function initCreatorAllowlist(initial) {
   input.addEventListener("input", clearError);
 
   render(list);
+
+  // Expose a listener-free refresh so the import path can swap the list in
+  // and re-render after writing an imported creatorAllowlist to sync (#968).
+  _refreshCreatorAllowlist = (newList) => {
+    list.length = 0;
+    list.push(...(Array.isArray(newList) ? newList : []));
+    render(list);
+  };
 }
 
 // Serializes tracking-category toggle mutations (#928). Independent of the
@@ -804,6 +849,11 @@ function initExportImport() {
       attributionLedgerEnabled: prefs.attributionLedgerEnabled,
       // #925: the popup-populated custom strip rules, handled like the other sync arrays.
       userCustomRules: prefs.userCustomRules,
+      // #968: round-trip the remaining user-settable prefs that were being
+      // silently dropped — an export/import cycle must not reset them.
+      experimentalParamClassesEnabled: prefs.experimentalParamClassesEnabled,
+      honorCreatorMode: prefs.honorCreatorMode,
+      creatorAllowlist: prefs.creatorAllowlist,
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -847,8 +897,11 @@ function initExportImport() {
       // error, is not acceptable.
       const { blacklist, whitelist, customParams, droppedBlacklist, droppedWhitelist, skippedParams } = capImportedLists(data);
       const skipped = skippedParams + droppedBlacklist + droppedWhitelist;
-      // devMode is device-local — exclude from sync BOOL_KEYS and handle separately
-      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled", "paramBreakdown", "showReportButton", "domainStats", "showBadge", "followShortenersEnabled", "canonicalExtractorEnabled", "crossSiteFrequencyEnabled", "attributionLedgerEnabled"];
+      // devMode is device-local — exclude from sync BOOL_KEYS and handle separately.
+      // followShortenersEnabled is ALSO excluded here: it gates on optional host
+      // permissions, so a file must never blindly flip it on (#964). It is
+      // handled below, gated on whether the grant is actually present.
+      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled", "paramBreakdown", "showReportButton", "domainStats", "showBadge", "honorCreatorMode", "experimentalParamClassesEnabled", "canonicalExtractorEnabled", "crossSiteFrequencyEnabled", "attributionLedgerEnabled"];
       const toSave = { blacklist, whitelist, customParams };
       for (const key of BOOL_KEYS) {
         if (typeof data[key] === "boolean") toSave[key] = data[key];
@@ -862,9 +915,30 @@ function initExportImport() {
       if (Array.isArray(data.disabledCategories) && data.disabledCategories.every(e => VALID_CATEGORIES.has(e))) {
         toSave.disabledCategories = data.disabledCategories;
       }
-      // Handle toastDuration (number 5-60)
+      // Handle toastDuration: snap to the nearest offered <option> so the
+      // stored value always matches a real control state (#968).
       if (typeof data.toastDuration === "number") {
-        toSave.toastDuration = Math.max(5, Math.min(60, data.toastDuration));
+        toSave.toastDuration = snapToastDuration(data.toastDuration);
+      }
+      // #964: followShortenersEnabled is permission-gated. An import may carry
+      // the preference but CANNOT grant the host permissions (no user gesture
+      // survives the async file read, and silently prompting on import is
+      // surprising). So enable it only when the grant is already present;
+      // otherwise force it off. This closes the gate-bypass and keeps the
+      // pref honest — the user re-enables it via the toggle, which prompts.
+      if (typeof data.followShortenersEnabled === "boolean") {
+        toSave.followShortenersEnabled =
+          data.followShortenersEnabled && (await hasShortenerPermissions());
+      }
+      // #968: round-trip the per-creator allowlist. Fold each imported entry
+      // through the same pure validator the add-box uses, so invalid entries,
+      // duplicates, and anything past the cap are dropped exactly as a manual
+      // add would handle them.
+      if (Array.isArray(data.creatorAllowlist)) {
+        toSave.creatorAllowlist = data.creatorAllowlist.reduce(
+          (acc, entry) => addCreatorAllowlistEntry(acc, entry).list,
+          [],
+        );
       }
       // #925: userCustomRules — validate each entry as a bare param name and
       // cap at the customParams ceiling (same shape/limit the popup enforces).
@@ -880,6 +954,19 @@ function initExportImport() {
         toSave.language = data.language;
       }
       await setPrefs(toSave);
+
+      // #965: importing a config is an explicit choice for this device. For
+      // guarded prefs (injectOwnAffiliate), getPrefs() overlays the per-device
+      // override LAST, so a stale onboarding-decline override would keep the
+      // extension's effective value at odds with the freshly imported sync
+      // value AND the checkbox. Reconcile the override to the imported value so
+      // sync, override, effective, and UI all agree. Only keys we actually
+      // wrote (BOOL_KEYS ∩ GUARDED_PREFS) are reconciled.
+      for (const key of BOOL_KEYS) {
+        if (GUARDED_PREFS.includes(key) && typeof data[key] === "boolean") {
+          await reconcileOverrideForExplicitChoice(key, data[key]);
+        }
+      }
 
       // Re-read prefs and update all UI toggles and lists
       const newPrefs = await chrome.storage.sync.get(PREF_DEFAULTS);
@@ -899,9 +986,19 @@ function initExportImport() {
       document.getElementById("show-report-button").checked = newPrefs.showReportButton;
       document.getElementById("domain-stats").checked = newPrefs.domainStats;
       document.getElementById("show-badge").checked = newPrefs.showBadge;
+      // #964: reflect the gated result — the checkbox must match the pref that
+      // actually landed (forced off unless the host grant was already present).
+      const followShortenersEl = document.getElementById("followShortenersEnabled");
+      if (followShortenersEl) followShortenersEl.checked = newPrefs.followShortenersEnabled;
+      // #968: refresh the previously-unrefreshed imported toggles + allowlist.
+      const honorCreatorEl = document.getElementById("honor-creator-mode");
+      if (honorCreatorEl) honorCreatorEl.checked = newPrefs.honorCreatorMode;
+      const experimentalParamEl = document.getElementById("experimental-param-classes");
+      if (experimentalParamEl) experimentalParamEl.checked = newPrefs.experimentalParamClassesEnabled;
+      if (Array.isArray(toSave.creatorAllowlist)) _refreshCreatorAllowlist?.(newPrefs.creatorAllowlist);
       // devMode is device-local — re-read from local storage after import
       document.getElementById("dev-mode").checked = await getDevMode();
-      document.getElementById("toast-duration-select").value = String(newPrefs.toastDuration || 15);
+      document.getElementById("toast-duration-select").value = String(snapToastDuration(newPrefs.toastDuration));
       syncDevTools();
       if (toSave.language) {
         _currentLang = toSave.language;

--- a/tests/unit/export-import.test.mjs
+++ b/tests/unit/export-import.test.mjs
@@ -151,10 +151,17 @@ describe("import settings (source verification)", () => {
     );
   });
 
-  test("8. import clamps toastDuration to 5-60 range", () => {
+  test("8. import snaps toastDuration to the nearest offered <option> (#968)", () => {
+    // #968: a continuous clamp let import persist a value (e.g. 45) that matched
+    // no <option>, leaving the control blank. The value is now snapped to the
+    // nearest offered option so pref and UI can never disagree.
     assert.ok(
-      OPTIONS_SOURCE.includes("Math.max(5, Math.min(60, data.toastDuration))"),
-      "Import must clamp toastDuration between 5 and 60"
+      OPTIONS_SOURCE.includes("snapToastDuration(data.toastDuration)"),
+      "Import must snap toastDuration via snapToastDuration"
+    );
+    assert.ok(
+      !OPTIONS_SOURCE.includes("Math.max(5, Math.min(60, data.toastDuration))"),
+      "Import must NOT use the legacy continuous clamp for toastDuration"
     );
   });
 
@@ -361,5 +368,103 @@ describe("import language round-trip (#729)", () => {
     for (const bad of ["", "xx", "EN", "en-US", "klingon", null, undefined, 42]) {
       assert.strictEqual(acceptLanguage(bad), false, `"${String(bad)}" must be rejected`);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Import/export hardening — regressions for #964, #965, #968
+// ---------------------------------------------------------------------------
+const OPTIONS_HTML = readFileSync(join(__dirname, "../../src/options/options.html"), "utf8");
+
+describe("import/export hardening (#964/#965/#968)", () => {
+
+  // #968 — data-loss round-trip
+  test("38. export round-trips the three previously-dropped prefs", () => {
+    for (const key of ["experimentalParamClassesEnabled", "honorCreatorMode", "creatorAllowlist"]) {
+      assert.ok(
+        OPTIONS_SOURCE.includes(`${key}: prefs.${key}`),
+        `Export payload must include "${key}" (was silently dropped)`
+      );
+    }
+  });
+
+  test("39. import round-trips honorCreatorMode + experimentalParamClassesEnabled as booleans", () => {
+    for (const key of ["honorCreatorMode", "experimentalParamClassesEnabled"]) {
+      assert.ok(
+        new RegExp(`BOOL_KEYS[\\s\\S]*"${key}"`).test(OPTIONS_SOURCE),
+        `Import BOOL_KEYS must include "${key}"`
+      );
+    }
+  });
+
+  test("40. import round-trips creatorAllowlist through the pure validator", () => {
+    assert.ok(
+      OPTIONS_SOURCE.includes("Array.isArray(data.creatorAllowlist)"),
+      "Import must validate creatorAllowlist is an array"
+    );
+    assert.ok(
+      /addCreatorAllowlistEntry\(\s*acc\s*,\s*entry\s*\)/.test(OPTIONS_SOURCE),
+      "Import must fold creatorAllowlist entries through addCreatorAllowlistEntry"
+    );
+  });
+
+  // #964 — permission-gate bypass
+  test("41. import gates followShortenersEnabled on the actual host grant", () => {
+    // Must NOT be in the blind BOOL_KEYS loop...
+    assert.ok(
+      !/BOOL_KEYS\s*=\s*\[[^\]]*"followShortenersEnabled"/.test(OPTIONS_SOURCE),
+      "followShortenersEnabled must NOT be a blindly-imported BOOL_KEY"
+    );
+    // ...and enabling it must depend on hasShortenerPermissions().
+    assert.ok(
+      /data\.followShortenersEnabled\s*&&\s*\(await hasShortenerPermissions\(\)\)/.test(OPTIONS_SOURCE),
+      "Import must only enable followShortenersEnabled when the host grant is present"
+    );
+    assert.ok(
+      OPTIONS_SOURCE.includes("chrome.permissions.contains"),
+      "hasShortenerPermissions must check chrome.permissions.contains"
+    );
+  });
+
+  // #965 — guarded-pref override desync
+  test("42. import reconciles the per-device override for guarded prefs", () => {
+    assert.ok(
+      /reconcileOverrideForExplicitChoice\(\s*key\s*,\s*data\[key\]\s*\)/.test(OPTIONS_SOURCE),
+      "Import must reconcile the per-device override to the imported guarded value"
+    );
+  });
+
+  // #968 — toast-duration select
+  test("43. toast-duration options span the full 5..60 range in the UI", () => {
+    for (const v of ["5", "10", "15", "30", "45", "60"]) {
+      assert.ok(
+        OPTIONS_HTML.includes(`value="${v}"`),
+        `toast-duration <select> must offer value="${v}" so the clamp ceiling is reachable`
+      );
+    }
+  });
+
+  test("44. snapToastDuration maps arbitrary values to the nearest offered option", () => {
+    // Mirror of the implementation (options.js is browser-only, not importable).
+    const TOAST_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60];
+    const snap = (n) => {
+      const v = Number.isFinite(n) ? n : 15;
+      return TOAST_DURATION_OPTIONS.reduce((a, b) => (Math.abs(b - v) < Math.abs(a - v) ? b : a));
+    };
+    assert.equal(snap(45), 45, "an offered value maps to itself");
+    assert.equal(snap(60), 60, "the ceiling is reachable");
+    assert.equal(snap(22), 15, "22 snaps to nearest (15, distance 7 < 8)");
+    assert.equal(snap(23), 30, "23 snaps to nearest (30, distance 7 < 8)");
+    assert.equal(snap(1000), 60, "out-of-range high clamps to 60");
+    assert.equal(snap(NaN), 15, "non-finite falls back to 15");
+    // The implementation must define both the option set and the snapper.
+    assert.ok(
+      OPTIONS_SOURCE.includes("TOAST_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60]"),
+      "options.js must define TOAST_DURATION_OPTIONS"
+    );
+    assert.ok(
+      OPTIONS_SOURCE.includes("function snapToastDuration"),
+      "options.js must define snapToastDuration"
+    );
   });
 });


### PR DESCRIPTION
Fixes three defects in the Settings import/export path found during the options audit.

## Closes
- Closes #964 — import bypassed the shortener host-permission gate + desynced the checkbox
- Closes #965 — import desynced guarded `injectOwnAffiliate` when a per-device override existed
- Closes #968 — round-trip lost data (toast-duration >30s unreachable + dropped prefs)

## Changes
- **#964**: `followShortenersEnabled` removed from the blind `BOOL_KEYS` import loop; enabling it on import is gated on `hasShortenerPermissions()` (`chrome.permissions.contains`). It can no longer be silently turned on by a file without the host grant the toggle enforces. The checkbox is refreshed to the value that actually landed.
- **#965**: import reconciles the per-device override for guarded prefs via `reconcileOverrideForExplicitChoice`, so sync / override / effective / checkbox all agree afterwards.
- **#968**: toast-duration is snapped to the nearest offered `<option>` (`snapToastDuration`) instead of a continuous clamp; the `<select>` now covers the full 5..60 range (adds 45s/60s). Export/import now round-trip `experimentalParamClassesEnabled`, `honorCreatorMode` and `creatorAllowlist`.

## Tests
- Full unit suite green (5581 pass / 0 fail).
- New regressions in `tests/unit/export-import.test.mjs` (38-44) covering all three fixes.

No version bump, no manifest change — behavior/UX fix only.
