### PR TITLE
fix(popup): copy actions no longer inflate stats or duplicate history/ledger

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1079,7 +1079,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // that onStartup can't reach. Runs in parallel with URL processing.
     maybeFetchRemoteRules(_remoteRulesDeps());
     const tabId = sender.tab?.id;
-    handleProcessUrl(message.url, { skipNotify: message.skipNotify, source: message.skipNotify ? "copy_selection" : "navigation", skipStats: !!message.skipStats, referrer: typeof message.referrer === "string" ? message.referrer : "" })
+    handleProcessUrl(message.url, { skipNotify: message.skipNotify, source: message.skipNotify ? "copy_selection" : "navigation", skipStats: !!message.skipStats, skipSideEffects: !!message.skipSideEffects, referrer: typeof message.referrer === "string" ? message.referrer : "" })
       .then(result => {
         updateTabBadge(tabId, result.junkRemoved ?? 0);
         if (typeof tabId === "number" && (result.preservedAffiliate || result.creatorReferralPreserved)) {
@@ -1404,7 +1404,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 });
 
-async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigation", skipStats = false, referrer = "" } = {}) {
+async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigation", skipStats = false, skipSideEffects = false, referrer = "" } = {}) {
   if (!rawUrl?.startsWith("http")) return { cleanUrl: rawUrl, action: "untouched", removedTracking: [], junkRemoved: 0, detectedAffiliate: null };
   // _domainRulesReady / _pathRulesReady are nulled on fetch failure to allow
   // retry on the next call. Both loaders run in a single outer Promise.all so
@@ -1471,7 +1471,13 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
   const urlChanged = result.cleanUrl !== rawUrl;
   let parsedRaw;
   try { parsedRaw = new URL(rawUrl); } catch { /* ignore */ }
-  if (result.action === "untouched" || (!urlChanged && result.junkRemoved === 0)) {
+  // #966: copy-safe reprocessing (skipSideEffects) must not mutate any
+  // user-visible tally. Copying an entry re-cleans an already-counted URL, so
+  // counting it again would inflate "URLs cleaned", prepend a DUPLICATE session
+  // history row (evicting real entries), and push a duplicate ledger event. When
+  // skipSideEffects is set we still compute the clean URL (and withOurAffiliate
+  // below) for the response, but write nothing.
+  if (!skipSideEffects && (result.action === "untouched" || (!urlChanged && result.junkRemoved === 0))) {
     if (parsedRaw?.search) {
       const passthroughEntry = { domain: parsedRaw.hostname.replace(/^www\./, "") };
       if (prefs.devMode) {
@@ -1482,7 +1488,7 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
     }
   }
   if (result.action !== "untouched" && (urlChanged || result.junkRemoved > 0)) {
-    if (!skipStats) {
+    if (!skipStats && !skipSideEffects) {
       incrementStat("urlsCleaned");
       if (result.junkRemoved > 0) incrementStat("junkRemoved", result.junkRemoved);
       if (prefs.domainStats && result.junkRemoved > 0) {
@@ -1492,38 +1498,44 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
         } catch { /* invalid URL, skip domain stat */ }
       }
     }
-    await appendHistory(rawUrl, result.cleanUrl, result.removedTracking ?? []);
-    if (parsedRaw) {
-      try {
-        const domain = parsedRaw.hostname.replace(/^www\./, "");
-        const cleanedEntry = {
-          source,
-          domain,
-          action: result.action,
-          junkRemoved: result.junkRemoved,
-        };
-        if (prefs.devMode) {
-          const parsedClean = new URL(result.cleanUrl);
-          cleanedEntry.path = parsedRaw.pathname;
-          cleanedEntry.removed = result.removedTracking;
-          cleanedEntry.originalParams = [...parsedRaw.searchParams.keys()];
-          cleanedEntry.cleanParams = [...parsedClean.searchParams.keys()];
-          cleanedEntry.cleanUrl = result.cleanUrl;
-        }
-        logAction("cleaned", cleanedEntry);
-      } catch { /* malformed cleanUrl — skip logging */ }
+    if (!skipSideEffects) {
+      await appendHistory(rawUrl, result.cleanUrl, result.removedTracking ?? []);
+      if (parsedRaw) {
+        try {
+          const domain = parsedRaw.hostname.replace(/^www\./, "");
+          const cleanedEntry = {
+            source,
+            domain,
+            action: result.action,
+            junkRemoved: result.junkRemoved,
+          };
+          if (prefs.devMode) {
+            const parsedClean = new URL(result.cleanUrl);
+            cleanedEntry.path = parsedRaw.pathname;
+            cleanedEntry.removed = result.removedTracking;
+            cleanedEntry.originalParams = [...parsedRaw.searchParams.keys()];
+            cleanedEntry.cleanParams = [...parsedClean.searchParams.keys()];
+            cleanedEntry.cleanUrl = result.cleanUrl;
+          }
+          logAction("cleaned", cleanedEntry);
+        } catch { /* malformed cleanUrl — skip logging */ }
+      }
     }
   }
   if (result.action === "detected_foreign") {
-    incrementStat("referralsSpotted");
-    const d = result.detectedAffiliate;
-    logAction("affiliate_detected", {
-      domain: parsedRaw?.hostname.replace(/^www\./, "") ?? "",
-      param: d?.param,
-      value: d?.value,
-      store: d?.pattern?.name ?? null,
-      action: result.action,
-    });
+    // #966: a copy must not bump referralsSpotted or log a detection either;
+    // the with-our-affiliate variant below still builds for the response.
+    if (!skipSideEffects) {
+      incrementStat("referralsSpotted");
+      const d = result.detectedAffiliate;
+      logAction("affiliate_detected", {
+        domain: parsedRaw?.hostname.replace(/^www\./, "") ?? "",
+        param: d?.param,
+        value: d?.value,
+        store: d?.pattern?.name ?? null,
+        action: result.action,
+      });
+    }
     // If injection is enabled, build the URL with our tag so "Remove it" can use it.
     // #523 phase 3: pattern.ourTag is now a { host -> tag } map, not a flat string.
     // Pick the tag for the cleanUrl's hostname; if we have no tag for this
@@ -1544,7 +1556,11 @@ async function handleProcessUrl(rawUrl, { skipNotify = false, source = "navigati
   // #460 (A2): mirror the cleaner outcome into the Attribution Ledger
   // so the popup's "Recent activity" section can render. Fire-and-forget
   // so a write hiccup never affects the caller's URL processing.
-  pushAttributionAndPersist(rawUrl, result, prefs, referrer);
+  // #966: skipped for copy-safe reprocessing so a copy doesn't push a
+  // duplicate ledger event for an already-recorded URL.
+  if (!skipSideEffects) {
+    pushAttributionAndPersist(rawUrl, result, prefs, referrer);
+  }
 
   return result;
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -95,7 +95,10 @@ function copyWithFeedback(text, { onSuccess, onError, onRevert }) {
  */
 async function getCopySafeCleanUrl(originalUrl) {
   try {
-    const response = await chrome.runtime.sendMessage({ type: "PROCESS_URL", url: originalUrl, skipNotify: true });
+    // #966: skipSideEffects — this is a copy of an already-processed history
+    // entry, so it must NOT re-count stats, duplicate the session history, or
+    // push another ledger event. skipNotify alone left those side effects on.
+    const response = await chrome.runtime.sendMessage({ type: "PROCESS_URL", url: originalUrl, skipNotify: true, skipSideEffects: true });
     if (response && typeof response.cleanUrl === "string" && response.cleanUrl) {
       return response.cleanUrl;
     }

--- a/tests/unit/copy-no-side-effects-966.test.mjs
+++ b/tests/unit/copy-no-side-effects-966.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * MUGA — #966: copy actions must not mutate stats, session history, or the
+ * attribution ledger.
+ *
+ * Before this fix the popup History copy affordances reprocessed the entry via
+ * PROCESS_URL with only `skipNotify: true`. In handleProcessUrl, `skipStats`
+ * gated ONLY incrementStat; appendHistory and pushAttributionAndPersist ran
+ * unconditionally. So copying an already-counted URL inflated "URLs cleaned",
+ * prepended a DUPLICATE session-history row (evicting real entries from the
+ * 10-item buffer), and pushed a duplicate ledger event.
+ *
+ * The fix threads a `skipSideEffects` flag end-to-end: the popup sets it, the
+ * PROCESS_URL handler forwards it, and handleProcessUrl gates ALL side effects
+ * (stats, domain stats, history, cleaned/passthrough/affiliate logging, and the
+ * ledger push) behind it — while still computing the clean URL for the response.
+ *
+ * service-worker.js and popup.js are browser-only (top-level chrome.*), so we
+ * pin the wiring via source inspection, the established pattern for this module
+ * (see sw-robustness-833.test.mjs, popup-copy-safe-history.test.mjs).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+const SW_SOURCE = readFileSync(resolve(root, "src/background/service-worker.js"), "utf8");
+const POPUP_SOURCE = readFileSync(resolve(root, "src/popup/popup.js"), "utf8");
+
+describe("#966 — copy-safe reprocessing skips all side effects", () => {
+
+  test("popup sends skipSideEffects:true on the copy-safe PROCESS_URL", () => {
+    assert.ok(
+      /type:\s*"PROCESS_URL"[^}]*skipSideEffects:\s*true/.test(POPUP_SOURCE),
+      "getCopySafeCleanUrl must send skipSideEffects:true",
+    );
+  });
+
+  test("handleProcessUrl accepts a skipSideEffects option", () => {
+    assert.ok(
+      /async function handleProcessUrl\(rawUrl,\s*\{[^}]*skipSideEffects\s*=\s*false/.test(SW_SOURCE),
+      "handleProcessUrl must destructure a skipSideEffects option (default false)",
+    );
+  });
+
+  test("PROCESS_URL handler forwards message.skipSideEffects", () => {
+    assert.ok(
+      /handleProcessUrl\(message\.url,\s*\{[^}]*skipSideEffects:\s*!!message\.skipSideEffects/.test(SW_SOURCE),
+      "the PROCESS_URL message handler must thread skipSideEffects through",
+    );
+  });
+
+  test("stats increment is gated by both skipStats and skipSideEffects", () => {
+    assert.ok(
+      SW_SOURCE.includes("if (!skipStats && !skipSideEffects) {"),
+      "urlsCleaned/junkRemoved stats must be gated by !skipStats && !skipSideEffects",
+    );
+  });
+
+  test("appendHistory is gated behind !skipSideEffects", () => {
+    // The history write must sit inside a `if (!skipSideEffects)` block.
+    const idx = SW_SOURCE.indexOf("await appendHistory(");
+    assert.ok(idx !== -1, "appendHistory call must exist");
+    const before = SW_SOURCE.slice(Math.max(0, idx - 200), idx);
+    assert.ok(
+      before.includes("if (!skipSideEffects) {"),
+      "appendHistory must be guarded by a !skipSideEffects block",
+    );
+  });
+
+  test("the attribution ledger push is gated behind !skipSideEffects", () => {
+    const idx = SW_SOURCE.indexOf("pushAttributionAndPersist(rawUrl, result, prefs, referrer)");
+    assert.ok(idx !== -1, "pushAttributionAndPersist call must exist");
+    const before = SW_SOURCE.slice(Math.max(0, idx - 220), idx);
+    assert.ok(
+      before.includes("if (!skipSideEffects) {"),
+      "pushAttributionAndPersist must be guarded by a !skipSideEffects block",
+    );
+  });
+
+  test("referralsSpotted is not bumped on a copy", () => {
+    // Targets the detected_foreign branch INSIDE handleProcessUrl. (A separate
+    // INCREMENT_STAT message handler also bumps referralsSpotted; that path is
+    // navigation-driven and out of scope, so match the guarded block directly.)
+    assert.ok(
+      /if \(!skipSideEffects\) \{\s*incrementStat\("referralsSpotted"\)/.test(SW_SOURCE),
+      "the handleProcessUrl detected_foreign branch must gate referralsSpotted behind !skipSideEffects",
+    );
+  });
+
+  test("the selection-copy product behavior is unchanged (still counts once)", () => {
+    // Out of scope for #966: copying a text selection of URLs still tallies one
+    // cleaned event. Guard against an accidental regression that silences it.
+    assert.ok(
+      /if \(anyChanged\) incrementStat\("urlsCleaned"\)/.test(SW_SOURCE),
+      "selection-copy must keep its single incrementStat(urlsCleaned)",
+    );
+  });
+});

--- a/tests/unit/popup-copy-safe-history.test.mjs
+++ b/tests/unit/popup-copy-safe-history.test.mjs
@@ -77,6 +77,7 @@ describe("#946 — getCopySafeCleanUrl helper (behavioral)", () => {
     assert.equal(sentMessage.type, "PROCESS_URL");
     assert.equal(sentMessage.url, "https://example.com/raw?tag=x", "must reprocess the ORIGINAL url, not the stale nav-time clean value");
     assert.equal(sentMessage.skipNotify, true, "must mirror handleProcessUrl's copy-safe effectivePrefs branch");
+    assert.equal(sentMessage.skipSideEffects, true, "#966: a copy must NOT re-count stats, duplicate history, or push a ledger event");
     assert.equal(result, "https://example.com/clean-no-tag");
   });
 


### PR DESCRIPTION
Fixes the popup History copy affordances re-counting and polluting history/ledger.

## Closes
- Closes #966

## Root cause
The copy-safe reprocessing path (#946) reprocessed the entry via `PROCESS_URL` with only `skipNotify: true`. In `handleProcessUrl`, `skipStats` gated ONLY `incrementStat`; `appendHistory` and `pushAttributionAndPersist` ran regardless. Copying an already-counted URL therefore inflated "URLs cleaned", prepended a duplicate session-history row (evicting real entries from the 10-item buffer), and pushed a duplicate ledger event.

## Fix
A `skipSideEffects` flag threaded end-to-end:
- `popup.js` `getCopySafeCleanUrl` sets `skipSideEffects: true`.
- The `PROCESS_URL` message handler forwards it.
- `handleProcessUrl` gates every side effect behind it: stats, domain stats, `appendHistory`, the cleaned/passthrough/affiliate `logAction` calls, `referralsSpotted`, and `pushAttributionAndPersist`. The clean URL is still computed for the response.

Out of scope / deliberately unchanged: the navigation-driven `INCREMENT_STAT` path and the selection-copy single-count product behavior.

## Tests
- Full unit suite green (5583 pass / 0 fail).
- New `tests/unit/copy-no-side-effects-966.test.mjs`; extended the #946 copy-safe test to assert the flag is sent.

No version bump, no manifest change.
