### PR TITLE
feat(popup): inline "why was this cleaned?" per-category description

### DIFF
--- a/src/lib/param-breakdown-view.js
+++ b/src/lib/param-breakdown-view.js
@@ -1,0 +1,57 @@
+/**
+ * MUGA — Param breakdown view-model (#986).
+ *
+ * Pure view-model for the popup's "why was this cleaned?" tracking-param
+ * breakdown. Groups the removed tracking-param names by category and resolves
+ * each category's localized label + description, reusing the description*
+ * fields TRACKING_PARAM_CATEGORIES already carries (src/lib/affiliates-data.js)
+ * but that the popup left unused until now.
+ *
+ * Why a separate module from the popup glue: popup.js is browser-only (DOM,
+ * chrome.*) and cannot be exercised under node:test, so the grouping / lang
+ * resolution logic that used to live inline in _renderParamBreakdown was
+ * untested. Extracting it here mirrors the precedent set by
+ * remote-rules-changelog-view.js (#984) and attribution-ledger-view.js:
+ * popup.js's _renderParamBreakdown is now a thin DOM shell that only consumes
+ * the rows this function returns.
+ *
+ * fr/it/ja have no description{Fr,It,Ja} fields in affiliates-data.js yet, so
+ * they gracefully fall back to the English `description`. Fast-follow: add
+ * native descriptions for those locales once translated copy exists.
+ *
+ * @param {string[]} removedTracking - Tracking param names removed from the URL.
+ * @param {string} lang - "es" | "pt" | "de" | "fr" | "it" | "ja" | "en"
+ * @param {Map<string, {
+ *   categoryKey: string,
+ *   label: string, labelEs?: string, labelPt?: string, labelDe?: string,
+ *   description?: string, descriptionEs?: string, descriptionPt?: string, descriptionDe?: string,
+ * }>} paramIndex - Reverse index (lowercase param -> category info), as built by popup.js's _buildParamIndex().
+ * @param {(key: string, lang: string) => string} translateOther - i18n t()-shaped function used to label the
+ *   "other" bucket for params not found in paramIndex (defaults to src/lib/i18n.js's `t`).
+ * @returns {{ categoryKey: string, label: string, description: string|null, params: string[] }[]}
+ */
+export function buildParamBreakdownView(removedTracking, lang, paramIndex, translateOther) {
+  if (!Array.isArray(removedTracking) || removedTracking.length === 0) return [];
+
+  const groups = new Map(); // categoryKey -> { categoryKey, label, description, params }
+
+  for (const param of removedTracking) {
+    const info = paramIndex.get(param.toLowerCase());
+    const catKey = info ? info.categoryKey : "other";
+
+    if (!groups.has(catKey)) {
+      const label = info
+        ? ({ es: info.labelEs, pt: info.labelPt, de: info.labelDe }[lang] || info.label)
+        : translateOther("param_category_other", lang);
+      // Unknown params have no category data at all, so no description exists
+      // to show — "other" rows render label + params only.
+      const description = info
+        ? ({ es: info.descriptionEs, pt: info.descriptionPt, de: info.descriptionDe }[lang] || info.description || null)
+        : null;
+      groups.set(catKey, { categoryKey: catKey, label, description, params: [] });
+    }
+    groups.get(catKey).params.push(param);
+  }
+
+  return [...groups.values()];
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -747,6 +747,15 @@ footer .footer-link-btn:hover { color: var(--accent-strong); }
   color: var(--text-3);
   word-break: break-all;
 }
+/* #986: "why was this cleaned?" category description. flex-basis: 100% on a
+   flex-wrap row pushes it onto its own line below the label + params. */
+.breakdown-desc {
+  flex-basis: 100%;
+  font-size: 10px;
+  color: var(--text-3);
+  opacity: .85;
+  line-height: 1.35;
+}
 
 /* Migration banner (#369) */
 .migration-banner {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -18,6 +18,7 @@ import {
 } from "../lib/cross-site-frequency.js";
 import { presentLedger, DEFAULT_LEDGER_CAPACITY } from "../lib/attribution-ledger.js";
 import { renderEntries as renderLedgerEntries } from "../lib/attribution-ledger-view.js";
+import { buildParamBreakdownView } from "../lib/param-breakdown-view.js";
 
 /** Creates a clipboard SVG icon (12x12) via createElementNS. */
 function _createClipboardSvg() {
@@ -111,7 +112,11 @@ async function getCopySafeCleanUrl(originalUrl) {
 
 // ── Param breakdown ───────────────────────────────────────────────────────────
 
-/** Builds a reverse index: param name → { category key, label, labelEs, labelPt, labelDe }. Cached as singleton. */
+/**
+ * Builds a reverse index: param name → { category key, label*, description* }.
+ * Cached as singleton (rebuilt across popup sessions only, not per render —
+ * the history list can render this for many entries in a single popup open).
+ */
 let _paramIndex = null;
 function _buildParamIndex() {
   if (_paramIndex) return _paramIndex;
@@ -124,45 +129,52 @@ function _buildParamIndex() {
         labelEs: catData.labelEs,
         labelPt: catData.labelPt,
         labelDe: catData.labelDe,
+        description: catData.description,
+        descriptionEs: catData.descriptionEs,
+        descriptionPt: catData.descriptionPt,
+        descriptionDe: catData.descriptionDe,
       });
     }
   }
   return _paramIndex;
 }
 
-/** Renders a param breakdown section showing removed params grouped by category. */
+/**
+ * Renders a param breakdown section showing removed params grouped by
+ * category, plus a "why was this cleaned?" description per category (#986).
+ * All grouping / lang-resolution logic lives in the pure, unit-tested
+ * buildParamBreakdownView() — this function is a thin DOM shell.
+ */
 function _renderParamBreakdown(removedTracking, lang) {
   const index = _buildParamIndex();
-  // Group params by category
-  const groups = new Map();
-  for (const param of removedTracking) {
-    const info = index.get(param.toLowerCase());
-    const catKey = info ? info.categoryKey : "other";
-    const label = info
-      ? ({ es: info.labelEs, pt: info.labelPt, de: info.labelDe }[lang] || info.label)
-      : t("param_category_other", lang);
-    if (!groups.has(catKey)) groups.set(catKey, { label, params: [] });
-    groups.get(catKey).params.push(param);
-  }
+  const rows = buildParamBreakdownView(removedTracking, lang, index, t);
 
   const container = document.createElement("div");
   container.className = "param-breakdown";
 
-  for (const [, group] of groups) {
-    const row = document.createElement("div");
-    row.className = "breakdown-row";
+  for (const row of rows) {
+    const rowEl = document.createElement("div");
+    rowEl.className = "breakdown-row";
 
     const catEl = document.createElement("span");
     catEl.className = "breakdown-cat";
-    catEl.textContent = group.label;
+    catEl.textContent = row.label;
 
     const paramsEl = document.createElement("span");
     paramsEl.className = "breakdown-params";
-    paramsEl.textContent = group.params.join(", ");
+    paramsEl.textContent = row.params.join(", ");
 
-    row.appendChild(catEl);
-    row.appendChild(paramsEl);
-    container.appendChild(row);
+    rowEl.appendChild(catEl);
+    rowEl.appendChild(paramsEl);
+
+    if (row.description) {
+      const descEl = document.createElement("span");
+      descEl.className = "breakdown-desc";
+      descEl.textContent = row.description;
+      rowEl.appendChild(descEl);
+    }
+
+    container.appendChild(rowEl);
   }
 
   return container;

--- a/tests/unit/param-breakdown-view.test.mjs
+++ b/tests/unit/param-breakdown-view.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * MUGA — Unit tests for buildParamBreakdownView (src/lib/param-breakdown-view.js) (#986)
+ *
+ * Run with: node --test tests/unit/param-breakdown-view.test.mjs
+ *
+ * Locks the grouping + lang-resolution logic for the popup's "why was this
+ * cleaned?" category breakdown, extracted out of the browser-only
+ * _renderParamBreakdown() in src/popup/popup.js so it can be unit-tested.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildParamBreakdownView } from "../../src/lib/param-breakdown-view.js";
+
+/** Fake reverse index mirroring what popup.js's _buildParamIndex() builds. */
+const INDEX = new Map([
+  ["utm_source", {
+    categoryKey: "utm",
+    label: "UTM / Campaign",
+    labelEs: "UTM / Campaña",
+    labelPt: "UTM / Campanha",
+    labelDe: "UTM / Kampagne",
+    description: "Google Analytics UTM parameters (utm_source, utm_medium, etc.)",
+    descriptionEs: "Parámetros UTM de Google Analytics",
+    descriptionPt: "Parâmetros UTM do Google Analytics",
+    descriptionDe: "Google Analytics UTM-Parameter",
+  }],
+  ["utm_medium", {
+    categoryKey: "utm",
+    label: "UTM / Campaign",
+    labelEs: "UTM / Campaña",
+    labelPt: "UTM / Campanha",
+    labelDe: "UTM / Kampagne",
+    description: "Google Analytics UTM parameters (utm_source, utm_medium, etc.)",
+    descriptionEs: "Parámetros UTM de Google Analytics",
+    descriptionPt: "Parâmetros UTM do Google Analytics",
+    descriptionDe: "Google Analytics UTM-Parameter",
+  }],
+  ["fbclid", {
+    categoryKey: "ads_click_ids",
+    label: "Paid Ads Clicks",
+    labelEs: "Clics de publicidad",
+    labelPt: "Cliques de anúncios",
+    labelDe: "Bezahlte Werbeklicks",
+    description: "Click IDs from Google Ads, Facebook, TikTok, LinkedIn, Microsoft, Twitter, etc.",
+    descriptionEs: "IDs de clic de Google Ads, Facebook, TikTok, etc.",
+    descriptionPt: "IDs de clique do Google Ads, Facebook, TikTok, etc.",
+    descriptionDe: "Klick-IDs von Google Ads, Facebook, TikTok, etc.",
+  }],
+]);
+
+/** Fake t()-shaped translator for the "other" category label. */
+function translateOther(key, lang) {
+  const table = {
+    en: "Other tracking",
+    es: "Otro rastreo",
+  };
+  return table[lang] || table.en;
+}
+
+describe("buildParamBreakdownView — pure view-model for the #986 param breakdown", () => {
+  test("empty input → empty array", () => {
+    assert.deepEqual(buildParamBreakdownView([], "en", INDEX, translateOther), []);
+    assert.deepEqual(buildParamBreakdownView(undefined, "en", INDEX, translateOther), []);
+  });
+
+  test("correct grouping: params from the same category collapse into one row", () => {
+    const rows = buildParamBreakdownView(["utm_source", "utm_medium"], "en", INDEX, translateOther);
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].categoryKey, "utm");
+    assert.strictEqual(rows[0].label, "UTM / Campaign");
+    assert.deepEqual(rows[0].params, ["utm_source", "utm_medium"]);
+  });
+
+  test("distinct categories produce distinct rows, in first-seen order", () => {
+    const rows = buildParamBreakdownView(["fbclid", "utm_source"], "en", INDEX, translateOther);
+    assert.strictEqual(rows.length, 2);
+    assert.strictEqual(rows[0].categoryKey, "ads_click_ids");
+    assert.strictEqual(rows[1].categoryKey, "utm");
+  });
+
+  test("lang resolution: es returns descriptionEs and labelEs", () => {
+    const rows = buildParamBreakdownView(["utm_source"], "es", INDEX, translateOther);
+    assert.strictEqual(rows[0].label, "UTM / Campaña");
+    assert.strictEqual(rows[0].description, "Parámetros UTM de Google Analytics");
+  });
+
+  test("lang resolution: pt and de also resolve to their localized description", () => {
+    const pt = buildParamBreakdownView(["fbclid"], "pt", INDEX, translateOther);
+    assert.strictEqual(pt[0].description, "IDs de clique do Google Ads, Facebook, TikTok, etc.");
+
+    const de = buildParamBreakdownView(["fbclid"], "de", INDEX, translateOther);
+    assert.strictEqual(de[0].description, "Klick-IDs von Google Ads, Facebook, TikTok, etc.");
+  });
+
+  test("unknown lang (e.g. fr/it/ja) falls back to the English description", () => {
+    for (const lang of ["fr", "it", "ja", "xx"]) {
+      const rows = buildParamBreakdownView(["utm_source"], lang, INDEX, translateOther);
+      assert.strictEqual(rows[0].label, "UTM / Campaign", `label fallback for ${lang}`);
+      assert.strictEqual(
+        rows[0].description,
+        "Google Analytics UTM parameters (utm_source, utm_medium, etc.)",
+        `description fallback for ${lang}`
+      );
+    }
+  });
+
+  test("unknown param → 'other' category, translated label, no description", () => {
+    const rows = buildParamBreakdownView(["some_mystery_param"], "en", INDEX, translateOther);
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].categoryKey, "other");
+    assert.strictEqual(rows[0].label, "Other tracking");
+    assert.strictEqual(rows[0].description, null);
+    assert.deepEqual(rows[0].params, ["some_mystery_param"]);
+  });
+
+  test("unknown param label is also localized via the translate callback (es)", () => {
+    const rows = buildParamBreakdownView(["some_mystery_param"], "es", INDEX, translateOther);
+    assert.strictEqual(rows[0].label, "Otro rastreo");
+    assert.strictEqual(rows[0].description, null);
+  });
+
+  test("param lookup is case-insensitive", () => {
+    const rows = buildParamBreakdownView(["UTM_SOURCE"], "en", INDEX, translateOther);
+    assert.strictEqual(rows[0].categoryKey, "utm");
+    assert.deepEqual(rows[0].params, ["UTM_SOURCE"], "original casing is preserved in the displayed param list");
+  });
+
+  test("known params without a localized field fall back to the English description", () => {
+    const indexNoEs = new Map([
+      ["x_param", {
+        categoryKey: "misc",
+        label: "Misc",
+        description: "English only description.",
+      }],
+    ]);
+    const rows = buildParamBreakdownView(["x_param"], "es", indexNoEs, translateOther);
+    assert.strictEqual(rows[0].description, "English only description.");
+  });
+});


### PR DESCRIPTION
Closes #986.

## What
The popup param breakdown showed only the category label plus the removed param names. `TRACKING_PARAM_CATEGORIES` (`src/lib/affiliates-data.js`) already carries `description`/`descriptionEs`/`descriptionPt`/`descriptionDe` fields that the popup never surfaced. This wires them in as a short per-category "why was this cleaned?" line.

Rescoped from the issue's literal per-param example to category-level, reusing existing data, so no new copy was written and no new-locale review is needed.

## How
- Grouping and lang resolution extracted into a new pure, unit-tested `buildParamBreakdownView()` (`src/lib/param-breakdown-view.js`), mirroring the `planChangelogView` (#984) / `attribution-ledger-view` precedent. `_renderParamBreakdown()` is now a thin DOM shell (`.textContent` only, no innerHTML).
- `.breakdown-desc` CSS drops the description onto its own line (`flex-basis:100%` on the existing `flex-wrap` row), muted and theme-aware via existing custom properties.
- fr/it/ja have no `description{Fr,It,Ja}` fields yet, so they fall back to the English `description` (flagged as fast-follow in a code comment; no invented translations).

## Tests
- New `tests/unit/param-breakdown-view.test.mjs`: 10 tests (grouping, es/pt/de resolution, fr/it/ja and unknown-lang fallback, unknown-param "other" bucket with null description, case-insensitivity).
- Full unit suite: 5741 pass, 1 skip (pre-existing/unrelated), 0 fail.

## Notes
- No em-dashes added; existing es descriptions are already peninsular.
- Follow-up: add native fr/it/ja category descriptions when translated copy exists.
