### PR TITLE
fix(content): add Shopify _pos/_ss/_sid to the hot-path STRIP subset

### DIFF
--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -62,7 +62,8 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
-    _pos: 1, _ss: 1, _sid: 1,
+    _pos: 1, _ss: 1, _psq: 1, _sid: 1, _fid: 1,
+    pr_prod_strat: 1, pr_rec_id: 1, pr_ref_pid: 1, pr_rec_pid: 1, pr_seq: 1,
   });
 
   function inlineCleanUrl(rawUrl) {

--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -62,6 +62,7 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
+    _pos: 1, _ss: 1, _sid: 1,
   });
 
   function inlineCleanUrl(rawUrl) {

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -67,7 +67,8 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
-    _pos: 1, _ss: 1, _sid: 1,
+    _pos: 1, _ss: 1, _psq: 1, _sid: 1, _fid: 1,
+    pr_prod_strat: 1, pr_rec_id: 1, pr_ref_pid: 1, pr_rec_pid: 1, pr_seq: 1,
   });
 
   /**

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -67,6 +67,7 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
+    _pos: 1, _ss: 1, _sid: 1,
   });
 
   /**

--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -61,6 +61,7 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
+    _pos: 1, _ss: 1, _sid: 1,
   });
 
   /**

--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -61,7 +61,8 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
-    _pos: 1, _ss: 1, _sid: 1,
+    _pos: 1, _ss: 1, _psq: 1, _sid: 1, _fid: 1,
+    pr_prod_strat: 1, pr_rec_id: 1, pr_ref_pid: 1, pr_rec_pid: 1, pr_seq: 1,
   });
 
   /**

--- a/src/content/window-name-defuser-mainworld.js
+++ b/src/content/window-name-defuser-mainworld.js
@@ -70,6 +70,7 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
+    _pos: 1, _ss: 1, _sid: 1,
   });
 
   /**

--- a/src/content/window-name-defuser-mainworld.js
+++ b/src/content/window-name-defuser-mainworld.js
@@ -70,7 +70,8 @@
     __s: 1, _ga: 1, _gl: 1, _gac: 1,
     ved: 1, ei: 1, sca_esv: 1, sxsrf: 1,
     mibextid: 1, share_id: 1,
-    _pos: 1, _ss: 1, _sid: 1,
+    _pos: 1, _ss: 1, _psq: 1, _sid: 1, _fid: 1,
+    pr_prod_strat: 1, pr_rec_id: 1, pr_ref_pid: 1, pr_rec_pid: 1, pr_seq: 1,
   });
 
   /**

--- a/tests/e2e/history-defuser-reclean.spec.mjs
+++ b/tests/e2e/history-defuser-reclean.spec.mjs
@@ -104,6 +104,45 @@ async function stubAmazonHost(page) {
   );
 }
 
+const SHOP_HOST = "shop.example";
+
+/**
+ * Stubs a Shopify-shaped storefront. The initial load is clean; the button
+ * simulates Shopify's storefront re-writing the URL with its search/collection
+ * context params (_pos, _ss, _sid) via history.replaceState AFTER a product
+ * link is followed inside the store. These params are re-added client-side, so
+ * DNR never sees them — the only race-free defence is the main-world sync
+ * STRIP subset (history-defuser-mainworld.js), which is exactly what a field
+ * report on a live Shopify store exposed as missing.
+ */
+async function stubShopifyHost(page) {
+  await page.route(`**://${SHOP_HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <button id="muga-shopify-btn">product link</button>
+        <script>
+          window.__mugaReplaceCount = 0;
+          const _origReplace = history.replaceState.bind(history);
+          history.replaceState = function (...args) {
+            window.__mugaReplaceCount++;
+            return _origReplace(...args);
+          };
+
+          // Shopify re-adds its storefront context params via replaceState
+          // as the user moves from a collection/search into a product.
+          document.getElementById("muga-shopify-btn").addEventListener("click", () => {
+            history.replaceState({ tag: "muga-test" }, "Product",
+              "/products/exfoliating-polish?_pos=7&_ss=r&_psq=x&_sid=bba2e42bf&_fid=y" +
+              "&pr_prod_strat=jac&pr_rec_id=1&pr_ref_pid=2&pr_rec_pid=3&pr_seq=uniform&variant=42");
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
 test.describe("SPA reclean on pushState (#951 Layer B)", () => {
   test.beforeEach(async ({ context, extensionId }) => {
     await completeOnboarding(context, extensionId);
@@ -156,6 +195,53 @@ test.describe("SPA reclean on pushState (#951 Layer B)", () => {
     // URL stayed stable after settling (no oscillation).
     const settledUrl = await page.evaluate(() => window.location.href);
     expect(settledUrl).toBe(finalUrl);
+
+    await page.close();
+  });
+
+  test("Shopify storefront params re-added via replaceState are stripped synchronously", async ({ context }) => {
+    const page = await context.newPage();
+    await stubShopifyHost(page);
+    await page.goto(`https://${SHOP_HOST}/index.html`);
+
+    // Wait for the main-world wrap flag set by history-defuser-mainworld.js.
+    await page.waitForFunction(() => window.__mugaHistoryDefused === true, { timeout: 10000 });
+
+    await page.locator("#muga-shopify-btn").click();
+
+    // The whole Shopify storefront family (_pos/_ss/_psq/_sid/_fid + pr_*) is on
+    // the main-world SYNC subset, so it is stripped inside the replaceState wrap
+    // BEFORE the URL is ever committed. Poll defensively for gate arrival, then
+    // assert the committed URL is already clean.
+    await page.waitForFunction(
+      () => !window.location.search.includes("_pos"),
+      { timeout: 10000 }
+    );
+
+    const finalPath = await page.evaluate(() => window.location.pathname);
+    const finalSearch = await page.evaluate(() => window.location.search);
+
+    // Every Shopify storefront param is gone.
+    for (const p of ["_pos", "_ss", "_psq", "_sid", "_fid",
+      "pr_prod_strat", "pr_rec_id", "pr_ref_pid", "pr_rec_pid", "pr_seq"]) {
+      expect(finalSearch).not.toContain(p);
+    }
+    // Functional param preserved; product path untouched.
+    expect(finalSearch).toContain("variant=42");
+    expect(finalPath).toBe("/products/exfoliating-polish");
+
+    // PROOF THE SYNC SUBSET DID THE WORK: the page called replaceState exactly
+    // once. The main-world wrapper cleaned the URL inline before committing, so
+    // the muga:history-committed reclean saw an already-clean URL and never
+    // called replaceState again. If the family were missing from the sync
+    // subset, the async reclean would have to correct it -> a SECOND
+    // replaceState -> count === 2. count === 1 pins the synchronous fix.
+    // REASON: proving the ABSENCE of a second (async) replaceState has no
+    // event to poll for — a short fixed settle wait is the only way to assert
+    // nothing further fired (same rationale as the Amazon test above).
+    await page.waitForTimeout(500);
+    const replaceCount = await page.evaluate(() => window.__mugaReplaceCount);
+    expect(replaceCount).toBe(1);
 
     await page.close();
   });

--- a/tests/unit/strip-table-parity.test.mjs
+++ b/tests/unit/strip-table-parity.test.mjs
@@ -185,3 +185,23 @@ test("irclickid, cjevent, awc are NOT in TRACKING_PARAMS — inverse attribution
     );
   }
 });
+
+// ── Shopify storefront params on the hot path ───────────────────────────────
+//
+// _pos / _ss / _sid are appended by Shopify's storefront to product links as
+// the user browses a collection or search (position, search session, session
+// ID). They are universal tracking noise (in TRACKING_PARAMS) and are stripped
+// by the full pipeline + DNR. They must ALSO live in the synchronous STRIP
+// subset: Shopify re-adds them client-side via history.replaceState, and the
+// subset is the only race-free strip before a page script can read
+// window.location.search. Regression guard so they can't drop off the hot path.
+test("Shopify storefront params (_pos, _ss, _sid) are on the hot-path STRIP subset", () => {
+  const stripKeys = new Set(extractStripKeys(extractStripTable(FILES[0])));
+  for (const param of ["_pos", "_ss", "_sid"]) {
+    assert.ok(
+      stripKeys.has(param),
+      `"${param}" must be in the content-script STRIP subset so Shopify's ` +
+      `client-side history.replaceState re-adds are stripped synchronously.`,
+    );
+  }
+});

--- a/tests/unit/strip-table-parity.test.mjs
+++ b/tests/unit/strip-table-parity.test.mjs
@@ -186,22 +186,41 @@ test("irclickid, cjevent, awc are NOT in TRACKING_PARAMS — inverse attribution
   }
 });
 
-// ── Shopify storefront params on the hot path ───────────────────────────────
+// ── Required hot-path params ────────────────────────────────────────────────
 //
-// _pos / _ss / _sid are appended by Shopify's storefront to product links as
-// the user browses a collection or search (position, search session, session
-// ID). They are universal tracking noise (in TRACKING_PARAMS) and are stripped
-// by the full pipeline + DNR. They must ALSO live in the synchronous STRIP
-// subset: Shopify re-adds them client-side via history.replaceState, and the
-// subset is the only race-free strip before a page script can read
-// window.location.search. Regression guard so they can't drop off the hot path.
-test("Shopify storefront params (_pos, _ss, _sid) are on the hot-path STRIP subset", () => {
+// The STRIP subset is intentionally SMALLER than TRACKING_PARAMS (it is the
+// curated hot-path subset), so we cannot assert full parity between the two.
+// What we CAN pin is that the highest-volume families a page can re-inject
+// client-side (via history.replaceState or a DOM link rewrite) never quietly
+// drop off the sync hot path — the only race-free strip before a page script
+// reads window.location.search. This is the guard that would have caught the
+// Shopify field report: _pos/_ss/_sid (and the pr_* recommendation family) are
+// in TRACKING_PARAMS so the async pipeline strips them, but they were missing
+// from the sync subset, so a client-side re-add survived until (and unless) the
+// async reclean fired.
+//
+// Every entry here must also be in TRACKING_PARAMS/landingParams (the #815 test
+// above already enforces that for whatever is in STRIP). This list is the
+// reverse contract: these MUST be present.
+const HOT_PATH_REQUIRED = [
+  // UTM core
+  "utm_source", "utm_medium", "utm_campaign",
+  // Highest-volume click IDs
+  "fbclid", "gclid", "msclkid", "ttclid",
+  // Shopify storefront family (search/collection context + product recs),
+  // re-added client-side via replaceState as the user browses a store.
+  "_pos", "_ss", "_psq", "_sid", "_fid",
+  "pr_prod_strat", "pr_rec_id", "pr_ref_pid", "pr_rec_pid", "pr_seq",
+];
+
+test("high-volume, client-side-reinjectable params stay on the hot-path STRIP subset", () => {
   const stripKeys = new Set(extractStripKeys(extractStripTable(FILES[0])));
-  for (const param of ["_pos", "_ss", "_sid"]) {
-    assert.ok(
-      stripKeys.has(param),
-      `"${param}" must be in the content-script STRIP subset so Shopify's ` +
-      `client-side history.replaceState re-adds are stripped synchronously.`,
-    );
-  }
+  const missing = HOT_PATH_REQUIRED.filter((p) => !stripKeys.has(p));
+  assert.deepEqual(
+    missing,
+    [],
+    `These params must be in the content-script STRIP subset so client-side ` +
+    `re-adds (e.g. Shopify's history.replaceState) are stripped synchronously, ` +
+    `not left to the async reclean which can miss on timing:\n  ${missing.join(", ")}`,
+  );
 });


### PR DESCRIPTION
## Field reports

Two Shopify product URLs observed unstripped while browsing (both bazacosmetics.com):
- `?_pos=7&_sid=..&_ss=r` (search/collection context)
- `?pr_prod_strat=..&pr_rec_id=..&pr_rec_pid=..&pr_ref_pid=..&pr_seq=..` (product recommendations)

These are **Shopify storefront params** present on every Shopify store, so this generalizes far beyond one site.

## Root cause

MUGA already strips the whole Shopify family via the full `processUrl` pipeline + DNR (they are in `TRACKING_PARAMS`, `affiliates-data.js`). The gap was the **synchronous** hot-path `STRIP` subset — hand-copied byte-identical into four content scripts — which omitted them. That subset is the only *race-free* strip that runs before a page script can read `window.location.search`. Shopify re-adds these params client-side via `history.replaceState` as you move from a collection/search into a product, so cleaning depended entirely on the async reclean firing; when it does not (prefs not yet loaded, `onboardingDone` false, or the `isRecleanLoop` guard giving up), the params persist.

## Change

- Added the full Shopify storefront family to the `STRIP` table in all four content scripts, in lockstep (byte-identical, enforced by the #723 parity guard): `_pos, _ss, _psq, _sid, _fid, pr_prod_strat, pr_rec_id, pr_ref_pid, pr_rec_pid, pr_seq`.
- All are already in `TRACKING_PARAMS`, so the #815 coherence guard passes (not affiliate landing params — no attribution risk).
- **Unit guard**: generalized to an explicit `HOT_PATH_REQUIRED` list (UTM core + top click IDs + Shopify family) so high-volume, client-side-reinjectable params can't silently drop off the hot path.
- **E2E regression** (real Chromium, extension loaded): drives a Shopify-style `history.replaceState` re-add and asserts the whole family is stripped **synchronously** — the page's `replaceState` count stays at exactly 1, proving the main-world sync subset (not the async reclean) did the work — while the functional `variant` param is preserved.

## Verification

- `strip-table-parity.test.mjs`: 4/4 (byte-identity + #815 coherence + hot-path-required).
- Full unit suite: **5731 pass, 0 fail, 1 skip**.
- `npx playwright test history-defuser-reclean`: **2/2 pass** (Amazon async path + new Shopify sync path).

The e2e is the live-browser repro the first revision could not offer: it exercises the real extension against a Shopify-shaped host and confirms the exact field scenario before/after.

## Follow-up

The STRIP subset being a hand-maintained, 4×-duplicated subset of `TRACKING_PARAMS` is the structural root of this drift class (two field reports needed two param-list edits). Tracked in a separate issue: derive the four tables from a single tagged source at build time.
