### PR TITLE
fix(background): storage-backed onboarding-tab dedup across SW cold starts

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1597,12 +1597,42 @@ chrome.runtime.onStartup.addListener(async () => {
   migrateConsentToLocal();
 });
 
-// --- Dedup flag: prevent opening onboarding twice in the same background lifetime ---
+// --- Dedup: open the onboarding tab at most once while consent is pending. ---
+// Two layers: a module flag guards a double-open within a single background
+// lifetime (onInstalled + fallback both firing), and a persisted
+// chrome.storage.local flag guards across MV3 service-worker cold starts (#967).
+// Without the persisted layer the volatile flag reset on every wake, so an
+// incomplete onboarding reopened a fresh tab on each navigation-triggered
+// restart. The persisted flag is cleared (clearOnboardingTabFlag) once consent
+// is valid, so a later ToS re-onboard can still surface the tab again.
 let _onboardingTabOpened = false;
-function openOnboardingOnce() {
+const ONBOARDING_TAB_FLAG = "mugaOnboardingTabOpened";
+
+async function openOnboardingOnce() {
   if (_onboardingTabOpened) return;
-  _onboardingTabOpened = true;
+  _onboardingTabOpened = true; // synchronous within-lifetime guard (no await above)
+  try {
+    const already = await new Promise((resolve) => {
+      chrome.storage.local.get({ [ONBOARDING_TAB_FLAG]: false }, (r) =>
+        resolve(!!(r && r[ONBOARDING_TAB_FLAG])));
+    });
+    if (already) return; // a prior lifetime already opened it — do not spam a new tab
+    // Set BEFORE creating the tab so a rapid second cold start can't double-open.
+    await new Promise((resolve) => {
+      chrome.storage.local.set({ [ONBOARDING_TAB_FLAG]: true }, () => resolve());
+    });
+  } catch { /* best-effort: worst case one extra tab, never a missing one */ }
   chrome.tabs.create({ url: chrome.runtime.getURL("onboarding/onboarding.html") });
+}
+
+// Clears the persisted onboarding-tab guard so a future re-onboard (ToS bump)
+// can open the tab again. Called when consent is valid — i.e. onboarding is not
+// currently needed — which is the natural point to reset the one-shot guard.
+function clearOnboardingTabFlag() {
+  _onboardingTabOpened = false;
+  try {
+    chrome.storage.local.remove(ONBOARDING_TAB_FLAG, () => void chrome.runtime.lastError);
+  } catch { /* ignore */ }
 }
 
 /**
@@ -1648,7 +1678,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   if (details.reason === "install") {
     const installPrefs = await getPrefs();
     if (shouldOpenOnboarding(installPrefs)) {
-      openOnboardingOnce();
+      await openOnboardingOnce();
     }
   }
 });
@@ -1662,7 +1692,11 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   try {
     const prefs = await getPrefs();
     if (shouldOpenOnboarding(prefs)) {
-      openOnboardingOnce();
+      await openOnboardingOnce();
+    } else {
+      // Consent satisfied — reset the one-shot guard so a future ToS re-onboard
+      // can surface the tab again (#967).
+      clearOnboardingTabFlag();
     }
     // Surface the consent-required badge on every cold start, not just
     // on first install. onInstalled does not fire on browser restart or

--- a/tests/unit/onboarding-tab-dedup-967.test.mjs
+++ b/tests/unit/onboarding-tab-dedup-967.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * MUGA — #967: the onboarding tab must open at most once while consent is
+ * pending, surviving MV3 service-worker cold starts.
+ *
+ * Before this fix the dedup guard was a module-level `_onboardingTabOpened`
+ * boolean. MV3 evicts the service worker after ~30s idle and re-executes the
+ * whole module on the next event, resetting the flag to false — so the
+ * background-load fallback IIFE reopened a fresh onboarding tab on every wake
+ * while onboarding was incomplete.
+ *
+ * The fix adds a persisted chrome.storage.local guard (ONBOARDING_TAB_FLAG)
+ * that survives cold starts, cleared once consent is valid so a later ToS
+ * re-onboard can surface the tab again.
+ *
+ * service-worker.js is browser-only (top-level chrome.*), so we pin the wiring
+ * via source inspection AND exercise the extracted openOnboardingOnce against a
+ * fake chrome, the established pattern for this module.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+const SW_SOURCE = readFileSync(resolve(root, "src/background/service-worker.js"), "utf8");
+
+/** Extracts a top-level `async function <name>(...) { ... }` block via brace matching. */
+function extractFunctionSource(src, name) {
+  const idx = src.indexOf(`async function ${name}`);
+  assert.ok(idx !== -1, `${name} must be defined as an async function`);
+  let depth = 0;
+  let started = false;
+  let i = idx;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") { depth++; started = true; }
+    else if (src[i] === "}") {
+      depth--;
+      if (started && depth === 0) { i++; break; }
+    }
+  }
+  return src.slice(idx, i);
+}
+
+/** Builds a callable openOnboardingOnce bound to a fake `chrome`, with fresh module state. */
+function buildOpenOnboardingOnce(fakeChrome) {
+  const fnSrc = extractFunctionSource(SW_SOURCE, "openOnboardingOnce");
+  const factory = new Function(
+    "chrome",
+    `"use strict";
+     let _onboardingTabOpened = false;
+     const ONBOARDING_TAB_FLAG = "mugaOnboardingTabOpened";
+     ${fnSrc}
+     return openOnboardingOnce;`,
+  );
+  return factory(fakeChrome);
+}
+
+/** Minimal chrome.storage.local + tabs stub backed by an in-memory store. */
+function makeFakeChrome(initialStore = {}) {
+  const store = { ...initialStore };
+  const calls = { created: 0, lastCreatedUrl: null };
+  const fakeChrome = {
+    storage: {
+      local: {
+        get: (defaults, cb) => cb({ ...defaults, ...store }),
+        set: (obj, cb) => { Object.assign(store, obj); cb && cb(); },
+        remove: (key, cb) => { delete store[key]; cb && cb(); },
+      },
+    },
+    tabs: {
+      create: ({ url }) => { calls.created++; calls.lastCreatedUrl = url; },
+    },
+    runtime: { getURL: (p) => p, lastError: null },
+  };
+  return { fakeChrome, store, calls };
+}
+
+describe("#967 — onboarding tab dedup survives SW cold starts", () => {
+
+  test("SW defines a persisted ONBOARDING_TAB_FLAG guard", () => {
+    assert.ok(
+      /const ONBOARDING_TAB_FLAG\s*=\s*"mugaOnboardingTabOpened"/.test(SW_SOURCE),
+      "service-worker must define a persisted onboarding-tab flag key",
+    );
+  });
+
+  test("openOnboardingOnce reads and writes the persisted flag in chrome.storage.local", () => {
+    const fnSrc = extractFunctionSource(SW_SOURCE, "openOnboardingOnce");
+    assert.ok(fnSrc.includes("chrome.storage.local.get"), "must read the persisted flag");
+    assert.ok(fnSrc.includes("chrome.storage.local.set"), "must persist the flag");
+    assert.ok(fnSrc.includes("ONBOARDING_TAB_FLAG"), "must key on ONBOARDING_TAB_FLAG");
+  });
+
+  test("consent-valid path clears the persisted guard for future re-onboards", () => {
+    assert.ok(
+      SW_SOURCE.includes("function clearOnboardingTabFlag"),
+      "must define clearOnboardingTabFlag",
+    );
+    // The fallback IIFE's else-branch (consent satisfied) must clear it.
+    assert.ok(
+      /shouldOpenOnboarding\(prefs\)\)\s*\{\s*await openOnboardingOnce\(\);\s*\}\s*else\s*\{\s*[\s\S]*clearOnboardingTabFlag\(\)/.test(SW_SOURCE),
+      "the fallback must clearOnboardingTabFlag when onboarding is not needed",
+    );
+  });
+
+  // Behavioral: run the real extracted function against a fake chrome.
+  test("first call opens exactly one tab and persists the flag", async () => {
+    const { fakeChrome, store, calls } = makeFakeChrome();
+    const openOnboardingOnce = buildOpenOnboardingOnce(fakeChrome);
+    await openOnboardingOnce();
+    assert.equal(calls.created, 1, "opens the onboarding tab on first pending call");
+    assert.equal(store.mugaOnboardingTabOpened, true, "persists the guard flag");
+    assert.ok(calls.lastCreatedUrl.includes("onboarding/onboarding.html"));
+  });
+
+  test("a later cold start does NOT reopen when the persisted flag is already set", async () => {
+    // Simulate a fresh SW lifetime (fresh module state) where the flag persisted
+    // from a previous lifetime is already true.
+    const { fakeChrome, calls } = makeFakeChrome({ mugaOnboardingTabOpened: true });
+    const openOnboardingOnce = buildOpenOnboardingOnce(fakeChrome);
+    await openOnboardingOnce();
+    assert.equal(calls.created, 0, "must not spam a new tab across cold starts");
+  });
+
+  test("two calls in the same lifetime open only one tab (module-flag guard)", async () => {
+    const { fakeChrome, calls } = makeFakeChrome();
+    const openOnboardingOnce = buildOpenOnboardingOnce(fakeChrome);
+    await openOnboardingOnce();
+    await openOnboardingOnce();
+    assert.equal(calls.created, 1, "within-lifetime double call opens one tab");
+  });
+});


### PR DESCRIPTION
Fixes the MV3 onboarding tab reopening on every service-worker cold start while onboarding is incomplete.

## Closes
- Closes #967

## Root cause
The dedup guard was a module-level `_onboardingTabOpened` boolean. MV3 evicts the service worker after ~30s idle and re-executes the whole module on the next event, resetting the flag to `false`. The background-load fallback IIFE then reopened a fresh onboarding tab on every wake while consent was still pending.

## Fix
`openOnboardingOnce` now also consults a persisted `chrome.storage.local` flag (`mugaOnboardingTabOpened`) that survives cold starts, so at most one tab opens while consent is pending. Details:
- The flag is set **before** `chrome.tabs.create` so a rapid second cold start can't double-open.
- It is cleared (`clearOnboardingTabFlag`) once consent is valid — the natural reset point — so a later ToS re-onboard can still surface the tab.
- The module flag is kept as the fast within-lifetime guard (onInstalled + fallback both firing).

## Tests
- Full unit suite green (5588 pass / 0 fail).
- New `tests/unit/onboarding-tab-dedup-967.test.mjs`: source guards + a behavioral test running the extracted `openOnboardingOnce` against a fake `chrome` (first call opens one tab + persists; a later cold start with the flag set does not reopen; two same-lifetime calls open one).

No version bump, no manifest change.
