### PR TITLE
chore(import-candidates): reusable triage classifier for AdGuard param candidates

### DIFF
--- a/tests/unit/candidate-triage.test.mjs
+++ b/tests/unit/candidate-triage.test.mjs
@@ -1,0 +1,326 @@
+/**
+ * MUGA, unit tests for the import-candidate triage classifier (#998, Phase 0, v2.1)
+ *
+ * Pins the v2.1 bucketing logic of annotateCandidate()/classifyCandidate() in
+ * tools/import-candidates/triage.mjs against fixture names, without any
+ * network access. Each fixture supplies synthetic external signals
+ * (clearurls_global, adguard_scoped_domains, and so on) so the classifier
+ * itself is exercised the same way the real pipeline would call it, while
+ * staying fully offline and deterministic.
+ *
+ * v1 had three safety defects: irclickid was promoted to
+ * universal_high_confidence, and cjevent/awc landed in needs_human -- all
+ * three are redirect-network landing params that a real integration reads at
+ * landing to populate the merchant's first-party attribution cookie
+ * (protected by the #815 strip-table parity guard). v2 fixed this with a
+ * hard affiliate-preserve exclusion (FIX 1) that runs before any other
+ * check.
+ *
+ * v2 had its own defect: its single vendor-signal list conflated pure
+ * tracking/ad-platform vendors with affiliate-NETWORK vendors, so it
+ * promoted affiliate-network attribution params (cj_aid, cj_pid, awinaffid,
+ * af_id, af_channel, adj_adgroup, adj_deeplink, impact_click_id,
+ * impact_ad_id) straight to universal_high_confidence. impact_click_id was
+ * especially dangerous: same network (Impact Radius) as the preserved
+ * irclickid. v2.1 fixes this by splitting the vendor-signal list into
+ * TRACKING_VENDOR_PATTERNS (safe for universal) and
+ * AFFILIATE_NETWORK_PATTERNS (routed to a new affiliate_network_review
+ * bucket, never universal), with the affiliate-network gate checked before
+ * the universal path.
+ *
+ * Coverage:
+ *   - FIX 1: irclickid, cjevent, awc must land in excluded_affiliate_preserve
+ *     and must NEVER be universal_high_confidence (the v1 regression).
+ *   - FIX 2: a danger-list name with only global attribution (no domain
+ *     scope) must land in likely_reject; a danger-list name WITH scoped
+ *     attribution must land in domain_scoped with caution: "functional-name".
+ *   - v2.1 NEW GATE: cj_aid, awinaffid, impact_click_id, af_id, and
+ *     adj_adgroup must land in affiliate_network_review and must NEVER be
+ *     universal_high_confidence (the v2 regression). taboola_click_id is a
+ *     pure ad-platform tracking vendor, not an affiliate network, so it
+ *     stays in universal_high_confidence.
+ *   - FIX 3: two-source agreement (adguard_global AND clearurls_global)
+ *     reaches universal_high_confidence; a tracking-vendor match combined
+ *     with adguard_global-only also reaches universal_high_confidence; a
+ *     ClearURLs-only vendor match (no adguard_global) does not.
+ *   - Legacy v1/v2 coverage retained where still valid under v2.1
+ *     precedence: one clean example per remaining bucket, plus the
+ *     short-but-domain-scoped and functional-name-with-zero-evidence edge
+ *     cases.
+ *
+ * All names used below (irclickid, cjevent, awc, q, code, utm, adj_adgroup,
+ * gclid, cj_aid, awinaffid, impact_click_id, af_id, taboola_click_id) are
+ * real names present in the 2026-07-05 candidate batch
+ * (tools/import-candidates/triage-2026-07-05.json); the external signals
+ * passed to annotateCandidate() are synthetic fixtures matching what the
+ * real pipeline computed for each, kept here for offline determinism.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { annotateCandidate, classifyCandidate } from "../../tools/import-candidates/triage.mjs";
+
+describe("FIX 1: affiliate-preserve exclusion runs first and stops all other buckets", () => {
+  test("irclickid: excluded_affiliate_preserve, never universal_high_confidence", () => {
+    const r = annotateCandidate("irclickid", {
+      adguard_global: true,
+      clearurls_scoped_domains: ["bestbuy.com"],
+    });
+    assert.strictEqual(r.is_affiliate_preserve, true);
+    assert.strictEqual(r.bucket, "excluded_affiliate_preserve");
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("cjevent: excluded_affiliate_preserve, never universal_high_confidence", () => {
+    const r = annotateCandidate("cjevent", { adguard_global: true });
+    assert.strictEqual(r.is_affiliate_preserve, true);
+    assert.strictEqual(r.bucket, "excluded_affiliate_preserve");
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("awc: excluded_affiliate_preserve, never universal_high_confidence", () => {
+    const r = annotateCandidate("awc", { adguard_global: true });
+    assert.strictEqual(r.is_affiliate_preserve, true);
+    assert.strictEqual(r.bucket, "excluded_affiliate_preserve");
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("an affiliate-preserve name is excluded even with strong corroborating signals", () => {
+    // Even both-global attribution must not pull a preserve-set name toward
+    // universal_high_confidence: FIX 1 stops processing before FIX 3 runs.
+    const r = annotateCandidate("tduid", {
+      adguard_global: true,
+      clearurls_global: true,
+    });
+    assert.strictEqual(r.bucket, "excluded_affiliate_preserve");
+  });
+});
+
+describe("FIX 2: hard danger list of load-bearing functional names", () => {
+  // "q" is a real name from the 2026-07-05 batch: AdGuard-global only, no
+  // scoped domains anywhere. A load-bearing name with only global (or no)
+  // attribution is unsafe to strip anywhere without a human decision.
+  test("q: danger name, global-only, no scoped domains -> likely_reject", () => {
+    const r = annotateCandidate("q", { adguard_global: true });
+    assert.strictEqual(r.is_danger_name, true);
+    assert.strictEqual(r.bucket, "likely_reject");
+    assert.match(r.reason, /load-bearing functional name/);
+  });
+
+  // "code" is a real name from the 2026-07-05 batch: AdGuard-global plus a
+  // ClearURLs scoped-domain hit. The domain scope limits the blast radius,
+  // so this becomes a reviewable domain_scoped candidate instead of an
+  // outright reject, flagged with caution: "functional-name" so a reviewer
+  // knows this name is also commonly load-bearing elsewhere.
+  test("code: danger name WITH scoped domains -> domain_scoped, caution functional-name", () => {
+    const r = annotateCandidate("code", {
+      adguard_global: true,
+      clearurls_scoped_domains: ["alibaba cloud arms"],
+    });
+    assert.strictEqual(r.is_danger_name, true);
+    assert.strictEqual(r.bucket, "domain_scoped");
+    assert.strictEqual(r.caution, "functional-name");
+  });
+
+  test("danger name never reaches universal_high_confidence even with full corroboration", () => {
+    const r = annotateCandidate("token", {
+      adguard_global: true,
+      clearurls_global: true,
+    });
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+});
+
+describe("v2.1 NEW GATE: affiliate-network params route to human review, never universal", () => {
+  // cj_aid, awinaffid, impact_click_id, af_id, adj_adgroup were all
+  // confirmed in universal_high_confidence under v2. This is the exact
+  // regression v2.1 fixes.
+  test("cj_aid: affiliate_network_review (CJ Affiliate), never universal_high_confidence", () => {
+    const r = annotateCandidate("cj_aid", { adguard_global: true });
+    assert.strictEqual(r.affiliate_network_match.matched, true);
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.match(r.network, /CJ Affiliate/);
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("awinaffid: affiliate_network_review (Awin), never universal_high_confidence", () => {
+    const r = annotateCandidate("awinaffid", { adguard_global: true });
+    assert.strictEqual(r.affiliate_network_match.matched, true);
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.match(r.network, /Awin/);
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  // impact_click_id: same network (Impact Radius) as the preserved
+  // irclickid -- the single most dangerous case v2 got wrong.
+  test("impact_click_id: affiliate_network_review (Impact Radius), never universal_high_confidence", () => {
+    const r = annotateCandidate("impact_click_id", {
+      adguard_global: true,
+      clearurls_global: true,
+    });
+    assert.strictEqual(r.affiliate_network_match.matched, true);
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.match(r.network, /Impact Radius/);
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("af_id: affiliate_network_review (AppsFlyer), never universal_high_confidence", () => {
+    const r = annotateCandidate("af_id", { adguard_global: true });
+    assert.strictEqual(r.affiliate_network_match.matched, true);
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.match(r.network, /AppsFlyer/);
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("adj_adgroup: affiliate_network_review (Adjust), never universal_high_confidence", () => {
+    const r = annotateCandidate("adj_adgroup", {
+      adguard_global: true,
+      clearurls_global: false,
+    });
+    assert.strictEqual(r.affiliate_network_match.matched, true);
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.match(r.network, /Adjust/);
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  // taboola_click_id is a pure ad-platform tracking vendor, not an
+  // affiliate network: it must stay in universal_high_confidence, proving
+  // the split doesn't over-broadly demote every "click_id"-shaped name.
+  test("taboola_click_id: tracking vendor, stays universal_high_confidence", () => {
+    const r = annotateCandidate("taboola_click_id", { adguard_global: true });
+    assert.strictEqual(r.affiliate_network_match.matched, false);
+    assert.strictEqual(r.tracking_vendor_match.matched, true);
+    assert.strictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("affiliate-network match wins over scoped attribution (routes to review, not domain_scoped)", () => {
+    // Sanity: an affiliate-network name with scoped attribution still goes
+    // to affiliate_network_review, not domain_scoped, because the gate
+    // runs before FIX 3's scoped-attribution fallback. "rakuten_mid" is not
+    // itself in the FIX 1 preserve set (ranmid/ransiteid/raneaid are), so
+    // this exercises the affiliate-network gate specifically, not FIX 1.
+    const r = annotateCandidate("rakuten_mid", {
+      adguard_scoped_domains: ["example.com"],
+    });
+    assert.strictEqual(r.is_affiliate_preserve, false);
+    assert.strictEqual(r.affiliate_network_match.matched, true);
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.match(r.network, /Rakuten/);
+  });
+});
+
+describe("FIX 3: source agreement and tracking-vendor corroboration", () => {
+  // "utm" is a real name from the 2026-07-05 batch with BOTH adguard_global
+  // and clearurls_global true, not in the preserve, danger, or
+  // affiliate-network lists.
+  test("utm: two-source agreement (adguard_global AND clearurls_global) -> universal_high_confidence", () => {
+    const r = annotateCandidate("utm", {
+      adguard_global: true,
+      clearurls_global: true,
+    });
+    assert.strictEqual(r.is_affiliate_preserve, false);
+    assert.strictEqual(r.is_danger_name, false);
+    assert.strictEqual(r.affiliate_network_match.matched, false);
+    assert.strictEqual(r.bucket, "universal_high_confidence");
+  });
+
+  test("clearurls_global-only vendor match without adguard_global does not reach universal_high_confidence", () => {
+    // FIX 3's universal path requires adguard_global specifically (either
+    // both-source agreement or adguard_global + tracking-vendor signal); a
+    // ClearURLs-only vendor match falls through to needs_human instead.
+    const r = annotateCandidate("gclid", { clearurls_global: true });
+    assert.strictEqual(r.tracking_vendor_match.matched, true);
+    assert.notStrictEqual(r.bucket, "universal_high_confidence");
+    assert.strictEqual(r.bucket, "needs_human");
+  });
+});
+
+describe("annotateCandidate, remaining bucket coverage retained from v1/v2", () => {
+  test("s-id: AdGuard scoped-domain attribution, no vendor signal -> domain_scoped, domains captured", () => {
+    const r = annotateCandidate("s-id", {
+      adguard_scoped_domains: ["item.rakuten.co.jp", "www.rakuten.co.jp"],
+    });
+    assert.strictEqual(r.bucket, "domain_scoped");
+    assert.deepEqual(r.adguard_scoped_domains, ["item.rakuten.co.jp", "www.rakuten.co.jp"]);
+  });
+
+  test("needs_human: global claim exists but no corroborating vendor signal (source)", () => {
+    const r = annotateCandidate("source", { clearurls_global: true });
+    assert.strictEqual(r.is_danger_name, false);
+    assert.strictEqual(r.affiliate_network_match.matched, false);
+    assert.strictEqual(r.tracking_vendor_match.matched, false);
+    assert.strictEqual(r.bucket, "needs_human");
+  });
+
+  test("likely_reject: no corroborating evidence in either source at all (___from_store)", () => {
+    const r = annotateCandidate("___from_store", {});
+    assert.strictEqual(r.bucket, "likely_reject");
+    assert.match(r.reason, /no corroborating tracking evidence/);
+  });
+
+  test("hsa_acc: AdGuard global attribution + hubspot tracking-vendor signal -> universal_high_confidence", () => {
+    const r = annotateCandidate("hsa_acc", { adguard_global: true });
+    assert.strictEqual(r.bucket, "universal_high_confidence");
+    assert.strictEqual(r.tracking_vendor_match.pattern, "hubspot");
+  });
+});
+
+describe("classifyCandidate, precedence order is checked independently of annotateCandidate", () => {
+  test("affiliate preserve wins over every other signal", () => {
+    const result = classifyCandidate({
+      is_affiliate_preserve: true,
+      is_danger_name: true,
+      clearurls_global: true,
+      clearurls_scoped_domains: ["example.com"],
+      adguard_global: true,
+      adguard_scoped_domains: ["example.com"],
+      affiliate_network_match: { matched: true, pattern: "cj-prefix", network: "CJ Affiliate (Commission Junction)" },
+      tracking_vendor_match: { matched: true, pattern: "utm" },
+    });
+    assert.strictEqual(result.bucket, "excluded_affiliate_preserve");
+  });
+
+  test("danger name with scoped domains wins over lack of global attribution", () => {
+    const result = classifyCandidate({
+      is_affiliate_preserve: false,
+      is_danger_name: true,
+      clearurls_global: false,
+      clearurls_scoped_domains: [],
+      adguard_global: false,
+      adguard_scoped_domains: ["example.com"],
+      affiliate_network_match: { matched: false, pattern: null, network: null },
+      tracking_vendor_match: { matched: false, pattern: null },
+    });
+    assert.strictEqual(result.bucket, "domain_scoped");
+    assert.strictEqual(result.caution, "functional-name");
+  });
+
+  test("affiliate-network match wins over danger name being false and over universal-qualifying signals", () => {
+    const result = classifyCandidate({
+      is_affiliate_preserve: false,
+      is_danger_name: false,
+      clearurls_global: true,
+      clearurls_scoped_domains: [],
+      adguard_global: true,
+      adguard_scoped_domains: [],
+      affiliate_network_match: { matched: true, pattern: "impact-prefix", network: "Impact Radius" },
+      tracking_vendor_match: { matched: true, pattern: "generic-click_id" },
+    });
+    assert.strictEqual(result.bucket, "affiliate_network_review");
+    assert.strictEqual(result.network, "Impact Radius");
+  });
+
+  test("universal_high_confidence requires adguard_global in every qualifying path", () => {
+    const result = classifyCandidate({
+      is_affiliate_preserve: false,
+      is_danger_name: false,
+      clearurls_global: true,
+      clearurls_scoped_domains: [],
+      adguard_global: false,
+      adguard_scoped_domains: [],
+      affiliate_network_match: { matched: false, pattern: null, network: null },
+      tracking_vendor_match: { matched: true, pattern: "utm" },
+    });
+    assert.notStrictEqual(result.bucket, "universal_high_confidence");
+  });
+});

--- a/tools/import-candidates/triage-2026-07-05.json
+++ b/tools/import-candidates/triage-2026-07-05.json
@@ -1,0 +1,29848 @@
+{
+  "generated_at": "2026-07-06T13:50:52.949Z",
+  "schema_version": "2.1",
+  "source_report_path": "C:\\Users\\parada\\Desktop\\test\\muga\\tools\\import-candidates\\report-2026-07-05.json",
+  "source_label": "AdGuard Filter 17 (URL Tracking Protection)",
+  "source_url": "https://filters.adtidy.org/extension/chromium/filters/17.txt",
+  "fetched_at": "2026-07-05T07:27:21.158Z",
+  "total_candidates": 1404,
+  "already_in_muga_dropped": 296,
+  "bucket_counts": {
+    "excluded_affiliate_preserve": 18,
+    "affiliate_network_review": 37,
+    "universal_high_confidence": 43,
+    "domain_scoped": 161,
+    "needs_human": 822,
+    "likely_reject": 27
+  },
+  "affiliate_preserve_set": [
+    "a8",
+    "admitad_uid",
+    "adref",
+    "aff_request_id",
+    "aff_trace_key",
+    "algo_expid",
+    "algo_pvid",
+    "awc",
+    "btsid",
+    "cjdata",
+    "cjevent",
+    "clickref",
+    "iclid",
+    "irclickid",
+    "irgwc",
+    "pubref",
+    "raneaid",
+    "ranmid",
+    "ransiteid",
+    "tagtag_uid",
+    "tduid",
+    "ttaid",
+    "ttcid",
+    "ttrk",
+    "ws_ab_test",
+    "wt_mc"
+  ],
+  "danger_names": [
+    "action",
+    "callback",
+    "code",
+    "country",
+    "date",
+    "email",
+    "format",
+    "host",
+    "id",
+    "ip",
+    "key",
+    "lang",
+    "locale",
+    "login",
+    "method",
+    "next",
+    "nonce",
+    "os",
+    "page",
+    "path",
+    "q",
+    "query",
+    "redirect",
+    "redirect_uri",
+    "region",
+    "return",
+    "s",
+    "session",
+    "sessionid",
+    "sid",
+    "sig",
+    "signature",
+    "sort",
+    "state",
+    "time",
+    "token",
+    "type",
+    "uri",
+    "url",
+    "user",
+    "userid",
+    "variant",
+    "ver",
+    "version",
+    "view"
+  ],
+  "tracking_vendor_labels": [
+    "utm",
+    "mtm",
+    "piwik-pro-pk",
+    "mailchimp-mc",
+    "hubspot",
+    "ga-linker",
+    "gclid",
+    "dclid",
+    "gbraid",
+    "wbraid",
+    "msclkid",
+    "ttclid",
+    "twclid",
+    "yclid",
+    "igshid",
+    "generic-clid",
+    "generic-clickid",
+    "generic-click_id",
+    "taboola",
+    "outbrain",
+    "dicbo",
+    "criteo",
+    "reddit-rdt",
+    "salesforce-sfmc",
+    "webtrekk-wt",
+    "etracker-etcc",
+    "matomo",
+    "piwik",
+    "gemius",
+    "aliexpress-oak",
+    "alibaba-spm",
+    "alibaba-scm",
+    "marketo-mkt",
+    "ebay-mkwid",
+    "ebay-mkevt",
+    "adobe-efid",
+    "adobe-s-kwcid",
+    "cmpid",
+    "ncid"
+  ],
+  "affiliate_network_labels": [
+    {
+      "label": "cj-prefix",
+      "network": "CJ Affiliate (Commission Junction)"
+    },
+    {
+      "label": "cj-commission",
+      "network": "CJ Affiliate (Commission Junction)"
+    },
+    {
+      "label": "awin",
+      "network": "Awin"
+    },
+    {
+      "label": "impact-prefix",
+      "network": "Impact Radius"
+    },
+    {
+      "label": "rakuten",
+      "network": "Rakuten Advertising (LinkShare)"
+    },
+    {
+      "label": "admitad",
+      "network": "Admitad"
+    },
+    {
+      "label": "partnerize",
+      "network": "Partnerize (Performance Horizon)"
+    },
+    {
+      "label": "tradedoubler",
+      "network": "Tradedoubler"
+    },
+    {
+      "label": "appsflyer-af",
+      "network": "AppsFlyer"
+    },
+    {
+      "label": "adjust",
+      "network": "Adjust"
+    },
+    {
+      "label": "airbridge",
+      "network": "Airbridge"
+    },
+    {
+      "label": "branch",
+      "network": "Branch"
+    },
+    {
+      "label": "generic-affiliate",
+      "network": "Generic affiliate marker"
+    }
+  ],
+  "adguard_data_source": "live",
+  "clearurls_data_source": "live",
+  "warnings": [],
+  "candidates": [
+    {
+      "name": "_1ld",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_1lp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "___from_store",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "___store",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "__da_seqno",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "__du__",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "__f__",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "__removesafearea__",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "__rr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_bdld",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_bg_fs",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_caid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_csrc_",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_cus_",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_cut_",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_cvid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_f",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_i",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_lc2_fpi",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_oak_freesia_scene",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "aliexpress-oak"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "aliexpress-oak"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "_oak_gallery_order",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "aliexpress-oak"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "aliexpress-oak"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "_oak_mp_inf",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "aliexpress-oak"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "aliexpress-oak"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "_oak_page_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "aliexpress-oak"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "aliexpress-oak"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "_oak_rec_ext_1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "aliexpress-oak"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "aliexpress-oak"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "_oak_region",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "aliexpress-oak"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "aliexpress-oak"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "_p",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_p_jump_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_p_rfs",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_rdt_arg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_rdt_idx",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_rdt_sid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_refid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_skw",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_source_",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_tp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_trans_",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_unique_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ads_account",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ads_channel",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ads_creative_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ads_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ads_set",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ads_sub_channel",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_bg_adid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_campaign",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_channel_scene",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_channel_src",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_cid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_from",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ns_catalog_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ns_crt_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ns_gid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ns_placement",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ns_product_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ns_site_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_ns_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_sessn_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "_x_vst_scene",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "a",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "a8",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "a_aid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "affiliate.privatevpn.com",
+        "expressvpn.com",
+        "vpnarea.com",
+        "wook.pt"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ab",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "abt_att",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "abtest",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "abtestvariant",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "acampid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bestbuy.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "acm",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "lazada.com.ph",
+        "lazada.vn"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "acr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "acrid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "act",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "actbtn",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "action",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [
+        "wikipedia.org"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "actionid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "otto.de",
+        "ottoversand.at"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "activityid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ad",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ad_domain",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ad_flag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ad_params",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ad_provider",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ad_reason_recommended_items",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ad_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adblock",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adbnr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adcampaignid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adclid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-clid"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "adcopy",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adcref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "fafit24.de"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "adef1043",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adg_ctx",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adgrpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adj_adgroup",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "adjust",
+        "network": "Adjust"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Adjust"
+    },
+    {
+      "name": "adj_adnomia_click_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "adjust",
+        "network": "Adjust"
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-click_id"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Adjust"
+    },
+    {
+      "name": "adj_deep_link",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "adjust",
+        "network": "Adjust"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Adjust"
+    },
+    {
+      "name": "adj_deeplink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "adjust",
+        "network": "Adjust"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Adjust"
+    },
+    {
+      "name": "adj_event_callback_dn2j7g_5mdnim",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "adjust",
+        "network": "Adjust"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Adjust"
+    },
+    {
+      "name": "adj_install_callback",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "adjust",
+        "network": "Adjust"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Adjust"
+    },
+    {
+      "name": "adjust_deeplink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "adjust",
+        "network": "Adjust"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Adjust"
+    },
+    {
+      "name": "adme5101",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "admitad_uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "admitad",
+        "network": "Admitad"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "adp_cid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adp_oid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "ads_identity_ads_promo_identity_placement_uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ads_identity_ads_promo_identity_site_uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ads_params",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adtag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adtype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adv",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "advert",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "advertisementid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "advertiser",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "advertising_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "advertising_tracking_enabled",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "adxarea",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "af_assettype_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_channel",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_creative_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_lnk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_permalink_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_placement_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_reengagement_window",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "af_rid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "appsflyer-af",
+        "network": "AppsFlyer"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "AppsFlyer"
+    },
+    {
+      "name": "afclid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-clid"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "aff",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_c",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_click_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-click_id"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_model",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_short_key",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_sub2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_sub3",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_sub4",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_sub5",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "aff_trace_key",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "aff_track",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "affid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "affijet-click",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "affil",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "affiliate",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "generic-affiliate",
+        "network": "Generic affiliate marker"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Generic affiliate marker"
+    },
+    {
+      "name": "affiliate_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "affiliate_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "affiliateid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "otto.de",
+        "ottoversand.at"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "affitest",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "affname",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "afftrack",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "afno",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "agentcode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "agentid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "aid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "adgardvpn-help.*",
+        "adguard-dns.io",
+        "adguard-vpn.*",
+        "adguard.com",
+        "adguard.info"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "airbridge_referrer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "airbridge",
+        "network": "Airbridge"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Airbridge"
+    },
+    {
+      "name": "al_imp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "algo_exp_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "algo_pvid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "aliexpress",
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "ali_trackid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "allianceid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "allow_app_redirect",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "amc",
+      "clearurls_global": true,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "an",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "android_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "anid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "reuters.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ap",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "app_pvid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "appclientid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "appid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "apppopyn",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "emart.ssg.com",
+        "m-emart.ssg.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "appsignature",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "appsrc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "apptype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "apv",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "arf",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "argsite",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "argument",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "article_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "artlist_aid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "asb",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "asb2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ascsubtag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "amazon",
+        "amazon search"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "asid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "associatetag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "asubid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "at",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "atlorigin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ats",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "attribution_code",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "attribution_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "attribution_sig",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "attribution_window",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "attributionid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "autogen_token",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "av",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "avtc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "avte",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "avts",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "awc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "awinaffid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "awin",
+        "network": "Awin"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Awin"
+    },
+    {
+      "name": "banerid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bannercode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bc_pid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bd_vid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bh",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "google"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "fafit24.de"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "bidtype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "google"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "bitcampaigncode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "google"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "block",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "boosteruid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "brand",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [
+        "coupang.com",
+        "danawa.com",
+        "elcorteingles.es",
+        "musinsa.com",
+        "oliveyoung.co.kr",
+        "shein.com",
+        "ssg.com",
+        "zalando.de",
+        "zalando.es"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "browser_dist",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "browser_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bvuuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bw",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "bxsign",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "c",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "c_ad",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_app",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_app_from",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_bm",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_dt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_ex",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_sys",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_try",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_u",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_ut",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_ver",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "c_wh",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "cachekey",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cachesdk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "caff",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "caid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "camk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "camp_no",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "campaign_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "campaign_name",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "campid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "otto.de",
+        "ottoversand.at"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "car",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cb_ref_code",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cbqsid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cexp_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cexp_var",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cg_referrer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ch_anime_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "channable",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "easynotebooks.de",
+        "notebook.de"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "chksm",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cj_aid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "cj-prefix",
+        "network": "CJ Affiliate (Commission Junction)"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "CJ Affiliate (Commission Junction)"
+    },
+    {
+      "name": "cj_pid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "cj-prefix",
+        "network": "CJ Affiliate (Commission Junction)"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "CJ Affiliate (Commission Junction)"
+    },
+    {
+      "name": "cjdata",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "cjevent",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "ckwhere",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "emart.ssg.com",
+        "m-emart.ssg.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "cl4url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "clckid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "click",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "click_from",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "click_metadata",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "clickorigin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "argos.co.uk"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "clickout_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "clickref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "clicktrackinfo",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "lazada"
+      ],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "lazada.com.ph",
+        "lazada.vn"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "client",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "client_e",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "client_m",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "client_t",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "client_ver",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "clientusertype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cmd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cmn_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cmnhd_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cmoa",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cmoa_pg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cnt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cnt_transit",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cnxclid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-clid"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "cobrand",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "code",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "alibaba cloud arms"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
+    },
+    {
+      "name": "collectionid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "compact_view",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "contact_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cookie",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "amazon",
+        "amazon search"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "cooper",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "sbs.co.kr"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "country",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "courseclaim",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cp_in",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cpt_c",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cpt_m",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cpt_n",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cpt_s",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "creative_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "crv_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "csource",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ctg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "curpageloguid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cursor",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cvrid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "decathlon.pl"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "cvrpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "decathlon.pl"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "cvrsid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "decathlon.pl"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "cx_art",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cx_clicks_art_mdl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cx_clicks_sldbox",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "cxt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "twitter.com",
+        "x.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "d",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "newegg.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "data1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "date",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 3,
+      "muga_preserve_conflict_domains": [
+        "aladin.co.kr"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "dc_data",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dcsext.recom",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "de_utm_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "deep_link_value",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "deeplink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "deferredfl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "destredirecturl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "device_code",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "device_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "devicetype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "devicetypeid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dicbo",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "dicbo"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "did",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "lazada"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "dmai",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dmid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dmmref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "dmm.co.jp",
+        "dmm.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "dnt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "domcomplete",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "domcontentloadedeventend",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "domcontentloadedeventstart",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dominteractive",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "domloading",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "downloadmode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ds_s_kwgid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dsp_click_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-click_id"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "dt_dapp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "weibo"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "163.com",
+        "douban.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "dt_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dt_platform",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dtm_user_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dtp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "dv",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "e",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "sharepoint.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ea_med",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ea_src",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "eccid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ecid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "deeplearning.ai"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ectag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ecuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "efr_campaign",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "efr_medium",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "efr_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "email",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "dailycodingproblem.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
+    },
+    {
+      "name": "emcid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "eml-mediaplan",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "eml-name",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "eml-publisher",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "en_txn7",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "enctid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "entrypoint",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "accounts.firefox.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "epi",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "microsoft.com",
+        "xbox.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "epid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "eqid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "erl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "es",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "etcc_cmp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "etracker-etcc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "etcc_med",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "etracker-etcc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "etcc_produkt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "etracker-etcc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "eurl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "event_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "eventid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "exc_ads",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "experienceid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "exportkey",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ext",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ext.referrer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "externalvisitorid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "extparam",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "extra",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "extra_params",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "f_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fb_asc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fd_bridge_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "feed_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "filtered_price",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "filterkey",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "flow",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [
+        "paypal.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "flowpath_page_no",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "flowpath_page_value",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fm",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "flipkart"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "fm_topics_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fmid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "for",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "form",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [
+        "bing.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fpcuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fpr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "yahoo.co.jp",
+        "yahoo.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "freesia_scene",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "friend",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "frm_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_block",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_button_waterfall_knb",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_country",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shein.co.uk",
+        "shein.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "from_ext",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_share",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_sku",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_spm_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_spmid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_srv",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "from_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fromjk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "fromreminder",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ftid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [
+        "maps.google.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "g_ccy",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "g_clk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "g_ep",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "g_lg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "g_region",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "g_site",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ga_account",
+      "clearurls_global": true,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "ga-linker"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "ga-linker"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "gacd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "gemius_identifier",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "gemius"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "gen",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "geoip_country",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "getid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "glid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "gs_l",
+      "clearurls_global": true,
+      "clearurls_scoped_domains": [
+        "google"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "gs_lcrp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "google"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "gspk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "gsxid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "gtmpos",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "guid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "height",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hhtmfrom",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "history_adids",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "history_postids",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "google.com",
+        "instagram.com",
+        "play.google.com",
+        "scholar.google.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "host",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "hvadid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hvbmt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hvdev",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hvlocphy",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hvnetw",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hvqmt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hvrand",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hvtargid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "hydadcr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "i",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "amazon.ca",
+        "amazon.co.jp",
+        "amazon.co.uk",
+        "amazon.com",
+        "amazon.com.au",
+        "amazon.com.br",
+        "amazon.com.mx",
+        "amazon.de",
+        "amazon.es",
+        "amazon.fr",
+        "amazon.in",
+        "amazon.it",
+        "amazon.nl",
+        "amazon.pl",
+        "amazon.se",
+        "amazon.sg"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "i2af",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "i3_ord",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "dmm.co.jp",
+        "dmm.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "i3_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "dmm.co.jp",
+        "dmm.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "i6",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "i_cid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "nikkei"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "iasid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ici",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shein.co.uk",
+        "shein.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "icid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "iclid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-clid"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "icm",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "icmp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "alternate.de",
+        "apple.com",
+        "bestbuy.com",
+        "dcinside.com",
+        "facebook.com",
+        "fb.com",
+        "mercari.com",
+        "play.google.com",
+        "sharepoint.com"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "idealoid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "identifier",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ig_rid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "iid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "flipkart"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ikco",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "impact_ad_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "impact-prefix",
+        "network": "Impact Radius"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Impact Radius"
+    },
+    {
+      "name": "impact_click_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "impact-prefix",
+        "network": "Impact Radius"
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-click_id"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Impact Radius"
+    },
+    {
+      "name": "impact_product_sku",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "impact-prefix",
+        "network": "Impact Radius"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Impact Radius"
+    },
+    {
+      "name": "impressionid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "in_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "index_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "infnews",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "info",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 3,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "initialissue",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "install_callback",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "install_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "interactionsessionid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "intpr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "intpr2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ip",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "ip_address",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "irclickid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bestbuy.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-clickid"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "clickid"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "iref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook",
+        "zoho.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "irgwc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bestbuy.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "is",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "is_mobile",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "isdramintegrated",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "isfreemail",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ismcid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "isshortened",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "isss",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "isuser",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "itid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "itmmeta",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "itmprp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "itscg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "itsct",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "iurl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "jd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "jsclck",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "jso",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "jumpreferrer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "kamigame_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "kampan",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "karea",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "key",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "key5sk1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "keywords",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "amazon"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [
+        "amazon.ca",
+        "amazon.co.jp",
+        "amazon.co.uk",
+        "amazon.com",
+        "amazon.com.au",
+        "amazon.com.br",
+        "amazon.com.mx",
+        "amazon.de",
+        "amazon.es",
+        "amazon.fr",
+        "amazon.in",
+        "amazon.it",
+        "amazon.nl",
+        "amazon.pl",
+        "amazon.se",
+        "amazon.sg",
+        "linkedin.com"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "kid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "klay",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "km_adgroup",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "km_matchtype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "km_partner",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "l",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "apple.com",
+        "apps.apple.com",
+        "fotocasa.es",
+        "github.com",
+        "indeed.com"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "l-id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "nikki.ne.jp",
+        "rakuten.co.jp",
+        "rebates.jp"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "landing",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "launchid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "laz_trackid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "lazada.com.ph",
+        "lazada.vn"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "lctg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "lfrom_processed",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "lg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "li",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "link_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "gog.com",
+        "norml.org"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "linked_creative_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "list",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "LinkedIn"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 3,
+      "muga_preserve_conflict_domains": [
+        "youtu.be",
+        "youtube.com"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ln",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "loadeventend",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "loadeventstart",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "locale",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "log",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "billiger.de"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "login",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "login-new",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "login-source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "login_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "loginfrom",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "loginuin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "lp_fol",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "lplid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ls",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "apple.com",
+        "apps.apple.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "lsadname2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "lsed",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "lvrid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "m",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mall_cid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mallcode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shein.co.uk",
+        "shein.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "manager",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "marketing-visitor-id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "matomo",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "matomo"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "mbid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "newyorker.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "mc",
+      "clearurls_global": true,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "mc_pc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "mailchimp-mc"
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "mailchimp"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "mclid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-clid"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "mcr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "media",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "media_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "medium",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "eonline.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "meta_redirectid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "method",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "mini_signature",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mks_referer_event",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mkttid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "lazada.com.ph",
+        "lazada.vn"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "mlid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "modelid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_api_as3_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_api_as3_url_bck",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_api_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_api_js_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_api_js_url_bc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_api_js_url_bck",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_assets",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_embed",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_game_assets",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_game_embed",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_game_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_game_uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_game_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_int",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_locale",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_player_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_site_https_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_site_name",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_site_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_timezone",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mp_view_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bestbuy.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "mpl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mpr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mpshare",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mr_download_reason",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mr_game_version",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mr_loader",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mrk_rec",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ms_rnd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "msid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "msktc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "msource",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bilibili.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "muclientname",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "mwid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "n_tw",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "native_mode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nats",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "naver",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "dt.co.kr"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "navigationstart",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nbt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ncid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "techcrunch"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "ncid"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "ncmp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nend_click_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-click_id"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "nettype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "new_session",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "news_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "newsletter",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "newsstand",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "sportalkorea.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "nid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nm_origem",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nm_ranking_rec",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nonce",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "ns_fee",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "bbc.co.uk",
+        "bbc.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ns_linkname",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "bbc.co.uk",
+        "bbc.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ns_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "bbc.co.uk",
+        "bbc.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "nsc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nsgid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nt_redirect_referrer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "nv",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "khan.co.kr"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "nvuuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "octid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "oe",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "oem",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "offer_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "offerid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "offerkey",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "offerlistid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "idealo.de"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "oiid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "old",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "openexternalbrowser",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "operation",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "oref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "defenseone.com",
+        "govexec.com",
+        "nextgov.com",
+        "route-fifty.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "orig_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "origin_referer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "origin_referral_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "original_referer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "originalreferer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "os",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "trendyol.com"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "osusume_banner",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "outlink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "sedaily.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "p",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "billiger.de"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "bilibili.com",
+        "daum.net",
+        "flipkart.com",
+        "github.com",
+        "yahoo.co.jp",
+        "yahoo.com",
+        "yandex.com",
+        "yandex.ru",
+        "zalando.de",
+        "zalando.es"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "p_a",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "p_c",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "p_cid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "p_n",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "p_s",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "p_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "p_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "page",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "alibaba cloud arms"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 3,
+      "muga_preserve_conflict_domains": [
+        "11st.co.kr",
+        "aliexpress.com",
+        "amazon.ca",
+        "amazon.co.jp",
+        "amazon.co.uk",
+        "amazon.com",
+        "amazon.com.au",
+        "amazon.com.br",
+        "amazon.com.mx",
+        "amazon.de",
+        "amazon.es",
+        "amazon.fr",
+        "amazon.in",
+        "amazon.it",
+        "amazon.nl",
+        "amazon.pl",
+        "amazon.se",
+        "amazon.sg",
+        "americanas.com.br",
+        "auction.co.kr",
+        "bbc.co.uk",
+        "bbc.com",
+        "bestbuy.com",
+        "coolblue.nl",
+        "coupang.com",
+        "danawa.com",
+        "daum.net",
+        "dcinside.com",
+        "docmorris.de",
+        "elcorteingles.es",
+        "elmundo.es",
+        "elpais.com",
+        "etsy.com",
+        "fiverr.com",
+        "flipkart.com",
+        "fotocasa.es",
+        "gitlab.com",
+        "gmarket.co.kr",
+        "kurly.com",
+        "lenovo.com",
+        "mediamarkt.de",
+        "mediamarkt.es",
+        "musinsa.com",
+        "namu.wiki",
+        "naver.com",
+        "oliveyoung.co.kr",
+        "paris.cl",
+        "pccomponentes.com",
+        "pinterest.com",
+        "rtve.es",
+        "shein.com",
+        "shopee.com",
+        "slickdeals.net",
+        "ssg.com",
+        "stackoverflow.com",
+        "tistory.com",
+        "tokopedia.com",
+        "walmart.com",
+        "wsj.com"
+      ],
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
+    },
+    {
+      "name": "pageuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pageview_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pageviewcount",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "parent_perf_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "partner_extra",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "partner_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "partner_slug",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "partnerid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "partnerize",
+        "network": "Partnerize (Performance Horizon)"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Partnerize (Performance Horizon)"
+    },
+    {
+      "name": "partnerizecampaignid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "partnerize",
+        "network": "Partnerize (Performance Horizon)"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "affiliate_network_review",
+      "network": "Partnerize (Performance Horizon)"
+    },
+    {
+      "name": "path",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "pathway",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pbs",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pbss",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pcat_vnexttracking_localwidget",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pcat_vnexttracking_onlineitrack",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pcat_vnexttracking_onlineplrss",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pcat_vnexttracking_retailerscoring",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pckg_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pcpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pcscpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "perf_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "persistent_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pfm_carac",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pfm_index",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pfm_page",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pfm_pos",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pfm_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pfx",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "fnnews.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "phfp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "proton.me",
+        "protonvpn.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "phone_code",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shein.co.uk",
+        "shein.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "pid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "alibaba cloud arms",
+        "flipkart"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "pixelid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "net-parade.it"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "place",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "plan",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "plateform",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "platform",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mozilla.org"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "plattr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "playeranalytics",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "plid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "plink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "sbs.co.kr"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "position",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "post_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pr-campaign",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pr-medium",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pr-source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "prelink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "premiumvisit",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "fanfictionero.com",
+        "fic.fan",
+        "ficbook.net",
+        "ficmania.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "previous_page",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "prnd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "product",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "profileid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "promo",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "vjav.com",
+        "vjav.tube"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "promoid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "promotionid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shopee.co.id",
+        "shopee.co.th",
+        "shopee.ph"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "proxyreferer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ps_partner_key",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ps_xid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pscd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "psid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "psprogram",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "pstool",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ptag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ptl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "hhdotru"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "pub_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "publication_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "publish_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "shopee"
+      ],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shopee.co.id",
+        "shopee.co.th",
+        "shopee.ph"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "pwsvid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "px",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "py",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "q",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "20minutos.es",
+        "alternate.de",
+        "americanas.com.br",
+        "as.com",
+        "bbc.co.uk",
+        "bbc.com",
+        "bestbuy.com",
+        "bhphotovideo.com",
+        "bing.com",
+        "bloomberg.com",
+        "cnbc.com",
+        "cnn.com",
+        "coolblue.nl",
+        "coupang.com",
+        "cyberport.de",
+        "dailymail.co.uk",
+        "danawa.com",
+        "daum.net",
+        "duckduckgo.com",
+        "elcorteingles.es",
+        "elmundo.es",
+        "elpais.com",
+        "epicgames.com",
+        "etsy.com",
+        "exito.com",
+        "facebook.com",
+        "falabella.com",
+        "falabella.com.co",
+        "fb.com",
+        "flipkart.com",
+        "gamestop.com",
+        "github.com",
+        "gitlab.com",
+        "google.com",
+        "imdb.com",
+        "indeed.com",
+        "interpark.com",
+        "kabum.com.br",
+        "kaufland.de",
+        "lenovo.com",
+        "maps.google.com",
+        "marca.com",
+        "meetup.com",
+        "mercadolibre.cl",
+        "mercadolibre.com.ar",
+        "mercadolibre.com.co",
+        "mercadolibre.com.mx",
+        "mercadolivre.com.br",
+        "msn.com",
+        "musinsa.com",
+        "namu.wiki",
+        "netflix.com",
+        "nike.com",
+        "notebooksbilliger.de",
+        "otto.de",
+        "palacio.mx",
+        "paris.cl",
+        "pccomponentes.com",
+        "pinterest.com",
+        "reddit.com",
+        "ripley.cl",
+        "rtve.es",
+        "scholar.google.com",
+        "shein.com",
+        "slickdeals.net",
+        "ssg.com",
+        "stackoverflow.com",
+        "target.com",
+        "thomann.de",
+        "tiktok.com",
+        "tokopedia.com",
+        "trendyol.com",
+        "twitter.com",
+        "vk.com",
+        "walmart.com",
+        "x.com",
+        "zalando.de",
+        "zalando.es"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "query",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "bonprix.de",
+        "docmorris.de",
+        "douglas.de",
+        "fandom.com",
+        "fiverr.com",
+        "mediamarkt.de",
+        "mediamarkt.es",
+        "musimundo.com",
+        "naver.com",
+        "nytimes.com",
+        "oliveyoung.co.kr",
+        "shopping.naver.com",
+        "ssg.com",
+        "twitch.tv",
+        "walmart.com",
+        "wsj.com",
+        "yes24.com"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "r",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "r_area",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ra",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "raneaid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "rakuten",
+        "network": "Rakuten Advertising (LinkShare)"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "rankinghour",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ranmid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "rakuten",
+        "network": "Rakuten Advertising (LinkShare)"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "ransiteid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "rakuten",
+        "network": "Rakuten Advertising (LinkShare)"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "rbtc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rct",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rdc_visitor_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rdr_refr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "realdomain",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "recarea",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "recom",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "vk.com",
+        "vk.ru"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "recommendid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "recruited_by_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "recruiter",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "redirect_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mozilla.org"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "redirected",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_cd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_code",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_content",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_kind",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_no",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_page",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_t",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ref_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "backit.me",
+        "epn.bz"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "refcode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "refer_page_el_sn",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "refer_page_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "refer_page_name",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "refer_page_sn",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "refer_share_channel",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "refer_share_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "refer_share_suin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "refer_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "reference_location",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "referenceid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "referer",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "referid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "referred_by",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "referrer_domain",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "referrer_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "referrercode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "referrersource",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "refined",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "refsrc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook",
+        "twitter",
+        "x"
+      ],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "twitter.com",
+        "x.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "region",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [
+        "tiktok.com"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "relatedarticle",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "request_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "requeststart",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "resource_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "response.id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "response.session",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "responseend",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "responsestart",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rf",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rf_code",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rfr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "realtor.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "rjptk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "indeed"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "rlid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rmai",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rsv_pq",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rsv_t",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rubricalias",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "rurl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "s-id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "item.rakuten.co.jp",
+        "www.rakuten.co.jp"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "s1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "s_mf",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sa_utm_channel",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sa_utm_ci",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sa_utm_tcn",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bing"
+      ],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "dailian.co.kr"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "bing.com"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "sc2id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc_content",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc_e",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc_i",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc_lid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc_llid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc_out",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sc_src",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "scene",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "scid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "rakuten-wallet.co.jp",
+        "rakuten.co.jp"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "scm-url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "aliexpress",
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "alibaba-scm"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sdfid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sdpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "search_domain",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "ya.ru",
+        "yandex.*"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "search_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "ya.ru",
+        "yandex.*"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "sec_uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "seesaa_related",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "send_time",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "serp_position",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "service_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "emart.ssg.com",
+        "m-emart.ssg.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "sess_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sessionid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "settlement",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sfmc_activity_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "salesforce-sfmc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sfmc_activity_name",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "salesforce-sfmc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sfmc_asset_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "salesforce-sfmc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sfmc_channel",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "salesforce-sfmc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sfmc_journey_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "salesforce-sfmc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sfmc_journey_name",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "salesforce-sfmc"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sh",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "forbes.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "share.ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "share_from",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bilibili.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "share_img",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "share_region",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "share_to",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sharedid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sharefrom",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "shareid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sharesource",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "shareuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "shopid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [
+        "bonprix.de"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "shoppingportalenabled",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "shortlink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "show-uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "showid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "showsignuppopup",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "shpxid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "shrsl_analytics_sscid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "shrsl_analytics_sstid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "signature",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "site",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "google"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "site_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "autoplus.fr"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "siteid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "idealo.de"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "siteno",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "emart.ssg.com",
+        "m-emart.ssg.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "sku_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "slot",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "reuters.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "slot_index",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "slref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "smc1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "smc2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "smc5",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "smrcid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sns_share_token",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "social",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "social_share_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "soft",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "source-serpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "source_caller",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "source_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "source_location",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "change.org"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "source_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "spartner",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "office-partner.de"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "easynotebooks.de",
+        "notebook.de"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "spatialtags",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "spec_gallery_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sphrase_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "spmid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "alibaba-spm"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "sr_fr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "src_cna",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "src_internal",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "src_module",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shein.co.uk",
+        "shein.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "src_player",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "src_tab_page_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shein.co.uk",
+        "shein.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [
+        "shein.com"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "src_uin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "srcid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "srcmarker2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "srctype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ss_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ss_pos",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ssspo",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sssrc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sstk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "indeed"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ssuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "state",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "statsuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "stid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "stm_medium",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shopee.co.id",
+        "shopee.co.th",
+        "shopee.ph"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "stm_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "shopee.co.id",
+        "shopee.co.th",
+        "shopee.ph"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "store",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "flipkart"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "stpe",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "style",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sub-campaign",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sub_1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sub_rt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "comemo.nikkei.com",
+        "diehardtales.com",
+        "greenplanet.kaneka.co.jp",
+        "j-yokatsu2.edu.city.uruma.okinawa.jp",
+        "labo.rheos.jp",
+        "note-harumi.sbfoods.co.jp",
+        "note.basicinc.jp",
+        "note.bcnretail.com",
+        "note.calbee.jp",
+        "note.com",
+        "note.gallery.intage.com",
+        "note.jp",
+        "note.kogakuin.ac.jp",
+        "note.minne.com",
+        "note.montblanc.design",
+        "note.nhkso.or.jp",
+        "note.pokkasapporo-fb.jp",
+        "note.roxx.co.jp",
+        "note.smartnews-ads.com",
+        "note.universal-music.co.jp",
+        "note.yamap.com",
+        "note.zochang.com",
+        "refalover-note.mainichi.jp",
+        "shanaiho.itandi.co.jp",
+        "uragawa-note.jpn.panasonic.com",
+        "webtripper.jp"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "subid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "subid1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "subid2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "subid3",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "subpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "suggest_reqid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "suid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "sv1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sv_campaign_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "svlink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sx",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "sy",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "szfrom",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_browse_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_category_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_page_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_request_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_search_query",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_search_query_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_sort_by",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-referrer_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t-src",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "tuta.com",
+        "tutanota.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "t-tap_index",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t_exp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t_lsid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t_network",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t_rid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t_s",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "t_ts",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "taboola_click_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-click_id"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "tag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "alibaba cloud arms",
+        "ceneo.pl"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "tag3",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "decathlon.pl",
+        "ibood.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "tag_ids",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tagtag_uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "taid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "reuters.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "targetedlink",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tbl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "td",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tduid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": true,
+        "pattern": "tradedoubler",
+        "network": "Tradedoubler"
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "telemetry-client-id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "temp_session",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "term",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [
+        "kickstarter.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tg_rhash",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tgp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "th",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "amazon",
+        "amazon search"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "amazon.ca",
+        "amazon.co.jp",
+        "amazon.co.uk",
+        "amazon.com",
+        "amazon.com.au",
+        "amazon.com.br",
+        "amazon.com.mx",
+        "amazon.de",
+        "amazon.es",
+        "amazon.fr",
+        "amazon.in",
+        "amazon.it",
+        "amazon.nl",
+        "amazon.pl",
+        "amazon.se",
+        "amazon.sg"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "tid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "time",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 3,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "timezone",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tksid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tm_hem",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "token",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [
+        "paypal.com"
+      ],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "tokenid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "top",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "top_gallery_url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tpsync",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tqi",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tr_aid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "track",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "track_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trackcode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "vk.com",
+        "vk.ru"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "tracking_cid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tracking_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "tracking_params",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trackingcode",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trackparams",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "traffic_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trafficfrom",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "lazada.com.ph",
+        "lazada.vn"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "traffictype",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "transaction_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "transit_from",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "transition_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "transition_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trcd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trflg",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trial_status",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "triedredirect",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trilibis_emulator_ua",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trip_sub1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_ecs_etag",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_email_type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_event",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_network",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_notif_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_outlook_origin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_thread_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trk_user",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "trkinfo",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": true,
+        "family": "generic-trk"
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ts",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "m.bilibili.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "ts_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tsid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "tst",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "twitchreferral",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "facebook"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "type",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre",
+        "xiaohongshu.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 3,
+      "muga_preserve_conflict_domains": [
+        "aladin.co.kr",
+        "facebook.com",
+        "github.com",
+        "gitlab.com",
+        "nytimes.com",
+        "reddit.com",
+        "thomann.de",
+        "twitch.tv"
+      ],
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
+    },
+    {
+      "name": "typeform-source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "u",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "LinkedIn Learning",
+        "tweakers"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "u1",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "walmart.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "u2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "uclick_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-click_id"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "uds",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ug_btm",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ui",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "uiaid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "uid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "alibaba cloud arms"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "uid.p",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "uin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "um",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "umt_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "union_lens",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "taobao.com",
+        "tmall.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "uniqueid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "gamespot.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "uniqueuserid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "up_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "bilibili.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "upsellorderorigin",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "uri",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "urischeme",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "url",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "url_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "url_src",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "urrad",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "belta.co.jp",
+        "u-s-s.jp"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "us",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "user_agent",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "user_flow",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "userid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "usi",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "usrclk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "usrclk_searchlistcassette",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "utm",
+      "clearurls_global": true,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "utm-term",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "utmid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "utml_campaign",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "utmtoken",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "utparam",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "taobao.com",
+        "tmall.com"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "v",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "mercadolibre"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "facebook.com",
+        "fb.com",
+        "youtube.com"
+      ],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "v_p",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "valid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "var",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "variant",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "veb",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vep",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ver",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "version",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": true,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
+    },
+    {
+      "name": "vfrm",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vfrmblk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vfrmrst",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "via",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "viewing_source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vis",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "visitor_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "visitor_status",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "visitorid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vktop",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vqd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "vtr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "wa_ref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "waad",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "nikkei"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "wadd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "wbapianalysisoriuicodes",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "web_only",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "web_src",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "weibo_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "weibo"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "wentrysource",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "wgexpiry",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [
+        "decathlon.pl",
+        "ibood.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "wgu",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "decathlon.pl",
+        "ibood.com"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "widget_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "widgetid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "widht",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "workflow",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "wpid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "wprov",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "wr",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "wt_af",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "wt_cd",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "wt_ds",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "wt_gl",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "wt_inf",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "wt_mc",
+      "clearurls_global": true,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": true,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "excluded_affiliate_preserve"
+    },
+    {
+      "name": "wt_pc",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "wt_so",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "webtrekk-wt"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    },
+    {
+      "name": "wtrackid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "x-a-medium",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "x-clickref",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "x-source",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "x_hk",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "x_imp",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xadid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xcust",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xdm_c",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xdm_e",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xdm_p",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xhuserid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [
+        "prvnizpravy.cz"
+      ],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "xid_param_2",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xmktid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xmt",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": false,
+      "adguard_scoped_domains": [
+        "threads.com",
+        "threads.net"
+      ],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "domain_scoped"
+    },
+    {
+      "name": "xuid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 1,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "xvcid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ym_tracking_id",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "yredirect",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "ytwchpos",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "z",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": true,
+      "genericness_score": 2,
+      "muga_preserve_conflict_domains": [
+        "maps.google.com",
+        "vk.com"
+      ],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "zdroj",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": false,
+        "pattern": null
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "needs_human"
+    },
+    {
+      "name": "zrclid",
+      "clearurls_global": false,
+      "clearurls_scoped_domains": [],
+      "adguard_global": true,
+      "adguard_scoped_domains": [],
+      "is_affiliate_preserve": false,
+      "is_danger_name": false,
+      "affiliate_network_match": {
+        "matched": false,
+        "pattern": null,
+        "network": null
+      },
+      "tracking_vendor_match": {
+        "matched": true,
+        "pattern": "generic-clid"
+      },
+      "tracking_prefix_family": {
+        "matched": false,
+        "family": null
+      },
+      "known_functional_risk": false,
+      "genericness_score": 0,
+      "muga_preserve_conflict_domains": [],
+      "bucket": "universal_high_confidence"
+    }
+  ]
+}

--- a/tools/import-candidates/triage-2026-07-05.md
+++ b/tools/import-candidates/triage-2026-07-05.md
@@ -1,0 +1,1258 @@
+# Import-candidate triage (2026-07-05), v2.1
+
+Source: AdGuard Filter 17 (URL Tracking Protection) (https://filters.adtidy.org/extension/chromium/filters/17.txt), report fetched at 2026-07-05T07:27:21.158Z.
+Candidate report file: C:\Users\parada\Desktop\test\muga\tools\import-candidates\report-2026-07-05.json
+
+## Data source availability
+
+- AdGuard raw: live (signals available)
+- ClearURLs raw: live (signals available)
+
+## Counts
+
+- Total candidates in input report: 1404
+- Already in MUGA (dropped from triage, counted only): 296
+- excluded_affiliate_preserve: 18
+- affiliate_network_review: 37
+- universal_high_confidence: 43
+- domain_scoped: 161
+- needs_human: 822
+- likely_reject: 27
+
+## Methodology (v2.1)
+
+MUGA has two strip mechanisms: universal (TRACKING_PARAMS / tracking-params.json DNR,
+stripped on every site) and domain-scoped (domain-rules.json, stripped only on named
+domains). Universal strip is reserved for unambiguous cross-site tracking params, since a
+bulk-add of short/generic names to the universal list previously caused a real
+false-positive regression (issue #1006).
+
+v1 additionally had a safety defect: it could promote an affiliate-redirect-network landing
+param (irclickid, cjevent, awc) into a strippable bucket, which would destroy creator
+commission on first-touch landings (test guard #815). v2 fixed this and added a hard danger
+list for load-bearing functional names, plus a single broadened vendor-signal list.
+
+v2.1 fixes a defect in that vendor-signal list: it conflated pure tracking/ad-platform
+vendors with affiliate-NETWORK vendors, so it promoted affiliate-network attribution params
+straight to universal_high_confidence. Confirmed regression under v2: cj_aid, cj_pid,
+awinaffid, af_id, af_channel, adj_adgroup, adj_deeplink, impact_click_id, and impact_ad_id
+were all in universal_high_confidence. impact_click_id is especially dangerous: it belongs
+to Impact Radius, the exact same network whose irclickid/irgwc/iclid landing params are
+already preserved by FIX 1 (test guard #815). v2.1 splits the vendor-signal list in two
+(TRACKING_VENDOR_PATTERNS, safe for universal; AFFILIATE_NETWORK_PATTERNS, routed to human
+review) and adds a new `affiliate_network_review` bucket, checked before the universal path.
+
+Distinction rule: ad-PLATFORM click ids (gclid, fbclid-family, msclkid, ttclid, twclid, ...)
+are the advertiser's own tracking, so they are SAFE to strip universally: no creator
+commission is at stake. Affiliate-NETWORK params (CJ, Awin, Impact Radius, Rakuten, Admitad,
+Partnerize, Tradedoubler, AppsFlyer, Adjust, Airbridge, Branch, generic affiliate markers)
+route commission to a content creator/publisher, so stripping them can rob attribution --
+these always go to human review, never straight to universal.
+
+Every surviving candidate (not already covered by MUGA) is classified with this exact
+precedence, checked IN THIS ORDER:
+
+### FIX 1 (runs first, before any other check)
+
+Any candidate whose lowercased name exactly matches an entry in the affiliate-preserve set
+is routed to `excluded_affiliate_preserve` and processing STOPS for that candidate: it can
+never reach universal_high_confidence, domain_scoped, needs_human, or likely_reject. This
+catches every param a redirect network (Awin, CJ Affiliate, Impact Radius, and so on) reads
+at landing to populate the merchant's first-party attribution cookie.
+
+The affiliate-preserve set is built dynamically from every `landingParams` entry across all
+`REDIRECT_NETWORK_PATTERNS` entries in src/lib/affiliates.js (re-exported from
+src/lib/redirect-networks.js). No distinct "honor creator referral" param set was found
+beyond landingParams (src/lib/honor-creator.js's shouldHonor() is about wrapper-URL
+pass-through, not a param-name preserve list), so the set below is landingParams only.
+
+Affiliate-preserve set used this run (26 params):
+
+`a8`, `admitad_uid`, `adref`, `aff_request_id`, `aff_trace_key`, `algo_expid`, `algo_pvid`, `awc`, `btsid`, `cjdata`, `cjevent`, `clickref`, `iclid`, `irclickid`, `irgwc`, `pubref`, `raneaid`, `ranmid`, `ransiteid`, `tagtag_uid`, `tduid`, `ttaid`, `ttcid`, `ttrk`, `ws_ab_test`, `wt_mc`
+
+### FIX 2 (runs second, only for candidates not caught by FIX 1)
+
+Hard danger list of load-bearing functional param names. A match here can NEVER reach
+universal_high_confidence:
+
+- if scoped attribution exists (adguard_scoped_domains or clearurls_scoped_domains
+  non-empty) -> `domain_scoped`, with `caution: "functional-name"`.
+- else -> `likely_reject` (reason: load-bearing functional name, unsafe to strip
+  universally, no domain scope).
+
+Danger list used this run (45 names, exactly as specified, no
+extensions -- the actual 2026-07-05 candidate batch was checked for present near-duplicates
+such as simple plurals and none were found):
+
+`action`, `callback`, `code`, `country`, `date`, `email`, `format`, `host`, `id`, `ip`, `key`, `lang`, `locale`, `login`, `method`, `next`, `nonce`, `os`, `page`, `path`, `q`, `query`, `redirect`, `redirect_uri`, `region`, `return`, `s`, `session`, `sessionid`, `sid`, `sig`, `signature`, `sort`, `state`, `time`, `token`, `type`, `uri`, `url`, `user`, `userid`, `variant`, `ver`, `version`, `view`
+
+### v2.1 NEW GATE (runs third, only for candidates not caught by FIX 1 or FIX 2)
+
+Affiliate-network gate. A match against `AFFILIATE_NETWORK_PATTERNS` always routes to
+`affiliate_network_review`, tagged with the matched network, and can NEVER reach
+`universal_high_confidence`. This runs BEFORE FIX 3's universal path, so an affiliate-network
+name that also happens to match a tracking-vendor pattern (for example impact_click_id also
+matching the generic click_id family) is still routed here, never to universal.
+
+AFFILIATE_NETWORK_PATTERNS used this run (13 entries,
+grouped by network; see the script for the one-line rationale documented per entry):
+
+- **CJ Affiliate (Commission Junction)**: `cj-prefix`, `cj-commission`
+- **Awin**: `awin`
+- **Impact Radius**: `impact-prefix`
+- **Rakuten Advertising (LinkShare)**: `rakuten`
+- **Admitad**: `admitad`
+- **Partnerize (Performance Horizon)**: `partnerize`
+- **Tradedoubler**: `tradedoubler`
+- **AppsFlyer**: `appsflyer-af`
+- **Adjust**: `adjust`
+- **Airbridge**: `airbridge`
+- **Branch**: `branch`
+- **Generic affiliate marker**: `generic-affiliate`
+
+### FIX 3 (runs fourth, only for candidates not caught by FIX 1, FIX 2, or the
+affiliate-network gate)
+
+- `universal_high_confidence` if: (adguard_global AND clearurls_global) OR (adguard_global
+  AND tracking_vendor_match.matched).
+- else if scoped attribution exists -> `domain_scoped`.
+- else if any global attribution exists (adguard_global OR clearurls_global) ->
+  `needs_human`.
+- else -> `likely_reject` (reason: no corroborating tracking evidence in either source).
+
+The tracking-vendor set is pure tracking/analytics/ad-platform/storefront vendors only (no
+affiliate-network vendors, split out in v2.1; see the gate above), used as a positive
+corroborating signal alongside an AdGuard global claim:
+
+`utm`, `mtm`, `piwik-pro-pk`, `mailchimp-mc`, `hubspot`, `ga-linker`, `gclid`, `dclid`, `gbraid`, `wbraid`, `msclkid`, `ttclid`, `twclid`, `yclid`, `igshid`, `generic-clid`, `generic-clickid`, `generic-click_id`, `taboola`, `outbrain`, `dicbo`, `criteo`, `reddit-rdt`, `salesforce-sfmc`, `webtrekk-wt`, `etracker-etcc`, `matomo`, `piwik`, `gemius`, `aliexpress-oak`, `alibaba-spm`, `alibaba-scm`, `marketo-mkt`, `ebay-mkwid`, `ebay-mkevt`, `adobe-efid`, `adobe-s-kwcid`, `cmpid`, `ncid`
+
+Each surviving candidate is also annotated with legacy/informational fields carried over
+from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_risk`,
+`genericness_score`. These remain for reviewer context only.
+
+## excluded_affiliate_preserve (18)
+
+- `a8`
+- `admitad_uid`
+- `adref`
+- `aff_trace_key`
+- `algo_pvid`
+- `awc`
+- `cjdata`
+- `cjevent`
+- `clickref`
+- `iclid`
+- `irclickid`
+- `irgwc`
+- `raneaid`
+- `ranmid`
+- `ransiteid`
+- `tagtag_uid`
+- `tduid`
+- `wt_mc`
+
+## affiliate_network_review (37)
+
+- `adj_adgroup` (network: Adjust)
+- `adj_adnomia_click_id` (network: Adjust)
+- `adj_deep_link` (network: Adjust)
+- `adj_deeplink` (network: Adjust)
+- `adj_event_callback_dn2j7g_5mdnim` (network: Adjust)
+- `adj_install_callback` (network: Adjust)
+- `adjust_deeplink` (network: Adjust)
+- `af_assettype_id` (network: AppsFlyer)
+- `af_channel` (network: AppsFlyer)
+- `af_creative_id` (network: AppsFlyer)
+- `af_id` (network: AppsFlyer)
+- `af_lnk` (network: AppsFlyer)
+- `af_permalink_id` (network: AppsFlyer)
+- `af_placement_id` (network: AppsFlyer)
+- `af_reengagement_window` (network: AppsFlyer)
+- `af_rid` (network: AppsFlyer)
+- `aff` (network: Generic affiliate marker)
+- `aff_c` (network: Generic affiliate marker)
+- `aff_click_id` (network: Generic affiliate marker)
+- `aff_model` (network: Generic affiliate marker)
+- `aff_short_key` (network: Generic affiliate marker)
+- `aff_sub2` (network: Generic affiliate marker)
+- `aff_sub3` (network: Generic affiliate marker)
+- `aff_sub4` (network: Generic affiliate marker)
+- `aff_sub5` (network: Generic affiliate marker)
+- `aff_track` (network: Generic affiliate marker)
+- `affid` (network: Generic affiliate marker)
+- `affiliate` (network: Generic affiliate marker)
+- `airbridge_referrer` (network: Airbridge)
+- `awinaffid` (network: Awin)
+- `cj_aid` (network: CJ Affiliate (Commission Junction))
+- `cj_pid` (network: CJ Affiliate (Commission Junction))
+- `impact_ad_id` (network: Impact Radius)
+- `impact_click_id` (network: Impact Radius)
+- `impact_product_sku` (network: Impact Radius)
+- `partnerid` (network: Partnerize (Performance Horizon))
+- `partnerizecampaignid` (network: Partnerize (Performance Horizon))
+
+## universal_high_confidence (43)
+
+- `_oak_freesia_scene`
+- `_oak_gallery_order`
+- `_oak_mp_inf`
+- `_oak_page_source`
+- `_oak_rec_ext_1`
+- `_oak_region`
+- `adclid`
+- `afclid`
+- `amc`
+- `cnxclid`
+- `dicbo`
+- `dsp_click_id`
+- `etcc_cmp`
+- `etcc_med`
+- `etcc_produkt`
+- `ga_account`
+- `gemius_identifier`
+- `gs_l`
+- `matomo`
+- `mc`
+- `mc_pc`
+- `mclid`
+- `ncid`
+- `nend_click_id`
+- `scm-url`
+- `sfmc_activity_id`
+- `sfmc_activity_name`
+- `sfmc_asset_id`
+- `sfmc_channel`
+- `sfmc_journey_id`
+- `sfmc_journey_name`
+- `spmid`
+- `taboola_click_id`
+- `uclick_id`
+- `utm`
+- `wt_af`
+- `wt_cd`
+- `wt_ds`
+- `wt_gl`
+- `wt_inf`
+- `wt_pc`
+- `wt_so`
+- `zrclid`
+
+## domain_scoped (161)
+
+- `a_aid` (domains: affiliate.privatevpn.com, expressvpn.com, vpnarea.com, wook.pt)
+- `abtest` (domains: taobao.com, tmall.com)
+- `acampid` (domains: bestbuy.com)
+- `acm` (domains: lazada.com.ph, lazada.vn, taobao.com, tmall.com)
+- `actionid` (domains: otto.de, ottoversand.at)
+- `adcref` (domains: facebook, fafit24.de)
+- `affiliateid` (domains: otto.de, ottoversand.at)
+- `aid` (domains: adgardvpn-help.*, adguard-dns.io, adguard-vpn.*, adguard.com, adguard.info)
+- `ali_trackid` (domains: taobao.com, tmall.com)
+- `anid` (domains: reuters.com)
+- `apppopyn` (domains: emart.ssg.com, m-emart.ssg.com)
+- `ascsubtag` (domains: amazon, amazon search)
+- `bid` (domains: fafit24.de, google)
+- `bidtype` (domains: google)
+- `bitcampaigncode` (domains: google)
+- `c_ad` (domains: mercadolibre)
+- `c_app` (domains: mercadolibre)
+- `c_app_from` (domains: mercadolibre)
+- `c_bm` (domains: mercadolibre)
+- `c_dt` (domains: mercadolibre)
+- `c_ex` (domains: mercadolibre)
+- `c_id` (domains: mercadolibre)
+- `c_sys` (domains: mercadolibre)
+- `c_try` (domains: mercadolibre)
+- `c_u` (domains: mercadolibre)
+- `c_ut` (domains: mercadolibre)
+- `c_ver` (domains: mercadolibre)
+- `c_wh` (domains: mercadolibre)
+- `campid` (domains: otto.de, ottoversand.at)
+- `channable` (domains: easynotebooks.de, notebook.de)
+- `ckwhere` (domains: emart.ssg.com, m-emart.ssg.com)
+- `clickorigin` (domains: argos.co.uk)
+- `clicktrackinfo` (domains: lazada, lazada.com.ph, lazada.vn)
+- `code` (domains: alibaba cloud arms) [caution: functional-name]
+- `cookie` (domains: amazon, amazon search)
+- `cooper` (domains: sbs.co.kr)
+- `cvrid` (domains: decathlon.pl)
+- `cvrpid` (domains: decathlon.pl)
+- `cvrsid` (domains: decathlon.pl)
+- `cxt` (domains: twitter.com, x.com)
+- `did` (domains: lazada)
+- `dmmref` (domains: dmm.co.jp, dmm.com, facebook)
+- `dt_dapp` (domains: 163.com, douban.com, weibo)
+- `ecid` (domains: deeplearning.ai)
+- `email` (domains: dailycodingproblem.com) [caution: functional-name]
+- `entrypoint` (domains: accounts.firefox.com)
+- `epi` (domains: microsoft.com, xbox.com)
+- `fm` (domains: flipkart)
+- `from_country` (domains: shein.co.uk, shein.com)
+- `gs_lcrp` (domains: google)
+- `i3_ord` (domains: dmm.co.jp, dmm.com)
+- `i3_ref` (domains: dmm.co.jp, dmm.com)
+- `i_cid` (domains: nikkei)
+- `ici` (domains: shein.co.uk, shein.com)
+- `iid` (domains: flipkart)
+- `iref` (domains: facebook, zoho.com)
+- `jumpreferrer` (domains: facebook)
+- `keywords` (domains: amazon)
+- `l` (domains: mercadolibre)
+- `l-id` (domains: nikki.ne.jp, rakuten.co.jp, rebates.jp)
+- `laz_trackid` (domains: lazada.com.ph, lazada.vn)
+- `link_id` (domains: gog.com, norml.org)
+- `list` (domains: LinkedIn)
+- `log` (domains: billiger.de)
+- `mallcode` (domains: shein.co.uk, shein.com)
+- `mbid` (domains: newyorker.com)
+- `medium` (domains: eonline.com)
+- `mkttid` (domains: lazada.com.ph, lazada.vn)
+- `mpid` (domains: bestbuy.com)
+- `msource` (domains: bilibili.com)
+- `naver` (domains: dt.co.kr)
+- `newsstand` (domains: sportalkorea.com)
+- `ns_fee` (domains: bbc.co.uk, bbc.com)
+- `ns_linkname` (domains: bbc.co.uk, bbc.com)
+- `ns_source` (domains: bbc.co.uk, bbc.com)
+- `nv` (domains: khan.co.kr)
+- `offerlistid` (domains: idealo.de)
+- `oref` (domains: defenseone.com, facebook, govexec.com, nextgov.com, route-fifty.com)
+- `originalreferer` (domains: facebook)
+- `outlink` (domains: sedaily.com)
+- `p` (domains: billiger.de)
+- `page` (domains: alibaba cloud arms) [caution: functional-name]
+- `pg` (domains: fnnews.com)
+- `phfp` (domains: proton.me, protonvpn.com)
+- `phone_code` (domains: shein.co.uk, shein.com)
+- `pid` (domains: alibaba cloud arms, flipkart)
+- `pl` (domains: net-parade.it)
+- `platform` (domains: mozilla.org)
+- `plink` (domains: sbs.co.kr)
+- `position` (domains: mercadolibre)
+- `premiumvisit` (domains: fanfictionero.com, fic.fan, ficbook.net, ficmania.com)
+- `promo` (domains: vjav.com, vjav.tube)
+- `promotionid` (domains: shopee.co.id, shopee.co.th, shopee.ph)
+- `proxyreferer` (domains: facebook)
+- `ptl` (domains: hhdotru)
+- `publish_id` (domains: shopee, shopee.co.id, shopee.co.th, shopee.ph)
+- `recom` (domains: vk.com, vk.ru)
+- `redirect_source` (domains: mozilla.org)
+- `ref_type` (domains: backit.me, epn.bz)
+- `refcode` (domains: facebook)
+- `referenceid` (domains: facebook)
+- `referer` (domains: facebook)
+- `referid` (domains: facebook)
+- `referrercode` (domains: facebook)
+- `referrersource` (domains: facebook)
+- `refined` (domains: facebook)
+- `refsrc` (domains: facebook, twitter, twitter.com, x, x.com)
+- `rid` (domains: realtor.com)
+- `rjptk` (domains: indeed)
+- `s-id` (domains: item.rakuten.co.jp, www.rakuten.co.jp)
+- `sc` (domains: bing, dailian.co.kr)
+- `scene` (domains: taobao.com, tmall.com)
+- `scid` (domains: rakuten-wallet.co.jp, rakuten.co.jp)
+- `search_domain` (domains: ya.ru, yandex.*)
+- `search_source` (domains: ya.ru, yandex.*)
+- `service_id` (domains: emart.ssg.com, m-emart.ssg.com)
+- `sh` (domains: forbes.com)
+- `share_from` (domains: bilibili.com)
+- `sharefrom` (domains: facebook)
+- `site` (domains: google)
+- `site_id` (domains: autoplus.fr)
+- `siteid` (domains: idealo.de)
+- `siteno` (domains: emart.ssg.com, m-emart.ssg.com)
+- `slot` (domains: reuters.com)
+- `slref` (domains: facebook)
+- `source_location` (domains: change.org)
+- `spartner` (domains: easynotebooks.de, notebook.de, office-partner.de)
+- `src_module` (domains: shein.co.uk, shein.com)
+- `src_tab_page_id` (domains: shein.co.uk, shein.com)
+- `sstk` (domains: indeed)
+- `stm_medium` (domains: shopee.co.id, shopee.co.th, shopee.ph)
+- `stm_source` (domains: shopee.co.id, shopee.co.th, shopee.ph)
+- `store` (domains: flipkart)
+- `sub_rt` (domains: comemo.nikkei.com, diehardtales.com, greenplanet.kaneka.co.jp, j-yokatsu2.edu.city.uruma.okinawa.jp, labo.rheos.jp, note-harumi.sbfoods.co.jp, note.basicinc.jp, note.bcnretail.com, note.calbee.jp, note.com, note.gallery.intage.com, note.jp, note.kogakuin.ac.jp, note.minne.com, note.montblanc.design, note.nhkso.or.jp, note.pokkasapporo-fb.jp, note.roxx.co.jp, note.smartnews-ads.com, note.universal-music.co.jp, note.yamap.com, note.zochang.com, refalover-note.mainichi.jp, shanaiho.itandi.co.jp, uragawa-note.jpn.panasonic.com, webtripper.jp)
+- `suid` (domains: taobao.com, tmall.com)
+- `t-src` (domains: tuta.com, tutanota.com)
+- `tag` (domains: alibaba cloud arms, ceneo.pl)
+- `tag3` (domains: decathlon.pl, ibood.com)
+- `taid` (domains: reuters.com)
+- `th` (domains: amazon, amazon search)
+- `trackcode` (domains: vk.com, vk.ru)
+- `tracking_id` (domains: mercadolibre)
+- `trafficfrom` (domains: lazada.com.ph, lazada.vn)
+- `ts` (domains: m.bilibili.com)
+- `twitchreferral` (domains: facebook)
+- `type` (domains: mercadolibre, xiaohongshu.com) [caution: functional-name]
+- `u` (domains: LinkedIn Learning, tweakers)
+- `u1` (domains: walmart.com)
+- `uid` (domains: alibaba cloud arms)
+- `union_lens` (domains: taobao.com, tmall.com)
+- `uniqueid` (domains: gamespot.com)
+- `up_id` (domains: bilibili.com)
+- `urrad` (domains: belta.co.jp, u-s-s.jp)
+- `utparam` (domains: taobao.com, tmall.com)
+- `v` (domains: mercadolibre)
+- `waad` (domains: nikkei)
+- `weibo_id` (domains: weibo)
+- `wgexpiry` (domains: decathlon.pl, ibood.com)
+- `wgu` (domains: decathlon.pl, ibood.com)
+- `xid` (domains: prvnizpravy.cz)
+- `xmt` (domains: threads.com, threads.net)
+
+## needs_human (822)
+
+- `_1ld`
+- `_1lp`
+- `___from_store`
+- `___store`
+- `__da_seqno`
+- `__du__`
+- `__f__`
+- `__removesafearea__`
+- `__rr`
+- `_bdld`
+- `_bg_fs`
+- `_caid`
+- `_csrc_`
+- `_cus_`
+- `_cut_`
+- `_cvid`
+- `_f`
+- `_i`
+- `_lc2_fpi`
+- `_p`
+- `_p_jump_id`
+- `_p_rfs`
+- `_rdt_arg`
+- `_rdt_idx`
+- `_rdt_sid`
+- `_ref`
+- `_refid`
+- `_skw`
+- `_source_`
+- `_tp`
+- `_trans_`
+- `_unique_id`
+- `_x_ads_account`
+- `_x_ads_channel`
+- `_x_ads_creative_id`
+- `_x_ads_id`
+- `_x_ads_set`
+- `_x_ads_sub_channel`
+- `_x_bg_adid`
+- `_x_campaign`
+- `_x_channel_scene`
+- `_x_channel_src`
+- `_x_cid`
+- `_x_from`
+- `_x_ns_catalog_id`
+- `_x_ns_crt_id`
+- `_x_ns_gid`
+- `_x_ns_placement`
+- `_x_ns_product_id`
+- `_x_ns_site_id`
+- `_x_ns_source`
+- `_x_sessn_id`
+- `_x_vst_scene`
+- `a`
+- `ab`
+- `abt_att`
+- `abtestvariant`
+- `acr`
+- `acrid`
+- `act`
+- `actbtn`
+- `activityid`
+- `ad`
+- `ad_domain`
+- `ad_flag`
+- `ad_params`
+- `ad_provider`
+- `ad_reason_recommended_items`
+- `ad_type`
+- `adblock`
+- `adbnr`
+- `adcampaignid`
+- `adcopy`
+- `adef1043`
+- `adg_ctx`
+- `adgrpid`
+- `adme5101`
+- `adp_cid`
+- `adp_oid`
+- `ads_identity_ads_promo_identity_placement_uid`
+- `ads_identity_ads_promo_identity_site_uid`
+- `ads_params`
+- `adtag`
+- `adtype`
+- `adv`
+- `advert`
+- `advertisementid`
+- `advertiser`
+- `advertising_id`
+- `advertising_tracking_enabled`
+- `adxarea`
+- `affijet-click`
+- `affil`
+- `affiliate_id`
+- `affiliate_ref`
+- `affitest`
+- `affname`
+- `afftrack`
+- `afno`
+- `agentcode`
+- `agentid`
+- `al_imp`
+- `algo_exp_id`
+- `allianceid`
+- `allow_app_redirect`
+- `an`
+- `android_id`
+- `ap`
+- `app_pvid`
+- `appclientid`
+- `appid`
+- `appsignature`
+- `appsrc`
+- `apptype`
+- `apv`
+- `arf`
+- `argsite`
+- `argument`
+- `article_id`
+- `artlist_aid`
+- `asb`
+- `asb2`
+- `asid`
+- `associatetag`
+- `asubid`
+- `at`
+- `atlorigin`
+- `ats`
+- `attribution_code`
+- `attribution_id`
+- `attribution_sig`
+- `attribution_window`
+- `attributionid`
+- `autogen_token`
+- `av`
+- `avtc`
+- `avte`
+- `avts`
+- `banerid`
+- `bannercode`
+- `bc_pid`
+- `bd_vid`
+- `bh`
+- `block`
+- `boosteruid`
+- `brand`
+- `browser_dist`
+- `browser_type`
+- `bvuuid`
+- `bw`
+- `bxsign`
+- `c`
+- `cachekey`
+- `cachesdk`
+- `caff`
+- `caid`
+- `camk`
+- `camp_no`
+- `campaign_id`
+- `campaign_name`
+- `car`
+- `cb_ref_code`
+- `cbqsid`
+- `cexp_id`
+- `cexp_var`
+- `cg_referrer`
+- `ch_anime_ref`
+- `chksm`
+- `cl4url`
+- `clckid`
+- `click`
+- `click_from`
+- `click_metadata`
+- `clickout_id`
+- `client`
+- `client_e`
+- `client_m`
+- `client_t`
+- `client_ver`
+- `clientusertype`
+- `cmd`
+- `cmn_id`
+- `cmnhd_ref`
+- `cmoa`
+- `cmoa_pg`
+- `cnt`
+- `cnt_transit`
+- `cobrand`
+- `collectionid`
+- `compact_view`
+- `contact_id`
+- `courseclaim`
+- `cp_in`
+- `cpt_c`
+- `cpt_m`
+- `cpt_n`
+- `cpt_s`
+- `creative_id`
+- `crv_id`
+- `csource`
+- `ctg`
+- `curpageloguid`
+- `cursor`
+- `cx_art`
+- `cx_clicks_art_mdl`
+- `cx_clicks_sldbox`
+- `d`
+- `data1`
+- `dc_data`
+- `dcsext.recom`
+- `de_utm_source`
+- `deep_link_value`
+- `deeplink`
+- `deferredfl`
+- `destredirecturl`
+- `device_code`
+- `device_type`
+- `devicetype`
+- `devicetypeid`
+- `dmai`
+- `dmid`
+- `dnt`
+- `domcomplete`
+- `domcontentloadedeventend`
+- `domcontentloadedeventstart`
+- `dominteractive`
+- `domloading`
+- `downloadmode`
+- `dpid`
+- `ds_s_kwgid`
+- `dt_id`
+- `dt_platform`
+- `dtm_user_id`
+- `dtp`
+- `dv`
+- `e`
+- `ea_med`
+- `ea_src`
+- `eccid`
+- `ectag`
+- `ecuid`
+- `efr_campaign`
+- `efr_medium`
+- `efr_source`
+- `emcid`
+- `eml-mediaplan`
+- `eml-name`
+- `eml-publisher`
+- `en_txn7`
+- `enctid`
+- `epid`
+- `eqid`
+- `erl`
+- `es`
+- `eurl`
+- `event_id`
+- `eventid`
+- `exc_ads`
+- `experienceid`
+- `exportkey`
+- `ext`
+- `ext.referrer`
+- `externalvisitorid`
+- `extparam`
+- `extra`
+- `extra_params`
+- `f_url`
+- `fb_asc`
+- `fd_bridge_id`
+- `feed_id`
+- `filtered_price`
+- `filterkey`
+- `flow`
+- `flowpath_page_no`
+- `flowpath_page_value`
+- `fm_topics_id`
+- `fmid`
+- `for`
+- `form`
+- `fpcuid`
+- `fpr`
+- `fr`
+- `freesia_scene`
+- `friend`
+- `frm_id`
+- `from_block`
+- `from_button_waterfall_knb`
+- `from_ext`
+- `from_share`
+- `from_sku`
+- `from_spm_id`
+- `from_spmid`
+- `from_srv`
+- `from_url`
+- `fromjk`
+- `fromreminder`
+- `ftid`
+- `g_ccy`
+- `g_clk`
+- `g_ep`
+- `g_lg`
+- `g_region`
+- `g_site`
+- `gacd`
+- `gen`
+- `geoip_country`
+- `getid`
+- `glid`
+- `gspk`
+- `gsxid`
+- `gtmpos`
+- `guid`
+- `height`
+- `hhtmfrom`
+- `history_adids`
+- `history_postids`
+- `hl`
+- `hvadid`
+- `hvbmt`
+- `hvdev`
+- `hvlocphy`
+- `hvnetw`
+- `hvqmt`
+- `hvrand`
+- `hvtargid`
+- `hydadcr`
+- `i`
+- `i2af`
+- `i6`
+- `iasid`
+- `icid`
+- `icm`
+- `icmp`
+- `idealoid`
+- `identifier`
+- `ig_rid`
+- `ikco`
+- `impressionid`
+- `in_id`
+- `index_ref`
+- `infnews`
+- `info`
+- `initialissue`
+- `install_callback`
+- `install_id`
+- `interactionsessionid`
+- `intpr`
+- `intpr2`
+- `ip_address`
+- `is`
+- `is_mobile`
+- `isdramintegrated`
+- `isfreemail`
+- `ismcid`
+- `isshortened`
+- `isss`
+- `isuser`
+- `itid`
+- `itmmeta`
+- `itmprp`
+- `itscg`
+- `itsct`
+- `iurl`
+- `jd`
+- `jsclck`
+- `jso`
+- `kamigame_source`
+- `kampan`
+- `karea`
+- `key5sk1`
+- `kid`
+- `klay`
+- `km_adgroup`
+- `km_matchtype`
+- `km_partner`
+- `landing`
+- `launchid`
+- `lctg`
+- `lfrom_processed`
+- `lg`
+- `li`
+- `linked_creative_id`
+- `ln`
+- `loadeventend`
+- `loadeventstart`
+- `login-new`
+- `login-source`
+- `login_source`
+- `loginfrom`
+- `loginuin`
+- `lp_fol`
+- `lplid`
+- `ls`
+- `lsadname2`
+- `lsed`
+- `lvrid`
+- `m`
+- `mall_cid`
+- `manager`
+- `marketing-visitor-id`
+- `mcr`
+- `media`
+- `media_source`
+- `meta_redirectid`
+- `mini_signature`
+- `mks_referer_event`
+- `mlid`
+- `modelid`
+- `mp_api_as3_url`
+- `mp_api_as3_url_bck`
+- `mp_api_id`
+- `mp_api_js_url`
+- `mp_api_js_url_bc`
+- `mp_api_js_url_bck`
+- `mp_assets`
+- `mp_embed`
+- `mp_game_assets`
+- `mp_game_embed`
+- `mp_game_id`
+- `mp_game_uid`
+- `mp_game_url`
+- `mp_int`
+- `mp_locale`
+- `mp_player_type`
+- `mp_site_https_url`
+- `mp_site_name`
+- `mp_site_url`
+- `mp_timezone`
+- `mp_view_type`
+- `mpl`
+- `mpr`
+- `mpshare`
+- `mr`
+- `mr_download_reason`
+- `mr_game_version`
+- `mr_loader`
+- `mrk_rec`
+- `ms_rnd`
+- `msid`
+- `msktc`
+- `muclientname`
+- `mwid`
+- `n_tw`
+- `native_mode`
+- `nats`
+- `navigationstart`
+- `nbt`
+- `ncmp`
+- `nettype`
+- `new_session`
+- `news_ref`
+- `newsletter`
+- `nid`
+- `nm_origem`
+- `nm_ranking_rec`
+- `nsc`
+- `nsgid`
+- `nt_redirect_referrer`
+- `nvuuid`
+- `octid`
+- `oe`
+- `oem`
+- `offer_id`
+- `offerid`
+- `offerkey`
+- `oiid`
+- `old`
+- `openexternalbrowser`
+- `operation`
+- `orig_ref`
+- `origin_referer`
+- `origin_referral_type`
+- `original_referer`
+- `osusume_banner`
+- `p_a`
+- `p_c`
+- `p_cid`
+- `p_n`
+- `p_s`
+- `p_source`
+- `p_type`
+- `pageuid`
+- `pageview_id`
+- `pageviewcount`
+- `parent_perf_id`
+- `partner_extra`
+- `partner_id`
+- `partner_slug`
+- `pathway`
+- `pbs`
+- `pbss`
+- `pcat_vnexttracking_localwidget`
+- `pcat_vnexttracking_onlineitrack`
+- `pcat_vnexttracking_onlineplrss`
+- `pcat_vnexttracking_retailerscoring`
+- `pckg_id`
+- `pcpid`
+- `pcscpid`
+- `pd`
+- `perf_id`
+- `persistent_id`
+- `pfm_carac`
+- `pfm_index`
+- `pfm_page`
+- `pfm_pos`
+- `pfm_type`
+- `pfx`
+- `pixelid`
+- `place`
+- `plan`
+- `plateform`
+- `plattr`
+- `playeranalytics`
+- `plid`
+- `post_id`
+- `pr`
+- `pr-campaign`
+- `pr-medium`
+- `pr-source`
+- `prelink`
+- `previous_page`
+- `prnd`
+- `product`
+- `profileid`
+- `promoid`
+- `ps_partner_key`
+- `ps_xid`
+- `pscd`
+- `psid`
+- `psprogram`
+- `pstool`
+- `ptag`
+- `pub_id`
+- `publication_id`
+- `pwsvid`
+- `px`
+- `py`
+- `r`
+- `r_area`
+- `ra`
+- `rankinghour`
+- `rbtc`
+- `rct`
+- `rd`
+- `rdc_visitor_id`
+- `rdr_refr`
+- `realdomain`
+- `recarea`
+- `recommendid`
+- `recruited_by_id`
+- `recruiter`
+- `redirected`
+- `ref_cd`
+- `ref_code`
+- `ref_content`
+- `ref_id`
+- `ref_kind`
+- `ref_no`
+- `ref_page`
+- `ref_t`
+- `refer_page_el_sn`
+- `refer_page_id`
+- `refer_page_name`
+- `refer_page_sn`
+- `refer_share_channel`
+- `refer_share_id`
+- `refer_share_suin`
+- `refer_source`
+- `reference_location`
+- `referred_by`
+- `referrer_domain`
+- `referrer_url`
+- `relatedarticle`
+- `request_id`
+- `requeststart`
+- `resource_id`
+- `response.id`
+- `response.session`
+- `responseend`
+- `responsestart`
+- `rf`
+- `rf_code`
+- `rfr`
+- `rlid`
+- `rmai`
+- `rp`
+- `rsv_pq`
+- `rsv_t`
+- `rubricalias`
+- `rurl`
+- `s1`
+- `s_mf`
+- `sa_utm_channel`
+- `sa_utm_ci`
+- `sa_utm_tcn`
+- `sc2id`
+- `sc_content`
+- `sc_e`
+- `sc_i`
+- `sc_lid`
+- `sc_llid`
+- `sc_out`
+- `sc_src`
+- `sdfid`
+- `sdpid`
+- `sec_uid`
+- `seesaa_related`
+- `send_time`
+- `serp_position`
+- `sess_id`
+- `settlement`
+- `share.ref`
+- `share_img`
+- `share_region`
+- `share_to`
+- `sharedid`
+- `shareid`
+- `sharesource`
+- `shareuid`
+- `shopid`
+- `shoppingportalenabled`
+- `shortlink`
+- `show-uid`
+- `showid`
+- `showsignuppopup`
+- `shpxid`
+- `shrsl_analytics_sscid`
+- `shrsl_analytics_sstid`
+- `sku_id`
+- `slot_index`
+- `smc1`
+- `smc2`
+- `smc5`
+- `smrcid`
+- `sns_share_token`
+- `social`
+- `social_share_type`
+- `soft`
+- `source-serpid`
+- `source_caller`
+- `source_id`
+- `source_type`
+- `spatialtags`
+- `spec_gallery_id`
+- `sphrase_id`
+- `sr_fr`
+- `src_cna`
+- `src_internal`
+- `src_player`
+- `src_uin`
+- `srcid`
+- `srcmarker2`
+- `srctype`
+- `ss_id`
+- `ss_pos`
+- `ssspo`
+- `sssrc`
+- `ssuid`
+- `statsuid`
+- `stid`
+- `stpe`
+- `style`
+- `sub-campaign`
+- `sub_1`
+- `subid`
+- `subid1`
+- `subid2`
+- `subid3`
+- `subpid`
+- `suggest_reqid`
+- `sv1`
+- `sv_campaign_id`
+- `svlink`
+- `sx`
+- `sy`
+- `szfrom`
+- `t-id`
+- `t-referrer_browse_type`
+- `t-referrer_category_id`
+- `t-referrer_page_type`
+- `t-referrer_request_id`
+- `t-referrer_search_query`
+- `t-referrer_search_query_source`
+- `t-referrer_sort_by`
+- `t-referrer_source`
+- `t-source`
+- `t-tap_index`
+- `t_exp`
+- `t_lsid`
+- `t_network`
+- `t_ref`
+- `t_rid`
+- `t_s`
+- `t_ts`
+- `tag_ids`
+- `targetedlink`
+- `tbl`
+- `td`
+- `telemetry-client-id`
+- `temp_session`
+- `term`
+- `tg`
+- `tg_rhash`
+- `tgp`
+- `tid`
+- `timezone`
+- `tksid`
+- `tm_hem`
+- `tokenid`
+- `top`
+- `top_gallery_url`
+- `tpsync`
+- `tqi`
+- `tr_aid`
+- `track`
+- `track_id`
+- `tracking_cid`
+- `tracking_params`
+- `trackingcode`
+- `trackparams`
+- `traffic_source`
+- `traffictype`
+- `transaction_id`
+- `transit_from`
+- `transition_id`
+- `transition_type`
+- `trcd`
+- `trflg`
+- `trial_status`
+- `trid`
+- `triedredirect`
+- `trilibis_emulator_ua`
+- `trip_sub1`
+- `trk_ecs_etag`
+- `trk_email_type`
+- `trk_event`
+- `trk_network`
+- `trk_notif_id`
+- `trk_outlook_origin`
+- `trk_thread_id`
+- `trk_user`
+- `trkinfo`
+- `ts_id`
+- `tsid`
+- `tst`
+- `typeform-source`
+- `u2`
+- `uds`
+- `ug_btm`
+- `ui`
+- `uiaid`
+- `uid.p`
+- `uin`
+- `um`
+- `umt_source`
+- `uniqueuserid`
+- `upsellorderorigin`
+- `urischeme`
+- `url_id`
+- `url_src`
+- `us`
+- `user_agent`
+- `user_flow`
+- `usi`
+- `usrclk`
+- `usrclk_searchlistcassette`
+- `utm-term`
+- `utmid`
+- `utml_campaign`
+- `utmtoken`
+- `v_p`
+- `valid`
+- `var`
+- `veb`
+- `vep`
+- `vfrm`
+- `vfrmblk`
+- `vfrmrst`
+- `via`
+- `viewing_source`
+- `vis`
+- `visitor_id`
+- `visitor_status`
+- `visitorid`
+- `vk`
+- `vktop`
+- `vqd`
+- `vtr`
+- `wa_ref`
+- `wadd`
+- `wbapianalysisoriuicodes`
+- `web_only`
+- `web_src`
+- `wentrysource`
+- `widget_id`
+- `widgetid`
+- `widht`
+- `workflow`
+- `wpid`
+- `wprov`
+- `wr`
+- `wtrackid`
+- `x-a-medium`
+- `x-clickref`
+- `x-source`
+- `x_hk`
+- `x_imp`
+- `xadid`
+- `xcust`
+- `xdm_c`
+- `xdm_e`
+- `xdm_p`
+- `xhuserid`
+- `xid_param_2`
+- `xmktid`
+- `xuid`
+- `xvcid`
+- `ym_tracking_id`
+- `yredirect`
+- `ytwchpos`
+- `z`
+- `zdroj`
+
+## likely_reject (27)
+
+- `action` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `country` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `date` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `host` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `id` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `ip` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `key` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `locale` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `login` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `method` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `nonce` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `os` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `path` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `q` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `query` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `region` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `sessionid` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `signature` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `state` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `time` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `token` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `uri` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `url` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `userid` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `variant` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `ver` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `version` -- load-bearing functional name, unsafe to strip universally, no domain scope
+

--- a/tools/import-candidates/triage.mjs
+++ b/tools/import-candidates/triage.mjs
@@ -1,0 +1,1315 @@
+/**
+ * MUGA import-candidates triage (#998, Phase 0, v2.1).
+ *
+ * A weekly auto-import bot flattens AdGuard Filter 17's $removeparam rules
+ * into a flat candidate list (tools/import-candidates/report-*.json). Many
+ * of those names are short or generic and are functional on some sites
+ * (search query, pagination, sort order, and similar), so they must never be
+ * bulk-added to the universal strip list (TRACKING_PARAMS /
+ * src/rules/tracking-params.json). Doing that caused a real false-positive
+ * regression previously (issue #1006).
+ *
+ * v1 additionally had three safety defects: it could promote an affiliate
+ * click-ID that a redirect network reads at landing (irclickid, cjevent,
+ * awc) into a strippable bucket, which would silently destroy creator
+ * commission on first-touch landings (test guard #815). v2 fixed this by
+ * checking an affiliate-preserve exclusion FIRST, before any other signal,
+ * and added a hard danger list for load-bearing functional names plus a
+ * broadened vendor-signal set for corroborating single-source global
+ * attribution.
+ *
+ * v2.1 fixes a defect in that broadened vendor-signal set: it conflated pure
+ * tracking/ad-platform vendors (safe to strip on every site) with
+ * affiliate-NETWORK vendors (whose params can carry creator/publisher
+ * commission attribution the same way the FIX 1 preserve set does).
+ * Confirmed regression: cj_aid, cj_pid, awinaffid, af_id, af_channel,
+ * adj_adgroup, adj_deeplink, impact_click_id, and impact_ad_id were all
+ * reaching universal_high_confidence under v2. impact_click_id is
+ * particularly dangerous: it belongs to Impact Radius, the exact same
+ * network whose irclickid/irgwc/iclid landing params are already preserved
+ * (test guard #815). v2.1 splits the single vendor-signal list into
+ * TRACKING_VENDOR_PATTERNS (pure tracking/analytics/ad-platform/storefront,
+ * safe to promote to universal) and AFFILIATE_NETWORK_PATTERNS
+ * (creator/affiliate attribution risk, routed to human review instead), and
+ * adds a new affiliate_network_review bucket that is checked before the
+ * universal path.
+ *
+ * The distinction: ad-PLATFORM click IDs (gclid, fbclid, msclkid, ttclid,
+ * ...) are the advertiser's own tracking and are safe to strip universally,
+ * because no creator commission is at stake. Affiliate-NETWORK params
+ * (cj_ prefix, awin, impact_ prefix, af_ prefix AppsFlyer, adj_ prefix
+ * Adjust, rakuten, admitad, partnerize, tradedoubler, airbridge, branch,
+ * generic aff/affid/affiliate markers) route commission to a content
+ * creator/publisher, so stripping
+ * them can rob attribution; these always go to human review, never
+ * straight to universal.
+ *
+ * This script re-derives per-candidate evidence from two independent signal
+ * sources (AdGuard Filter 17 raw text, ClearURLs rules database), cross
+ * references MUGA's two strip mechanisms for dedup, and buckets every
+ * surviving candidate into one of six reviewer queues:
+ *
+ *   - excluded_affiliate_preserve: never touch, this is a redirect-network
+ *     landing param required for creator/affiliate attribution.
+ *   - affiliate_network_review: matches a known affiliate-network vendor
+ *     (v2.1, NEW). Never universal; a human must decide preserve vs strip
+ *     vs domain-scope per network.
+ *   - universal_high_confidence: safe for TRACKING_PARAMS (every site).
+ *   - domain_scoped: safe for domain-rules.json (named domains only).
+ *   - needs_human: signals conflict or are too weak to auto-decide.
+ *   - likely_reject: no real tracking evidence, probably a functional param
+ *     (or a load-bearing functional name with only global/no attribution).
+ *
+ * MUGA has two strip mechanisms (see CONTEXT.md):
+ *   - Universal: src/lib/affiliates-data.js (TRACKING_PARAMS) and
+ *     src/rules/tracking-params.json (DNR). Stripped on every site. Reserve
+ *     for unambiguous cross-site tracking params only.
+ *   - Domain-scoped: src/rules/domain-rules.json. Stripped only on named
+ *     domains. The safe home for a param that is tracking on specific sites
+ *     but risky/functional elsewhere.
+ *
+ * This module is READ-ONLY with respect to the live rule files: it never
+ * writes to src/lib/affiliates-data.js, src/lib/affiliates.js,
+ * src/rules/domain-rules.json, or src/rules/tracking-params.json. It only
+ * reads them (and src/lib/redirect-networks.js, via affiliates.js) for
+ * dedup and affiliate-preserve lookups.
+ *
+ * Network fetches (AdGuard raw, ClearURLs raw) are best-effort: any failure
+ * (timeout, DNS, non-2xx) is caught, a warning is logged, and the affected
+ * signal degrades to "no data" (null) rather than crashing the run. Cached
+ * raw files from tools/rule-ingestion/quarantine/ are used as a fallback.
+ * This fallback behavior is unchanged from v1/v2.
+ *
+ * Public API (named exports, no default):
+ *   Pure classification (no I/O, unit-testable without network):
+ *     matchTrackingPrefixFamily(name)       legacy/informational only
+ *     isKnownFunctionalRisk(name)            legacy/informational only
+ *     genericnessScore(name)                 legacy/informational only
+ *     isAffiliatePreserveParam(name)          FIX 1 (v2)
+ *     isDangerName(name)                      FIX 2 (v2)
+ *     matchAffiliateNetwork(name)              v2.1 NEW, checked before FIX 3
+ *     matchTrackingVendor(name)                FIX 3 (v2, split in v2.1)
+ *     classifyCandidate(signals)              v2.1 bucket precedence
+ *     annotateCandidate(name, externalSignals)
+ *   Parsing (pure, given raw text):
+ *     parseAdguardRemoveparamWithDomains(rawText)
+ *     lookupAdguard(index, name)
+ *     buildClearUrlsIndex(rawText)
+ *     lookupClearUrls(index, name)
+ *   I/O (impure, hits disk/network):
+ *     loadCandidateReport(path)
+ *     loadMugaDedupSets()
+ *     fetchAdguardRaw(), fetchClearUrlsRaw()
+ *     runTriage(opts), orchestrates everything and writes the two report files.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { adguardTp } from "../rule-ingestion/adapters/adguard-tp.mjs";
+import { clearurls } from "../rule-ingestion/adapters/clearurls.mjs";
+import { REDIRECT_NETWORK_PATTERNS } from "../../src/lib/affiliates.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Curated triage signal lists (documented, not the live strip rules) ──────
+
+// tracking_prefix_family: known prefixes/patterns for well-established
+// tracking systems. Kept from v1 as an informational/legacy signal only:
+// v2 bucket gating no longer reads this field (see FIX 3's dedicated
+// VENDOR_SIGNAL_PATTERNS below, which supersedes it for bucket decisions).
+/** @type {Array<[string, RegExp]>} */
+const TRACKING_PREFIX_FAMILIES = [
+  ["utm", /^utm_/], // Google/GA campaign parameters (utm_source, utm_medium, ...)
+  ["mailchimp", /^mc_/], // Mailchimp campaign/email tracking (mc_cid, mc_eid)
+  ["piwik-pro", /^pk_/], // Piwik PRO / legacy Piwik campaign tracking (pk_campaign, pk_kwd, pk_source)
+  ["matomo-mtm", /^mtm_/], // Matomo tag-manager campaign tracking
+  ["hubspot", /^hsa_|^_hs/], // HubSpot ad tracking (hsa_*) and email/session tracking (_hsenc, _hsmi, _hstc)
+  ["ga-linker", /^ga_|^_ga$|^_ga_|^_gl$/], // GA4/gtag cross-domain linker params and ga_* variants
+  ["clickid", /(?:^|_)(g|dc|wb|gb|ms|tt|tw|sc|ob)?clid$|clickid$/i], // ad-network click ids: gclid, dclid, wbraid/gbraid, msclkid, ttclid, twclid, fbclid, clickid, and lookalikes
+  ["fbclid-family", /^fb(clid|_action_|_source|_ref)/i], // Meta/Facebook click and campaign attribution
+  ["aliexpress-oak", /(^|_)oak(_|$)/i], // AliExpress oak_ / _oak_ affiliate-adjacent tracking token family
+  ["alibaba-spm-scm", /^(spm|scm)([0-9_].*)?$/i], // Alibaba/AliExpress "super position model" (spm) and scm tracking tokens
+  ["marketo-mkt", /^mkt_|^mkwid$|^mkevt$/i], // Marketo campaign tracking; eBay mkevt/mkwid affiliate-adjacent tracking
+  ["cmpid", /^cmpid$|_cmpid$/i], // generic "campaign id" token used across many ad platforms
+  ["generic-trk", /^trk[a-z_]*$|_trk$/i], // generic "track" token prefix/suffix used across many trackers
+  ["adobe-efid", /^ef_id$/i], // Adobe / Efficient Frontier ad click id
+  ["s-kwcid", /^s_kwcid$/i], // Adobe Analytics paid-search keyword click id
+];
+
+// known_functional_risk: names that are frequently legitimate site
+// functionality (search query, pagination, sort order, language selection,
+// view/tab state, generic ids) on at least some sites. Kept from v1 as an
+// informational/legacy signal only: v2 bucket gating uses the dedicated,
+// broader DANGER_NAMES list (FIX 2) instead of this narrower set.
+//
+// Single- and double-character names (p, q, s, l, t, v, f, d, i, n, m, o, r,
+// k, and so on) are handled generically by the length check below instead of
+// being enumerated one by one: any name that short is too generic to trust
+// blindly regardless of what letter it happens to be.
+const SHORT_GENERIC_LEN_THRESHOLD = 2;
+const KNOWN_FUNCTIONAL_RISK_NAMES = new Set([
+  "id", "page", "sort", "lang", "type", "tab", "view", "from", "ref",
+]);
+
+// genericness score: auxiliary signal only (not a bucket gate in v1 or v2).
+// Higher means "looks more like a coined English/functional word than a
+// tracking token". Simple heuristic: very short names score higher, and
+// membership in a small common-token list adds more. Documented, not
+// exhaustive.
+const COMMON_ENGLISH_TOKENS = new Set([
+  "page", "view", "tab", "type", "sort", "list", "item", "user", "name",
+  "date", "time", "home", "info", "help", "more", "next", "back", "open",
+  "edit", "save", "show", "hide", "from", "search", "query", "ref",
+]);
+
+/**
+ * @param {string} name Candidate param name.
+ * @returns {{ matched: boolean, family: string|null }}
+ */
+export function matchTrackingPrefixFamily(name) {
+  const lower = String(name).toLowerCase();
+  for (const [family, regex] of TRACKING_PREFIX_FAMILIES) {
+    if (regex.test(lower)) return { matched: true, family };
+  }
+  return { matched: false, family: null };
+}
+
+/**
+ * @param {string} name Candidate param name.
+ * @returns {boolean}
+ */
+export function isKnownFunctionalRisk(name) {
+  const lower = String(name).toLowerCase();
+  if (lower.length <= SHORT_GENERIC_LEN_THRESHOLD) return true;
+  return KNOWN_FUNCTIONAL_RISK_NAMES.has(lower);
+}
+
+/**
+ * Auxiliary informational signal, not used to gate buckets.
+ * @param {string} name Candidate param name.
+ * @returns {number}
+ */
+export function genericnessScore(name) {
+  const lower = String(name).toLowerCase();
+  let score = 0;
+  if (lower.length <= 2) score += 2;
+  else if (lower.length <= 4) score += 1;
+  if (COMMON_ENGLISH_TOKENS.has(lower)) score += 2;
+  return score;
+}
+
+// ── v2 FIX 1: affiliate-preserve exclusion set ───────────────────────────────
+//
+// Built dynamically from REDIRECT_NETWORK_PATTERNS in src/lib/affiliates.js
+// (re-exported from src/lib/redirect-networks.js), collecting every
+// `landingParams` entry across every redirect network. These are params a
+// redirect network (Awin, CJ Affiliate, Impact Radius, and so on) reads at
+// the FIRST landing after a click to populate the merchant's first-party
+// attribution cookie. Stripping them universally would destroy creator
+// commission (test guard #815, tests/unit/strip-table-parity.test.mjs).
+//
+// This is dynamic (not hardcoded) so it always tracks the live
+// REDIRECT_NETWORK_PATTERNS table without needing a manual update here.
+//
+// A distinct "honor creator referral" param set (beyond landingParams) was
+// searched for in src/lib/cleaner.js and src/lib/affiliates*.js (shouldHonor,
+// honor, creator, landingParams). The only match is src/lib/honor-creator.js,
+// which decides whether to pass through a *wrapper URL* unmodified
+// (`shouldHonor()`, gated on prefs.honorCreatorMode + detectWrapper() +
+// prefs.creatorAllowlist) -- it is about wrapper redirects (social redirects,
+// link shorteners), not about a param-name preserve list. It does not define
+// any param names distinct from landingParams. So the affiliate-preserve set
+// below is built from landingParams only.
+function buildAffiliatePreserveSet() {
+  const set = new Set();
+  for (const network of REDIRECT_NETWORK_PATTERNS) {
+    for (const p of network.landingParams ?? []) {
+      set.add(String(p).toLowerCase());
+    }
+  }
+  return set;
+}
+
+const AFFILIATE_PRESERVE_SET = buildAffiliatePreserveSet();
+
+/**
+ * @param {string} name Candidate param name.
+ * @returns {boolean} true if this exact name is a redirect-network landing
+ *   param (must never be promoted to any strippable bucket).
+ */
+export function isAffiliatePreserveParam(name) {
+  return AFFILIATE_PRESERVE_SET.has(String(name).toLowerCase());
+}
+
+// ── v2 FIX 2: hard danger list of load-bearing functional param names ───────
+//
+// These names are frequently load-bearing site functionality (search query,
+// pagination, auth/session state, generic identifiers, locale/version
+// selection) on at least some sites. A match here can NEVER reach
+// universal_high_confidence. If the candidate also carries scoped-domain
+// attribution, the domain scope limits the blast radius (domain_scoped,
+// flagged with caution: "functional-name"); with only global or no
+// attribution, it is unsafe to strip anywhere without a human decision
+// (likely_reject).
+//
+// Base list as specified for this triage pass. Checked against the actual
+// 2026-07-05 candidate batch for present near-duplicates (simple plurals
+// such as "ids"/"urls"/"tokens"/"sessions"/"keys"/"codes"/etc.): none were
+// found in that batch, so the list below is used exactly as given, with no
+// extensions.
+const DANGER_NAMES = new Set([
+  "q", "query", "s", "url", "uri", "token", "nonce", "sig", "signature",
+  "state", "code", "login", "id", "key", "session", "sessionid", "sid",
+  "user", "userid", "email", "page", "path", "lang", "locale", "country",
+  "region", "version", "ver", "variant", "type", "sort", "view", "os",
+  "host", "ip", "date", "time", "method", "action", "format", "callback",
+  "redirect", "redirect_uri", "return", "next",
+]);
+
+/**
+ * @param {string} name Candidate param name.
+ * @returns {boolean}
+ */
+export function isDangerName(name) {
+  return DANGER_NAMES.has(String(name).toLowerCase());
+}
+
+// ── v2.1: vendor-signal set split in two ─────────────────────────────────────
+//
+// v2 had a single VENDOR_SIGNAL_PATTERNS list that conflated pure tracking
+// vendors with affiliate-NETWORK vendors, so it promoted affiliate-network
+// attribution params straight to universal_high_confidence (cj_aid, cj_pid,
+// awinaffid, af_id, af_channel, adj_adgroup, adj_deeplink, impact_click_id,
+// impact_ad_id were all confirmed in universal_high_confidence under v2).
+// v2.1 fixes this by splitting the list:
+//
+//   - TRACKING_VENDOR_PATTERNS: pure tracking/analytics/ad-platform/
+//     storefront vendors. No creator commission is at stake, so these are
+//     SAFE to combine with an AdGuard global claim to reach
+//     universal_high_confidence. This includes ad-PLATFORM click ids
+//     (gclid, fbclid-family via generic-clickid/clid, msclkid, ttclid, ...):
+//     the advertiser's own tracking, distinct from affiliate-NETWORK ids.
+//
+//   - AFFILIATE_NETWORK_PATTERNS: vendors that route commission to a
+//     content creator/publisher (CJ, Awin, Impact Radius, Rakuten, Admitad,
+//     Partnerize, Tradedoubler, AppsFlyer, Adjust, Airbridge, Branch, and
+//     generic affiliate markers). A match here can NEVER reach
+//     universal_high_confidence: it is routed to the new
+//     affiliate_network_review bucket for a human preserve-vs-strip-vs-scope
+//     decision per network, the same risk class FIX 1's exact-name preserve
+//     set protects against for redirect-network landing params.
+//
+// Both lists are checked with the same "first match wins, lowercased,
+// substring/prefix regex" convention as v2's single list. A name matching
+// BOTH lists is treated as an affiliate-network match (see classifyCandidate
+// precedence below): the affiliate-network gate is checked before the
+// universal path, so overlap can never leak an affiliate-network name into
+// universal_high_confidence.
+
+/**
+ * Pure tracking/analytics/ad-platform/storefront vendor signal. Positive
+ * corroborating signal for candidates that survive FIX 1, FIX 2, and the
+ * affiliate-network gate. Used only to combine with an AdGuard global claim
+ * to reach universal_high_confidence (see classifyCandidate below) -- never
+ * sufficient by itself.
+ * @type {Array<[string, RegExp]>}
+ */
+const TRACKING_VENDOR_PATTERNS = [
+  ["utm", /^utm_/], // Google/GA campaign parameters
+  ["mtm", /^mtm_/], // Matomo tag-manager campaign tracking
+  ["piwik-pro-pk", /^pk_/], // Piwik PRO / legacy Piwik campaign tracking
+  ["mailchimp-mc", /^mc_/], // Mailchimp campaign/email tracking
+  ["hubspot", /^hsa_|^_hs/], // HubSpot ad tracking and email/session tracking
+  ["ga-linker", /^ga_|^_ga$|^_ga_|^_gl$/], // GA4/gtag cross-domain linker params
+  ["gclid", /^gclid$/], // Google Ads click id, advertiser's own tracking
+  ["dclid", /^dclid$/], // Google Display/DoubleClick click id
+  ["gbraid", /^gbraid$/], // Google Ads iOS-privacy click id
+  ["wbraid", /^wbraid$/], // Google Ads web-to-app click id
+  ["msclkid", /^msclkid$/], // Microsoft/Bing Ads click id
+  ["ttclid", /^ttclid$/], // TikTok Ads click id
+  ["twclid", /^twclid$/], // Twitter/X Ads click id
+  ["yclid", /^yclid$/], // Yandex Direct click id
+  ["igshid", /igshid/], // Instagram share id
+  ["generic-clid", /clid$/], // generic ad-platform click id family (fbclid and lookalikes)
+  ["generic-clickid", /clickid$/], // generic ad-platform click id family
+  ["generic-click_id", /click_id$/], // generic ad-platform click id family
+  ["taboola", /taboola/], // Taboola native-ad platform
+  ["outbrain", /outbrain/], // Outbrain native-ad platform
+  ["dicbo", /dicbo/], // ad-platform click id family
+  ["criteo", /criteo/], // Criteo retargeting/ad platform
+  ["reddit-rdt", /^rdt_/], // Reddit Ads click tracking
+  ["salesforce-sfmc", /^sfmc_/], // Salesforce Marketing Cloud email/campaign tracking
+  ["webtrekk-wt", /^wt_/], // Webtrekk analytics
+  ["etracker-etcc", /etcc/], // etracker analytics
+  ["matomo", /matomo/], // Matomo analytics
+  ["piwik", /piwik/], // Piwik analytics
+  ["gemius", /gemius/], // Gemius analytics
+  ["aliexpress-oak", /_oak/], // AliExpress storefront tracking token, not a redirect-network landing param
+  ["alibaba-spm", /^spm/], // Alibaba/AliExpress "super position model" storefront tracking
+  ["alibaba-scm", /^scm/], // Alibaba/AliExpress storefront tracking
+  ["marketo-mkt", /^mkt_/], // Marketo campaign tracking
+  ["ebay-mkwid", /mkwid/], // eBay marketing/campaign tracking
+  ["ebay-mkevt", /mkevt/], // eBay marketing/campaign tracking
+  ["adobe-efid", /^ef_id$/], // Adobe / Efficient Frontier ad click id
+  ["adobe-s-kwcid", /^s_kwcid$/], // Adobe Analytics paid-search keyword click id
+  ["cmpid", /cmpid/], // generic "campaign id" token used across many ad platforms
+  ["ncid", /ncid/], // generic ad-network campaign id token
+];
+
+/**
+ * Affiliate-NETWORK vendor signal (v2.1 NEW). These vendors pay commission
+ * to a content creator/publisher based on the attribution param surviving
+ * to landing/checkout, the same risk class as FIX 1's exact-name preserve
+ * set. A match here NEVER reaches universal_high_confidence; it always
+ * routes to affiliate_network_review for a human decision. Each entry
+ * documents the network it belongs to (surfaced in the JSON/markdown
+ * report) and a one-line rationale.
+ * @type {Array<[string, RegExp, string]>} [label, regex, networkDisplayName]
+ */
+const AFFILIATE_NETWORK_PATTERNS = [
+  // CJ Affiliate (Commission Junction): cj_-prefixed params carry the CJ
+  // publisher/click attribution chain, same network guarded by the
+  // preserved cjevent/cjdata landing params.
+  ["cj-prefix", /^cj_/, "CJ Affiliate (Commission Junction)"],
+  ["cj-commission", /commission/i, "CJ Affiliate (Commission Junction)"],
+  // Awin: awinaffid is Awin's own affiliate-id attribution param, same
+  // network already preserved via the awc/wt_mc landing params.
+  ["awin", /awin/i, "Awin"],
+  // Impact Radius: impact_-prefixed params belong to the exact same network
+  // whose irclickid/irgwc/iclid landing params are already preserved (test
+  // guard #815); an unenumerated impact_ param is very likely a sibling
+  // attribution token from that network.
+  ["impact-prefix", /^impact_/, "Impact Radius"],
+  // Rakuten Advertising (LinkShare): ranmid/ransiteid/raneaid are already
+  // preserved landing params; the broader "rakuten" token catches sibling
+  // Rakuten attribution params not yet enumerated there.
+  ["rakuten", /rakuten|^ranmid$|^ransiteid$|^raneaid$/i, "Rakuten Advertising (LinkShare)"],
+  // Admitad: network-specific affiliate/publisher attribution.
+  ["admitad", /admitad/i, "Admitad"],
+  // Partnerize (Performance Horizon): clickref/pubref/adref are already
+  // preserved; the broader partnerize/partnerid naming family catches
+  // sibling attribution tokens.
+  ["partnerize", /partnerize|partnerid/i, "Partnerize (Performance Horizon)"],
+  // Tradedoubler: tduid is already preserved (moved out of TRACKING_PARAMS
+  // in #695); the broader "tradedoubler" token catches sibling params.
+  ["tradedoubler", /tradedoubler|^tduid$/i, "Tradedoubler"],
+  // AppsFlyer: af_-prefixed params are mobile app-install attribution
+  // (distinct from ad-platform click ids); stripping can break mobile
+  // affiliate/app-install payouts.
+  ["appsflyer-af", /^af_/, "AppsFlyer"],
+  // Adjust: adj_-prefixed params / bare "adjust" are mobile attribution,
+  // same risk class as AppsFlyer.
+  ["adjust", /^adj_|adjust/i, "Adjust"],
+  ["airbridge", /airbridge/i, "Airbridge"],
+  ["branch", /branch/i, "Branch"],
+  // Generic affiliate markers: not tied to one named network, but the token
+  // itself declares affiliate intent, so route to review instead of
+  // assuming it is safe to strip.
+  ["generic-affiliate", /^aff$|^affid$|^affiliate$|^aff_/i, "Generic affiliate marker"],
+];
+
+/**
+ * @param {string} name Candidate param name.
+ * @returns {{ matched: boolean, pattern: string|null }}
+ */
+export function matchTrackingVendor(name) {
+  const lower = String(name).toLowerCase();
+  for (const [label, regex] of TRACKING_VENDOR_PATTERNS) {
+    if (regex.test(lower)) return { matched: true, pattern: label };
+  }
+  return { matched: false, pattern: null };
+}
+
+/**
+ * @param {string} name Candidate param name.
+ * @returns {{ matched: boolean, pattern: string|null, network: string|null }}
+ */
+export function matchAffiliateNetwork(name) {
+  const lower = String(name).toLowerCase();
+  for (const [label, regex, network] of AFFILIATE_NETWORK_PATTERNS) {
+    if (regex.test(lower)) return { matched: true, pattern: label, network };
+  }
+  return { matched: false, pattern: null, network: null };
+}
+
+// ── Bucketing (pure, deterministic, precedence-ordered) ──────────────────────
+
+/**
+ * Assigns exactly one bucket per candidate, checked in this precedence
+ * order (documented again in the .md report for reviewers). FIX 1, FIX 2,
+ * and the v2.1 affiliate-network gate run before any other check, in this
+ * exact order, and stop processing for that candidate as soon as they
+ * match.
+ *
+ *   FIX 1. excluded_affiliate_preserve: signals.is_affiliate_preserve is
+ *      true. Processing stops here; this candidate can never reach any
+ *      other bucket. Catches irclickid, cjevent, awc, and every other
+ *      redirect-network landing param (test guard #815).
+ *
+ *   FIX 2. Danger-list gate, only for candidates not caught by FIX 1:
+ *      signals.is_danger_name is true. Can never reach
+ *      universal_high_confidence.
+ *        - if scoped attribution exists -> domain_scoped, caution:
+ *          "functional-name".
+ *        - else -> likely_reject (reason: load-bearing functional name,
+ *          unsafe to strip universally, no domain scope).
+ *
+ *   v2.1 NEW GATE. Affiliate-network gate, only for candidates not caught
+ *      by FIX 1 or FIX 2: signals.affiliate_network_match.matched is true.
+ *      Always -> affiliate_network_review, tagged with the matched network.
+ *      Can never reach universal_high_confidence: fixes the v2 regression
+ *      where cj_aid, awinaffid, impact_click_id, af_id, adj_adgroup, and
+ *      siblings were promoted straight to universal_high_confidence.
+ *
+ *   FIX 3. For candidates not caught by FIX 1, FIX 2, or the affiliate-
+ *      network gate:
+ *      - universal_high_confidence if: (adguard_global AND clearurls_global)
+ *        OR (adguard_global AND tracking_vendor_match.matched).
+ *      - else if scoped attribution exists -> domain_scoped.
+ *      - else if any global attribution exists (adguard_global OR
+ *        clearurls_global) -> needs_human.
+ *      - else -> likely_reject (reason: no corroborating tracking evidence
+ *        in either source).
+ *
+ * @param {object} signals
+ * @param {boolean|null} signals.clearurls_global
+ * @param {string[]} signals.clearurls_scoped_domains
+ * @param {boolean|null} signals.adguard_global
+ * @param {string[]} signals.adguard_scoped_domains
+ * @param {boolean} signals.is_affiliate_preserve
+ * @param {boolean} signals.is_danger_name
+ * @param {{matched: boolean, pattern: string|null, network: string|null}} signals.affiliate_network_match
+ * @param {{matched: boolean, pattern: string|null}} signals.tracking_vendor_match
+ * @returns {{ bucket: "excluded_affiliate_preserve"|"affiliate_network_review"|"universal_high_confidence"|"domain_scoped"|"needs_human"|"likely_reject", caution?: string, reason?: string, network?: string }}
+ */
+export function classifyCandidate(signals) {
+  const anyGlobal = Boolean(signals.clearurls_global) || Boolean(signals.adguard_global);
+  const anyScoped =
+    (signals.clearurls_scoped_domains?.length ?? 0) > 0 ||
+    (signals.adguard_scoped_domains?.length ?? 0) > 0;
+
+  // FIX 1 (must run first, before any other check).
+  if (signals.is_affiliate_preserve) {
+    return { bucket: "excluded_affiliate_preserve" };
+  }
+
+  // FIX 2 (runs second, only for candidates not caught by FIX 1).
+  if (signals.is_danger_name) {
+    if (anyScoped) {
+      return { bucket: "domain_scoped", caution: "functional-name" };
+    }
+    return {
+      bucket: "likely_reject",
+      reason: "load-bearing functional name, unsafe to strip universally, no domain scope",
+    };
+  }
+
+  // v2.1 NEW GATE (runs third, only for candidates not caught by FIX 1 or
+  // FIX 2, and before FIX 3's universal path).
+  if (signals.affiliate_network_match?.matched) {
+    return { bucket: "affiliate_network_review", network: signals.affiliate_network_match.network };
+  }
+
+  // FIX 3 (runs fourth, only for candidates not caught by FIX 1, FIX 2, or
+  // the affiliate-network gate).
+  const vendorMatched = Boolean(signals.tracking_vendor_match?.matched);
+  const adguardGlobal = Boolean(signals.adguard_global);
+  const clearurlsGlobal = Boolean(signals.clearurls_global);
+  if ((adguardGlobal && clearurlsGlobal) || (adguardGlobal && vendorMatched)) {
+    return { bucket: "universal_high_confidence" };
+  }
+  if (anyScoped) {
+    return { bucket: "domain_scoped" };
+  }
+  if (anyGlobal) {
+    return { bucket: "needs_human" };
+  }
+  return { bucket: "likely_reject", reason: "no corroborating tracking evidence in either source" };
+}
+
+/**
+ * Combines name-derived signals (affiliate-preserve match, danger-list
+ * match, vendor-signal match, plus the legacy/informational prefix-family,
+ * functional-risk, and genericness signals) with externally supplied
+ * evidence (AdGuard / ClearURLs lookups) into one fully annotated, bucketed
+ * record. Pure: no I/O.
+ *
+ * @param {string} name
+ * @param {object} external
+ * @param {boolean|null} [external.clearurls_global]
+ * @param {string[]} [external.clearurls_scoped_domains]
+ * @param {boolean|null} [external.adguard_global]
+ * @param {string[]} [external.adguard_scoped_domains]
+ * @param {string[]} [external.muga_preserve_conflict_domains] Domains where this
+ *   name is already an explicit preserveParams entry in domain-rules.json
+ *   (informational only, surfaces likely functional-risk elsewhere; not a
+ *   bucket gate).
+ * @returns {object} Fully annotated candidate record including `bucket` and,
+ *   when applicable, `caution`, `reason`, and/or `network`.
+ */
+export function annotateCandidate(name, external = {}) {
+  // Legacy/informational signals, kept for reviewer context (not used to
+  // gate v2.1 buckets; see classifyCandidate above for the current rules).
+  const tracking_prefix_family = matchTrackingPrefixFamily(name);
+  const known_functional_risk = isKnownFunctionalRisk(name);
+  const genericness_score = genericnessScore(name);
+
+  // Bucket-gating signals.
+  const is_affiliate_preserve = isAffiliatePreserveParam(name);
+  const is_danger_name = isDangerName(name);
+  const affiliate_network_match = matchAffiliateNetwork(name); // v2.1 NEW
+  const tracking_vendor_match = matchTrackingVendor(name);
+
+  const signals = {
+    name,
+    clearurls_global: external.clearurls_global ?? null,
+    clearurls_scoped_domains: external.clearurls_scoped_domains ?? [],
+    adguard_global: external.adguard_global ?? null,
+    adguard_scoped_domains: external.adguard_scoped_domains ?? [],
+    is_affiliate_preserve,
+    is_danger_name,
+    affiliate_network_match,
+    tracking_vendor_match,
+    tracking_prefix_family,
+    known_functional_risk,
+    genericness_score,
+    muga_preserve_conflict_domains: external.muga_preserve_conflict_domains ?? [],
+  };
+
+  const classification = classifyCandidate(signals);
+  signals.bucket = classification.bucket;
+  if (classification.caution) signals.caution = classification.caution;
+  if (classification.reason) signals.reason = classification.reason;
+  if (classification.network) signals.network = classification.network;
+  return signals;
+}
+
+// ── AdGuard Filter 17 parsing (domain-aware) ─────────────────────────────────
+//
+// tools/rule-ingestion/adapters/adguard-tp.mjs and its underlying
+// parseRemoveparamRules() (tools/import-upstream.mjs) already extract a flat
+// Set of param names, but that flattening loses the `,domain=` modifier that
+// tells us a rule is scoped to specific sites rather than global. This
+// parser mirrors the same line-matching and validation conventions but keeps
+// the domain scope alongside each name.
+
+// Mirrors the param-name validation in tools/import-upstream.mjs's
+// parseRemoveparamRules: alphanumeric, underscore, hyphen, dot only.
+const ADGUARD_PARAM_NAME_RE = /^[a-z0-9_\-.]{1,64}$/;
+
+/**
+ * @param {string} rawText Raw AdGuard Filter 17 text.
+ * @returns {{ index: Map<string, {global: boolean, domains: Set<string>}>, skipped: number }}
+ */
+export function parseAdguardRemoveparamWithDomains(rawText) {
+  const index = new Map();
+  let skipped = 0;
+
+  const ensure = (name) => {
+    if (!index.has(name)) index.set(name, { global: false, domains: new Set() });
+    return index.get(name);
+  };
+
+  for (const rawLine of String(rawText).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("!") || line.startsWith("[")) continue;
+
+    const paramMatch = /\$.*?removeparam=([^,$]+)/i.exec(line);
+    if (!paramMatch) continue;
+
+    const spec = paramMatch[1].trim();
+    if (!spec) { skipped++; continue; }
+    // Regex specs (/.../ ) and bare negations (~...) need manual review;
+    // not handled by this literal-name parser (same skip convention as
+    // parseRemoveparamRules).
+    if (spec.startsWith("/") || spec.startsWith("~")) { skipped++; continue; }
+
+    const names = [];
+    for (const piece of spec.split("|")) {
+      const name = piece.trim().toLowerCase();
+      if (!name) { skipped++; continue; }
+      if (!ADGUARD_PARAM_NAME_RE.test(name)) { skipped++; continue; }
+      names.push(name);
+    }
+    if (names.length === 0) continue;
+
+    const domainMatch = /domain=([^,$]+)/i.exec(line);
+    let scopedDomains = [];
+    let isGlobal = true;
+    if (domainMatch) {
+      const parts = domainMatch[1]
+        .trim()
+        .split("|")
+        .map((d) => d.trim().toLowerCase())
+        .filter(Boolean);
+      const positive = parts.filter((d) => !d.startsWith("~"));
+      if (positive.length > 0) {
+        // Positive domain list: the rule applies ONLY on these domains.
+        scopedDomains = positive;
+        isGlobal = false;
+      }
+      // else: only negated domains (domain=~a.com|~b.com), meaning "applies
+      // everywhere except these few sites". Treated as global here: no
+      // scoped domains are captured for a rule that is broader than the
+      // exceptions it lists.
+    }
+
+    for (const name of names) {
+      const entry = ensure(name);
+      if (isGlobal) entry.global = true;
+      for (const d of scopedDomains) entry.domains.add(d);
+    }
+  }
+
+  return { index, skipped };
+}
+
+/**
+ * @param {Map<string, {global: boolean, domains: Set<string>}>|null} index
+ * @param {string} name
+ * @returns {{ global: boolean|null, domains: string[] }}
+ */
+export function lookupAdguard(index, name) {
+  if (!index) return { global: null, domains: [] }; // no data at all: unknown, not a negative match
+  const entry = index.get(String(name).toLowerCase());
+  if (!entry) return { global: false, domains: [] };
+  return { global: entry.global, domains: Array.from(entry.domains).sort() };
+}
+
+// ── ClearURLs parsing (domain-aware) ─────────────────────────────────────────
+//
+// tools/rule-ingestion/adapters/clearurls.mjs and tools/moat-expansion/adapters/
+// clearurls-moat.mjs already parse this JSON for other purposes (safe-literal
+// extraction and referralMarketing extraction respectively). Neither answers
+// "is this literal name matched by ANY provider's rule, and is that provider
+// global or domain-scoped", so this builds a small regex index for that
+// specific lookup instead of duplicating either adapter's extraction logic.
+//
+// ClearURLs' own "globalRules" provider (urlPattern ".*") holds the rules
+// applied on every site; every other provider key is treated as a
+// domain-scoped signal, using the provider key itself as the domain
+// identifier (provider keys are usually recognizable site/brand names but
+// are not always a literal registrable domain string, e.g. "amazon" rather
+// than "amazon.com" -- a human reviewer should confirm the exact domain
+// before adding a domain-rules.json entry).
+//
+// Provider rules are regex fragments (not always simple literals), so
+// candidate names are tested with a full-string anchor
+// (^(?:pattern)$) rather than substring search. This can occasionally
+// over-match on short/generic fragments for a given provider; that risk is
+// acceptable here because it only ever routes a candidate into the safer
+// domain_scoped bucket, never universal_high_confidence.
+
+/**
+ * @param {string} rawText Raw ClearURLs rules.json text.
+ * @returns {{ globalPatterns: RegExp[], scopedPatterns: {provider: string, regex: RegExp}[] } | null}
+ */
+export function buildClearUrlsIndex(rawText) {
+  let data;
+  try {
+    data = JSON.parse(rawText);
+  } catch {
+    return null;
+  }
+
+  const providers =
+    data?.providers && typeof data.providers === "object" && !Array.isArray(data.providers)
+      ? data.providers
+      : {};
+
+  const globalPatterns = [];
+  const scopedPatterns = [];
+
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    const isGlobalProvider = providerKey === "globalRules" || provider?.urlPattern === ".*";
+    const rules = Array.isArray(provider?.rules) ? provider.rules : [];
+
+    for (const rawPattern of rules) {
+      let regex;
+      try {
+        regex = new RegExp(`^(?:${rawPattern})$`, "i");
+      } catch {
+        continue; // invalid regex fragment in upstream data: skip defensively
+      }
+      if (isGlobalProvider) globalPatterns.push(regex);
+      else scopedPatterns.push({ provider: providerKey, regex });
+    }
+  }
+
+  return { globalPatterns, scopedPatterns };
+}
+
+/**
+ * @param {{globalPatterns: RegExp[], scopedPatterns: {provider: string, regex: RegExp}[]}|null} index
+ * @param {string} name
+ * @returns {{ global: boolean|null, domains: string[] }}
+ */
+export function lookupClearUrls(index, name) {
+  if (!index) return { global: null, domains: [] }; // no data at all: unknown
+  const global = index.globalPatterns.some((re) => re.test(name));
+  const domainSet = new Set();
+  for (const { provider, regex } of index.scopedPatterns) {
+    if (regex.test(name)) domainSet.add(provider);
+  }
+  return { global, domains: Array.from(domainSet).sort() };
+}
+
+// ── MUGA dedup sets (read-only lookups against the live rule files) ─────────
+
+/**
+ * Strips `//` line comments before extracting quoted string literals from a
+ * source block. WITHOUT this, comment text such as:
+ *   // "ref" removed: it's the affiliate param for PcComponentes ...
+ * would be misread as "ref" being present in TRACKING_PARAMS, when the
+ * comment is documenting exactly the opposite (a deliberate exclusion for
+ * affiliate-attribution safety). Getting this wrong would make the triage
+ * silently drop an affiliate-sensitive name as "already handled".
+ * @param {string} text
+ * @returns {string}
+ */
+function stripLineComments(text) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\/\/.*$/, ""))
+    .join("\n");
+}
+
+/**
+ * Reads TRACKING_PARAMS, TRACKING_PREFIXES, domain-rules.json stripParams,
+ * domain-rules.json preserveParams, and tracking-params.json removeParams
+ * for dedup lookups. Read-only: never writes to any of these files.
+ *
+ * @param {object} [paths]
+ * @returns {{
+ *   universalNames: Set<string>,
+ *   universalPrefixes: string[],
+ *   domainStripMap: Map<string, string[]>,
+ *   domainPreserveMap: Map<string, string[]>,
+ * }}
+ */
+export function loadMugaDedupSets(paths = {}) {
+  const affiliatesDataPath = paths.affiliatesDataPath ?? resolve(__dirname, "../../src/lib/affiliates-data.js");
+  const domainRulesPath = paths.domainRulesPath ?? resolve(__dirname, "../../src/rules/domain-rules.json");
+  const trackingParamsJsonPath = paths.trackingParamsJsonPath ?? resolve(__dirname, "../../src/rules/tracking-params.json");
+
+  const universalNames = new Set();
+  const universalPrefixes = [];
+  const domainStripMap = new Map();
+  const domainPreserveMap = new Map();
+
+  try {
+    const src = readFileSync(affiliatesDataPath, "utf8");
+    const cleaned = stripLineComments(src);
+
+    const paramsBlockMatch = /export const TRACKING_PARAMS\s*=\s*\[([\s\S]*?)\n\];/.exec(cleaned);
+    if (paramsBlockMatch) {
+      for (const m of paramsBlockMatch[1].matchAll(/"([a-zA-Z0-9_.\-]+)"/g)) {
+        universalNames.add(m[1].toLowerCase());
+      }
+    }
+
+    const prefixesBlockMatch = /export const TRACKING_PREFIXES\s*=\s*\[([\s\S]*?)\n\];/.exec(cleaned);
+    if (prefixesBlockMatch) {
+      for (const m of prefixesBlockMatch[1].matchAll(/"([a-zA-Z0-9_.\-]+)"/g)) {
+        universalPrefixes.push(m[1].toLowerCase());
+      }
+    }
+  } catch (err) {
+    console.warn(`[triage] could not read ${affiliatesDataPath}: ${err.message}`);
+  }
+
+  try {
+    const rules = JSON.parse(readFileSync(trackingParamsJsonPath, "utf8"));
+    if (Array.isArray(rules)) {
+      for (const rule of rules) {
+        const removeParams = rule?.action?.redirect?.transform?.queryTransform?.removeParams;
+        if (Array.isArray(removeParams)) {
+          for (const p of removeParams) universalNames.add(String(p).toLowerCase());
+        }
+      }
+    }
+  } catch (err) {
+    console.warn(`[triage] could not read ${trackingParamsJsonPath}: ${err.message}`);
+  }
+
+  try {
+    const domainRules = JSON.parse(readFileSync(domainRulesPath, "utf8"));
+    if (Array.isArray(domainRules)) {
+      for (const entry of domainRules) {
+        const domain = entry?.domain;
+        if (!domain) continue;
+        for (const p of entry.stripParams ?? []) {
+          const key = String(p).toLowerCase();
+          if (!domainStripMap.has(key)) domainStripMap.set(key, []);
+          domainStripMap.get(key).push(domain);
+        }
+        for (const p of entry.preserveParams ?? []) {
+          const key = String(p).toLowerCase();
+          if (!domainPreserveMap.has(key)) domainPreserveMap.set(key, []);
+          domainPreserveMap.get(key).push(domain);
+        }
+      }
+    }
+  } catch (err) {
+    console.warn(`[triage] could not read ${domainRulesPath}: ${err.message}`);
+  }
+
+  return { universalNames, universalPrefixes, domainStripMap, domainPreserveMap };
+}
+
+/**
+ * @param {{universalNames: Set<string>, universalPrefixes: string[], domainStripMap: Map<string,string[]>}} dedup
+ * @param {string} name
+ * @returns {boolean}
+ */
+export function isAlreadyInMuga(dedup, name) {
+  const lower = String(name).toLowerCase();
+  if (dedup.universalNames.has(lower)) return true;
+  if (dedup.domainStripMap.has(lower)) return true;
+  for (const prefix of dedup.universalPrefixes) {
+    if (lower.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+// ── Candidate report loading ─────────────────────────────────────────────────
+
+/**
+ * @param {string} reportPath
+ * @returns {{ candidates: string[], meta: object }}
+ */
+export function loadCandidateReport(reportPath) {
+  const raw = readFileSync(reportPath, "utf8");
+  const data = JSON.parse(raw);
+  const candidates = Array.isArray(data?.new_candidates) ? data.new_candidates : [];
+  return { candidates, meta: data ?? {} };
+}
+
+const DEFAULT_REPO_REPORT_PATH = resolve(__dirname, "report-2026-07-05.json");
+const DEFAULT_SCRATCHPAD_REPORT_PATH =
+  "C:/Users/parada/AppData/Local/Temp/claude/C--Users-parada-Desktop-test-muga/248c41ba-c18f-422a-bf19-11daaec03817/scratchpad/adguard-candidates-2026-07-05.json";
+
+/**
+ * Resolves the candidate report path: an explicit CLI argument wins;
+ * otherwise prefer the in-repo path for this batch, falling back to the
+ * scratchpad copy. Future weekly batches should pass an explicit path.
+ * @param {string|undefined} cliArg
+ * @returns {string}
+ */
+export function resolveCandidateReportPath(cliArg) {
+  if (cliArg) return cliArg;
+  if (existsSync(DEFAULT_REPO_REPORT_PATH)) return DEFAULT_REPO_REPORT_PATH;
+  return DEFAULT_SCRATCHPAD_REPORT_PATH;
+}
+
+/**
+ * @param {object|null} meta Candidate report top-level object.
+ * @param {string} reportPath
+ * @returns {string} YYYY-MM-DD
+ */
+export function deriveDateSuffix(meta, reportPath) {
+  if (meta?.fetched_at) {
+    const d = new Date(meta.fetched_at);
+    if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+  }
+  const m = /(\d{4}-\d{2}-\d{2})/.exec(reportPath ?? "");
+  if (m) return m[1];
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ── Network fetch with cache fallback (never throws) ─────────────────────────
+
+/**
+ * @param {object} opts
+ * @param {string} opts.label For log messages.
+ * @param {() => Promise<string>} opts.fetchFn Adapter fetchRaw call, pre-bound.
+ * @param {string[]} opts.cachePaths Candidate cache file paths, checked in order.
+ * @param {string[]} opts.warnings Mutable array; failures/fallbacks are pushed here.
+ * @returns {Promise<{ text: string|null, source: "live"|"cache"|"none" }>}
+ */
+async function fetchRawWithFallback({ label, fetchFn, cachePaths, warnings }) {
+  try {
+    const text = await fetchFn();
+    return { text, source: "live" };
+  } catch (err) {
+    warnings.push(`[triage] live fetch failed for ${label}: ${err?.message ?? err}`);
+  }
+
+  for (const cachePath of cachePaths) {
+    try {
+      const text = readFileSync(cachePath, "utf8");
+      warnings.push(`[triage] using cached raw for ${label}: ${cachePath}`);
+      return { text, source: "cache" };
+    } catch {
+      // try next candidate cache path
+    }
+  }
+
+  warnings.push(`[triage] no cached raw available for ${label}; signal degraded to unknown/no-data`);
+  return { text: null, source: "none" };
+}
+
+/** @param {string[]} warnings @returns {Promise<{text: string|null, source: string}>} */
+export function fetchAdguardRaw(warnings) {
+  return fetchRawWithFallback({
+    label: "adguard-tp",
+    fetchFn: () => adguardTp.fetchRaw(),
+    cachePaths: [
+      resolve(__dirname, "../rule-ingestion/quarantine/adguard-tp.raw"),
+      resolve(__dirname, "../rule-ingestion/adapters/adguard-tp.raw"),
+    ],
+    warnings,
+  });
+}
+
+/** @param {string[]} warnings @returns {Promise<{text: string|null, source: string}>} */
+export function fetchClearUrlsRaw(warnings) {
+  return fetchRawWithFallback({
+    label: "clearurls",
+    fetchFn: () => clearurls.fetchRaw(),
+    cachePaths: [
+      resolve(__dirname, "../moat-expansion/quarantine/clearurls.raw"),
+      resolve(__dirname, "../rule-ingestion/quarantine/clearurls.raw"),
+    ],
+    warnings,
+  });
+}
+
+// ── Report rendering ─────────────────────────────────────────────────────────
+
+const BUCKET_ORDER = [
+  "excluded_affiliate_preserve",
+  "affiliate_network_review",
+  "universal_high_confidence",
+  "domain_scoped",
+  "needs_human",
+  "likely_reject",
+];
+
+/** @param {object[]} records @param {object} meta @returns {string} */
+function renderMarkdownReport(records, meta) {
+  const lines = [];
+  lines.push(`# Import-candidate triage (${meta.dateSuffix}), v2.1`);
+  lines.push("");
+  lines.push(
+    `Source: ${meta.sourceLabel ?? "AdGuard Filter 17"} (${meta.sourceUrl ?? "unknown URL"}), report fetched at ${meta.fetchedAt ?? "unknown time"}.`,
+  );
+  lines.push(`Candidate report file: ${meta.reportPath}`);
+  lines.push("");
+  lines.push("## Data source availability");
+  lines.push("");
+  lines.push(`- AdGuard raw: ${meta.adguardSource} (${meta.adguardSource === "none" ? "signals unknown/no-data" : "signals available"})`);
+  lines.push(`- ClearURLs raw: ${meta.clearurlsSource} (${meta.clearurlsSource === "none" ? "signals unknown/no-data" : "signals available"})`);
+  if (meta.warnings.length > 0) {
+    lines.push("");
+    lines.push("Warnings during this run:");
+    for (const w of meta.warnings) lines.push(`- ${w}`);
+  }
+  lines.push("");
+  lines.push("## Counts");
+  lines.push("");
+  lines.push(`- Total candidates in input report: ${meta.totalCandidates}`);
+  lines.push(`- Already in MUGA (dropped from triage, counted only): ${meta.alreadyInMugaDropped}`);
+  for (const bucket of BUCKET_ORDER) {
+    lines.push(`- ${bucket}: ${meta.bucketCounts[bucket] ?? 0}`);
+  }
+  lines.push("");
+  lines.push("## Methodology (v2.1)");
+  lines.push("");
+  lines.push("MUGA has two strip mechanisms: universal (TRACKING_PARAMS / tracking-params.json DNR,");
+  lines.push("stripped on every site) and domain-scoped (domain-rules.json, stripped only on named");
+  lines.push("domains). Universal strip is reserved for unambiguous cross-site tracking params, since a");
+  lines.push("bulk-add of short/generic names to the universal list previously caused a real");
+  lines.push("false-positive regression (issue #1006).");
+  lines.push("");
+  lines.push("v1 additionally had a safety defect: it could promote an affiliate-redirect-network landing");
+  lines.push("param (irclickid, cjevent, awc) into a strippable bucket, which would destroy creator");
+  lines.push("commission on first-touch landings (test guard #815). v2 fixed this and added a hard danger");
+  lines.push("list for load-bearing functional names, plus a single broadened vendor-signal list.");
+  lines.push("");
+  lines.push("v2.1 fixes a defect in that vendor-signal list: it conflated pure tracking/ad-platform");
+  lines.push("vendors with affiliate-NETWORK vendors, so it promoted affiliate-network attribution params");
+  lines.push("straight to universal_high_confidence. Confirmed regression under v2: cj_aid, cj_pid,");
+  lines.push("awinaffid, af_id, af_channel, adj_adgroup, adj_deeplink, impact_click_id, and impact_ad_id");
+  lines.push("were all in universal_high_confidence. impact_click_id is especially dangerous: it belongs");
+  lines.push("to Impact Radius, the exact same network whose irclickid/irgwc/iclid landing params are");
+  lines.push("already preserved by FIX 1 (test guard #815). v2.1 splits the vendor-signal list in two");
+  lines.push("(TRACKING_VENDOR_PATTERNS, safe for universal; AFFILIATE_NETWORK_PATTERNS, routed to human");
+  lines.push("review) and adds a new `affiliate_network_review` bucket, checked before the universal path.");
+  lines.push("");
+  lines.push("Distinction rule: ad-PLATFORM click ids (gclid, fbclid-family, msclkid, ttclid, twclid, ...)");
+  lines.push("are the advertiser's own tracking, so they are SAFE to strip universally: no creator");
+  lines.push("commission is at stake. Affiliate-NETWORK params (CJ, Awin, Impact Radius, Rakuten, Admitad,");
+  lines.push("Partnerize, Tradedoubler, AppsFlyer, Adjust, Airbridge, Branch, generic affiliate markers)");
+  lines.push("route commission to a content creator/publisher, so stripping them can rob attribution --");
+  lines.push("these always go to human review, never straight to universal.");
+  lines.push("");
+  lines.push("Every surviving candidate (not already covered by MUGA) is classified with this exact");
+  lines.push("precedence, checked IN THIS ORDER:");
+  lines.push("");
+  lines.push("### FIX 1 (runs first, before any other check)");
+  lines.push("");
+  lines.push("Any candidate whose lowercased name exactly matches an entry in the affiliate-preserve set");
+  lines.push("is routed to `excluded_affiliate_preserve` and processing STOPS for that candidate: it can");
+  lines.push("never reach universal_high_confidence, domain_scoped, needs_human, or likely_reject. This");
+  lines.push("catches every param a redirect network (Awin, CJ Affiliate, Impact Radius, and so on) reads");
+  lines.push("at landing to populate the merchant's first-party attribution cookie.");
+  lines.push("");
+  lines.push("The affiliate-preserve set is built dynamically from every `landingParams` entry across all");
+  lines.push("`REDIRECT_NETWORK_PATTERNS` entries in src/lib/affiliates.js (re-exported from");
+  lines.push("src/lib/redirect-networks.js). No distinct \"honor creator referral\" param set was found");
+  lines.push("beyond landingParams (src/lib/honor-creator.js's shouldHonor() is about wrapper-URL");
+  lines.push("pass-through, not a param-name preserve list), so the set below is landingParams only.");
+  lines.push("");
+  lines.push(`Affiliate-preserve set used this run (${meta.affiliatePreserveList.length} params):`);
+  lines.push("");
+  lines.push(meta.affiliatePreserveList.map((p) => `\`${p}\``).join(", "));
+  lines.push("");
+  lines.push("### FIX 2 (runs second, only for candidates not caught by FIX 1)");
+  lines.push("");
+  lines.push("Hard danger list of load-bearing functional param names. A match here can NEVER reach");
+  lines.push("universal_high_confidence:");
+  lines.push("");
+  lines.push("- if scoped attribution exists (adguard_scoped_domains or clearurls_scoped_domains");
+  lines.push("  non-empty) -> `domain_scoped`, with `caution: \"functional-name\"`.");
+  lines.push("- else -> `likely_reject` (reason: load-bearing functional name, unsafe to strip");
+  lines.push("  universally, no domain scope).");
+  lines.push("");
+  lines.push(`Danger list used this run (${meta.dangerList.length} names, exactly as specified, no`);
+  lines.push("extensions -- the actual 2026-07-05 candidate batch was checked for present near-duplicates");
+  lines.push("such as simple plurals and none were found):");
+  lines.push("");
+  lines.push(meta.dangerList.map((p) => `\`${p}\``).join(", "));
+  lines.push("");
+  lines.push("### v2.1 NEW GATE (runs third, only for candidates not caught by FIX 1 or FIX 2)");
+  lines.push("");
+  lines.push("Affiliate-network gate. A match against `AFFILIATE_NETWORK_PATTERNS` always routes to");
+  lines.push("`affiliate_network_review`, tagged with the matched network, and can NEVER reach");
+  lines.push("`universal_high_confidence`. This runs BEFORE FIX 3's universal path, so an affiliate-network");
+  lines.push("name that also happens to match a tracking-vendor pattern (for example impact_click_id also");
+  lines.push("matching the generic click_id family) is still routed here, never to universal.");
+  lines.push("");
+  lines.push(`AFFILIATE_NETWORK_PATTERNS used this run (${meta.affiliateNetworkEntries.length} entries,`);
+  lines.push("grouped by network; see the script for the one-line rationale documented per entry):");
+  lines.push("");
+  {
+    const byNetwork = new Map();
+    for (const entry of meta.affiliateNetworkEntries) {
+      if (!byNetwork.has(entry.network)) byNetwork.set(entry.network, []);
+      byNetwork.get(entry.network).push(entry.label);
+    }
+    for (const [network, labels] of byNetwork) {
+      lines.push(`- **${network}**: ${labels.map((l) => `\`${l}\``).join(", ")}`);
+    }
+  }
+  lines.push("");
+  lines.push("### FIX 3 (runs fourth, only for candidates not caught by FIX 1, FIX 2, or the");
+  lines.push("affiliate-network gate)");
+  lines.push("");
+  lines.push("- `universal_high_confidence` if: (adguard_global AND clearurls_global) OR (adguard_global");
+  lines.push("  AND tracking_vendor_match.matched).");
+  lines.push("- else if scoped attribution exists -> `domain_scoped`.");
+  lines.push("- else if any global attribution exists (adguard_global OR clearurls_global) ->");
+  lines.push("  `needs_human`.");
+  lines.push("- else -> `likely_reject` (reason: no corroborating tracking evidence in either source).");
+  lines.push("");
+  lines.push("The tracking-vendor set is pure tracking/analytics/ad-platform/storefront vendors only (no");
+  lines.push("affiliate-network vendors, split out in v2.1; see the gate above), used as a positive");
+  lines.push("corroborating signal alongside an AdGuard global claim:");
+  lines.push("");
+  lines.push(meta.trackingVendorLabels.map((p) => `\`${p}\``).join(", "));
+  lines.push("");
+  lines.push("Each surviving candidate is also annotated with legacy/informational fields carried over");
+  lines.push("from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_risk`,");
+  lines.push("`genericness_score`. These remain for reviewer context only.");
+  lines.push("");
+
+  for (const bucket of BUCKET_ORDER) {
+    const bucketRecords = records.filter((r) => r.bucket === bucket);
+    lines.push(`## ${bucket} (${bucketRecords.length})`);
+    lines.push("");
+    if (bucketRecords.length === 0) {
+      lines.push("(none)");
+      lines.push("");
+      continue;
+    }
+    if (bucket === "affiliate_network_review") {
+      for (const r of bucketRecords) {
+        lines.push(`- \`${r.name}\` (network: ${r.network ?? "unknown"})`);
+      }
+    } else if (bucket === "domain_scoped") {
+      for (const r of bucketRecords) {
+        const domains = Array.from(new Set([...r.clearurls_scoped_domains, ...r.adguard_scoped_domains])).sort();
+        const cautionSuffix = r.caution ? ` [caution: ${r.caution}]` : "";
+        lines.push(`- \`${r.name}\` (domains: ${domains.length > 0 ? domains.join(", ") : "none captured"})${cautionSuffix}`);
+      }
+    } else if (bucket === "likely_reject") {
+      for (const r of bucketRecords) {
+        const reasonSuffix = r.reason ? ` -- ${r.reason}` : "";
+        lines.push(`- \`${r.name}\`${reasonSuffix}`);
+      }
+    } else {
+      for (const r of bucketRecords) {
+        lines.push(`- \`${r.name}\``);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+// ── Orchestration ─────────────────────────────────────────────────────────────
+
+/**
+ * Runs the full triage pipeline: loads candidates, fetches/parses signal
+ * sources (best-effort), classifies every non-dropped candidate, and writes
+ * the JSON + Markdown deliverables. Never throws: all failures are caught,
+ * logged, and degraded.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.reportPath] Override for the candidate report path.
+ * @returns {Promise<{ bucketCounts: object, alreadyInMugaDropped: number, totalCandidates: number, outputJsonPath: string, outputMdPath: string }>}
+ */
+export async function runTriage(opts = {}) {
+  const warnings = [];
+  const reportPath = resolveCandidateReportPath(opts.reportPath);
+
+  let candidates = [];
+  let meta = {};
+  try {
+    const loaded = loadCandidateReport(reportPath);
+    candidates = loaded.candidates;
+    meta = loaded.meta;
+  } catch (err) {
+    console.error(`[triage] could not load candidate report at ${reportPath}: ${err.message}`);
+    return {
+      bucketCounts: Object.fromEntries(BUCKET_ORDER.map((b) => [b, 0])),
+      alreadyInMugaDropped: 0,
+      totalCandidates: 0,
+      outputJsonPath: null,
+      outputMdPath: null,
+    };
+  }
+
+  const dedup = loadMugaDedupSets();
+
+  const [adguardRaw, clearurlsRaw] = await Promise.all([
+    fetchAdguardRaw(warnings),
+    fetchClearUrlsRaw(warnings),
+  ]);
+
+  const adguardIndex = adguardRaw.text ? parseAdguardRemoveparamWithDomains(adguardRaw.text).index : null;
+  const clearurlsIndex = clearurlsRaw.text ? buildClearUrlsIndex(clearurlsRaw.text) : null;
+
+  let alreadyInMugaDropped = 0;
+  const records = [];
+
+  for (const rawName of candidates) {
+    const name = String(rawName).trim();
+    if (!name) continue;
+
+    if (isAlreadyInMuga(dedup, name)) {
+      alreadyInMugaDropped++;
+      continue;
+    }
+
+    const adguardInfo = lookupAdguard(adguardIndex, name);
+    const clearurlsInfo = lookupClearUrls(clearurlsIndex, name);
+    const preserveDomains = dedup.domainPreserveMap.get(name.toLowerCase()) ?? [];
+
+    const record = annotateCandidate(name, {
+      clearurls_global: clearurlsInfo.global,
+      clearurls_scoped_domains: clearurlsInfo.domains,
+      adguard_global: adguardInfo.global,
+      adguard_scoped_domains: adguardInfo.domains,
+      muga_preserve_conflict_domains: preserveDomains,
+    });
+
+    records.push(record);
+  }
+
+  const bucketCounts = Object.fromEntries(BUCKET_ORDER.map((b) => [b, 0]));
+  for (const r of records) bucketCounts[r.bucket] = (bucketCounts[r.bucket] ?? 0) + 1;
+
+  const dateSuffix = deriveDateSuffix(meta, reportPath);
+  const outputJsonPath = resolve(__dirname, `triage-${dateSuffix}.json`);
+  const outputMdPath = resolve(__dirname, `triage-${dateSuffix}.md`);
+
+  const jsonOutput = {
+    generated_at: new Date().toISOString(),
+    schema_version: "2.1",
+    source_report_path: reportPath,
+    source_label: meta.source ?? null,
+    source_url: meta.source_url ?? null,
+    fetched_at: meta.fetched_at ?? null,
+    total_candidates: candidates.length,
+    already_in_muga_dropped: alreadyInMugaDropped,
+    bucket_counts: bucketCounts,
+    affiliate_preserve_set: Array.from(AFFILIATE_PRESERVE_SET).sort(),
+    danger_names: Array.from(DANGER_NAMES).sort(),
+    tracking_vendor_labels: TRACKING_VENDOR_PATTERNS.map(([label]) => label),
+    affiliate_network_labels: AFFILIATE_NETWORK_PATTERNS.map(([label, , network]) => ({ label, network })),
+    adguard_data_source: adguardRaw.source,
+    clearurls_data_source: clearurlsRaw.source,
+    warnings,
+    candidates: records,
+  };
+
+  try {
+    writeFileSync(outputJsonPath, JSON.stringify(jsonOutput, null, 2) + "\n", "utf8");
+  } catch (err) {
+    console.error(`[triage] could not write ${outputJsonPath}: ${err.message}`);
+  }
+
+  try {
+    const md = renderMarkdownReport(records, {
+      dateSuffix,
+      sourceLabel: meta.source,
+      sourceUrl: meta.source_url,
+      fetchedAt: meta.fetched_at,
+      reportPath,
+      adguardSource: adguardRaw.source,
+      clearurlsSource: clearurlsRaw.source,
+      totalCandidates: candidates.length,
+      alreadyInMugaDropped,
+      bucketCounts,
+      warnings,
+      affiliatePreserveList: Array.from(AFFILIATE_PRESERVE_SET).sort(),
+      dangerList: Array.from(DANGER_NAMES).sort(),
+      trackingVendorLabels: TRACKING_VENDOR_PATTERNS.map(([label]) => label),
+      affiliateNetworkEntries: AFFILIATE_NETWORK_PATTERNS.map(([label, , network]) => ({ label, network })),
+    });
+    writeFileSync(outputMdPath, md + "\n", "utf8");
+  } catch (err) {
+    console.error(`[triage] could not write ${outputMdPath}: ${err.message}`);
+  }
+
+  console.log("[triage] done (v2.1).");
+  console.log(`[triage] total candidates: ${candidates.length}`);
+  console.log(`[triage] already_in_muga_dropped: ${alreadyInMugaDropped}`);
+  for (const bucket of BUCKET_ORDER) {
+    console.log(`[triage] ${bucket}: ${bucketCounts[bucket] ?? 0}`);
+  }
+  console.log(`[triage] adguard data source: ${adguardRaw.source}`);
+  console.log(`[triage] clearurls data source: ${clearurlsRaw.source}`);
+  for (const w of warnings) console.warn(w);
+
+  return { bucketCounts, alreadyInMugaDropped, totalCandidates: candidates.length, outputJsonPath, outputMdPath };
+}
+
+// ── CLI entry point ──────────────────────────────────────────────────────────
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMainModule) {
+  runTriage({ reportPath: process.argv[2] }).catch((err) => {
+    // runTriage is written to never throw; this is a last-resort net so an
+    // unexpected error still exits non-zero instead of crashing the process
+    // with an unhandled rejection.
+    console.error(`[triage] unexpected error: ${err?.stack ?? err}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Adds `tools/import-candidates/triage.mjs`, a reusable classifier that buckets the weekly AdGuard Filter 17 candidates (#998) into safe/review/reject groups so a human reviews small high-confidence buckets instead of 1404 raw names.

Precedence hard-excludes MUGA's affiliate-preservation set (#815 landingParams) first, then load-bearing functional names, then splits vendor signals into tracking-vendors (promotable) vs affiliate-networks (review) so attribution params never reach the universal bucket.

Analysis tooling only, no live rules changed. Includes 2026-07-05 artifacts + a unit test pinning bucket precedence. Buckets this run: excluded 18 / affiliate_network_review 37 / universal 43 / domain_scoped 161 / needs_human 822 / likely_reject 27 / already-in-muga 296.