### PR TITLE
refactor(options): versioned settings schema + single import/export validator

### DIFF
--- a/src/lib/settings-schema.js
+++ b/src/lib/settings-schema.js
@@ -1,0 +1,258 @@
+/**
+ * MUGA: Settings export/import schema
+ *
+ * Single source of truth for the Settings export/import feature (#973
+ * follow-up). Previously this logic was duplicated three ways inside
+ * options.js: the export payload literal, the import BOOL_KEYS array, and
+ * the per-key import validation branches. All three now derive from
+ * SETTINGS_FIELDS below.
+ *
+ * Pure module: no chrome/DOM APIs, no side effects. The caller (options.js)
+ * owns all storage reads/writes and the async shortener-permission check —
+ * planImport() only decides WHAT should be saved, never performs the save.
+ *
+ * Regression coverage this module exists to protect (see
+ * tests/unit/settings-schema.test.mjs):
+ *   - #964: followShortenersEnabled must never be handed back in `toSave`.
+ *     It is permission-gated and the permission check requires chrome APIs,
+ *     so planImport only reports the raw request via `special`.
+ *   - #965: guarded prefs (injectOwnAffiliate) must appear in `toSave` as
+ *     plain booleans so options.js can run reconcileOverrideForExplicitChoice
+ *     against them exactly as before.
+ *   - #968: toastDuration/experimentalParamClassesEnabled/honorCreatorMode/
+ *     creatorAllowlist must round-trip through export + import.
+ */
+
+import { isValidListEntry, isValidCustomParam, capImportedLists, IMPORT_LIST_CAPS } from "./validation.js";
+import { addEntry as addCreatorAllowlistEntry } from "./creator-allowlist.js";
+import { SUPPORTED_LANGS } from "./i18n.js";
+
+/**
+ * Schema version stamped onto every export from this build. Bumping this is
+ * a no-op today (there are no migrations yet) but gives future imports a
+ * `data.schemaVersion` to branch on via migrate() below.
+ */
+export const SETTINGS_SCHEMA_VERSION = 1;
+
+/**
+ * Discrete toast-duration values offered by the options UI. The persisted
+ * pref is snapped to the nearest of these so the pref and the <select> can
+ * never disagree — an imported/legacy value like 22 or 45 always maps to a
+ * real <option> instead of leaving the control blank (#968).
+ */
+export const TOAST_DURATION_OPTIONS = Object.freeze([5, 10, 15, 30, 45, 60]);
+
+/** Snaps an arbitrary duration to the nearest offered <option> value. */
+export function snapToastDuration(n) {
+  const v = Number.isFinite(n) ? n : 15;
+  return TOAST_DURATION_OPTIONS.reduce((a, b) =>
+    Math.abs(b - v) < Math.abs(a - v) ? b : a);
+}
+
+/**
+ * Tracking-category keys accepted for `disabledCategories`. Kept as its own
+ * literal set (not derived from TRACKING_PARAM_CATEGORIES in affiliates.js)
+ * so this import allowlist cannot silently drift if that taxonomy changes
+ * shape — it is a storage-schema concern, not a UI-taxonomy one.
+ */
+const VALID_CATEGORIES = new Set(["utm", "ads", "email", "social", "platform_noise", "generic"]);
+
+/**
+ * Ordered descriptor list for every user-settable pref the export/import
+ * feature touches. This is the one place that conceptually replaces the
+ * three scattered copies that used to live in options.js.
+ *
+ * `kind` values:
+ *   - "boolean"         — plain boolean pref, imported via typeof-check only
+ *   - "list"            — blacklist/whitelist/customParams, handled together
+ *                          via capImportedLists (shared caps + validation)
+ *   - "categories"       — disabledCategories, validated against VALID_CATEGORIES
+ *   - "toastDuration"    — snapped via snapToastDuration
+ *   - "language"        — validated against SUPPORTED_LANGS
+ *   - "creatorAllowlist" — folded through addCreatorAllowlistEntry
+ *   - "customRulesList"  — userCustomRules, filtered via isValidCustomParam + capped
+ *   - "permissionGated"  — followShortenersEnabled: requires a chrome.permissions
+ *                          check that cannot happen inside this pure module
+ *   - "local"            — devMode: chrome.storage.local, not a synced pref
+ *
+ * `guarded: true` marks prefs that also appear in GUARDED_PREFS
+ * (synced-affiliate-pref-guard.js) and therefore need per-device override
+ * reconciliation on explicit import — informational here; the reconcile
+ * loop itself stays in options.js and imports GUARDED_PREFS directly so
+ * there is exactly one copy of that membership list.
+ */
+export const SETTINGS_FIELDS = Object.freeze([
+  { key: "enabled", kind: "boolean" },
+  { key: "injectOwnAffiliate", kind: "boolean", guarded: true },
+  { key: "notifyForeignAffiliate", kind: "boolean" },
+  { key: "stripAllAffiliates", kind: "boolean" },
+  { key: "dnrEnabled", kind: "boolean" },
+  { key: "blockPings", kind: "boolean" },
+  { key: "ampRedirect", kind: "boolean" },
+  { key: "unwrapRedirects", kind: "boolean" },
+  { key: "blacklist", kind: "list" },
+  { key: "whitelist", kind: "list" },
+  { key: "customParams", kind: "list" },
+  { key: "contextMenuEnabled", kind: "boolean" },
+  { key: "disabledCategories", kind: "categories" },
+  { key: "toastDuration", kind: "toastDuration" },
+  { key: "language", kind: "language" },
+  { key: "devMode", kind: "local" },
+  { key: "paramBreakdown", kind: "boolean" },
+  { key: "showReportButton", kind: "boolean" },
+  { key: "domainStats", kind: "boolean" },
+  { key: "showBadge", kind: "boolean" },
+  { key: "followShortenersEnabled", kind: "permissionGated" },
+  { key: "canonicalExtractorEnabled", kind: "boolean" },
+  { key: "crossSiteFrequencyEnabled", kind: "boolean" },
+  { key: "attributionLedgerEnabled", kind: "boolean" },
+  { key: "userCustomRules", kind: "customRulesList" },
+  { key: "experimentalParamClassesEnabled", kind: "boolean" },
+  { key: "honorCreatorMode", kind: "boolean" },
+  { key: "creatorAllowlist", kind: "creatorAllowlist" },
+]);
+
+/**
+ * Plain boolean pref keys (the 18-entry set formerly hardcoded as BOOL_KEYS
+ * in options.js). Exported so options.js can reuse the exact same list for
+ * the post-import GUARDED_PREFS reconcile loop instead of maintaining a
+ * second copy.
+ */
+export const BOOLEAN_KEYS = Object.freeze(
+  SETTINGS_FIELDS.filter((f) => f.kind === "boolean").map((f) => f.key),
+);
+
+/**
+ * Migration seam for future schema versions. Currently a no-op: there is
+ * exactly one schema version, and legacy files with no `schemaVersion` at
+ * all must import exactly as they do today. Do NOT reject unknown/future
+ * versions here — that is out of scope for this slice.
+ *
+ * @param {object} data - Parsed import payload.
+ * @param {number|undefined} _fromVersion - data.schemaVersion, if present.
+ * @returns {object} The (possibly transformed) data to validate/import.
+ */
+function migrate(data, _fromVersion) {
+  return data;
+}
+
+/**
+ * Builds the export payload from the current synced prefs. Pure: the
+ * caller reads chrome.storage.sync + devMode + the manifest version and
+ * passes them in.
+ *
+ * @param {object} prefs - Raw chrome.storage.sync.get(PREF_DEFAULTS) result.
+ * @param {{devMode?: boolean, appVersion?: string}} [opts]
+ * @returns {object} Flat export payload (same shape as before this refactor,
+ *   plus `schemaVersion`).
+ */
+export function buildExportPayload(prefs, { devMode, appVersion } = {}) {
+  const payload = {
+    muga: true,
+    version: appVersion,
+    schemaVersion: SETTINGS_SCHEMA_VERSION,
+  };
+  for (const field of SETTINGS_FIELDS) {
+    payload[field.key] = field.kind === "local" ? devMode : prefs[field.key];
+  }
+  return payload;
+}
+
+/**
+ * Validates and plans a Settings import. Pure and synchronous — never
+ * touches chrome APIs. Anything that would throw/reject today (missing or
+ * falsy `muga`, non-array/malformed lists) returns `{ ok: false }` so the
+ * caller can show the same catch-all `import_error` toast as before.
+ *
+ * @param {*} data - Parsed JSON from the imported file.
+ * @returns {object} `{ ok: false }` on failure, or `{ ok: true, toSave,
+ *   special: { followShortenersRequested, devMode }, skipped }` on success.
+ */
+export function planImport(data) {
+  if (!data || typeof data !== "object") return { ok: false };
+
+  const migrated = migrate(data, data.schemaVersion);
+
+  if (
+    !migrated.muga ||
+    !Array.isArray(migrated.blacklist) ||
+    !Array.isArray(migrated.whitelist) ||
+    !Array.isArray(migrated.customParams)
+  ) {
+    return { ok: false };
+  }
+
+  // Structural integrity only: a malformed blacklist/whitelist ENTRY signals
+  // a corrupt or foreign file, so abort. Exceeding a size cap does NOT — see
+  // capImportedLists below (#911).
+  if (!migrated.blacklist.every(isValidListEntry) || !migrated.whitelist.every(isValidListEntry)) {
+    return { ok: false };
+  }
+
+  const { blacklist, whitelist, customParams, droppedBlacklist, droppedWhitelist, skippedParams } =
+    capImportedLists(migrated);
+  const skipped = skippedParams + droppedBlacklist + droppedWhitelist;
+
+  const toSave = { blacklist, whitelist, customParams };
+
+  // devMode is device-local and followShortenersEnabled is permission-gated —
+  // both are deliberately excluded from BOOLEAN_KEYS (see their `kind` above)
+  // so this loop can never touch either.
+  for (const key of BOOLEAN_KEYS) {
+    if (typeof migrated[key] === "boolean") toSave[key] = migrated[key];
+  }
+
+  if (Array.isArray(migrated.disabledCategories) && migrated.disabledCategories.every((e) => VALID_CATEGORIES.has(e))) {
+    toSave.disabledCategories = migrated.disabledCategories;
+  }
+
+  if (typeof migrated.toastDuration === "number") {
+    toSave.toastDuration = snapToastDuration(migrated.toastDuration);
+  }
+
+  // #968: fold each imported creator-allowlist entry through the same pure
+  // validator the add-box uses, so invalid entries, duplicates, and
+  // anything past the cap are dropped exactly as a manual add would handle
+  // them.
+  if (Array.isArray(migrated.creatorAllowlist)) {
+    toSave.creatorAllowlist = migrated.creatorAllowlist.reduce(
+      (acc, entry) => addCreatorAllowlistEntry(acc, entry).list,
+      [],
+    );
+  }
+
+  // #925: userCustomRules — validate each entry as a bare param name and
+  // cap at the customParams ceiling (same shape/limit the popup enforces).
+  if (Array.isArray(migrated.userCustomRules)) {
+    toSave.userCustomRules = migrated.userCustomRules
+      .filter(isValidCustomParam)
+      .slice(0, IMPORT_LIST_CAPS.customParams);
+  }
+
+  // Validate against the full SUPPORTED_LANGS list (not a hardcoded subset,
+  // #729) so codes added later (fr/it/ja, #707) survive a round-trip.
+  if (SUPPORTED_LANGS.some((l) => l.code === migrated.language)) {
+    toSave.language = migrated.language;
+  }
+
+  return {
+    ok: true,
+    toSave,
+    special: {
+      // #964: the raw request only. Whether it actually lands as `true` on
+      // save depends on chrome.permissions.contains(), which this pure
+      // module cannot call — options.js resolves that and merges the
+      // result into its own toSave before calling setPrefs().
+      //
+      // `followShortenersProvided` distinguishes "file carries the key as a
+      // real boolean" (write it, gated) from "absent" (leave the stored value
+      // untouched). options.js branches on THIS, not on the raw `data`, so the
+      // decision stays derived from the migrated payload — if a future
+      // migrate() rewrites the field, the gate follows it automatically.
+      followShortenersProvided: typeof migrated.followShortenersEnabled === "boolean",
+      followShortenersRequested: migrated.followShortenersEnabled === true,
+      devMode: typeof migrated.devMode === "boolean" ? migrated.devMode : undefined,
+    },
+    skipped,
+  };
+}

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -7,7 +7,7 @@ import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates
 import { PREF_DEFAULTS, getPrefs, setPrefs, getDevMode, setDevMode, getShortenerStats } from "../lib/storage.js";
 import { getConsent } from "../lib/consent-storage.js";
 import { isFirefox as detectFirefox } from "../lib/browser-detect.js";
-import { isValidListEntry, isValidCustomParam, capImportedLists, IMPORT_LIST_CAPS } from "../lib/validation.js";
+import { isValidListEntry, IMPORT_LIST_CAPS } from "../lib/validation.js";
 import { REMOTE_RULES_URL } from "../lib/remote-rules.js";
 import {
   addEntry as addCreatorAllowlistEntry,
@@ -17,6 +17,7 @@ import { GENERIC_SHORTENERS } from "../lib/native-shortener-resolver.js";
 import { GUARDED_PREFS } from "../lib/synced-affiliate-pref-guard.js";
 import { reconcileOverrideForExplicitChoice } from "../lib/per-device-prefs.js";
 import { createMutex, withSyncMutation } from "./sync-mutation.js";
+import { snapToastDuration, buildExportPayload, planImport, BOOLEAN_KEYS } from "../lib/settings-schema.js";
 
 let _currentLang = "en";
 
@@ -93,20 +94,6 @@ function showConfirm(msg) {
     okBtn.addEventListener("click", () => close(true));
     overlay.addEventListener("click", (e) => { if (e.target === overlay) close(false); });
   });
-}
-
-// Discrete toast-duration values offered by the UI. The persisted pref is
-// snapped to the nearest of these so the pref and the <select> can never
-// disagree — an imported/legacy value like 22 or 45 always maps to a real
-// <option> instead of leaving the control blank (#968). The set spans the
-// full 5..60 range the control accepts, so the ceiling is reachable via UI.
-const TOAST_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60];
-
-/** Snaps an arbitrary duration to the nearest offered <option> value. */
-function snapToastDuration(n) {
-  const v = Number.isFinite(n) ? n : 15;
-  return TOAST_DURATION_OPTIONS.reduce((a, b) =>
-    Math.abs(b - v) < Math.abs(a - v) ? b : a);
 }
 
 /**
@@ -819,42 +806,10 @@ function initExportImport() {
     try { prefs = await chrome.storage.sync.get(PREF_DEFAULTS); } catch (err) { console.error("[MUGA] export prefs:", err); return; }
     // devMode is device-local (not in PREF_DEFAULTS) — read separately
     const devModeLocal = await getDevMode();
-    const payload = {
-      muga: true,
-      version: chrome.runtime.getManifest().version,
-      enabled: prefs.enabled,
-      injectOwnAffiliate: prefs.injectOwnAffiliate,
-      notifyForeignAffiliate: prefs.notifyForeignAffiliate,
-      stripAllAffiliates: prefs.stripAllAffiliates,
-      dnrEnabled: prefs.dnrEnabled,
-      blockPings: prefs.blockPings,
-      ampRedirect: prefs.ampRedirect,
-      unwrapRedirects: prefs.unwrapRedirects,
-      blacklist: prefs.blacklist,
-      whitelist: prefs.whitelist,
-      customParams: prefs.customParams,
-      contextMenuEnabled: prefs.contextMenuEnabled,
-      disabledCategories: prefs.disabledCategories,
-      toastDuration: prefs.toastDuration,
-      language: prefs.language,
+    const payload = buildExportPayload(prefs, {
       devMode: devModeLocal,
-      paramBreakdown: prefs.paramBreakdown,
-      showReportButton: prefs.showReportButton,
-      domainStats: prefs.domainStats,
-      showBadge: prefs.showBadge,
-      followShortenersEnabled: prefs.followShortenersEnabled,
-      // #925: privacy booleans are now user-controllable, so round-trip them.
-      canonicalExtractorEnabled: prefs.canonicalExtractorEnabled,
-      crossSiteFrequencyEnabled: prefs.crossSiteFrequencyEnabled,
-      attributionLedgerEnabled: prefs.attributionLedgerEnabled,
-      // #925: the popup-populated custom strip rules, handled like the other sync arrays.
-      userCustomRules: prefs.userCustomRules,
-      // #968: round-trip the remaining user-settable prefs that were being
-      // silently dropped — an export/import cycle must not reset them.
-      experimentalParamClassesEnabled: prefs.experimentalParamClassesEnabled,
-      honorCreatorMode: prefs.honorCreatorMode,
-      creatorAllowlist: prefs.creatorAllowlist,
-    };
+      appVersion: chrome.runtime.getManifest().version,
+    });
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -881,78 +836,42 @@ function initExportImport() {
     try {
       const text = await file.text();
       const data = JSON.parse(text);
-      if (!data.muga || !Array.isArray(data.blacklist) || !Array.isArray(data.whitelist) || !Array.isArray(data.customParams)) {
-        throw new Error("invalid");
-      }
-      // Structural integrity only: a malformed blacklist/whitelist ENTRY signals a
-      // corrupt or foreign file, so abort. Exceeding a size cap does NOT — a valid
-      // MUGA export can legitimately be larger than fits in chrome.storage.sync.
-      if (!data.blacklist.every(isValidListEntry) || !data.whitelist.every(isValidListEntry)) {
-        throw new Error("invalid");
-      }
-      // Filter (#818) + cap (#911) the three lists via the canonical helper.
-      // Oversized lists are TRUNCATED rather than rejected wholesale, and the
-      // user is told how many entries were dropped — silently discarding data,
-      // or failing a valid-but-large file with a misleading "not a MUGA file"
-      // error, is not acceptable.
-      const { blacklist, whitelist, customParams, droppedBlacklist, droppedWhitelist, skippedParams } = capImportedLists(data);
-      const skipped = skippedParams + droppedBlacklist + droppedWhitelist;
-      // devMode is device-local — exclude from sync BOOL_KEYS and handle separately.
-      // followShortenersEnabled is ALSO excluded here: it gates on optional host
-      // permissions, so a file must never blindly flip it on (#964). It is
-      // handled below, gated on whether the grant is actually present.
-      const BOOL_KEYS = ["enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates", "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled", "paramBreakdown", "showReportButton", "domainStats", "showBadge", "honorCreatorMode", "experimentalParamClassesEnabled", "canonicalExtractorEnabled", "crossSiteFrequencyEnabled", "attributionLedgerEnabled"];
-      const toSave = { blacklist, whitelist, customParams };
-      for (const key of BOOL_KEYS) {
-        if (typeof data[key] === "boolean") toSave[key] = data[key];
-      }
+      // Structural validation, list capping/filtering, boolean-key extraction,
+      // disabledCategories/toastDuration/creatorAllowlist/userCustomRules/language
+      // handling all live in the pure planImport() (settings-schema.js) now — the
+      // single source of truth shared with buildExportPayload(). Anything that
+      // would have thrown here before (missing muga, malformed lists, invalid
+      // entries) now comes back as { ok: false } and falls into the same
+      // catch-all import_error toast below.
+      const plan = planImport(data);
+      if (!plan.ok) throw new Error("invalid");
+      const skipped = plan.skipped;
+
       // devMode from imported file → local storage
-      if (typeof data.devMode === "boolean") {
-        await setDevMode(data.devMode);
+      if (plan.special.devMode !== undefined) {
+        await setDevMode(plan.special.devMode);
       }
-      // Handle disabledCategories (validated against known category keys)
-      const VALID_CATEGORIES = new Set(["utm", "ads", "email", "social", "platform_noise", "generic"]);
-      if (Array.isArray(data.disabledCategories) && data.disabledCategories.every(e => VALID_CATEGORIES.has(e))) {
-        toSave.disabledCategories = data.disabledCategories;
-      }
-      // Handle toastDuration: snap to the nearest offered <option> so the
-      // stored value always matches a real control state (#968).
-      if (typeof data.toastDuration === "number") {
-        toSave.toastDuration = snapToastDuration(data.toastDuration);
-      }
+
       // #964: followShortenersEnabled is permission-gated. An import may carry
       // the preference but CANNOT grant the host permissions (no user gesture
       // survives the async file read, and silently prompting on import is
       // surprising). So enable it only when the grant is already present;
       // otherwise force it off. This closes the gate-bypass and keeps the
       // pref honest — the user re-enables it via the toggle, which prompts.
-      if (typeof data.followShortenersEnabled === "boolean") {
+      // planImport is pure and cannot call chrome.permissions itself, so it
+      // only reports the request via plan.special (followShortenersProvided =
+      // "the file carries a real boolean"; followShortenersRequested = "that
+      // boolean is true") and this async gate stays here. As before, this
+      // field is written ONLY when the imported file carries it as a boolean —
+      // a missing key leaves the stored value untouched instead of silently
+      // forcing it off. We branch on plan.special, not raw `data`, so the
+      // decision follows any future migrate() transform of the payload.
+      const toSave = { ...plan.toSave };
+      if (plan.special.followShortenersProvided) {
         toSave.followShortenersEnabled =
-          data.followShortenersEnabled && (await hasShortenerPermissions());
+          plan.special.followShortenersRequested && (await hasShortenerPermissions());
       }
-      // #968: round-trip the per-creator allowlist. Fold each imported entry
-      // through the same pure validator the add-box uses, so invalid entries,
-      // duplicates, and anything past the cap are dropped exactly as a manual
-      // add would handle them.
-      if (Array.isArray(data.creatorAllowlist)) {
-        toSave.creatorAllowlist = data.creatorAllowlist.reduce(
-          (acc, entry) => addCreatorAllowlistEntry(acc, entry).list,
-          [],
-        );
-      }
-      // #925: userCustomRules — validate each entry as a bare param name and
-      // cap at the customParams ceiling (same shape/limit the popup enforces).
-      if (Array.isArray(data.userCustomRules)) {
-        toSave.userCustomRules = data.userCustomRules
-          .filter(isValidCustomParam)
-          .slice(0, IMPORT_LIST_CAPS.customParams);
-      }
-      // Handle language (any supported locale) — validate against SUPPORTED_LANGS
-      // so codes added after the legacy en/es/pt/de set (fr/it/ja, #707) survive
-      // an export→import round-trip instead of being silently dropped.
-      if (SUPPORTED_LANGS.some(l => l.code === data.language)) {
-        toSave.language = data.language;
-      }
+
       await setPrefs(toSave);
 
       // #965: importing a config is an explicit choice for this device. For
@@ -960,11 +879,14 @@ function initExportImport() {
       // override LAST, so a stale onboarding-decline override would keep the
       // extension's effective value at odds with the freshly imported sync
       // value AND the checkbox. Reconcile the override to the imported value so
-      // sync, override, effective, and UI all agree. Only keys we actually
-      // wrote (BOOL_KEYS ∩ GUARDED_PREFS) are reconciled.
-      for (const key of BOOL_KEYS) {
-        if (GUARDED_PREFS.includes(key) && typeof data[key] === "boolean") {
-          await reconcileOverrideForExplicitChoice(key, data[key]);
+      // sync, override, effective, and UI all agree. Only guarded keys we
+      // actually wrote (present in plan.toSave, i.e. BOOLEAN_KEYS ∩
+      // GUARDED_PREFS that arrived as booleans) are reconciled, and we read the
+      // value from the plan — not raw `data` — so it follows any future
+      // migrate() transform.
+      for (const key of GUARDED_PREFS) {
+        if (BOOLEAN_KEYS.includes(key) && key in plan.toSave) {
+          await reconcileOverrideForExplicitChoice(key, plan.toSave[key]);
         }
       }
 

--- a/tests/unit/export-import.test.mjs
+++ b/tests/unit/export-import.test.mjs
@@ -1,9 +1,13 @@
 /**
- * MUGA: Comprehensive tests for export/import settings feature in options.js.
+ * MUGA: Comprehensive tests for the Settings export/import feature.
  *
- * The export/import code is browser-only (chrome.storage.sync, DOM APIs), so we
- * verify logic via source string inspection and extracted pure-function testing,
- * following the same pattern as sanitize-import.test.mjs.
+ * The core export/import logic (buildExportPayload/planImport) was extracted
+ * from options.js into the pure module src/lib/settings-schema.js (single
+ * source of truth). These tests exercise ACTUAL behavior against that
+ * module rather than inspecting options.js source text. A few pieces of
+ * behavior (file-size gate, DOM refresh, fileInput reset) remain inline in
+ * options.js because they are DOM/chrome-bound; those specific assertions
+ * still read OPTIONS_SOURCE.
  */
 
 import { test, describe } from "node:test";
@@ -13,31 +17,46 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isValidListEntry, isValidCustomParam, capImportedLists, IMPORT_LIST_CAPS } from "../../src/lib/validation.js";
 import { SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+import {
+  SETTINGS_SCHEMA_VERSION,
+  buildExportPayload,
+  planImport,
+  snapToastDuration,
+  TOAST_DURATION_OPTIONS,
+} from "../../src/lib/settings-schema.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OPTIONS_SOURCE = readFileSync(join(__dirname, "../../src/options/options.js"), "utf8");
+const SETTINGS_SCHEMA_SOURCE = readFileSync(join(__dirname, "../../src/lib/settings-schema.js"), "utf8");
+
+// A minimal valid import payload, reused as a base by several tests below.
+function validImportData(overrides = {}) {
+  return {
+    muga: true,
+    blacklist: [],
+    whitelist: [],
+    customParams: [],
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
-// Source verification tests — export
+// Export behavior — buildExportPayload
 // ---------------------------------------------------------------------------
-describe("export settings (source verification)", () => {
+describe("export settings (buildExportPayload behavior)", () => {
 
   test("1. export includes muga: true flag", () => {
-    assert.ok(
-      OPTIONS_SOURCE.includes("muga: true"),
-      "Export payload must include muga: true marker"
-    );
+    const payload = buildExportPayload({}, { devMode: false, appVersion: "1.0.0" });
+    assert.strictEqual(payload.muga, true);
   });
 
-  test("2. export includes version from manifest", () => {
-    assert.ok(
-      OPTIONS_SOURCE.includes("chrome.runtime.getManifest().version"),
-      "Export payload must include version from manifest"
-    );
+  test("2. export includes version from manifest and schemaVersion", () => {
+    const payload = buildExportPayload({}, { devMode: false, appVersion: "3.4.5" });
+    assert.strictEqual(payload.version, "3.4.5");
+    assert.strictEqual(payload.schemaVersion, SETTINGS_SCHEMA_VERSION);
   });
 
   test("32. export includes ALL expected boolean keys", () => {
-    // devMode is device-local (chrome.storage.local), read via getDevMode(), not prefs.devMode
     const SYNC_BOOL_KEYS = [
       "enabled",
       "injectOwnAffiliate",
@@ -56,130 +75,106 @@ describe("export settings (source verification)", () => {
       "crossSiteFrequencyEnabled",
       "attributionLedgerEnabled",
     ];
-    // Verify each sync boolean key appears in the export payload block
+    const prefs = Object.fromEntries(SYNC_BOOL_KEYS.map((k) => [k, true]));
+    const payload = buildExportPayload(prefs, { devMode: true, appVersion: "1.0.0" });
     for (const key of SYNC_BOOL_KEYS) {
-      assert.ok(
-        OPTIONS_SOURCE.includes(`${key}: prefs.${key}`),
-        `Export payload must include boolean key "${key}"`
-      );
+      assert.strictEqual(payload[key], true, `Export payload must include boolean key "${key}"`);
     }
-    // devMode comes from local storage (devModeLocal), not prefs
-    assert.ok(
-      OPTIONS_SOURCE.includes("devMode: devModeLocal"),
-      "Export payload must set devMode from devModeLocal (local storage)"
-    );
+    // devMode comes from local storage (devModeLocal param), not prefs
+    assert.strictEqual(payload.devMode, true, "Export payload must set devMode from the devMode param (local storage)");
   });
 
   test("33. export includes ALL expected array keys", () => {
     const EXPECTED_ARRAY_KEYS = ["blacklist", "whitelist", "customParams", "disabledCategories"];
+    const prefs = Object.fromEntries(EXPECTED_ARRAY_KEYS.map((k) => [k, [k]]));
+    const payload = buildExportPayload(prefs, { devMode: false, appVersion: "1.0.0" });
     for (const key of EXPECTED_ARRAY_KEYS) {
-      assert.ok(
-        OPTIONS_SOURCE.includes(`${key}: prefs.${key}`),
-        `Export payload must include array key "${key}"`
-      );
+      assert.deepStrictEqual(payload[key], [key], `Export payload must include array key "${key}"`);
     }
   });
 
   test("34. export includes toastDuration field", () => {
-    // toastDuration is not in the export payload (not in the payload block),
-    // but it IS handled during import. Verify the import handling exists.
-    assert.ok(
-      OPTIONS_SOURCE.includes("toastDuration"),
-      "toastDuration must appear in options.js"
-    );
+    const payload = buildExportPayload({ toastDuration: 30 }, { devMode: false, appVersion: "1.0.0" });
+    assert.strictEqual(payload.toastDuration, 30);
+  });
+
+  test("export payload stays flat (no nested 'settings' key)", () => {
+    const payload = buildExportPayload({ enabled: true }, { devMode: false, appVersion: "1.0.0" });
+    assert.strictEqual(payload.settings, undefined, "export payload must not nest fields under a 'settings' key");
+    assert.strictEqual(typeof payload.enabled, "boolean");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Source verification tests — import
+// Import behavior — planImport
 // ---------------------------------------------------------------------------
-describe("import settings (source verification)", () => {
+describe("import settings (planImport behavior)", () => {
 
   test("3. import checks data.muga flag", () => {
-    assert.ok(
-      OPTIONS_SOURCE.includes("!data.muga"),
-      "Import must check data.muga flag to validate file format"
-    );
+    assert.deepStrictEqual(planImport(validImportData({ muga: false })), { ok: false });
+    assert.deepStrictEqual(planImport(validImportData({ muga: undefined })), { ok: false });
   });
 
   test("4. import validates arrays with Array.isArray", () => {
-    const matches = OPTIONS_SOURCE.match(/Array\.isArray\(data\.\w+\)/g);
-    assert.ok(matches, "Import must use Array.isArray to validate arrays");
-    assert.ok(matches.length >= 3, `Expected at least 3 Array.isArray checks, found ${matches.length}`);
+    assert.deepStrictEqual(planImport(validImportData({ blacklist: "not-an-array" })), { ok: false });
+    assert.deepStrictEqual(planImport(validImportData({ whitelist: null })), { ok: false });
+    assert.deepStrictEqual(planImport(validImportData({ customParams: {} })), { ok: false });
   });
 
   test("5. import caps lists (500, 500, 200) by TRUNCATION, not whole-import rejection (#911)", () => {
-    // #911: the old behavior hard-threw when a list exceeded its cap, rejecting
-    // a valid-but-large export with a misleading "not a MUGA file" error. Caps
-    // now live in IMPORT_LIST_CAPS and are enforced by truncation in capImportedLists.
     assert.equal(IMPORT_LIST_CAPS.blacklist, 500);
     assert.equal(IMPORT_LIST_CAPS.whitelist, 500);
     assert.equal(IMPORT_LIST_CAPS.customParams, 200);
-    const over = {
+    const plan = planImport(validImportData({
       blacklist: Array.from({ length: 600 }, (_, i) => `b${i}.com`),
       whitelist: Array.from({ length: 600 }, (_, i) => `w${i}.com`),
       customParams: Array.from({ length: 300 }, (_, i) => `p_${i}`),
-    };
-    const out = capImportedLists(over);
-    assert.equal(out.blacklist.length, 500);
-    assert.equal(out.whitelist.length, 500);
-    assert.equal(out.customParams.length, 200);
-    // The count-based whole-import throw must be gone.
-    assert.ok(
-      !/data\.customParams\.length\s*>\s*200/.test(OPTIONS_SOURCE),
-      "Import must NOT abort the whole import when customParams exceeds the cap"
-    );
+    }));
+    assert.equal(plan.ok, true);
+    assert.equal(plan.toSave.blacklist.length, 500);
+    assert.equal(plan.toSave.whitelist.length, 500);
+    assert.equal(plan.toSave.customParams.length, 200);
+    assert.ok(plan.skipped > 0, "over-cap entries must be reported as skipped");
   });
 
   test("6. import validates list entries with isValidListEntry and delegates param cleaning to capImportedLists (#818/#911)", () => {
-    assert.ok(
-      OPTIONS_SOURCE.includes("isValidListEntry"),
-      "Import must validate blacklist/whitelist entries with isValidListEntry"
-    );
-    // #818 param validation (isValidCustomParam, MAX_PARAM_LEN=64, denylist +
-    // affiliate guard) now runs inside capImportedLists; the handler delegates to it.
-    assert.ok(
-      OPTIONS_SOURCE.includes("capImportedLists(data)"),
-      "Import must delegate customParams filtering/capping to capImportedLists"
-    );
+    // A malformed blacklist ENTRY (not just an oversized list) signals a
+    // corrupt/foreign file and must abort the whole import.
+    assert.deepStrictEqual(planImport(validImportData({ blacklist: ["ok.com", "bad entry with spaces"] })), { ok: false });
+    // customParams filtering/capping is delegated to capImportedLists, not
+    // reimplemented — cross-check plan output against calling it directly.
+    const data = validImportData({ customParams: ["ref_code", "q", "promo_id"] });
+    const plan = planImport(data);
+    const direct = capImportedLists(data);
+    assert.deepStrictEqual(plan.toSave.customParams, direct.customParams);
   });
 
   test("7. import validates boolean keys by typeof", () => {
-    assert.ok(
-      OPTIONS_SOURCE.includes('typeof data[key] === "boolean"'),
-      "Import must validate boolean keys with typeof === boolean"
-    );
+    const plan = planImport(validImportData({ enabled: "true", injectOwnAffiliate: true, dnrEnabled: 1 }));
+    assert.equal(plan.ok, true);
+    assert.strictEqual(plan.toSave.enabled, undefined, "non-boolean typed value must not be imported");
+    assert.strictEqual(plan.toSave.injectOwnAffiliate, true);
+    assert.strictEqual(plan.toSave.dnrEnabled, undefined, "non-boolean typed value must not be imported");
   });
 
   test("8. import snaps toastDuration to the nearest offered <option> (#968)", () => {
-    // #968: a continuous clamp let import persist a value (e.g. 45) that matched
-    // no <option>, leaving the control blank. The value is now snapped to the
-    // nearest offered option so pref and UI can never disagree.
-    assert.ok(
-      OPTIONS_SOURCE.includes("snapToastDuration(data.toastDuration)"),
-      "Import must snap toastDuration via snapToastDuration"
-    );
-    assert.ok(
-      !OPTIONS_SOURCE.includes("Math.max(5, Math.min(60, data.toastDuration))"),
-      "Import must NOT use the legacy continuous clamp for toastDuration"
-    );
+    const plan = planImport(validImportData({ toastDuration: 22 }));
+    assert.equal(plan.ok, true);
+    assert.strictEqual(plan.toSave.toastDuration, snapToastDuration(22));
+    assert.strictEqual(plan.toSave.toastDuration, 15, "22 must snap to 15 (distance 7 < 8)");
   });
 
   test("9. import validates language against the full SUPPORTED_LANGS list", () => {
-    // Regression for #729: the import allowlist must be data-driven from
-    // SUPPORTED_LANGS, NOT a hardcoded subset. A hardcoded array silently drops
-    // any locale added later (fr/it/ja, #707) on an export→import round-trip.
-    assert.ok(
-      OPTIONS_SOURCE.includes("SUPPORTED_LANGS.some(l => l.code === data.language)"),
-      "Import must validate language against SUPPORTED_LANGS, not a hardcoded subset"
-    );
-    assert.ok(
-      !/\[\s*"en",\s*"es",\s*"pt",\s*"de"\s*\]\.includes\(data\.language\)/.test(OPTIONS_SOURCE),
-      "Import must NOT use the legacy hardcoded en/es/pt/de language allowlist"
-    );
+    for (const { code } of SUPPORTED_LANGS) {
+      const plan = planImport(validImportData({ language: code }));
+      assert.strictEqual(plan.toSave.language, code, `language "${code}" must round-trip`);
+    }
+    const rejected = planImport(validImportData({ language: "klingon" }));
+    assert.strictEqual(rejected.toSave.language, undefined, "unsupported language must not be imported");
   });
 
   test("10. file size limit is 102400 bytes", () => {
+    // This gate is DOM/File-bound and stays inline in options.js.
     assert.ok(
       OPTIONS_SOURCE.includes("file.size > 102400"),
       "Import must reject files larger than 102400 bytes"
@@ -187,17 +182,14 @@ describe("import settings (source verification)", () => {
   });
 
   test("11. import validates disabledCategories against known category keys", () => {
-    assert.ok(
-      OPTIONS_SOURCE.includes("Array.isArray(data.disabledCategories)"),
-      "Import must validate disabledCategories is an array"
-    );
-    assert.ok(
-      OPTIONS_SOURCE.includes("VALID_CATEGORIES"),
-      "Import must validate disabledCategories against VALID_CATEGORIES set"
-    );
+    const valid = planImport(validImportData({ disabledCategories: ["utm", "ads"] }));
+    assert.deepStrictEqual(valid.toSave.disabledCategories, ["utm", "ads"]);
+    const invalid = planImport(validImportData({ disabledCategories: ["utm", "not-a-category"] }));
+    assert.strictEqual(invalid.toSave.disabledCategories, undefined, "an unknown category must reject the whole array");
   });
 
   test("12. after import, UI elements are refreshed", () => {
+    // DOM refresh wiring stays inline in options.js.
     assert.ok(
       OPTIONS_SOURCE.includes("syncDevTools()"),
       "Import must call syncDevTools() to refresh dev tools UI"
@@ -225,6 +217,15 @@ describe("import settings (source verification)", () => {
       OPTIONS_SOURCE.includes('fileInput.value = ""'),
       "Import must clear fileInput.value after processing"
     );
+  });
+
+  test("legacy file with no schemaVersion still imports exactly as today", () => {
+    const legacy = validImportData({ enabled: true, toastDuration: 45 });
+    assert.strictEqual(legacy.schemaVersion, undefined);
+    const plan = planImport(legacy);
+    assert.equal(plan.ok, true);
+    assert.strictEqual(plan.toSave.enabled, true);
+    assert.strictEqual(plan.toSave.toastDuration, 45);
   });
 });
 
@@ -337,18 +338,17 @@ describe("isValidCustomParam (canonical customParams validator, #818)", () => {
 //
 // The import language allowlist must accept EVERY code exported by the picker.
 // Export writes `language: prefs.language` (any SUPPORTED_LANGS code), so import
-// must mirror that set. acceptLanguage() replicates the import guard against the
+// must mirror that set. This now exercises the real planImport() against the
 // real SUPPORTED_LANGS so a future edit to one side without the other fails here.
 // ---------------------------------------------------------------------------
 describe("import language round-trip (#729)", () => {
-  // Mirror of the import-handler guard at options.js (data-driven, not hardcoded).
-  const acceptLanguage = (lang) => SUPPORTED_LANGS.some((l) => l.code === lang);
 
   test("35. every SUPPORTED_LANGS code survives an export→import round-trip", () => {
     for (const { code } of SUPPORTED_LANGS) {
+      const plan = planImport(validImportData({ language: code }));
       assert.strictEqual(
-        acceptLanguage(code),
-        true,
+        plan.toSave.language,
+        code,
         `exported language "${code}" must be accepted on import`
       );
     }
@@ -360,13 +360,15 @@ describe("import language round-trip (#729)", () => {
         SUPPORTED_LANGS.some((l) => l.code === code),
         `"${code}" must be a supported language`
       );
-      assert.strictEqual(acceptLanguage(code), true, `"${code}" must round-trip`);
+      const plan = planImport(validImportData({ language: code }));
+      assert.strictEqual(plan.toSave.language, code, `"${code}" must round-trip`);
     }
   });
 
   test("37. unknown/invalid language codes are rejected", () => {
     for (const bad of ["", "xx", "EN", "en-US", "klingon", null, undefined, 42]) {
-      assert.strictEqual(acceptLanguage(bad), false, `"${String(bad)}" must be rejected`);
+      const plan = planImport(validImportData({ language: bad }));
+      assert.strictEqual(plan.toSave.language, undefined, `"${String(bad)}" must be rejected`);
     }
   });
 });
@@ -380,45 +382,45 @@ describe("import/export hardening (#964/#965/#968)", () => {
 
   // #968 — data-loss round-trip
   test("38. export round-trips the three previously-dropped prefs", () => {
-    for (const key of ["experimentalParamClassesEnabled", "honorCreatorMode", "creatorAllowlist"]) {
-      assert.ok(
-        OPTIONS_SOURCE.includes(`${key}: prefs.${key}`),
-        `Export payload must include "${key}" (was silently dropped)`
-      );
-    }
+    const prefs = {
+      experimentalParamClassesEnabled: true,
+      honorCreatorMode: true,
+      creatorAllowlist: ["youtube.com/@example"],
+    };
+    const payload = buildExportPayload(prefs, { devMode: false, appVersion: "1.0.0" });
+    assert.strictEqual(payload.experimentalParamClassesEnabled, true, "was silently dropped");
+    assert.strictEqual(payload.honorCreatorMode, true, "was silently dropped");
+    assert.deepStrictEqual(payload.creatorAllowlist, ["youtube.com/@example"], "was silently dropped");
   });
 
   test("39. import round-trips honorCreatorMode + experimentalParamClassesEnabled as booleans", () => {
-    for (const key of ["honorCreatorMode", "experimentalParamClassesEnabled"]) {
-      assert.ok(
-        new RegExp(`BOOL_KEYS[\\s\\S]*"${key}"`).test(OPTIONS_SOURCE),
-        `Import BOOL_KEYS must include "${key}"`
-      );
-    }
+    const plan = planImport(validImportData({ honorCreatorMode: true, experimentalParamClassesEnabled: true }));
+    assert.strictEqual(plan.toSave.honorCreatorMode, true, 'toSave must include "honorCreatorMode"');
+    assert.strictEqual(plan.toSave.experimentalParamClassesEnabled, true, 'toSave must include "experimentalParamClassesEnabled"');
   });
 
   test("40. import round-trips creatorAllowlist through the pure validator", () => {
-    assert.ok(
-      OPTIONS_SOURCE.includes("Array.isArray(data.creatorAllowlist)"),
-      "Import must validate creatorAllowlist is an array"
-    );
-    assert.ok(
-      /addCreatorAllowlistEntry\(\s*acc\s*,\s*entry\s*\)/.test(OPTIONS_SOURCE),
-      "Import must fold creatorAllowlist entries through addCreatorAllowlistEntry"
-    );
+    const plan = planImport(validImportData({ creatorAllowlist: ["YouTube.com/@Example", "youtube.com/@example"] }));
+    // addCreatorAllowlistEntry normalizes case and drops the duplicate
+    assert.deepStrictEqual(plan.toSave.creatorAllowlist, ["youtube.com/@example"]);
   });
 
   // #964 — permission-gate bypass
-  test("41. import gates followShortenersEnabled on the actual host grant", () => {
-    // Must NOT be in the blind BOOL_KEYS loop...
+  test("41. followShortenersEnabled is NOT included in toSave; only surfaced via special", () => {
+    const plan = planImport(validImportData({ followShortenersEnabled: true }));
+    assert.strictEqual(plan.toSave.followShortenersEnabled, undefined, "followShortenersEnabled must never be in toSave (pure module cannot check permissions)");
+    assert.strictEqual(plan.special.followShortenersRequested, true);
+
+    const planFalse = planImport(validImportData({ followShortenersEnabled: false }));
+    assert.strictEqual(planFalse.special.followShortenersRequested, false);
+
+    const planMissing = planImport(validImportData({}));
+    assert.strictEqual(planMissing.special.followShortenersRequested, false);
+
+    // The actual host-permission gate stays in options.js.
     assert.ok(
-      !/BOOL_KEYS\s*=\s*\[[^\]]*"followShortenersEnabled"/.test(OPTIONS_SOURCE),
-      "followShortenersEnabled must NOT be a blindly-imported BOOL_KEY"
-    );
-    // ...and enabling it must depend on hasShortenerPermissions().
-    assert.ok(
-      /data\.followShortenersEnabled\s*&&\s*\(await hasShortenerPermissions\(\)\)/.test(OPTIONS_SOURCE),
-      "Import must only enable followShortenersEnabled when the host grant is present"
+      /followShortenersRequested\s*&&\s*\(await hasShortenerPermissions\(\)\)/.test(OPTIONS_SOURCE),
+      "options.js must only enable followShortenersEnabled when the host grant is present"
     );
     assert.ok(
       OPTIONS_SOURCE.includes("chrome.permissions.contains"),
@@ -427,9 +429,14 @@ describe("import/export hardening (#964/#965/#968)", () => {
   });
 
   // #965 — guarded-pref override desync
-  test("42. import reconciles the per-device override for guarded prefs", () => {
+  test("42. injectOwnAffiliate is reconcilable: present in toSave when boolean", () => {
+    const plan = planImport(validImportData({ injectOwnAffiliate: true }));
+    assert.strictEqual(plan.toSave.injectOwnAffiliate, true);
+    // The reconcile call stays in options.js, but reads the value from the
+    // plan (plan.toSave[key]) rather than raw `data`, so it follows any future
+    // migrate() transform of the payload instead of silently diverging.
     assert.ok(
-      /reconcileOverrideForExplicitChoice\(\s*key\s*,\s*data\[key\]\s*\)/.test(OPTIONS_SOURCE),
+      /reconcileOverrideForExplicitChoice\(\s*key\s*,\s*plan\.toSave\[key\]\s*\)/.test(OPTIONS_SOURCE),
       "Import must reconcile the per-device override to the imported guarded value"
     );
   });
@@ -445,26 +452,21 @@ describe("import/export hardening (#964/#965/#968)", () => {
   });
 
   test("44. snapToastDuration maps arbitrary values to the nearest offered option", () => {
-    // Mirror of the implementation (options.js is browser-only, not importable).
-    const TOAST_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60];
-    const snap = (n) => {
-      const v = Number.isFinite(n) ? n : 15;
-      return TOAST_DURATION_OPTIONS.reduce((a, b) => (Math.abs(b - v) < Math.abs(a - v) ? b : a));
-    };
-    assert.equal(snap(45), 45, "an offered value maps to itself");
-    assert.equal(snap(60), 60, "the ceiling is reachable");
-    assert.equal(snap(22), 15, "22 snaps to nearest (15, distance 7 < 8)");
-    assert.equal(snap(23), 30, "23 snaps to nearest (30, distance 7 < 8)");
-    assert.equal(snap(1000), 60, "out-of-range high clamps to 60");
-    assert.equal(snap(NaN), 15, "non-finite falls back to 15");
-    // The implementation must define both the option set and the snapper.
+    assert.deepStrictEqual([...TOAST_DURATION_OPTIONS], [5, 10, 15, 30, 45, 60]);
+    assert.equal(snapToastDuration(45), 45, "an offered value maps to itself");
+    assert.equal(snapToastDuration(60), 60, "the ceiling is reachable");
+    assert.equal(snapToastDuration(22), 15, "22 snaps to nearest (15, distance 7 < 8)");
+    assert.equal(snapToastDuration(23), 30, "23 snaps to nearest (30, distance 7 < 8)");
+    assert.equal(snapToastDuration(1000), 60, "out-of-range high clamps to 60");
+    assert.equal(snapToastDuration(NaN), 15, "non-finite falls back to 15");
+    // The single source of truth now lives in settings-schema.js.
     assert.ok(
-      OPTIONS_SOURCE.includes("TOAST_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60]"),
-      "options.js must define TOAST_DURATION_OPTIONS"
+      SETTINGS_SCHEMA_SOURCE.includes("export const TOAST_DURATION_OPTIONS"),
+      "settings-schema.js must define TOAST_DURATION_OPTIONS"
     );
     assert.ok(
-      OPTIONS_SOURCE.includes("function snapToastDuration"),
-      "options.js must define snapToastDuration"
+      SETTINGS_SCHEMA_SOURCE.includes("export function snapToastDuration"),
+      "settings-schema.js must define snapToastDuration"
     );
   });
 });

--- a/tests/unit/import-settings-cap.test.mjs
+++ b/tests/unit/import-settings-cap.test.mjs
@@ -122,9 +122,19 @@ describe("import handler no longer hard-rejects on size (#911)", () => {
   });
 
   test("import handler delegates list cleaning to capImportedLists", () => {
+    // The graceful filter+cap call now lives in the pure planImport()
+    // (src/lib/settings-schema.js), which options.js's import handler calls.
+    const SETTINGS_SCHEMA_SOURCE = readFileSync(
+      join(__dirname, "../../src/lib/settings-schema.js"),
+      "utf8"
+    );
     assert.ok(
-      OPTIONS_SOURCE.includes("capImportedLists(data)"),
-      "import handler must call capImportedLists(data) for graceful filter + cap"
+      SETTINGS_SCHEMA_SOURCE.includes("capImportedLists(migrated)"),
+      "planImport must call capImportedLists(migrated) for graceful filter + cap"
+    );
+    assert.ok(
+      OPTIONS_SOURCE.includes("planImport(data)"),
+      "import handler must delegate to planImport(data)"
     );
   });
 

--- a/tests/unit/options-import-param-validation.test.mjs
+++ b/tests/unit/options-import-param-validation.test.mjs
@@ -199,15 +199,25 @@ describe("T3 validation.js source — exports and canonical imports", () => {
 });
 
 // ── T4: options.js source guards ─────────────────────────────────────────────
+//
+// #973 follow-up: the export/import logic (including the capImportedLists
+// call) was extracted from options.js into the pure src/lib/settings-schema.js
+// (planImport/buildExportPayload, single source of truth). options.js now
+// delegates to planImport() instead of calling capImportedLists directly.
 
-describe("T4 options.js — delegates param cleaning to capImportedLists, no inline validator", () => {
-  test("imports capImportedLists from validation.js", () => {
-    // #911: the import handler no longer applies isValidCustomParam inline; it
+describe("T4 options.js — delegates param cleaning to planImport, no inline validator", () => {
+  const SETTINGS_SCHEMA_SOURCE = readFileSync(
+    join(__dirname, "../../src/lib/settings-schema.js"),
+    "utf8"
+  );
+
+  test("planImport (settings-schema.js) uses capImportedLists from validation.js", () => {
+    // #911: the import path no longer applies isValidCustomParam inline; it
     // delegates filtering + capping to capImportedLists (which applies the
     // canonical isValidCustomParam under the hood — asserted in T3/below).
     assert.ok(
-      OPTIONS_SOURCE.includes("capImportedLists"),
-      "options.js must import/use capImportedLists"
+      SETTINGS_SCHEMA_SOURCE.includes("capImportedLists"),
+      "settings-schema.js must import/use capImportedLists"
     );
     assert.ok(
       VALIDATION_SOURCE.includes("export function capImportedLists("),
@@ -215,19 +225,25 @@ describe("T4 options.js — delegates param cleaning to capImportedLists, no inl
     );
   });
 
-  test("no inline isValidParam definition remains", () => {
+  test("no inline isValidParam definition remains anywhere", () => {
     assert.ok(
       !OPTIONS_SOURCE.includes("const isValidParam ="),
       "options.js must not contain the old inline isValidParam definition"
     );
+    assert.ok(
+      !SETTINGS_SCHEMA_SOURCE.includes("const isValidParam ="),
+      "settings-schema.js must not contain the old inline isValidParam definition"
+    );
   });
 
-  test("import path applies canonical param validation via capImportedLists", () => {
-    // The import handler calls capImportedLists(data); capImportedLists in
-    // validation.js is what runs isValidCustomParam over the imported params.
+  test("options.js delegates the whole import decision to planImport(data)", () => {
     assert.ok(
-      OPTIONS_SOURCE.includes("capImportedLists(data)"),
-      "import handler must call capImportedLists(data)"
+      OPTIONS_SOURCE.includes("planImport(data)"),
+      "options.js import handler must call planImport(data)"
+    );
+    assert.ok(
+      SETTINGS_SCHEMA_SOURCE.includes("capImportedLists(migrated)"),
+      "planImport must call capImportedLists(migrated)"
     );
     assert.ok(
       VALIDATION_SOURCE.includes("filter(isValidCustomParam)"),
@@ -237,7 +253,7 @@ describe("T4 options.js — delegates param cleaning to capImportedLists, no inl
 
   test("param cleaning filters invalid customParams (not whole-abort)", () => {
     // The behavior: filter invalid entries, count rejections, import the rest —
-    // never throw when only some customParams are invalid. This now lives in
+    // never throw when only some customParams are invalid. This lives in
     // capImportedLists (validation.js), which uses .filter() (not .every() abort).
     assert.ok(
       VALIDATION_SOURCE.includes("filter(isValidCustomParam)"),
@@ -245,11 +261,14 @@ describe("T4 options.js — delegates param cleaning to capImportedLists, no inl
     );
   });
 
-  test("import path reports rejected customParam count to user", () => {
-    // Guard that the skipped-count variable exists in the import handler
+  test("planImport reports rejected customParam count via `skipped`", () => {
     assert.ok(
-      OPTIONS_SOURCE.includes("skipped") || OPTIONS_SOURCE.includes("rejected"),
-      "import path must track and report the count of rejected customParams"
+      SETTINGS_SCHEMA_SOURCE.includes("skipped"),
+      "planImport must track and return the count of rejected customParams"
+    );
+    assert.ok(
+      OPTIONS_SOURCE.includes("import_params_skipped"),
+      "options.js import handler must surface the partial-import toast"
     );
   });
 });

--- a/tests/unit/options-patterns.test.mjs
+++ b/tests/unit/options-patterns.test.mjs
@@ -401,11 +401,17 @@ describe("addEntry — list-size caps mirror the import path (#728 item 28)", ()
     assert.equal(IMPORT_LIST_CAPS.blacklist, 500);
     assert.equal(IMPORT_LIST_CAPS.whitelist, 500);
     assert.equal(IMPORT_LIST_CAPS.customParams, 200);
-    // The import handler must delegate to capImportedLists (which applies these
-    // caps), not carry its own divergent length literals.
+    // The import handler delegates the whole decision to planImport() (#973
+    // follow-up, settings-schema.js), which applies these caps via
+    // capImportedLists internally — not carrying its own divergent literals.
     assert.ok(
-      optionsJs.includes("capImportedLists(data)"),
-      "import path must apply the caps via capImportedLists, the shared source of truth"
+      optionsJs.includes("planImport(data)"),
+      "import path must apply the caps via planImport, the shared source of truth"
+    );
+    const settingsSchemaJs = readFileSync(join(ROOT, "src/lib/settings-schema.js"), "utf8");
+    assert.ok(
+      settingsSchemaJs.includes("capImportedLists(migrated)"),
+      "planImport must apply the caps via capImportedLists"
     );
   });
 });

--- a/tests/unit/options-show-badge-toggle.test.mjs
+++ b/tests/unit/options-show-badge-toggle.test.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { PREF_DEFAULTS } from "../../src/lib/prefs.js";
 import { TRANSLATIONS, SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+import { BOOLEAN_KEYS, buildExportPayload } from "../../src/lib/settings-schema.js";
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dir, "../..");
@@ -53,14 +54,15 @@ describe("#910 — the toggle has an HTML row and a bindToggle wiring", () => {
 });
 
 describe("#910 — export/import round-trips showBadge", () => {
+  // #973 follow-up: export/import logic moved to the pure src/lib/settings-schema.js
+  // (buildExportPayload/BOOLEAN_KEYS), single source of truth for options.js.
   test("export payload includes showBadge", () => {
-    assert.ok(optionsJs.includes("showBadge: prefs.showBadge"), "export payload must include showBadge");
+    const payload = buildExportPayload({ showBadge: true }, { devMode: false, appVersion: "1.0.0" });
+    assert.strictEqual(payload.showBadge, true, "export payload must include showBadge");
   });
 
-  test("import BOOL_KEYS includes showBadge", () => {
-    const boolKeysMatch = optionsJs.match(/const BOOL_KEYS = \[([^\]]*)\]/);
-    assert.ok(boolKeysMatch, "import handler must define BOOL_KEYS");
-    assert.ok(boolKeysMatch[1].includes('"showBadge"'), "BOOL_KEYS must include showBadge so import applies it");
+  test("BOOLEAN_KEYS includes showBadge", () => {
+    assert.ok(BOOLEAN_KEYS.includes("showBadge"), "BOOLEAN_KEYS must include showBadge so import applies it");
   });
 
   test("import handler refreshes the #show-badge checkbox after import", () => {

--- a/tests/unit/options-surfaced-prefs.test.mjs
+++ b/tests/unit/options-surfaced-prefs.test.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { PREF_DEFAULTS } from "../../src/lib/prefs.js";
 import { TRANSLATIONS, SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+import { BOOLEAN_KEYS, buildExportPayload, planImport } from "../../src/lib/settings-schema.js";
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dir, "../..");
@@ -108,36 +109,31 @@ describe("#925 — userCustomRules view/remove editor", () => {
 });
 
 describe("#925 — export/import round-trips the newly-surfaced prefs", () => {
+  // #973 follow-up: export/import logic moved to the pure src/lib/settings-schema.js
+  // (buildExportPayload/planImport/BOOLEAN_KEYS), single source of truth for options.js.
   test("export payload includes the three privacy booleans", () => {
+    const prefs = { canonicalExtractorEnabled: true, crossSiteFrequencyEnabled: true, attributionLedgerEnabled: true };
+    const payload = buildExportPayload(prefs, { devMode: false, appVersion: "1.0.0" });
     for (const key of ["canonicalExtractorEnabled", "crossSiteFrequencyEnabled", "attributionLedgerEnabled"]) {
-      assert.ok(
-        optionsJs.includes(`${key}: prefs.${key}`),
-        `export payload must include ${key}`
-      );
+      assert.strictEqual(payload[key], true, `export payload must include ${key}`);
     }
   });
 
-  test("import BOOL_KEYS includes the three privacy booleans", () => {
-    const boolKeysMatch = optionsJs.match(/const BOOL_KEYS = \[([^\]]*)\]/);
-    assert.ok(boolKeysMatch, "import handler must define BOOL_KEYS");
+  test("BOOLEAN_KEYS includes the three privacy booleans", () => {
     for (const key of ["canonicalExtractorEnabled", "crossSiteFrequencyEnabled", "attributionLedgerEnabled"]) {
-      assert.ok(
-        boolKeysMatch[1].includes(`"${key}"`),
-        `BOOL_KEYS must include ${key} so import applies it`
-      );
+      assert.ok(BOOLEAN_KEYS.includes(key), `BOOLEAN_KEYS must include ${key} so import applies it`);
     }
   });
 
   test("userCustomRules is exported and validated on import", () => {
-    assert.ok(
-      optionsJs.includes("userCustomRules: prefs.userCustomRules"),
-      "export payload must include userCustomRules"
-    );
-    assert.ok(
-      optionsJs.includes("Array.isArray(data.userCustomRules)") &&
-        optionsJs.includes(".filter(isValidCustomParam)"),
-      "import must validate userCustomRules entries with isValidCustomParam"
-    );
+    const payload = buildExportPayload({ userCustomRules: ["ref_code"] }, { devMode: false, appVersion: "1.0.0" });
+    assert.deepStrictEqual(payload.userCustomRules, ["ref_code"], "export payload must include userCustomRules");
+
+    const plan = planImport({
+      muga: true, blacklist: [], whitelist: [], customParams: [],
+      userCustomRules: ["ref_code", "q", "bad entry"],
+    });
+    assert.deepStrictEqual(plan.toSave.userCustomRules, ["ref_code"], "import must validate userCustomRules entries with isValidCustomParam");
   });
 });
 

--- a/tests/unit/sanitize-import.test.mjs
+++ b/tests/unit/sanitize-import.test.mjs
@@ -16,6 +16,10 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const I18N_SOURCE = readFileSync(join(__dirname, "../../src/lib/i18n.js"), "utf8");
 const OPTIONS_SOURCE = readFileSync(join(__dirname, "../../src/options/options.js"), "utf8");
+// #973 follow-up: the import structural checks (muga flag, array types) now
+// live in the pure planImport() in settings-schema.js, not inline in
+// options.js — see export-import.test.mjs for full behavior coverage.
+const SETTINGS_SCHEMA_SOURCE = readFileSync(join(__dirname, "../../src/lib/settings-schema.js"), "utf8");
 
 // ---------------------------------------------------------------------------
 // sanitizeHTML security (i18n.js)
@@ -106,19 +110,25 @@ describe("sanitizeHTML security (i18n.js source verification)", () => {
 // ---------------------------------------------------------------------------
 // Import validation (options.js)
 // ---------------------------------------------------------------------------
-describe("import validation robustness (options.js source verification)", () => {
+describe("import validation robustness (options.js + settings-schema.js source verification)", () => {
 
   test("import checks for muga flag in imported data", () => {
+    // The structural check moved into planImport() (settings-schema.js) but
+    // options.js still delegates to it on every import.
     assert.ok(
-      OPTIONS_SOURCE.includes("data.muga"),
-      "Import must check for .muga flag to validate file format"
+      SETTINGS_SCHEMA_SOURCE.includes("migrated.muga"),
+      "planImport must check for .muga flag to validate file format"
+    );
+    assert.ok(
+      OPTIONS_SOURCE.includes("planImport(data)"),
+      "options.js must delegate import validation to planImport(data)"
     );
   });
 
   test("import validates array types for lists", () => {
     assert.ok(
-      OPTIONS_SOURCE.includes("Array.isArray"),
-      "Import must validate arrays with Array.isArray"
+      SETTINGS_SCHEMA_SOURCE.includes("Array.isArray"),
+      "planImport must validate arrays with Array.isArray"
     );
   });
 

--- a/tests/unit/settings-schema.test.mjs
+++ b/tests/unit/settings-schema.test.mjs
@@ -1,0 +1,335 @@
+/**
+ * MUGA: Unit tests for src/lib/settings-schema.js
+ *
+ * Single source of truth for the Settings export/import feature (#973
+ * follow-up). This module is pure (no chrome/DOM APIs), so it is fully
+ * testable via direct import — no source-string inspection needed.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { SUPPORTED_LANGS } from "../../src/lib/i18n.js";
+import { IMPORT_LIST_CAPS } from "../../src/lib/validation.js";
+import {
+  SETTINGS_SCHEMA_VERSION,
+  SETTINGS_FIELDS,
+  BOOLEAN_KEYS,
+  TOAST_DURATION_OPTIONS,
+  snapToastDuration,
+  buildExportPayload,
+  planImport,
+} from "../../src/lib/settings-schema.js";
+
+function validImportData(overrides = {}) {
+  return {
+    muga: true,
+    blacklist: [],
+    whitelist: [],
+    customParams: [],
+    ...overrides,
+  };
+}
+
+// A representative prefs object matching PREF_DEFAULTS shape, with every
+// field set to a distinct, checkable value.
+const SAMPLE_PREFS = {
+  enabled: true,
+  injectOwnAffiliate: true,
+  notifyForeignAffiliate: true,
+  stripAllAffiliates: false,
+  blacklist: ["evil.com"],
+  whitelist: ["good.com::tag::abc"],
+  customParams: ["ref_code"],
+  dnrEnabled: true,
+  contextMenuEnabled: true,
+  blockPings: true,
+  ampRedirect: true,
+  unwrapRedirects: true,
+  language: "es",
+  disabledCategories: ["utm"],
+  toastDuration: 30,
+  paramBreakdown: true,
+  showReportButton: true,
+  domainStats: true,
+  showBadge: true,
+  followShortenersEnabled: true,
+  canonicalExtractorEnabled: true,
+  crossSiteFrequencyEnabled: true,
+  attributionLedgerEnabled: true,
+  userCustomRules: ["promo_id"],
+  experimentalParamClassesEnabled: true,
+  honorCreatorMode: true,
+  creatorAllowlist: ["youtube.com/@example"],
+};
+
+describe("SETTINGS_SCHEMA_VERSION", () => {
+  test("is a positive integer, currently 1", () => {
+    assert.strictEqual(SETTINGS_SCHEMA_VERSION, 1);
+    assert.ok(Number.isInteger(SETTINGS_SCHEMA_VERSION) && SETTINGS_SCHEMA_VERSION > 0);
+  });
+});
+
+describe("SETTINGS_FIELDS / BOOLEAN_KEYS", () => {
+  test("BOOLEAN_KEYS has exactly the 18 documented plain-boolean prefs", () => {
+    const EXPECTED = [
+      "enabled", "injectOwnAffiliate", "notifyForeignAffiliate", "stripAllAffiliates",
+      "dnrEnabled", "blockPings", "ampRedirect", "unwrapRedirects", "contextMenuEnabled",
+      "paramBreakdown", "showReportButton", "domainStats", "showBadge", "honorCreatorMode",
+      "experimentalParamClassesEnabled", "canonicalExtractorEnabled", "crossSiteFrequencyEnabled",
+      "attributionLedgerEnabled",
+    ];
+    assert.deepStrictEqual([...BOOLEAN_KEYS].sort(), [...EXPECTED].sort());
+    assert.strictEqual(BOOLEAN_KEYS.length, 18);
+  });
+
+  test("followShortenersEnabled and devMode are NOT in BOOLEAN_KEYS", () => {
+    assert.ok(!BOOLEAN_KEYS.includes("followShortenersEnabled"));
+    assert.ok(!BOOLEAN_KEYS.includes("devMode"));
+  });
+
+  test("SETTINGS_FIELDS has no duplicate keys (single source of truth)", () => {
+    const keys = SETTINGS_FIELDS.map((f) => f.key);
+    assert.strictEqual(new Set(keys).size, keys.length);
+  });
+
+  test("injectOwnAffiliate is flagged guarded", () => {
+    const field = SETTINGS_FIELDS.find((f) => f.key === "injectOwnAffiliate");
+    assert.strictEqual(field.guarded, true);
+  });
+});
+
+describe("buildExportPayload", () => {
+  test("full round-trip: every SETTINGS_FIELDS key is present with the correct value", () => {
+    const payload = buildExportPayload(SAMPLE_PREFS, { devMode: true, appVersion: "9.9.9" });
+    for (const field of SETTINGS_FIELDS) {
+      if (field.kind === "local") {
+        assert.strictEqual(payload[field.key], true, `"${field.key}" must come from the devMode param`);
+      } else {
+        assert.deepStrictEqual(payload[field.key], SAMPLE_PREFS[field.key], `"${field.key}" must round-trip from prefs`);
+      }
+    }
+  });
+
+  test("payload is flat (no nested 'settings' object) and stays a plain object", () => {
+    const payload = buildExportPayload(SAMPLE_PREFS, { devMode: false, appVersion: "1.0.0" });
+    assert.strictEqual(payload.settings, undefined);
+    assert.strictEqual(Object.getPrototypeOf(payload), Object.prototype);
+  });
+
+  test("includes muga: true, version, and schemaVersion", () => {
+    const payload = buildExportPayload({}, { devMode: false, appVersion: "2.0.0" });
+    assert.strictEqual(payload.muga, true);
+    assert.strictEqual(payload.version, "2.0.0");
+    assert.strictEqual(payload.schemaVersion, SETTINGS_SCHEMA_VERSION);
+  });
+
+  test("is pure: does not mutate the input prefs object", () => {
+    const prefs = { ...SAMPLE_PREFS };
+    const frozen = Object.freeze({ ...prefs });
+    assert.doesNotThrow(() => buildExportPayload(frozen, { devMode: false, appVersion: "1.0.0" }));
+  });
+});
+
+describe("planImport — structural validation", () => {
+  test("returns { ok: false } for missing/falsy muga", () => {
+    assert.deepStrictEqual(planImport(validImportData({ muga: false })), { ok: false });
+    assert.deepStrictEqual(planImport({ blacklist: [], whitelist: [], customParams: [] }), { ok: false });
+  });
+
+  test("returns { ok: false } for non-array blacklist/whitelist/customParams", () => {
+    assert.deepStrictEqual(planImport(validImportData({ blacklist: "nope" })), { ok: false });
+    assert.deepStrictEqual(planImport(validImportData({ whitelist: 42 })), { ok: false });
+    assert.deepStrictEqual(planImport(validImportData({ customParams: null })), { ok: false });
+  });
+
+  test("returns { ok: false } for a malformed blacklist/whitelist entry", () => {
+    assert.deepStrictEqual(planImport(validImportData({ blacklist: ["has space.com"] })), { ok: false });
+    assert.deepStrictEqual(planImport(validImportData({ whitelist: ["a::b::c::d"] })), { ok: false });
+  });
+
+  test("returns { ok: false } for non-object input", () => {
+    assert.deepStrictEqual(planImport(null), { ok: false });
+    assert.deepStrictEqual(planImport(undefined), { ok: false });
+    assert.deepStrictEqual(planImport("not json"), { ok: false });
+  });
+});
+
+describe("planImport — legacy files (no schemaVersion)", () => {
+  test("a file with no schemaVersion field imports exactly as a versioned one would", () => {
+    const legacy = validImportData({ enabled: true, toastDuration: 45, language: "de" });
+    assert.strictEqual(legacy.schemaVersion, undefined);
+    const plan = planImport(legacy);
+    assert.equal(plan.ok, true);
+    assert.strictEqual(plan.toSave.enabled, true);
+    assert.strictEqual(plan.toSave.toastDuration, 45);
+    assert.strictEqual(plan.toSave.language, "de");
+  });
+
+  test("an unrecognized/future schemaVersion is not rejected in this slice", () => {
+    const plan = planImport(validImportData({ schemaVersion: 999, enabled: true }));
+    assert.equal(plan.ok, true);
+    assert.strictEqual(plan.toSave.enabled, true);
+  });
+
+  // #911: a real user file (Edge 149, MUGA 2.3) with ~1400 custom params was
+  // wrongly rejected as "not a muga configuration". A legacy export — no
+  // schemaVersion, an old manifest `version`, an oversized list, and none of
+  // the fields added after 2.3 — must still import: the big list truncates to
+  // the cap (never rejects), and absent newer fields keep their defaults.
+  test("a legacy 2.3-era file with ~1400 custom params imports (truncates, never rejects) (#911)", () => {
+    const bigParams = Array.from({ length: 1400 }, (_, i) => `ptrk${i}`);
+    const legacy = {
+      muga: true,
+      version: "2.3",
+      blacklist: ["evil.com"],
+      whitelist: [],
+      customParams: bigParams,
+      // fields that did not exist in 2.3 are intentionally absent
+    };
+    assert.strictEqual(legacy.schemaVersion, undefined);
+
+    const plan = planImport(legacy);
+    assert.equal(plan.ok, true, "an oversized legacy list must truncate, not reject");
+    assert.strictEqual(plan.toSave.customParams.length, IMPORT_LIST_CAPS.customParams);
+    assert.ok(plan.skipped > 0, "the over-cap entries must be reported as skipped");
+
+    // Absent post-2.3 fields must not be written, so their defaults survive.
+    for (const key of ["creatorAllowlist", "experimentalParamClassesEnabled", "honorCreatorMode", "canonicalExtractorEnabled"]) {
+      assert.strictEqual(plan.toSave[key], undefined, `absent legacy field "${key}" must keep its default`);
+    }
+  });
+});
+
+describe("planImport — full round-trip of every field", () => {
+  test("every BOOLEAN_KEYS entry round-trips when true", () => {
+    const data = validImportData(Object.fromEntries(BOOLEAN_KEYS.map((k) => [k, true])));
+    const plan = planImport(data);
+    assert.equal(plan.ok, true);
+    for (const key of BOOLEAN_KEYS) {
+      assert.strictEqual(plan.toSave[key], true, `"${key}" must round-trip`);
+    }
+  });
+
+  test("lists round-trip through capImportedLists", () => {
+    const plan = planImport(validImportData({
+      blacklist: ["a.com"],
+      whitelist: ["b.com::tag::x"],
+      customParams: ["ref_code"],
+    }));
+    assert.deepStrictEqual(plan.toSave.blacklist, ["a.com"]);
+    assert.deepStrictEqual(plan.toSave.whitelist, ["b.com::tag::x"]);
+    assert.deepStrictEqual(plan.toSave.customParams, ["ref_code"]);
+    assert.strictEqual(plan.skipped, 0);
+  });
+
+  test("disabledCategories round-trips when every entry is valid", () => {
+    const plan = planImport(validImportData({ disabledCategories: ["utm", "generic"] }));
+    assert.deepStrictEqual(plan.toSave.disabledCategories, ["utm", "generic"]);
+  });
+
+  test("disabledCategories with any invalid entry is rejected wholesale", () => {
+    const plan = planImport(validImportData({ disabledCategories: ["utm", "bogus"] }));
+    assert.strictEqual(plan.toSave.disabledCategories, undefined);
+  });
+
+  test("toastDuration snaps via the shared snapToastDuration", () => {
+    for (const raw of [1, 12, 22, 23, 999, NaN]) {
+      const plan = planImport(validImportData({ toastDuration: raw }));
+      assert.strictEqual(plan.toSave.toastDuration, snapToastDuration(raw));
+    }
+  });
+
+  test("language round-trips for every SUPPORTED_LANGS code, rejects unknown codes", () => {
+    for (const { code } of SUPPORTED_LANGS) {
+      const plan = planImport(validImportData({ language: code }));
+      assert.strictEqual(plan.toSave.language, code);
+    }
+    const rejected = planImport(validImportData({ language: "not-a-lang" }));
+    assert.strictEqual(rejected.toSave.language, undefined);
+  });
+
+  test("experimentalParamClassesEnabled and honorCreatorMode round-trip (#968)", () => {
+    const plan = planImport(validImportData({
+      experimentalParamClassesEnabled: true,
+      honorCreatorMode: true,
+    }));
+    assert.strictEqual(plan.toSave.experimentalParamClassesEnabled, true);
+    assert.strictEqual(plan.toSave.honorCreatorMode, true);
+  });
+
+  test("creatorAllowlist round-trips through the pure validator, dropping dupes/invalid entries (#968)", () => {
+    const plan = planImport(validImportData({
+      creatorAllowlist: ["youtube.com/@a", "YOUTUBE.COM/@A", "not valid entry!"],
+    }));
+    assert.deepStrictEqual(plan.toSave.creatorAllowlist, ["youtube.com/@a"]);
+  });
+
+  test("userCustomRules is filtered via isValidCustomParam and capped", () => {
+    const plan = planImport(validImportData({
+      userCustomRules: ["ref_code", "q", "tag", "promo id"],
+    }));
+    // "q" (denylisted) and "tag" (affiliate guard) and "promo id" (bad format) are dropped.
+    assert.deepStrictEqual(plan.toSave.userCustomRules, ["ref_code"]);
+  });
+});
+
+describe("planImport — #964 followShortenersEnabled permission gate", () => {
+  test("followShortenersEnabled never appears in toSave — pure module cannot check permissions", () => {
+    const plan = planImport(validImportData({ followShortenersEnabled: true }));
+    assert.strictEqual(plan.toSave.followShortenersEnabled, undefined);
+  });
+
+  test("special.followShortenersRequested reflects the raw imported value", () => {
+    assert.strictEqual(planImport(validImportData({ followShortenersEnabled: true })).special.followShortenersRequested, true);
+    assert.strictEqual(planImport(validImportData({ followShortenersEnabled: false })).special.followShortenersRequested, false);
+    assert.strictEqual(planImport(validImportData({})).special.followShortenersRequested, false);
+    assert.strictEqual(planImport(validImportData({ followShortenersEnabled: "true" })).special.followShortenersRequested, false, "non-boolean truthy values must not be treated as a request");
+  });
+
+  // options.js branches on followShortenersProvided (not raw data) to tell
+  // "present as false" (write false) apart from "absent" (leave untouched),
+  // keeping the gate derived from the migrated plan.
+  test("special.followShortenersProvided is true only for a real boolean, false for absent/non-boolean", () => {
+    assert.strictEqual(planImport(validImportData({ followShortenersEnabled: true })).special.followShortenersProvided, true);
+    assert.strictEqual(planImport(validImportData({ followShortenersEnabled: false })).special.followShortenersProvided, true);
+    assert.strictEqual(planImport(validImportData({})).special.followShortenersProvided, false);
+    assert.strictEqual(planImport(validImportData({ followShortenersEnabled: "true" })).special.followShortenersProvided, false);
+  });
+});
+
+describe("planImport — #965 guarded pref reconciliation input", () => {
+  test("injectOwnAffiliate lands in toSave as a plain boolean so options.js can reconcile it", () => {
+    const plan = planImport(validImportData({ injectOwnAffiliate: true }));
+    assert.strictEqual(plan.toSave.injectOwnAffiliate, true);
+    const planFalse = planImport(validImportData({ injectOwnAffiliate: false }));
+    assert.strictEqual(planFalse.toSave.injectOwnAffiliate, false);
+  });
+});
+
+describe("planImport — devMode (local-only, not a synced pref)", () => {
+  test("special.devMode carries the raw boolean, undefined when absent", () => {
+    assert.strictEqual(planImport(validImportData({ devMode: true })).special.devMode, true);
+    assert.strictEqual(planImport(validImportData({ devMode: false })).special.devMode, false);
+    assert.strictEqual(planImport(validImportData({})).special.devMode, undefined);
+  });
+
+  test("devMode never appears in toSave (it is not a synced pref)", () => {
+    const plan = planImport(validImportData({ devMode: true }));
+    assert.strictEqual(plan.toSave.devMode, undefined);
+  });
+});
+
+describe("TOAST_DURATION_OPTIONS / snapToastDuration", () => {
+  test("options span the full 5..60 range", () => {
+    assert.deepStrictEqual([...TOAST_DURATION_OPTIONS], [5, 10, 15, 30, 45, 60]);
+  });
+
+  test("snaps to the nearest offered option", () => {
+    assert.equal(snapToastDuration(5), 5);
+    assert.equal(snapToastDuration(60), 60);
+    assert.equal(snapToastDuration(22), 15);
+    assert.equal(snapToastDuration(23), 30);
+    assert.equal(snapToastDuration(1000), 60);
+    assert.equal(snapToastDuration(NaN), 15);
+  });
+});


### PR DESCRIPTION
Closes #987

## Summary
- Extracts the ad-hoc, inline Settings export/import logic out of a DOM handler in `options.js` into one **pure** module `src/lib/settings-schema.js`: `SETTINGS_SCHEMA_VERSION`, a `SETTINGS_FIELDS` descriptor list (single source of truth), `buildExportPayload()`, and a pure `planImport()` validator/planner.
- Root-fix for the #964/#965/#968 import-bug class: one place lists every user-settable pref, one validator, one versioned export.
- Strictly **behavior-preserving** — no field added or dropped, every guard kept.

## Changes
| File | Change |
|------|--------|
| `src/lib/settings-schema.js` | New pure module: schema version, field descriptors, `buildExportPayload`, `planImport`, `migrate` seam, `snapToastDuration`, category allowlist |
| `src/options/options.js` | Import/export handler thinned (~143 lines); export builds via `buildExportPayload`, import validates via `planImport`; async permission gate + override reconcile stay here and derive from the migrated plan |
| `tests/unit/settings-schema.test.mjs` | New: 33 real behavior unit tests (guards, round-trip, legacy/#911, purity) |
| `tests/unit/*.mjs` (8 files) | Import/export tests repointed from `OPTIONS_SOURCE` string matches to real `planImport`/`buildExportPayload` assertions |

## Behavior preservation
- Export stays **flat** (top-level keys) and only **adds** `schemaVersion`; existing `version` (manifest) kept for back-compat with old files and the e2e spec.
- **#964**: `followShortenersEnabled` never lands in `toSave`; the async `hasShortenerPermissions()` gate stays in `options.js`.
- **#965**: guarded `injectOwnAffiliate` still reconciled via `reconcileOverrideForExplicitChoice`.
- **#968**: `toastDuration` snap + `creatorAllowlist`/`experimentalParamClassesEnabled`/`honorCreatorMode` round-trip unchanged.
- `remoteRulesEnabled` remains intentionally out of the round-trip (unchanged from main).

## Backward compatibility (#911)
- `planImport` **never rejects on version**; identity `migrate()` seam for legacy/missing `schemaVersion`.
- Old files with missing newer fields import and keep defaults; oversized lists **truncate** via `capImportedLists` instead of being rejected as "not a MUGA configuration".
- The shortener gate and override reconcile now read from the **migrated plan**, not raw `data`, so a future migration cannot silently diverge.

## Test plan
- [x] `npm test` — 5648 pass / 0 fail / 1 skip
- [x] `npm run typecheck` — clean
- [x] `npm run lint:js` (changed files) — clean
- [x] Dual blind adversarial review — no behavior-preservation defects confirmed

## Scope
Slice A (behavior-preserving foundation). Deferred follow-ups: round-trip `remoteRulesEnabled`, granular import error copy (unsupported-version vs corrupt vs foreign file).

https://claude.ai/code/session_014SFUhYLkHNj1T3oNaeHUqz