### PR TITLE
fix(onboarding): correct remote-rules disclosure copy on fresh install

### DIFF
--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -247,6 +247,8 @@ export default Object.freeze({
   ob_synced_from_other_device: "Diese Einstellung wurde auf einem anderen Gerät aktiviert. Bestätige sie für dieses Gerät oder hebe die Auswahl auf, um sie hier deaktiviert zu lassen.",
   ob_remote_rules_title: "Remote-Regelaktualisierungen",
   ob_remote_rules_desc: "Dein anderes Gerät hat Remote-Regelaktualisierungen aktiviert. Wenn aktiviert, lädt MUGA einmal pro Woche eine signierte Tracking-Parameter-Liste von einem öffentlichen GitHub-Pages-Endpunkt, um deinen Schutz aktuell zu halten. Es werden keine Nutzerdaten gesendet.",
+  ob_remote_rules_desc_default: "Remote-Regelaktualisierungen sind standardmäßig aktiviert. Wenn aktiviert, lädt MUGA einmal pro Woche eine signierte Tracking-Parameter-Liste von einem öffentlichen GitHub-Pages-Endpunkt, um deinen Schutz aktuell zu halten. Es werden keine Nutzerdaten gesendet.",
+  ob_remote_rules_default_note: "Standardmäßig aktiviert. Bestätige sie für dieses Gerät oder hebe die Auswahl auf, um sie hier deaktiviert zu lassen.",
   ob_remote_rules_check_label: "Remote-Regelaktualisierungen auf diesem Gerät aktivieren",
   ob_reonboard_delta_title: "Seit deiner letzten Zustimmung wurden einige Klauseln ergänzt",
   ob_reonboard_delta_desc: "Deine bisherige Zustimmung gilt weiterhin. Überprüfe die neuen Klauseln unten; akzeptieren schaltet die neuen Verhaltensweisen frei, ablehnen lässt MUGA unter den zuvor akzeptierten Bedingungen weiterlaufen.",

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -247,6 +247,8 @@ export default Object.freeze({
   ob_synced_from_other_device: "This setting was enabled on another device. Confirm it for this device, or uncheck to keep it off here.",
   ob_remote_rules_title: "Remote rule updates",
   ob_remote_rules_desc: "Your other device has remote rule updates enabled. With this on, MUGA performs a weekly fetch of a signed tracking-param list from a public GitHub Pages endpoint to keep your protection fresh. No user data is sent.",
+  ob_remote_rules_desc_default: "Remote rule updates are on by default. With this on, MUGA performs a weekly fetch of a signed tracking-param list from a public GitHub Pages endpoint to keep your protection fresh. No user data is sent.",
+  ob_remote_rules_default_note: "On by default. Confirm it for this device, or uncheck to keep it off here.",
   ob_remote_rules_check_label: "Enable remote rule updates on this device",
   ob_reonboard_delta_title: "A few terms have been added since you last accepted",
   ob_reonboard_delta_desc: "Your existing acceptance still applies. Review the new clauses below; accepting unlocks the new behaviours, declining keeps MUGA running under your previously accepted terms.",

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -247,6 +247,8 @@ export default Object.freeze({
   ob_synced_from_other_device: "Este ajuste fue activado en otro dispositivo. Confírmalo para este dispositivo o desmarca la casilla para mantenerlo desactivado aquí.",
   ob_remote_rules_title: "Actualizaciones remotas de reglas",
   ob_remote_rules_desc: "Tu otro dispositivo tiene activadas las actualizaciones remotas de reglas. Con esto activo, MUGA hace una descarga semanal de una lista firmada de parámetros de rastreo desde un endpoint público de GitHub Pages para mantener tu protección al día. No se envían datos del usuario.",
+  ob_remote_rules_desc_default: "Las actualizaciones remotas de reglas vienen activadas por defecto. Con esto activo, MUGA hace una descarga semanal de una lista firmada de parámetros de rastreo desde un endpoint público de GitHub Pages para mantener tu protección al día. No se envían datos del usuario.",
+  ob_remote_rules_default_note: "Activado por defecto. Confírmalo para este dispositivo o desmarca la casilla para mantenerlo desactivado aquí.",
   ob_remote_rules_check_label: "Activar actualizaciones remotas de reglas en este dispositivo",
   ob_reonboard_delta_title: "Se han añadido algunas cláusulas desde la última vez que aceptaste",
   ob_reonboard_delta_desc: "Tu aceptación previa sigue siendo válida. Revisa las cláusulas nuevas abajo; aceptar habilita los nuevos comportamientos, rechazar mantiene MUGA funcionando bajo los términos que ya habías aceptado.",

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -247,6 +247,8 @@ export default Object.freeze({
   ob_synced_from_other_device: "Ce paramètre a été activé sur un autre appareil. Confirmez-le pour cet appareil, ou décochez pour le laisser désactivé ici.",
   ob_remote_rules_title: "Mises à jour de règles à distance",
   ob_remote_rules_desc: "Votre autre appareil a les mises à jour de règles à distance activées. Avec cette option, MUGA effectue une récupération hebdomadaire d'une liste signée de paramètres de pistage depuis un endpoint GitHub Pages public pour garder votre protection à jour. Aucune donnée utilisateur n'est envoyée.",
+  ob_remote_rules_desc_default: "Les mises à jour de règles à distance sont activées par défaut. Avec cette option, MUGA effectue une récupération hebdomadaire d'une liste signée de paramètres de pistage depuis un endpoint GitHub Pages public pour garder votre protection à jour. Aucune donnée utilisateur n'est envoyée.",
+  ob_remote_rules_default_note: "Activé par défaut. Confirmez-le pour cet appareil, ou décochez pour le laisser désactivé ici.",
   ob_remote_rules_check_label: "Activer les mises à jour de règles à distance sur cet appareil",
   ob_reonboard_delta_title: "Quelques clauses ont été ajoutées depuis votre dernière acceptation",
   ob_reonboard_delta_desc: "Votre acceptation existante reste valable. Examinez les nouvelles clauses ci-dessous ; accepter active les nouveaux comportements, refuser laisse MUGA fonctionner selon les conditions précédemment acceptées.",

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -247,6 +247,8 @@ export default Object.freeze({
   ob_synced_from_other_device: "Questa impostazione è stata attivata su un altro dispositivo. Confermala per questo dispositivo, oppure deseleziona per tenerla disattivata qui.",
   ob_remote_rules_title: "Aggiornamenti remoti delle regole",
   ob_remote_rules_desc: "L'altro tuo dispositivo ha gli aggiornamenti remoti delle regole attivati. Con questa opzione, MUGA scarica settimanalmente un elenco firmato di parametri di tracciamento da un endpoint pubblico di GitHub Pages per mantenere aggiornata la protezione. Nessun dato utente viene inviato.",
+  ob_remote_rules_desc_default: "Gli aggiornamenti remoti delle regole sono attivati per impostazione predefinita. Con questa opzione, MUGA scarica settimanalmente un elenco firmato di parametri di tracciamento da un endpoint pubblico di GitHub Pages per mantenere aggiornata la protezione. Nessun dato utente viene inviato.",
+  ob_remote_rules_default_note: "Attivato per impostazione predefinita. Confermalo per questo dispositivo, oppure deseleziona per tenerlo disattivato qui.",
   ob_remote_rules_check_label: "Attiva gli aggiornamenti remoti delle regole su questo dispositivo",
   ob_reonboard_delta_title: "Alcune clausole sono state aggiunte dall'ultima volta che hai accettato",
   ob_reonboard_delta_desc: "La tua accettazione esistente è ancora valida. Esamina le nuove clausole qui sotto; accettare attiva i nuovi comportamenti, rifiutare mantiene MUGA in esecuzione secondo i termini accettati in precedenza.",

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -247,6 +247,8 @@ export default Object.freeze({
   ob_synced_from_other_device: "この設定は別のデバイスで有効になりました。このデバイスでも確認するか、ここではオフのままにするにはチェックを外してください。",
   ob_remote_rules_title: "ルールのリモート更新",
   ob_remote_rules_desc: "他のデバイスでルールのリモート更新が有効になっています。これを有効にすると、MUGAは公開GitHub Pagesエンドポイントから署名済みのトラッキングパラメータリストを週次取得して保護を最新に保ちます。ユーザーデータは送信されません。",
+  ob_remote_rules_desc_default: "ルールのリモート更新はデフォルトで有効です。これを有効にすると、MUGAは公開GitHub Pagesエンドポイントから署名済みのトラッキングパラメータリストを週次取得して保護を最新に保ちます。ユーザーデータは送信されません。",
+  ob_remote_rules_default_note: "デフォルトで有効です。このデバイスでも確認するか、ここではオフのままにするにはチェックを外してください。",
   ob_remote_rules_check_label: "このデバイスでルールのリモート更新を有効にする",
   ob_reonboard_delta_title: "前回の同意以降、いくつかの条項が追加されました",
   ob_reonboard_delta_desc: "既存の同意は引き続き有効です。下記の新しい条項を確認してください。同意すると新しい動作が有効になり、拒否すると以前同意した条件のままMUGAが動作し続けます。",

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -247,6 +247,8 @@ export default Object.freeze({
   ob_synced_from_other_device: "Esta configuração foi ativada em outro dispositivo. Confirme-a para este dispositivo ou desmarque para mantê-la desativada aqui.",
   ob_remote_rules_title: "Atualizações remotas de regras",
   ob_remote_rules_desc: "Seu outro dispositivo tem as atualizações remotas de regras ativadas. Com isto ligado, MUGA faz um download semanal de uma lista assinada de parâmetros de rastreamento de um endpoint público do GitHub Pages para manter sua proteção atualizada. Nenhum dado do usuário é enviado.",
+  ob_remote_rules_desc_default: "As atualizações remotas de regras vêm ativadas por padrão. Com isto ligado, MUGA faz um download semanal de uma lista assinada de parâmetros de rastreamento de um endpoint público do GitHub Pages para manter sua proteção atualizada. Nenhum dado do usuário é enviado.",
+  ob_remote_rules_default_note: "Ativado por padrão. Confirme-o para este dispositivo ou desmarque para mantê-lo desativado aqui.",
   ob_remote_rules_check_label: "Ativar atualizações remotas de regras neste dispositivo",
   ob_reonboard_delta_title: "Algumas cláusulas foram adicionadas desde sua última aceitação",
   ob_reonboard_delta_desc: "Sua aceitação anterior continua válida. Revise as novas cláusulas abaixo; aceitar habilita os novos comportamentos, recusar mantém o MUGA funcionando sob os termos previamente aceitos.",

--- a/src/onboarding/onboarding.html
+++ b/src/onboarding/onboarding.html
@@ -120,14 +120,14 @@
     <div class="section" id="remote-rules-section" hidden>
       <div class="section-title" data-i18n="ob_remote_rules_title">Remote rule updates</div>
       <div class="affiliate-body">
-        <p data-i18n="ob_remote_rules_desc">
+        <p id="remote-rules-desc" data-i18n="ob_remote_rules_desc">
           Your other device has remote rule updates enabled. With this on, MUGA performs a weekly fetch of a signed tracking-param list from a public GitHub Pages endpoint to keep your protection fresh. No user data is sent.
         </p>
         <label class="consent-check" id="remote-rules-label">
           <input type="checkbox" id="remote-rules-check" data-i18n-aria-label="aria_onboarding_remote_rules_check">
           <div class="consent-check-label">
             <strong data-i18n="ob_remote_rules_check_label">Enable remote rule updates on this device</strong>
-            <small data-i18n="ob_synced_from_other_device">This setting was enabled on another device. Confirm it for this device, or uncheck to keep it off here.</small>
+            <small id="remote-rules-note" data-i18n="ob_synced_from_other_device">This setting was enabled on another device. Confirm it for this device, or uncheck to keep it off here.</small>
           </div>
         </label>
       </div>

--- a/src/onboarding/onboarding.js
+++ b/src/onboarding/onboarding.js
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   applyTranslations(lang);
 
   // --- Read state ----------------------------------------------------------
-  const [syncPrefs, localConsent, existingOverrides, fixtures] = await Promise.all([
+  const [syncPrefs, localConsent, existingOverrides, fixtures, remoteRulesSyncedFromDevice] = await Promise.all([
     new Promise((resolve) => {
       // Source the fallbacks from PREF_DEFAULTS so onboarding sees the SAME
       // default as getPrefs() when a key is absent from sync. After #888
@@ -69,6 +69,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     getConsent(),
     getOverrides(),
     getTestFixtures(),
+    new Promise((resolve) => {
+      // Raw presence read (NO defaults) so we can tell a value genuinely synced
+      // from another device apart from the on-by-default fallback (#969). On a
+      // fresh install remoteRulesEnabled is absent from sync, so the disclosure
+      // must not claim another device enabled it.
+      chrome.storage.sync.get("remoteRulesEnabled", (r) =>
+        resolve(!!(r && r.remoteRulesEnabled === true)));
+    }),
   ]);
 
   // Test-only overrides (#407). Fixtures are null in production.
@@ -136,6 +144,15 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (pending.has("remoteRulesEnabled")) {
     if (remoteRulesSection) remoteRulesSection.hidden = false;
     if (remoteRulesCheck) remoteRulesCheck.checked = true;
+    if (!remoteRulesSyncedFromDevice) {
+      // On-by-default (e.g. a fresh install), NOT synced from another device:
+      // swap in accurate copy instead of the "your other device enabled it"
+      // wording, which is false when the value comes from the default (#969).
+      const descEl = document.getElementById("remote-rules-desc");
+      const noteEl = document.getElementById("remote-rules-note");
+      if (descEl) descEl.textContent = t("ob_remote_rules_desc_default", lang);
+      if (noteEl) noteEl.textContent = t("ob_remote_rules_default_note", lang);
+    }
   }
 
   function updateButton() {

--- a/tests/unit/onboarding-remote-rules-copy-969.test.mjs
+++ b/tests/unit/onboarding-remote-rules-copy-969.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * MUGA — #969: on a fresh install the onboarding remote-rules disclosure must
+ * NOT claim "your other device enabled it".
+ *
+ * remoteRulesEnabled defaults to true (#888), so on a fresh install the
+ * per-device confirmation section surfaces (correct — the user should be able
+ * to opt out of the weekly fetch during onboarding). But the copy asserted the
+ * value came from another device, which is false when it comes from the default.
+ *
+ * The fix reads sync WITHOUT defaults to tell a genuinely-synced value apart
+ * from the on-by-default fallback, and swaps in accurate copy
+ * (ob_remote_rules_desc_default / ob_remote_rules_default_note) for the
+ * default-on case while keeping the "other device" wording for a real sync.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import en from "../../src/lib/locales/en.mjs";
+import es from "../../src/lib/locales/es.mjs";
+import pt from "../../src/lib/locales/pt.mjs";
+import de from "../../src/lib/locales/de.mjs";
+import fr from "../../src/lib/locales/fr.mjs";
+import it from "../../src/lib/locales/it.mjs";
+import ja from "../../src/lib/locales/ja.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "../..");
+const ONB_JS = readFileSync(resolve(root, "src/onboarding/onboarding.js"), "utf8");
+const ONB_HTML = readFileSync(resolve(root, "src/onboarding/onboarding.html"), "utf8");
+
+const LOCALES = { en, es, pt, de, fr, it, ja };
+const NEW_KEYS = ["ob_remote_rules_desc_default", "ob_remote_rules_default_note"];
+
+describe("#969 — remote-rules disclosure copy distinguishes default-on from synced", () => {
+
+  test("onboarding.js reads remoteRulesEnabled presence WITHOUT defaults", () => {
+    assert.ok(
+      /chrome\.storage\.sync\.get\("remoteRulesEnabled",/.test(ONB_JS),
+      "must do a raw (no-default) presence read to detect a genuinely synced value",
+    );
+    assert.ok(
+      ONB_JS.includes("remoteRulesSyncedFromDevice"),
+      "must compute a remoteRulesSyncedFromDevice signal",
+    );
+  });
+
+  test("onboarding.js swaps in the default-on copy when NOT synced from another device", () => {
+    assert.ok(
+      /if \(!remoteRulesSyncedFromDevice\)/.test(ONB_JS),
+      "must branch on the not-synced (default-on) case",
+    );
+    assert.ok(
+      ONB_JS.includes('t("ob_remote_rules_desc_default"'),
+      "must apply the default-on description",
+    );
+    assert.ok(
+      ONB_JS.includes('t("ob_remote_rules_default_note"'),
+      "must apply the default-on note",
+    );
+  });
+
+  test("the two overridable elements have stable ids", () => {
+    assert.ok(ONB_HTML.includes('id="remote-rules-desc"'), "desc element needs an id to override");
+    assert.ok(ONB_HTML.includes('id="remote-rules-note"'), "note element needs an id to override");
+  });
+
+  test("the default-on copy exists and is non-empty in every locale", () => {
+    for (const [code, dict] of Object.entries(LOCALES)) {
+      for (const key of NEW_KEYS) {
+        assert.ok(
+          typeof dict[key] === "string" && dict[key].trim().length > 0,
+          `locale "${code}" must define a non-empty "${key}"`,
+        );
+      }
+    }
+  });
+
+  test("the default-on copy does not claim another device (EN + ES sanity)", () => {
+    assert.ok(!/other device/i.test(en.ob_remote_rules_desc_default), "EN desc must not say 'other device'");
+    assert.ok(!/other device/i.test(en.ob_remote_rules_default_note), "EN note must not say 'other device'");
+    assert.ok(!/otro dispositivo/i.test(es.ob_remote_rules_desc_default), "ES desc must not say 'otro dispositivo'");
+    assert.ok(!/otro dispositivo/i.test(es.ob_remote_rules_default_note), "ES note must not say 'otro dispositivo'");
+    // And they DO convey the on-by-default framing.
+    assert.ok(/by default/i.test(en.ob_remote_rules_desc_default), "EN desc must convey on-by-default");
+    assert.ok(/por defecto/i.test(es.ob_remote_rules_desc_default), "ES desc must convey por defecto");
+  });
+
+  test("no user-facing em-dash in the new copy (project copy rule)", () => {
+    for (const [code, dict] of Object.entries(LOCALES)) {
+      for (const key of NEW_KEYS) {
+        assert.ok(!dict[key].includes("—"), `locale "${code}" key "${key}" must not contain an em-dash`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes the false "your other device enabled remote rule updates" copy shown on a fresh install.

## Closes
- Closes #969

## Root cause
`remoteRulesEnabled` defaults to `true` (#888), so on a fresh install the per-device confirmation section correctly surfaces (the user should be able to opt out of the weekly fetch during onboarding). But its copy asserted the value came from another device. `pendingConfirmations` only sees the merged value, so it can't tell an on-by-default value from a genuinely synced one.

## Fix
Onboarding does an extra raw `chrome.storage.sync.get("remoteRulesEnabled")` (no defaults) to detect whether the value is genuinely present in sync. When it's on-by-default (absent from sync, e.g. a fresh install), it swaps in accurate copy via two newly-id'd elements:
- `ob_remote_rules_desc_default` — "Remote rule updates are on by default. …"
- `ob_remote_rules_default_note` — "On by default. Confirm it for this device, or uncheck to keep it off here."

The "enabled on another device" wording is kept only for a real cross-device sync. Both keys added across all 7 locales (peninsular es, no em-dashes).

## Tests
- Full unit suite green (5596 pass / 0 fail), including i18n key-parity and fallback-sync.
- New `tests/unit/onboarding-remote-rules-copy-969.test.mjs`.

No version bump, no manifest change — copy/logic fix only.
