### PR TITLE
fix(ci): force-add gitignored moat report so weekly bot commit succeeds

### DIFF
--- a/.github/workflows/moat-expansion.yml
+++ b/.github/workflows/moat-expansion.yml
@@ -69,7 +69,9 @@ jobs:
           # If a branch from a previous failed run exists, recreate from main.
           git checkout -B "$BRANCH"
 
-          git add tools/moat-expansion/reports/
+          # Reports are gitignored (see .gitignore) so they never reach main via a
+          # direct push; force-add the archival copy so it lands on the bot branch.
+          git add -f "${{ steps.report.outputs.report_file }}"
           git commit -m "auto-moat: affiliate-param gap report ($DATE)"
           git push -u origin "$BRANCH" --force-with-lease
 


### PR DESCRIPTION
## Problem

The weekly **Moat expansion** workflow failed on its first run with real gaps (#1000). Root cause: `.gitignore` intentionally ignores `tools/moat-expansion/reports/report-*.md` so reports never reach `main` via a direct push — but the commit step used a plain `git add tools/moat-expansion/reports/`, which silently skips ignored paths. With nothing staged, `git commit` exited `1` under `set -eo pipefail`.

This path had never run before because every prior week returned `gap_count=0` and exited early.

## Fix

Force-add the concrete report file already captured in `steps.report.outputs.report_file`:

```diff
-          git add tools/moat-expansion/reports/
+          git add -f "${{ steps.report.outputs.report_file }}"
```

This respects the documented design (reports ignored in local + main, committed to the bot branch only via the workflow PR) and reuses the same output var the *Open or update pull request* step already relies on.

## Verification

- Static: the failing step staged nothing because the only matching file was gitignored; `-f` overrides that for the one archival file.
- The alert issue #1000 auto-closes when this workflow next succeeds.

Closes #1000