### PR TITLE
fix(remote-rules): extend affiliate guard against attribution-param stripping

### DIFF
--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -132,6 +132,31 @@ export const AFFILIATE_PARAM_GUARD = Object.freeze(new Set([
   "afsrc", "af_id",
   // Generic partner / ref family
   "partner", "partnerid", "affid", "aff_id", "refcode",
+  // Adjust
+  "adj_adgroup", "adj_adnomia_click_id", "adj_deep_link", "adj_deeplink",
+  "adj_event_callback_dn2j7g_5mdnim", "adj_install_callback", "adjust_deeplink",
+  // AppsFlyer
+  // These are deep-link/config params, not pure click IDs. Guarding them is
+  // intentional and conservative: when a param plausibly carries attribution,
+  // we preserve it. The cost of a wrong strip is silent creator-economics
+  // harm; the cost of a wrong preserve is one un-stripped low-value param.
+  "af_assettype_id", "af_channel", "af_creative_id", "af_lnk",
+  "af_permalink_id", "af_placement_id", "af_reengagement_window", "af_rid",
+  // Generic affiliate
+  "aff", "aff_c", "aff_click_id", "aff_model", "aff_short_key", "aff_sub2",
+  "aff_sub3", "aff_sub4", "aff_sub5", "aff_track", "affiliate",
+  // Airbridge
+  "airbridge_referrer",
+  // Awin
+  "awinaffid",
+  // Commission Junction
+  "cj_aid", "cj_pid",
+  // Impact Radius
+  "impact_ad_id", "impact_click_id", "impact_product_sku",
+  // Partnerize
+  "partnerizecampaignid",
+  // Connexity (shopping affiliate, flagged separately from the AdGuard triage)
+  "cnxclid",
 ]));
 
 // ── Storage key defaults ──────────────────────────────────────────────────────

--- a/tests/unit/remote-rules.test.mjs
+++ b/tests/unit/remote-rules.test.mjs
@@ -570,6 +570,65 @@ describe("validateParams — content validation (REQ-VALIDATE-2 through REQ-VALI
     assert.strictEqual(r.code, ERR.DENYLIST_HIT);
   });
 
+  // Newly-added affiliate-network params (candidate-triage of AdGuard Filter 17,
+  // 2026-07) — a compromised or buggy remote payload must never be able to
+  // strip these, or creator/publisher attribution is silently lost with no
+  // user-visible symptom. One representative param per network.
+  describe("affiliate guard — newly-added network params (REQ-VALIDATE-5)", () => {
+    const freshPub = () => new Date(nowMs - 1000 * 60 * 60).toISOString();
+
+    const newlyAdded = [
+      ["impact_click_id", "Impact Radius"],
+      ["cj_aid", "Commission Junction"],
+      ["awinaffid", "Awin"],
+      ["adj_deeplink", "Adjust"],
+      ["af_channel", "AppsFlyer"],
+      ["cnxclid", "Connexity"],
+      ["aff_click_id", "Generic affiliate"],
+      ["airbridge_referrer", "Airbridge"],
+      ["partnerizecampaignid", "Partnerize"],
+    ];
+
+    for (const [param, network] of newlyAdded) {
+      test(`rejects '${param}' (${network}) → DENYLIST_HIT`, () => {
+        const r = validateParams([param], { version: 0, published: null }, nowMs, {
+          newVersion: 1,
+          newPublished: freshPub(),
+        });
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.code, ERR.DENYLIST_HIT);
+      });
+    }
+
+    // Positive control: a normal, non-guarded tracking param must still pass.
+    test("positive control: fresh utm-style param is NOT rejected", () => {
+      const r = validateParams(["utm_campaign_source_2026"], { version: 0, published: null }, nowMs, {
+        newVersion: 1,
+        newPublished: freshPub(),
+      });
+      assert.strictEqual(r.ok, true);
+      assert.deepEqual(r.accepted, ["utm_campaign_source_2026"]);
+    });
+  });
+
+  // Already-present affiliate guard entries — unchanged behavior after this
+  // change (guard is additive only; existing entries must keep rejecting).
+  describe("affiliate guard — pre-existing entries unchanged", () => {
+    const freshPub = () => new Date(nowMs - 1000 * 60 * 60).toISOString();
+    const preExisting = ["af_id", "partnerid", "affid", "aff_id", "awc", "irclickid", "irgwc", "partner"];
+
+    for (const param of preExisting) {
+      test(`still rejects pre-existing entry '${param}' → DENYLIST_HIT`, () => {
+        const r = validateParams([param], { version: 0, published: null }, nowMs, {
+          newVersion: 1,
+          newPublished: freshPub(),
+        });
+        assert.strictEqual(r.ok, false);
+        assert.strictEqual(r.code, ERR.DENYLIST_HIT);
+      });
+    }
+  });
+
   // Post-filter count (REQ-VALIDATE-6)
   test("exactly 500 params → accepted (boundary)", () => {
     const freshPub = new Date(nowMs - 1000 * 60 * 60).toISOString();


### PR DESCRIPTION
Extends `AFFILIATE_PARAM_GUARD` (REQ-VALIDATE-5) in `src/lib/remote-rules.js` so the hot-updatable remote param pipeline can never strip affiliate-attribution params.

## Why
Stripping an attribution param is uniquely dangerous: the browsing user sees no breakage (page loads fine), so the harm to the creator/publisher is **silent and never reported**. The client-side guard is the only defense. Before we use the remote list to push tracking params aggressively, the guard must be comprehensive.

A candidate triage of AdGuard Filter 17 (#998, PR #1015) surfaced affiliate-network params missing from the guard.

## Change
Additive only (per the file's maintenance rule: adding is always safe; removing needs review). Adds, grouped by network: Adjust, AppsFlyer (deep-link/config params, guarded conservatively), generic `aff_*`, Airbridge, Awin (`awinaffid`), Commission Junction (`cj_aid`/`cj_pid`), Impact Radius (`impact_*`), Partnerize, Connexity (`cnxclid`). Skipped names already present (`af_id`, `awc`, `irclickid`, `irgwc`, `partnerid`, `affid`, `aff_id`, `partner`).

## Tests
Per-network rejection tests, a positive control (a normal utm-style param still accepted), and a regression block for the 8 pre-existing entries. `npm test` 5851 pass / 0 fail; `remote-rules` suite 122 pass / 0 fail; lint + typecheck clean. Only `remote-rules.js` (+25) and its test (+59) changed.