### PR TITLE
chore(i18n): community-locale parity report + contributor workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,21 @@ jobs:
       - name: Check i18n quality (no FIXME / stubs / empty locale slots) (#621)
         run: npm run check:i18n
 
+      - name: Community locale parity report (#990)
+        # Non-blocking: pt/de/fr/it/ja are community-maintained and allowed to
+        # have gaps (missing keys degrade to the EN string at runtime — see
+        # src/lib/i18n.js's t() fallback). This step surfaces the gap in the
+        # job summary for contributors; it must never fail the build. The
+        # tool always exits 0 when called with no args, and continue-on-error
+        # is the second line of defense against a hard crash.
+        continue-on-error: true
+        run: |
+          {
+            echo "## Community locale translation parity (#990)"
+            echo ""
+            node tools/missing-translations.mjs
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Run unit tests
         run: npm test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,22 @@ node tools/missing-translations.mjs ja        # JA only
 
 The script's output is markdown suitable for pasting into the per-language tracking issues. Submit a PR editing the matching key in the relevant `src/lib/locales/<code>.mjs` file and the CI suite will validate the EN+ES floor for you.
 
+### CI parity report (#990)
+
+Every CI run includes a **non-blocking** "Community locale parity report" step that runs `node tools/missing-translations.mjs` for all five community locales and posts the result to the job summary (visible on the "Summary" tab of the workflow run). It never fails the build — pt/de/fr/it/ja are allowed to have gaps, and a missing key falls back to the English string at runtime (`src/lib/i18n.js`'s `t()`). Use it as a quick pointer to where a community locale could use a follow-up PR; it does not gate a merge. The blocking gates that do apply to every PR are:
+
+- `tests/unit/i18n-locale-modules.test.mjs` (#834) — every locale file's key set must exactly match `en.mjs` (no additions, no omissions; a missing key is a `null`/absent slot, not a dropped key).
+- `tests/unit/i18n-completeness.test.mjs` (#359) — `en` and `es` must both have a non-empty, distinct value for every key.
+- `npm run check:i18n` (`tools/check-i18n-fixme.mjs`) — no FIXME markers or empty locale slots in any locale file.
+
+### Copy rules for any new string
+
+Whether you're adding a key to `en.mjs`/`es.mjs` or improving an existing community-locale string, the same house rules apply:
+
+- `es` locale = peninsular/Castilian Spanish (e.g. "enlace", "ajustes"; avoid Latino forms).
+- No em-dashes in user-facing copy.
+- Every string keeps MUGA's URL-cleaner framing explicit (MUGA cleans URLs), even where the surrounding narrative talks about "denoise" or "noise removal".
+
 ### Community locales: native-speaker review welcome
 
 The community-locale strings were produced with AI assistance. They are linguistically sound but have not been signed off by native speakers. If you spot a string that reads awkward, regional, or just wrong, a PR fixing only that single key is a great first contribution:

--- a/tests/unit/missing-translations.test.mjs
+++ b/tests/unit/missing-translations.test.mjs
@@ -7,12 +7,27 @@
  */
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { missingKeys, formatReport } from "../../tools/missing-translations.mjs";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { missingKeys, formatReport, COMMUNITY_LOCALES } from "../../tools/missing-translations.mjs";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const TOOL_SOURCE = readFileSync(join(__dir, "../../tools/missing-translations.mjs"), "utf8");
+
+describe("missing-translations — COMMUNITY_LOCALES (#990)", () => {
+  test("covers all five community locales (pt, de, fr, it, ja)", () => {
+    assert.deepEqual([...COMMUNITY_LOCALES].sort(), ["de", "fr", "it", "ja", "pt"]);
+  });
+});
 
 describe("missing-translations — missingKeys()", () => {
   test("returns an array", () => {
     assert.ok(Array.isArray(missingKeys("pt")));
     assert.ok(Array.isArray(missingKeys("de")));
+    assert.ok(Array.isArray(missingKeys("fr")));
+    assert.ok(Array.isArray(missingKeys("it")));
+    assert.ok(Array.isArray(missingKeys("ja")));
   });
 
   test("returns deterministically (idempotent — same input, same output)", () => {
@@ -49,6 +64,24 @@ describe("missing-translations — formatReport()", () => {
     assert.equal(typeof out, "string");
     assert.ok(out.length > 0);
     assert.ok(out.startsWith("# DE translations needed"));
+  });
+
+  for (const lang of ["fr", "it", "ja"]) {
+    test(`returns a non-empty markdown string for ${lang.toUpperCase()}`, () => {
+      const out = formatReport(lang);
+      assert.equal(typeof out, "string");
+      assert.ok(out.length > 0);
+      assert.ok(out.startsWith(`# ${lang.toUpperCase()} translations needed`));
+    });
+  }
+
+  test("does not hardcode a two-locale (PT/DE-only) contribution-flow message (#990)", () => {
+    // Regression guard: the contribution-flow blurb used to say
+    // "PT and DE PRs..." verbatim, which read wrong once FR/IT/JA joined
+    // the community-locale set. Checked against source, not output, because
+    // the live data currently has zero missing keys in every community
+    // locale, so the affected branch of formatReport() never executes.
+    assert.ok(!TOOL_SOURCE.includes("PT and DE PRs"));
   });
 
   test("output is deterministic across calls", () => {

--- a/tools/missing-translations.mjs
+++ b/tools/missing-translations.mjs
@@ -1,22 +1,26 @@
 /**
- * MUGA: Missing-translations diff tool (#361)
+ * MUGA: Missing-translations diff tool (#361, extended #990)
  *
  * Reads `src/lib/i18n.js` and produces, for each community-maintained
- * language (PT, DE), a markdown bullet list of i18n keys that are
- * missing or empty in that language. The output is suitable for
- * pasting into the per-language tracking issues.
+ * language (PT, DE, FR, IT, JA), a markdown bullet list of i18n keys
+ * that are missing or empty in that language. The output is suitable
+ * for pasting into the per-language tracking issues, or for the
+ * non-blocking CI parity report (see .github/workflows/ci.yml).
  *
  * Usage:
- *   node tools/missing-translations.mjs           # both languages, stdout
+ *   node tools/missing-translations.mjs           # all community locales, stdout
  *   node tools/missing-translations.mjs pt        # PT only
  *   node tools/missing-translations.mjs de        # DE only
+ *   node tools/missing-translations.mjs fr        # FR only
+ *   node tools/missing-translations.mjs it        # IT only
+ *   node tools/missing-translations.mjs ja        # JA only
  *
  * Idempotent: same input → same output. Keys are emitted in the order
  * they appear in TRANSLATIONS.
  */
 import { TRANSLATIONS } from "../src/lib/i18n.js";
 
-const COMMUNITY_LOCALES = ["pt", "de"];
+export const COMMUNITY_LOCALES = ["pt", "de", "fr", "it", "ja"];
 
 /**
  * Returns the list of keys missing in `lang`. A key is "missing" if
@@ -59,7 +63,7 @@ export function formatReport(lang) {
 
   lines.push(`${missing.length} of ${total} keys missing in ${langLabel}. Each key below needs a translation in \`src/lib/locales/${lang}.mjs\`.`);
   lines.push("");
-  lines.push(`**Contribution flow:** edit the matching key in \`src/lib/locales/${lang}.mjs\`, run \`npm test\`, open a PR. PT and DE PRs do not need native-speaker review by the maintainer (the maintainer is not a native speaker of either) — the EN+ES floor enforced by the test suite is what gates a merge.`);
+  lines.push(`**Contribution flow:** edit the matching key in \`src/lib/locales/${lang}.mjs\`, run \`npm test\`, open a PR. Community-locale PRs do not need native-speaker review by the maintainer (the maintainer is not a native speaker of any of them); the EN+ES floor enforced by the test suite is what gates a merge.`);
   lines.push("");
   lines.push("## Missing keys");
   lines.push("");


### PR DESCRIPTION
Closes #990.

## What
Two additive deliverables; the enforcement infra (EN/ES key-parity, #834; FIXME/stub check, #621) already existed and is untouched.

1. **Community-locale parity report in CI** — a new NON-BLOCKING step runs `tools/missing-translations.mjs` for all community locales and appends the markdown to the job summary. Community locales (pt/de/fr/it/ja) are allowed gaps (missing keys degrade to the EN string at runtime via `i18n.js` `t()`), so this surfaces gaps for contributors without ever failing the build (`continue-on-error: true`, and the tool exits 0 with no args). The existing blocking `check:i18n` step is left as-is.
2. **Contributor workflow docs** — extended the existing CONTRIBUTING Translations section: which locales are official (en/es) vs community, how to run the tool locally, the CI report, and the copy rules (peninsular/Castilian es, no em-dashes, URL-cleaner framing).

## Tooling
- `COMMUNITY_LOCALES` extended `["pt","de"]` to `["pt","de","fr","it","ja"]` and exported for testability.
- Latent bug fixed: the contribution-flow blurb hardcoded `PT and DE` (with an em-dash) regardless of the reported locale.

## Tests
- `tools/missing-translations.mjs`: all 5 community locales report 331/331 keys present.
- Added fr/it/ja coverage + a source-regression guard for the hardcoded-string bug to `missing-translations.test.mjs`.
- Full unit suite: 5751 pass, 1 skip (pre-existing), 0 fail. lint + typecheck clean. CI YAML validated.
