### PR TITLE
chore(import-candidates): cross-check triage against remote guard + denylist

### DIFF
--- a/tests/unit/candidate-triage.test.mjs
+++ b/tests/unit/candidate-triage.test.mjs
@@ -324,3 +324,75 @@ describe("classifyCandidate, precedence order is checked independently of annota
     assert.notStrictEqual(result.bucket, "universal_high_confidence");
   });
 });
+
+describe("v2.3 guard cross-check: remote-rules guard/denylist can never reach universal", () => {
+  test("ascsubtag (AFFILIATE_PARAM_GUARD, no vendor pattern) -> affiliate_network_review, never universal even with two-source agreement", () => {
+    // ascsubtag is the Amazon Associates SubTag the remote guard protects
+    // (the ADR-0005 catastrophic path). Two full sources agreeing must NOT
+    // promote it.
+    const r = annotateCandidate("ascsubtag", { adguard_global: true, clearurls_global: true });
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.strictEqual(r.network, "remote-rules AFFILIATE_PARAM_GUARD");
+  });
+
+  test("campid (AFFILIATE_PARAM_GUARD) -> affiliate_network_review, not universal", () => {
+    const r = annotateCandidate("campid", { adguard_global: true });
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+  });
+
+  test("af_id (guard AND AppsFlyer vendor) keeps the richer vendor label", () => {
+    // The specific-vendor gate runs before the generic guard catch-all.
+    const r = annotateCandidate("af_id", { adguard_global: true });
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+    assert.match(r.network, /AppsFlyer/);
+  });
+
+  test("classifyCandidate: guard flag beats two-source universal promotion", () => {
+    const r = classifyCandidate({
+      is_affiliate_preserve: false,
+      is_danger_name: false,
+      is_remote_affiliate_guard: true,
+      is_remote_denylist: false,
+      clearurls_global: true,
+      clearurls_scoped_domains: [],
+      adguard_global: true,
+      adguard_scoped_domains: [],
+      affiliate_network_match: { matched: false, pattern: null, network: null },
+      tracking_vendor_match: { matched: true, pattern: "utm" },
+    });
+    assert.strictEqual(r.bucket, "affiliate_network_review");
+  });
+
+  test("classifyCandidate: remote-denylist functional name -> likely_reject (global-only), never universal", () => {
+    const r = classifyCandidate({
+      is_affiliate_preserve: false,
+      is_danger_name: false,
+      is_remote_affiliate_guard: false,
+      is_remote_denylist: true,
+      clearurls_global: true,
+      clearurls_scoped_domains: [],
+      adguard_global: true,
+      adguard_scoped_domains: [],
+      affiliate_network_match: { matched: false, pattern: null, network: null },
+      tracking_vendor_match: { matched: true, pattern: "utm" },
+    });
+    assert.strictEqual(r.bucket, "likely_reject");
+  });
+
+  test("classifyCandidate: remote-denylist functional name with scope -> domain_scoped, not universal", () => {
+    const r = classifyCandidate({
+      is_affiliate_preserve: false,
+      is_danger_name: false,
+      is_remote_affiliate_guard: false,
+      is_remote_denylist: true,
+      clearurls_global: false,
+      clearurls_scoped_domains: ["example.com"],
+      adguard_global: false,
+      adguard_scoped_domains: [],
+      affiliate_network_match: { matched: false, pattern: null, network: null },
+      tracking_vendor_match: { matched: false, pattern: null },
+    });
+    assert.strictEqual(r.bucket, "domain_scoped");
+    assert.strictEqual(r.caution, "functional-name");
+  });
+});

--- a/tools/import-candidates/triage-2026-07-05.json
+++ b/tools/import-candidates/triage-2026-07-05.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-06T22:21:43.382Z",
+  "generated_at": "2026-07-07T07:27:31.069Z",
   "schema_version": "2.1",
   "source_report_path": "C:\\Users\\parada\\Desktop\\test\\muga\\tools\\import-candidates\\report-2026-07-05.json",
   "source_label": "AdGuard Filter 17 (URL Tracking Protection)",
@@ -9,8 +9,8 @@
   "already_in_muga_dropped": 296,
   "bucket_counts": {
     "excluded_affiliate_preserve": 18,
-    "affiliate_network_review": 45,
-    "universal_high_confidence": 43,
+    "affiliate_network_review": 46,
+    "universal_high_confidence": 42,
     "domain_scoped": 156,
     "needs_human": 816,
     "likely_reject": 30
@@ -2771,7 +2771,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -2800,7 +2800,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -2829,7 +2829,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -2858,7 +2858,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -2887,7 +2887,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -2916,7 +2916,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -2945,7 +2945,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3452,7 +3452,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3481,7 +3481,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3510,7 +3510,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3568,7 +3568,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3597,7 +3597,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3626,7 +3626,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3655,7 +3655,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3684,7 +3684,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3741,7 +3741,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3770,7 +3770,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3799,7 +3799,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3828,7 +3828,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3857,7 +3857,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3886,7 +3886,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3915,7 +3915,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3944,7 +3944,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -3973,7 +3973,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -4030,7 +4030,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -4144,7 +4144,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -4464,7 +4464,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -5742,7 +5742,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -7166,7 +7166,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -7195,7 +7195,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -7936,7 +7936,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
@@ -7954,7 +7954,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "universal_high_confidence"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "cobrand",
@@ -13258,7 +13259,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -13287,7 +13288,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -13316,7 +13317,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
@@ -18966,7 +18967,7 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
-      "is_remote_affiliate_guard": false,
+      "is_remote_affiliate_guard": true,
       "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,

--- a/tools/import-candidates/triage-2026-07-05.json
+++ b/tools/import-candidates/triage-2026-07-05.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-06T13:50:52.949Z",
+  "generated_at": "2026-07-06T22:21:43.382Z",
   "schema_version": "2.1",
   "source_report_path": "C:\\Users\\parada\\Desktop\\test\\muga\\tools\\import-candidates\\report-2026-07-05.json",
   "source_label": "AdGuard Filter 17 (URL Tracking Protection)",
@@ -9,11 +9,11 @@
   "already_in_muga_dropped": 296,
   "bucket_counts": {
     "excluded_affiliate_preserve": 18,
-    "affiliate_network_review": 37,
+    "affiliate_network_review": 45,
     "universal_high_confidence": 43,
-    "domain_scoped": 161,
-    "needs_human": 822,
-    "likely_reject": 27
+    "domain_scoped": 156,
+    "needs_human": 816,
+    "likely_reject": 30
   },
   "affiliate_preserve_set": [
     "a8",
@@ -197,6 +197,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -223,6 +225,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -249,6 +253,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -275,6 +281,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -301,6 +309,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -327,6 +337,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -353,6 +365,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -379,6 +393,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -405,6 +421,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -431,6 +449,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -457,6 +477,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -483,6 +505,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -509,6 +533,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -535,6 +561,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -561,6 +589,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -587,6 +617,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -613,6 +645,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -639,6 +673,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -665,6 +701,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -691,6 +729,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -717,6 +757,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -743,6 +785,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -769,6 +813,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -795,6 +841,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -821,6 +869,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -847,6 +897,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -873,6 +925,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -899,6 +953,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -925,6 +981,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -951,6 +1009,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -977,6 +1037,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1003,6 +1065,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1029,6 +1093,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1055,6 +1121,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1081,6 +1149,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1107,6 +1177,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1133,6 +1205,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1159,6 +1233,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1185,6 +1261,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1211,6 +1289,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1237,6 +1317,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1263,6 +1345,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1289,6 +1373,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1315,6 +1401,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1341,6 +1429,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1367,6 +1457,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1393,6 +1485,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1419,6 +1513,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1445,6 +1541,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1471,6 +1569,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1497,6 +1597,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1523,6 +1625,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1549,6 +1653,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1575,6 +1681,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1601,6 +1709,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1627,6 +1737,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1653,6 +1765,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1679,6 +1793,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1705,6 +1821,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1731,6 +1849,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1757,6 +1877,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1788,6 +1910,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1814,6 +1938,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1840,6 +1966,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1869,6 +1997,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1895,6 +2025,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1923,6 +2055,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1955,6 +2089,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -1981,6 +2117,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2007,6 +2145,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2033,6 +2173,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2059,6 +2201,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2085,6 +2229,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2117,6 +2263,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2143,6 +2291,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2169,6 +2319,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2195,6 +2347,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2221,6 +2375,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2247,6 +2403,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2273,6 +2431,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2299,6 +2459,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2325,6 +2487,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2351,6 +2515,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2377,6 +2543,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2403,6 +2571,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2429,6 +2599,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2455,6 +2627,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2485,6 +2659,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2511,6 +2687,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2537,6 +2715,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2563,6 +2743,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2589,6 +2771,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "adjust",
@@ -2616,6 +2800,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "adjust",
@@ -2643,6 +2829,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "adjust",
@@ -2670,6 +2858,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "adjust",
@@ -2697,6 +2887,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "adjust",
@@ -2724,6 +2916,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "adjust",
@@ -2751,6 +2945,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "adjust",
@@ -2778,6 +2974,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2804,6 +3002,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "admitad",
@@ -2830,6 +3030,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2856,6 +3058,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2884,6 +3088,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2910,6 +3116,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2936,6 +3144,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2962,6 +3172,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -2988,6 +3200,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3014,6 +3228,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3040,6 +3256,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3066,6 +3284,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3092,6 +3312,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3118,6 +3340,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3144,6 +3368,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3170,6 +3396,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3196,6 +3424,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3222,6 +3452,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3249,6 +3481,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3276,6 +3510,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3303,6 +3539,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3330,6 +3568,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3357,6 +3597,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3384,6 +3626,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3411,6 +3655,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3438,6 +3684,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "appsflyer-af",
@@ -3465,6 +3713,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3491,6 +3741,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3518,6 +3770,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3545,6 +3799,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3572,6 +3828,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3599,6 +3857,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3626,6 +3886,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3653,6 +3915,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3680,6 +3944,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3707,6 +3973,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3734,6 +4002,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3760,6 +4030,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3787,6 +4059,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3814,6 +4088,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3840,6 +4116,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3866,6 +4144,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "generic-affiliate",
@@ -3893,6 +4173,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3909,7 +4191,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "needs_human"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "affiliate_ref",
@@ -3919,6 +4202,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3948,6 +4233,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -3974,6 +4261,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4000,6 +4289,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4026,6 +4317,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4052,6 +4345,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4078,6 +4373,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4104,6 +4401,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4136,6 +4435,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4152,7 +4453,8 @@
       "known_functional_risk": false,
       "genericness_score": 1,
       "muga_preserve_conflict_domains": [],
-      "bucket": "domain_scoped"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "airbridge_referrer",
@@ -4162,6 +4464,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "airbridge",
@@ -4189,6 +4493,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4215,6 +4521,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4245,6 +4553,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4274,6 +4584,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4300,6 +4612,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4326,6 +4640,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4352,6 +4668,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4378,6 +4696,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4404,6 +4724,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4432,6 +4754,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4458,6 +4782,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4484,6 +4810,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4510,6 +4838,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4536,6 +4866,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4565,6 +4897,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4591,6 +4925,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4617,6 +4953,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4643,6 +4981,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4669,6 +5009,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4695,6 +5037,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4721,6 +5065,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4747,6 +5093,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4773,6 +5121,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4799,6 +5149,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4825,6 +5177,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4851,6 +5205,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4880,6 +5236,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4896,7 +5254,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "domain_scoped"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "asid",
@@ -4906,6 +5265,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4932,6 +5293,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4948,7 +5311,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "needs_human"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "asubid",
@@ -4958,6 +5322,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -4984,6 +5350,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5010,6 +5378,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5036,6 +5406,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5062,6 +5434,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5088,6 +5462,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5114,6 +5490,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5140,6 +5518,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5166,6 +5546,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5192,6 +5574,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5218,6 +5602,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5244,6 +5630,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5270,6 +5658,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5296,6 +5686,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5322,6 +5714,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5348,6 +5742,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "awin",
@@ -5375,6 +5771,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5401,6 +5799,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5427,6 +5827,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5453,6 +5855,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5479,6 +5883,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5509,6 +5915,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5537,6 +5945,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5565,6 +5975,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5591,6 +6003,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5617,6 +6031,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5643,6 +6059,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5679,6 +6097,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5705,6 +6125,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5731,6 +6153,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5757,6 +6181,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5783,6 +6209,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5809,6 +6237,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5837,6 +6267,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5865,6 +6297,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5893,6 +6327,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5921,6 +6357,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5949,6 +6387,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -5977,6 +6417,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6005,6 +6447,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6033,6 +6477,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6061,6 +6507,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6089,6 +6537,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6117,6 +6567,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6145,6 +6597,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6173,6 +6627,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6199,6 +6655,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6225,6 +6683,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6251,6 +6711,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6277,6 +6739,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6303,6 +6767,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6329,6 +6795,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6355,6 +6823,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6381,6 +6851,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6410,6 +6882,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6426,7 +6900,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "domain_scoped"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "car",
@@ -6436,6 +6911,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6462,6 +6939,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6488,6 +6967,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6514,6 +6995,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6540,6 +7023,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6566,6 +7051,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6592,6 +7079,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6621,6 +7110,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6647,6 +7138,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6673,6 +7166,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "cj-prefix",
@@ -6700,6 +7195,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "cj-prefix",
@@ -6727,6 +7224,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6753,6 +7252,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6782,6 +7283,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6808,6 +7311,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6834,6 +7339,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6860,6 +7367,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6886,6 +7395,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6912,6 +7423,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6940,6 +7453,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6966,6 +7481,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -6994,6 +7511,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7025,6 +7544,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7051,6 +7572,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7077,6 +7600,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7103,6 +7628,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7129,6 +7656,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7155,6 +7684,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7181,6 +7712,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7207,6 +7740,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7233,6 +7768,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7259,6 +7796,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7285,6 +7824,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7311,6 +7852,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7337,6 +7880,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7363,6 +7908,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7389,6 +7936,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7415,6 +7964,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7443,6 +7994,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7470,6 +8023,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7496,6 +8051,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7522,6 +8079,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7551,6 +8110,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7579,6 +8140,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7605,6 +8168,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7632,6 +8197,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7658,6 +8225,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7684,6 +8253,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7710,6 +8281,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7736,6 +8309,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7762,6 +8337,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7788,6 +8365,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7814,6 +8393,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7840,6 +8421,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7866,6 +8449,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7892,6 +8477,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7918,6 +8505,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7946,6 +8535,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -7974,6 +8565,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8002,6 +8595,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8028,6 +8623,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8054,6 +8651,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8080,6 +8679,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8109,6 +8710,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8135,6 +8738,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8163,6 +8768,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8189,6 +8796,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8218,6 +8827,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8244,6 +8855,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8270,6 +8883,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8296,6 +8911,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8322,6 +8939,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8348,6 +8967,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8374,6 +8995,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8400,6 +9023,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8426,6 +9051,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8452,6 +9079,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8478,6 +9107,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8504,6 +9135,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8532,6 +9165,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8558,6 +9193,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8584,6 +9221,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8615,6 +9254,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8641,6 +9282,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8667,6 +9310,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8693,6 +9338,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8719,6 +9366,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8745,6 +9394,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8771,6 +9422,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8797,6 +9450,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8823,6 +9478,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8849,6 +9506,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8875,6 +9534,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8906,6 +9567,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8932,6 +9595,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8958,6 +9623,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -8984,6 +9651,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9010,6 +9679,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9036,6 +9707,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9062,6 +9735,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9090,6 +9765,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9116,6 +9793,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9142,6 +9821,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9170,6 +9851,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9196,6 +9879,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9222,6 +9907,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9248,6 +9935,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9274,6 +9963,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9300,6 +9991,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9328,6 +10021,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9355,6 +10050,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9381,6 +10078,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9407,6 +10106,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9433,6 +10134,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9459,6 +10162,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9485,6 +10190,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9513,6 +10220,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9542,6 +10251,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9568,6 +10279,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9594,6 +10307,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9620,6 +10335,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9646,6 +10363,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9672,6 +10391,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9698,6 +10419,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9724,6 +10447,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9750,6 +10475,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9776,6 +10503,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9802,6 +10531,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9828,6 +10559,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9854,6 +10587,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9880,6 +10615,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9906,6 +10643,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9932,6 +10671,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9958,6 +10699,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -9984,6 +10727,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10010,6 +10755,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10036,6 +10783,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10062,6 +10811,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10088,6 +10839,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10114,6 +10867,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10140,6 +10895,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10166,6 +10923,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10192,6 +10951,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10218,6 +10979,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10246,6 +11009,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10272,6 +11037,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10300,6 +11067,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10326,6 +11095,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10352,6 +11123,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10378,6 +11151,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10404,6 +11179,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10432,6 +11209,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10458,6 +11237,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10484,6 +11265,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10513,6 +11296,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10539,6 +11324,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10565,6 +11352,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10591,6 +11380,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10617,6 +11408,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10646,6 +11439,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10672,6 +11467,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10698,6 +11495,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10724,6 +11523,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10750,6 +11551,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10776,6 +11579,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10802,6 +11607,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10828,6 +11635,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10854,6 +11663,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10880,6 +11691,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10906,6 +11719,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10934,6 +11749,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10960,6 +11777,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -10986,6 +11805,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11012,6 +11833,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11038,6 +11861,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11064,6 +11889,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11090,6 +11917,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11116,6 +11945,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11142,6 +11973,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11168,6 +12001,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11194,6 +12029,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11220,6 +12057,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11246,6 +12085,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11274,6 +12115,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11302,6 +12145,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11328,6 +12173,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11354,6 +12201,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11380,6 +12229,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11406,6 +12257,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11432,6 +12285,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11448,7 +12303,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "needs_human"
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
     },
     {
       "name": "hhtmfrom",
@@ -11458,6 +12314,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11484,6 +12342,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11510,6 +12370,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11536,6 +12398,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11557,7 +12421,8 @@
         "play.google.com",
         "scholar.google.com"
       ],
-      "bucket": "needs_human"
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
     },
     {
       "name": "host",
@@ -11567,6 +12432,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11594,6 +12461,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11620,6 +12489,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11646,6 +12517,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11672,6 +12545,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11698,6 +12573,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11724,6 +12601,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11750,6 +12629,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11776,6 +12657,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11802,6 +12685,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11828,6 +12713,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11871,6 +12758,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11900,6 +12789,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11929,6 +12820,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11955,6 +12848,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -11983,6 +12878,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12009,6 +12906,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12038,6 +12937,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12064,6 +12965,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12090,6 +12993,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12116,6 +13021,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12142,6 +13049,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12168,6 +13077,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12205,6 +13116,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12231,6 +13144,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12257,6 +13172,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12285,6 +13202,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12311,6 +13230,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12337,6 +13258,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "impact-prefix",
@@ -12364,6 +13287,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "impact-prefix",
@@ -12391,6 +13316,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "impact-prefix",
@@ -12418,6 +13345,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12444,6 +13373,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12470,6 +13401,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12496,6 +13429,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12522,6 +13457,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12548,6 +13485,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12574,6 +13513,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12600,6 +13541,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12626,6 +13569,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12652,6 +13597,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12678,6 +13625,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12704,6 +13653,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12731,6 +13682,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12759,6 +13712,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12788,6 +13743,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12816,6 +13773,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12842,6 +13801,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12868,6 +13829,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12894,6 +13857,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12920,6 +13885,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12946,6 +13913,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12972,6 +13941,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -12998,6 +13969,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13024,6 +13997,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13050,6 +14025,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13076,6 +14053,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13102,6 +14081,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13128,6 +14109,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13154,6 +14137,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13180,6 +14165,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13206,6 +14193,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13232,6 +14221,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13258,6 +14249,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13286,6 +14279,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13312,6 +14307,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13338,6 +14335,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13364,6 +14363,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13390,6 +14391,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13417,6 +14420,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13445,6 +14450,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13479,7 +14486,8 @@
         "amazon.sg",
         "linkedin.com"
       ],
-      "bucket": "domain_scoped"
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
     },
     {
       "name": "kid",
@@ -13489,6 +14497,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13515,6 +14525,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13541,6 +14553,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13567,6 +14581,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13593,6 +14609,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13621,6 +14639,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13657,6 +14677,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13683,6 +14705,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13709,6 +14733,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13738,6 +14764,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13764,6 +14792,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13790,6 +14820,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13816,6 +14848,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13842,6 +14876,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13871,6 +14907,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13897,6 +14935,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13925,6 +14965,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13954,6 +14996,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -13980,6 +15024,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14006,6 +15052,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14032,6 +15080,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14061,6 +15111,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14087,6 +15139,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14114,6 +15168,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14140,6 +15196,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14166,6 +15224,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14192,6 +15252,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14218,6 +15280,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14244,6 +15308,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14270,6 +15336,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14296,6 +15364,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14325,6 +15395,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14351,6 +15423,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14377,6 +15451,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14403,6 +15479,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14429,6 +15507,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14458,6 +15538,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14484,6 +15566,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14510,6 +15594,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14536,6 +15622,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14564,6 +15652,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14590,6 +15680,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14616,6 +15708,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14642,6 +15736,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14668,6 +15764,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14694,6 +15792,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14720,6 +15820,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14748,6 +15850,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14774,6 +15878,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14800,6 +15906,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14827,6 +15935,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14853,6 +15963,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14882,6 +15994,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14908,6 +16022,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14934,6 +16050,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14960,6 +16078,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -14986,6 +16106,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15012,6 +16134,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15038,6 +16162,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15064,6 +16190,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15090,6 +16218,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15116,6 +16246,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15142,6 +16274,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15168,6 +16302,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15194,6 +16330,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15220,6 +16358,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15246,6 +16386,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15272,6 +16414,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15298,6 +16442,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15324,6 +16470,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15350,6 +16498,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15376,6 +16526,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15402,6 +16554,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15428,6 +16582,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15454,6 +16610,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15480,6 +16638,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15508,6 +16668,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15534,6 +16696,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15560,6 +16724,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15586,6 +16752,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15612,6 +16780,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15638,6 +16808,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15664,6 +16836,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15690,6 +16864,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15716,6 +16892,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15742,6 +16920,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15768,6 +16948,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15794,6 +16976,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15822,6 +17006,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15848,6 +17034,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15874,6 +17062,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15900,6 +17090,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15926,6 +17118,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15952,6 +17146,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -15980,6 +17176,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16006,6 +17204,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16032,6 +17232,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16060,6 +17262,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16086,6 +17290,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16112,6 +17318,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16138,6 +17346,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16164,6 +17374,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16190,6 +17402,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16216,6 +17430,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16244,6 +17460,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16270,6 +17488,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16296,6 +17516,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16322,6 +17544,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16348,6 +17572,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16378,6 +17604,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16407,6 +17635,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16436,6 +17666,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16462,6 +17694,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16488,6 +17722,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16514,6 +17750,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16542,6 +17780,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16568,6 +17808,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16594,6 +17836,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16620,6 +17864,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16646,6 +17892,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16672,6 +17920,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16698,6 +17948,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16724,6 +17976,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16752,6 +18006,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16778,6 +18034,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16804,6 +18062,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16830,6 +18090,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16856,6 +18118,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16889,6 +18153,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16915,6 +18181,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16941,6 +18209,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16967,6 +18237,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -16993,6 +18265,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17021,6 +18295,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17047,6 +18323,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17076,6 +18354,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17104,6 +18384,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17132,6 +18414,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17159,7 +18443,8 @@
         "zalando.de",
         "zalando.es"
       ],
-      "bucket": "domain_scoped"
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
     },
     {
       "name": "p_a",
@@ -17169,6 +18454,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17195,6 +18482,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17221,6 +18510,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17247,6 +18538,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17273,6 +18566,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17299,6 +18594,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17325,6 +18622,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17353,6 +18652,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17440,6 +18741,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17466,6 +18769,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17492,6 +18797,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17518,6 +18825,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17544,6 +18853,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17570,6 +18881,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17596,6 +18909,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17622,6 +18937,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "partnerize",
@@ -17649,6 +18966,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "partnerize",
@@ -17676,6 +18995,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17703,6 +19024,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17729,6 +19052,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17755,6 +19080,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17781,6 +19108,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17807,6 +19136,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17833,6 +19164,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17859,6 +19192,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17885,6 +19220,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17911,6 +19248,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17937,6 +19276,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17963,6 +19304,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -17989,6 +19332,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18015,6 +19360,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18041,6 +19388,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18067,6 +19416,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18093,6 +19444,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18119,6 +19472,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18145,6 +19500,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18171,6 +19528,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18199,6 +19558,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18215,7 +19576,8 @@
       "known_functional_risk": true,
       "genericness_score": 2,
       "muga_preserve_conflict_domains": [],
-      "bucket": "domain_scoped"
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
     },
     {
       "name": "phfp",
@@ -18228,6 +19590,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18257,6 +19621,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18286,6 +19652,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18312,6 +19680,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18340,6 +19710,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18366,6 +19738,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18392,6 +19766,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18418,6 +19794,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18446,6 +19824,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18472,6 +19852,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18498,6 +19880,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18524,6 +19908,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18552,6 +19938,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18580,6 +19968,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18606,6 +19996,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18632,6 +20024,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18658,6 +20052,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18684,6 +20080,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18710,6 +20108,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18736,6 +20136,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18767,6 +20169,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18793,6 +20197,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18819,6 +20225,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18845,6 +20253,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18871,6 +20281,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18900,6 +20312,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18926,6 +20340,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18956,6 +20372,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -18984,6 +20402,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19010,6 +20430,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19036,6 +20458,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19062,6 +20486,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19088,6 +20514,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19114,6 +20542,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19140,6 +20570,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19166,6 +20598,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19194,6 +20628,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19220,6 +20656,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19246,6 +20684,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19278,6 +20718,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19304,6 +20746,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19330,6 +20774,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19356,6 +20802,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19382,6 +20830,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19488,6 +20938,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19533,6 +20985,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19559,6 +21013,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19585,6 +21041,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19611,6 +21069,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "rakuten",
@@ -19637,6 +21097,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19663,6 +21125,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "rakuten",
@@ -19689,6 +21153,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "rakuten",
@@ -19715,6 +21181,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19741,6 +21209,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19767,6 +21237,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19793,6 +21265,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19819,6 +21293,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19845,6 +21321,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19871,6 +21349,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19900,6 +21380,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19926,6 +21408,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19952,6 +21436,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -19978,6 +21464,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20006,6 +21494,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20032,6 +21522,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20058,6 +21550,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20084,6 +21578,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20110,6 +21606,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20136,6 +21634,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20162,6 +21662,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20188,6 +21690,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20214,6 +21718,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20240,6 +21746,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20269,6 +21777,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20297,6 +21807,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20313,7 +21825,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "domain_scoped"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "refer_page_el_sn",
@@ -20323,6 +21836,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20349,6 +21864,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20375,6 +21892,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20401,6 +21920,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20427,6 +21948,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20453,6 +21976,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20479,6 +22004,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20505,6 +22032,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20531,6 +22060,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20559,6 +22090,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20587,6 +22120,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20615,6 +22150,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20641,6 +22178,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20667,6 +22206,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20693,6 +22234,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20721,6 +22264,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20749,6 +22294,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20777,6 +22324,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20810,6 +22359,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20836,6 +22387,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20865,6 +22418,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20891,6 +22446,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20917,6 +22474,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20943,6 +22502,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20969,6 +22530,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -20995,6 +22558,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21021,6 +22586,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21047,6 +22614,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21073,6 +22642,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21099,6 +22670,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21125,6 +22698,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21153,6 +22728,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21181,6 +22758,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21207,6 +22786,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21233,6 +22814,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21259,6 +22842,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21285,6 +22870,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21311,6 +22898,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21337,6 +22926,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21363,6 +22954,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21392,6 +22985,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21418,6 +23013,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21444,6 +23041,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21470,6 +23069,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21496,6 +23097,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21522,6 +23125,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21552,6 +23157,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21580,6 +23187,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21606,6 +23215,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21632,6 +23243,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21658,6 +23271,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21684,6 +23299,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21710,6 +23327,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21736,6 +23355,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21762,6 +23383,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21791,6 +23414,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21820,6 +23445,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21850,6 +23477,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21876,6 +23505,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21902,6 +23533,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21931,6 +23564,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21960,6 +23595,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -21986,6 +23623,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22012,6 +23651,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22038,6 +23679,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22064,6 +23707,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22093,6 +23738,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22119,6 +23766,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22145,6 +23794,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22172,6 +23823,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22198,6 +23851,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22224,6 +23879,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22250,6 +23907,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22276,6 +23935,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22302,6 +23963,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22328,6 +23991,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22356,6 +24021,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22382,6 +24049,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22410,6 +24079,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22436,6 +24107,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22462,6 +24135,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22488,6 +24163,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22514,6 +24191,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22542,6 +24221,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22568,6 +24249,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22594,6 +24277,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22620,6 +24305,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22646,6 +24333,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22674,6 +24363,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22700,6 +24391,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22726,6 +24419,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22752,6 +24447,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22778,6 +24475,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22804,6 +24503,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22830,6 +24531,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22856,6 +24559,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22882,6 +24587,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22911,6 +24618,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22939,6 +24648,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22967,6 +24678,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -22996,6 +24709,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23022,6 +24737,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23050,6 +24767,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23076,6 +24795,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23104,6 +24825,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23130,6 +24853,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23156,6 +24881,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23182,6 +24909,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23208,6 +24937,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23234,6 +24965,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23260,6 +24993,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23286,6 +25021,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23312,6 +25049,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23338,6 +25077,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23364,6 +25105,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23390,6 +25133,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23418,6 +25163,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23444,6 +25191,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23475,6 +25224,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23501,6 +25252,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23527,6 +25280,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23553,6 +25308,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23579,6 +25336,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23605,6 +25364,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23631,6 +25392,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23657,6 +25420,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23686,6 +25451,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23712,6 +25479,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23741,6 +25510,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23769,6 +25540,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23795,6 +25568,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23821,6 +25596,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23847,6 +25624,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23873,6 +25652,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23899,6 +25680,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23925,6 +25708,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23951,6 +25736,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -23979,6 +25766,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24005,6 +25794,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24031,6 +25822,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24058,6 +25851,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24084,6 +25879,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24114,6 +25911,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24144,6 +25943,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24172,6 +25973,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24198,6 +26001,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24224,6 +26029,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24250,6 +26057,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24276,6 +26085,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24329,6 +26140,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24355,6 +26168,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24371,7 +26186,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "needs_human"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "subid1",
@@ -24381,6 +26197,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24407,6 +26225,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24433,6 +26253,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24459,6 +26281,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24485,6 +26309,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24514,6 +26340,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24540,6 +26368,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24566,6 +26396,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24592,6 +26424,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24618,6 +26452,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24644,6 +26480,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24670,6 +26508,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24696,6 +26536,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24722,6 +26564,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24748,6 +26592,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24774,6 +26620,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24800,6 +26648,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24826,6 +26676,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24852,6 +26704,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24878,6 +26732,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24904,6 +26760,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24930,6 +26788,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24959,6 +26819,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -24985,6 +26847,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25011,6 +26875,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25037,6 +26903,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25063,6 +26931,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25089,6 +26959,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25115,6 +26987,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25141,6 +27015,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25167,6 +27043,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25193,6 +27071,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25222,6 +27102,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": true,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25238,7 +27120,8 @@
       "known_functional_risk": false,
       "genericness_score": 1,
       "muga_preserve_conflict_domains": [],
-      "bucket": "domain_scoped"
+      "bucket": "affiliate_network_review",
+      "network": "remote-rules AFFILIATE_PARAM_GUARD"
     },
     {
       "name": "tag3",
@@ -25251,6 +27134,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25277,6 +27162,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25303,6 +27190,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25331,6 +27220,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25357,6 +27248,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25383,6 +27276,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25409,6 +27304,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25435,6 +27332,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": true,
         "pattern": "tradedoubler",
@@ -25461,6 +27360,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25487,6 +27388,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25513,6 +27416,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25541,6 +27446,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25567,6 +27474,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25593,6 +27502,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25622,6 +27533,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25665,6 +27578,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25691,6 +27606,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25718,6 +27635,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25734,7 +27653,8 @@
       "known_functional_risk": false,
       "genericness_score": 0,
       "muga_preserve_conflict_domains": [],
-      "bucket": "needs_human"
+      "bucket": "likely_reject",
+      "reason": "load-bearing functional name, unsafe to strip universally, no domain scope"
     },
     {
       "name": "tksid",
@@ -25744,6 +27664,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25770,6 +27692,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25796,6 +27720,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25825,6 +27751,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25851,6 +27779,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25877,6 +27807,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25903,6 +27835,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25929,6 +27863,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25955,6 +27891,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -25981,6 +27919,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26007,6 +27947,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26036,6 +27978,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26062,6 +28006,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26090,6 +28036,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26116,6 +28064,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26142,6 +28092,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26168,6 +28120,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26194,6 +28148,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26223,6 +28179,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26249,6 +28207,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26275,6 +28235,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26301,6 +28263,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26327,6 +28291,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26353,6 +28319,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26379,6 +28347,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26405,6 +28375,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26431,6 +28403,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26457,6 +28431,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26483,6 +28459,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26509,6 +28487,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26535,6 +28515,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26561,6 +28543,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26587,6 +28571,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26613,6 +28599,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26639,6 +28627,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26665,6 +28655,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26691,6 +28683,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26717,6 +28711,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26743,6 +28739,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26769,6 +28767,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26797,6 +28797,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26823,6 +28825,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26849,6 +28853,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26875,6 +28881,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26903,6 +28911,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26932,6 +28942,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26968,6 +28980,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -26997,6 +29011,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27025,6 +29041,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27051,6 +29069,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27077,6 +29097,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27103,6 +29125,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27129,6 +29153,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27155,6 +29181,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27181,6 +29209,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27209,6 +29239,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27225,7 +29257,8 @@
       "known_functional_risk": false,
       "genericness_score": 1,
       "muga_preserve_conflict_domains": [],
-      "bucket": "domain_scoped"
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
     },
     {
       "name": "uid.p",
@@ -27235,6 +29268,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27261,6 +29296,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27287,6 +29324,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27313,6 +29352,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27342,6 +29383,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27370,6 +29413,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27396,6 +29441,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27424,6 +29471,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27450,6 +29499,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27476,6 +29527,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27503,6 +29556,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27529,6 +29584,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27556,6 +29613,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27582,6 +29641,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27611,6 +29672,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27637,6 +29700,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27663,6 +29728,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27689,6 +29756,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27715,6 +29784,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27742,6 +29813,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27768,6 +29841,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27794,6 +29869,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27820,6 +29897,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27846,6 +29925,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27872,6 +29953,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27898,6 +29981,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27924,6 +30009,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27953,6 +30040,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -27981,6 +30070,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": true,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28001,7 +30092,8 @@
         "fb.com",
         "youtube.com"
       ],
-      "bucket": "domain_scoped"
+      "bucket": "domain_scoped",
+      "caution": "functional-name"
     },
     {
       "name": "v_p",
@@ -28011,6 +30103,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28037,6 +30131,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28063,6 +30159,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28089,6 +30187,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28116,6 +30216,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28142,6 +30244,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28168,6 +30272,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28195,6 +30301,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": true,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28222,6 +30330,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28248,6 +30358,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28274,6 +30386,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28300,6 +30414,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28326,6 +30442,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28352,6 +30470,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28378,6 +30498,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28404,6 +30526,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28430,6 +30554,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28456,6 +30582,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28482,6 +30610,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28508,6 +30638,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28534,6 +30666,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28560,6 +30694,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28588,6 +30724,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28614,6 +30752,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28640,6 +30780,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28666,6 +30808,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28692,6 +30836,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28720,6 +30866,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28746,6 +30894,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28775,6 +30925,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28804,6 +30956,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28830,6 +30984,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28856,6 +31012,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28882,6 +31040,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28908,6 +31068,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28934,6 +31096,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28960,6 +31124,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -28986,6 +31152,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29012,6 +31180,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29038,6 +31208,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29064,6 +31236,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29090,6 +31264,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29116,6 +31292,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29142,6 +31320,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": true,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29168,6 +31348,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29194,6 +31376,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29220,6 +31404,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29246,6 +31432,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29272,6 +31460,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29298,6 +31488,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29324,6 +31516,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29350,6 +31544,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29376,6 +31572,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29402,6 +31600,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29428,6 +31628,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29454,6 +31656,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29480,6 +31684,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29506,6 +31712,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29534,6 +31742,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29560,6 +31770,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29586,6 +31798,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29615,6 +31829,8 @@
       ],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29641,6 +31857,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29667,6 +31885,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29693,6 +31913,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29719,6 +31941,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29745,6 +31969,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29771,6 +31997,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29800,6 +32028,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,
@@ -29826,6 +32056,8 @@
       "adguard_scoped_domains": [],
       "is_affiliate_preserve": false,
       "is_danger_name": false,
+      "is_remote_affiliate_guard": false,
+      "is_remote_denylist": false,
       "affiliate_network_match": {
         "matched": false,
         "pattern": null,

--- a/tools/import-candidates/triage-2026-07-05.md
+++ b/tools/import-candidates/triage-2026-07-05.md
@@ -13,8 +13,8 @@ Candidate report file: C:\Users\parada\Desktop\test\muga\tools\import-candidates
 - Total candidates in input report: 1404
 - Already in MUGA (dropped from triage, counted only): 296
 - excluded_affiliate_preserve: 18
-- affiliate_network_review: 45
-- universal_high_confidence: 43
+- affiliate_network_review: 46
+- universal_high_confidence: 42
 - domain_scoped: 156
 - needs_human: 816
 - likely_reject: 30
@@ -151,7 +151,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `tduid`
 - `wt_mc`
 
-## affiliate_network_review (45)
+## affiliate_network_review (46)
 
 - `adj_adgroup` (network: Adjust)
 - `adj_adnomia_click_id` (network: Adjust)
@@ -190,6 +190,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `campid` (network: remote-rules AFFILIATE_PARAM_GUARD)
 - `cj_aid` (network: CJ Affiliate (Commission Junction))
 - `cj_pid` (network: CJ Affiliate (Commission Junction))
+- `cnxclid` (network: remote-rules AFFILIATE_PARAM_GUARD)
 - `impact_ad_id` (network: Impact Radius)
 - `impact_click_id` (network: Impact Radius)
 - `impact_product_sku` (network: Impact Radius)
@@ -199,7 +200,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `subid` (network: remote-rules AFFILIATE_PARAM_GUARD)
 - `tag` (network: remote-rules AFFILIATE_PARAM_GUARD)
 
-## universal_high_confidence (43)
+## universal_high_confidence (42)
 
 - `_oak_freesia_scene`
 - `_oak_gallery_order`
@@ -210,7 +211,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `adclid`
 - `afclid`
 - `amc`
-- `cnxclid`
 - `dicbo`
 - `dsp_click_id`
 - `etcc_cmp`

--- a/tools/import-candidates/triage-2026-07-05.md
+++ b/tools/import-candidates/triage-2026-07-05.md
@@ -13,11 +13,11 @@ Candidate report file: C:\Users\parada\Desktop\test\muga\tools\import-candidates
 - Total candidates in input report: 1404
 - Already in MUGA (dropped from triage, counted only): 296
 - excluded_affiliate_preserve: 18
-- affiliate_network_review: 37
+- affiliate_network_review: 45
 - universal_high_confidence: 43
-- domain_scoped: 161
-- needs_human: 822
-- likely_reject: 27
+- domain_scoped: 156
+- needs_human: 816
+- likely_reject: 30
 
 ## Methodology (v2.1)
 
@@ -151,7 +151,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `tduid`
 - `wt_mc`
 
-## affiliate_network_review (37)
+## affiliate_network_review (45)
 
 - `adj_adgroup` (network: Adjust)
 - `adj_adnomia_click_id` (network: Adjust)
@@ -181,8 +181,13 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `aff_track` (network: Generic affiliate marker)
 - `affid` (network: Generic affiliate marker)
 - `affiliate` (network: Generic affiliate marker)
+- `affiliate_id` (network: remote-rules AFFILIATE_PARAM_GUARD)
+- `aid` (network: remote-rules AFFILIATE_PARAM_GUARD)
 - `airbridge_referrer` (network: Airbridge)
+- `ascsubtag` (network: remote-rules AFFILIATE_PARAM_GUARD)
+- `associatetag` (network: remote-rules AFFILIATE_PARAM_GUARD)
 - `awinaffid` (network: Awin)
+- `campid` (network: remote-rules AFFILIATE_PARAM_GUARD)
 - `cj_aid` (network: CJ Affiliate (Commission Junction))
 - `cj_pid` (network: CJ Affiliate (Commission Junction))
 - `impact_ad_id` (network: Impact Radius)
@@ -190,6 +195,9 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `impact_product_sku` (network: Impact Radius)
 - `partnerid` (network: Partnerize (Performance Horizon))
 - `partnerizecampaignid` (network: Partnerize (Performance Horizon))
+- `refcode` (network: remote-rules AFFILIATE_PARAM_GUARD)
+- `subid` (network: remote-rules AFFILIATE_PARAM_GUARD)
+- `tag` (network: remote-rules AFFILIATE_PARAM_GUARD)
 
 ## universal_high_confidence (43)
 
@@ -237,7 +245,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `wt_so`
 - `zrclid`
 
-## domain_scoped (161)
+## domain_scoped (156)
 
 - `a_aid` (domains: affiliate.privatevpn.com, expressvpn.com, vpnarea.com, wook.pt)
 - `abtest` (domains: taobao.com, tmall.com)
@@ -246,11 +254,9 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `actionid` (domains: otto.de, ottoversand.at)
 - `adcref` (domains: facebook, fafit24.de)
 - `affiliateid` (domains: otto.de, ottoversand.at)
-- `aid` (domains: adgardvpn-help.*, adguard-dns.io, adguard-vpn.*, adguard.com, adguard.info)
 - `ali_trackid` (domains: taobao.com, tmall.com)
 - `anid` (domains: reuters.com)
 - `apppopyn` (domains: emart.ssg.com, m-emart.ssg.com)
-- `ascsubtag` (domains: amazon, amazon search)
 - `bid` (domains: fafit24.de, google)
 - `bidtype` (domains: google)
 - `bitcampaigncode` (domains: google)
@@ -267,7 +273,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `c_ut` (domains: mercadolibre)
 - `c_ver` (domains: mercadolibre)
 - `c_wh` (domains: mercadolibre)
-- `campid` (domains: otto.de, ottoversand.at)
 - `channable` (domains: easynotebooks.de, notebook.de)
 - `ckwhere` (domains: emart.ssg.com, m-emart.ssg.com)
 - `clickorigin` (domains: argos.co.uk)
@@ -296,7 +301,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `iid` (domains: flipkart)
 - `iref` (domains: facebook, zoho.com)
 - `jumpreferrer` (domains: facebook)
-- `keywords` (domains: amazon)
+- `keywords` (domains: amazon) [caution: functional-name]
 - `l` (domains: mercadolibre)
 - `l-id` (domains: nikki.ne.jp, rakuten.co.jp, rebates.jp)
 - `laz_trackid` (domains: lazada.com.ph, lazada.vn)
@@ -319,9 +324,9 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `oref` (domains: defenseone.com, facebook, govexec.com, nextgov.com, route-fifty.com)
 - `originalreferer` (domains: facebook)
 - `outlink` (domains: sedaily.com)
-- `p` (domains: billiger.de)
+- `p` (domains: billiger.de) [caution: functional-name]
 - `page` (domains: alibaba cloud arms) [caution: functional-name]
-- `pg` (domains: fnnews.com)
+- `pg` (domains: fnnews.com) [caution: functional-name]
 - `phfp` (domains: proton.me, protonvpn.com)
 - `phone_code` (domains: shein.co.uk, shein.com)
 - `pid` (domains: alibaba cloud arms, flipkart)
@@ -338,7 +343,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `recom` (domains: vk.com, vk.ru)
 - `redirect_source` (domains: mozilla.org)
 - `ref_type` (domains: backit.me, epn.bz)
-- `refcode` (domains: facebook)
 - `referenceid` (domains: facebook)
 - `referer` (domains: facebook)
 - `referid` (domains: facebook)
@@ -375,7 +379,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `sub_rt` (domains: comemo.nikkei.com, diehardtales.com, greenplanet.kaneka.co.jp, j-yokatsu2.edu.city.uruma.okinawa.jp, labo.rheos.jp, note-harumi.sbfoods.co.jp, note.basicinc.jp, note.bcnretail.com, note.calbee.jp, note.com, note.gallery.intage.com, note.jp, note.kogakuin.ac.jp, note.minne.com, note.montblanc.design, note.nhkso.or.jp, note.pokkasapporo-fb.jp, note.roxx.co.jp, note.smartnews-ads.com, note.universal-music.co.jp, note.yamap.com, note.zochang.com, refalover-note.mainichi.jp, shanaiho.itandi.co.jp, uragawa-note.jpn.panasonic.com, webtripper.jp)
 - `suid` (domains: taobao.com, tmall.com)
 - `t-src` (domains: tuta.com, tutanota.com)
-- `tag` (domains: alibaba cloud arms, ceneo.pl)
 - `tag3` (domains: decathlon.pl, ibood.com)
 - `taid` (domains: reuters.com)
 - `th` (domains: amazon, amazon search)
@@ -387,13 +390,13 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `type` (domains: mercadolibre, xiaohongshu.com) [caution: functional-name]
 - `u` (domains: LinkedIn Learning, tweakers)
 - `u1` (domains: walmart.com)
-- `uid` (domains: alibaba cloud arms)
+- `uid` (domains: alibaba cloud arms) [caution: functional-name]
 - `union_lens` (domains: taobao.com, tmall.com)
 - `uniqueid` (domains: gamespot.com)
 - `up_id` (domains: bilibili.com)
 - `urrad` (domains: belta.co.jp, u-s-s.jp)
 - `utparam` (domains: taobao.com, tmall.com)
-- `v` (domains: mercadolibre)
+- `v` (domains: mercadolibre) [caution: functional-name]
 - `waad` (domains: nikkei)
 - `weibo_id` (domains: weibo)
 - `wgexpiry` (domains: decathlon.pl, ibood.com)
@@ -401,7 +404,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `xid` (domains: prvnizpravy.cz)
 - `xmt` (domains: threads.com, threads.net)
 
-## needs_human (822)
+## needs_human (816)
 
 - `_1ld`
 - `_1lp`
@@ -496,7 +499,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `adxarea`
 - `affijet-click`
 - `affil`
-- `affiliate_id`
 - `affiliate_ref`
 - `affitest`
 - `affname`
@@ -526,7 +528,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `asb`
 - `asb2`
 - `asid`
-- `associatetag`
 - `asubid`
 - `at`
 - `atlorigin`
@@ -715,11 +716,9 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `gsxid`
 - `gtmpos`
 - `guid`
-- `height`
 - `hhtmfrom`
 - `history_adids`
 - `history_postids`
-- `hl`
 - `hvadid`
 - `hvbmt`
 - `hvdev`
@@ -1067,7 +1066,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `style`
 - `sub-campaign`
 - `sub_1`
-- `subid`
 - `subid1`
 - `subid2`
 - `subid3`
@@ -1108,7 +1106,6 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `tg_rhash`
 - `tgp`
 - `tid`
-- `timezone`
 - `tksid`
 - `tm_hem`
 - `tokenid`
@@ -1226,11 +1223,13 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `z`
 - `zdroj`
 
-## likely_reject (27)
+## likely_reject (30)
 
 - `action` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `country` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `date` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `height` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `hl` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `host` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `id` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `ip` -- load-bearing functional name, unsafe to strip universally, no domain scope
@@ -1248,6 +1247,7 @@ from v1 (not used to gate buckets): `tracking_prefix_family`, `known_functional_
 - `signature` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `state` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `time` -- load-bearing functional name, unsafe to strip universally, no domain scope
+- `timezone` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `token` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `uri` -- load-bearing functional name, unsafe to strip universally, no domain scope
 - `url` -- load-bearing functional name, unsafe to strip universally, no domain scope

--- a/tools/import-candidates/triage.mjs
+++ b/tools/import-candidates/triage.mjs
@@ -110,6 +110,10 @@ import { dirname, resolve } from "node:path";
 import { adguardTp } from "../rule-ingestion/adapters/adguard-tp.mjs";
 import { clearurls } from "../rule-ingestion/adapters/clearurls.mjs";
 import { REDIRECT_NETWORK_PATTERNS } from "../../src/lib/affiliates.js";
+// v2.3 guard cross-check: the remote-rules pipeline rejects these at signing
+// time (REQ-VALIDATE-4/5). Mirroring them here keeps the triage from ever
+// surfacing a param in a promotable bucket that could never actually ship.
+import { AFFILIATE_PARAM_GUARD, REMOTE_PARAM_DENYLIST } from "../../src/lib/remote-rules.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -480,6 +484,8 @@ export function matchAffiliateNetwork(name) {
  * @param {string[]} signals.adguard_scoped_domains
  * @param {boolean} signals.is_affiliate_preserve
  * @param {boolean} signals.is_danger_name
+ * @param {boolean} [signals.is_remote_affiliate_guard]
+ * @param {boolean} [signals.is_remote_denylist]
  * @param {{matched: boolean, pattern: string|null, network: string|null}} signals.affiliate_network_match
  * @param {{matched: boolean, pattern: string|null}} signals.tracking_vendor_match
  * @returns {{ bucket: "excluded_affiliate_preserve"|"affiliate_network_review"|"universal_high_confidence"|"domain_scoped"|"needs_human"|"likely_reject", caution?: string, reason?: string, network?: string }}
@@ -495,8 +501,24 @@ export function classifyCandidate(signals) {
     return { bucket: "excluded_affiliate_preserve" };
   }
 
-  // FIX 2 (runs second, only for candidates not caught by FIX 1).
-  if (signals.is_danger_name) {
+  // v2.1 gate: known affiliate-network vendor match routes to human review with
+  // its network label. Runs before the generic guard cross-check so a param
+  // that matches a specific network keeps the richer, more useful label.
+  if (signals.affiliate_network_match?.matched) {
+    return { bucket: "affiliate_network_review", network: signals.affiliate_network_match.network };
+  }
+
+  // v2.3 guard cross-check. The remote-rules pipeline REJECTS these at signing
+  // time; mirror that so the triage never promotes a param that could never
+  // ship. AFFILIATE_PARAM_GUARD is attribution (never strip) -> review; it is a
+  // catch-all for guard params without a specific vendor pattern above.
+  if (signals.is_remote_affiliate_guard) {
+    return { bucket: "affiliate_network_review", network: "remote-rules AFFILIATE_PARAM_GUARD" };
+  }
+
+  // FIX 2: danger names and remote-denylist functional names get the same
+  // treatment: never universal (scoped -> domain_scoped, else -> likely_reject).
+  if (signals.is_danger_name || signals.is_remote_denylist) {
     if (anyScoped) {
       return { bucket: "domain_scoped", caution: "functional-name" };
     }
@@ -506,14 +528,7 @@ export function classifyCandidate(signals) {
     };
   }
 
-  // v2.1 NEW GATE (runs third, only for candidates not caught by FIX 1 or
-  // FIX 2, and before FIX 3's universal path).
-  if (signals.affiliate_network_match?.matched) {
-    return { bucket: "affiliate_network_review", network: signals.affiliate_network_match.network };
-  }
-
-  // FIX 3 (runs fourth, only for candidates not caught by FIX 1, FIX 2, or
-  // the affiliate-network gate).
+  // FIX 3 (runs last, only for candidates not caught by the gates above).
   const vendorMatched = Boolean(signals.tracking_vendor_match?.matched);
   const adguardGlobal = Boolean(signals.adguard_global);
   const clearurlsGlobal = Boolean(signals.clearurls_global);
@@ -561,6 +576,11 @@ export function annotateCandidate(name, external = {}) {
   const is_danger_name = isDangerName(name);
   const affiliate_network_match = matchAffiliateNetwork(name); // v2.1 NEW
   const tracking_vendor_match = matchTrackingVendor(name);
+  // v2.3 guard cross-check signals (case-insensitive, matching the remote
+  // pipeline which lowercases before comparing).
+  const _lower = name.toLowerCase();
+  const is_remote_affiliate_guard = AFFILIATE_PARAM_GUARD.has(_lower);
+  const is_remote_denylist = REMOTE_PARAM_DENYLIST.has(_lower);
 
   const signals = {
     name,
@@ -570,6 +590,8 @@ export function annotateCandidate(name, external = {}) {
     adguard_scoped_domains: external.adguard_scoped_domains ?? [],
     is_affiliate_preserve,
     is_danger_name,
+    is_remote_affiliate_guard,
+    is_remote_denylist,
     affiliate_network_match,
     tracking_vendor_match,
     tracking_prefix_family,


### PR DESCRIPTION
Follow-up hardening to the candidate-triage tooling (#1015).

## Problem
The classifier could place a param in a promotable bucket even when MUGA's remote-rules pipeline would reject it at signing (REQ-VALIDATE-4/5). Notably `campid` (eBay affiliate) and `ascsubtag` (Amazon Associates, the ADR-0005 catastrophic path) surfaced outside `affiliate_network_review`.

## Fix
Imports `AFFILIATE_PARAM_GUARD` and `REMOTE_PARAM_DENYLIST` from `remote-rules.js` and adds two precedence gates:
- guard params -> `affiliate_network_review` (never universal),
- denylist functional names -> `domain_scoped` (scoped) or `likely_reject`.

The specific-vendor gate runs before the generic guard catch-all, so a vendor-matched name like `af_id` keeps its richer `AppsFlyer` label while pure-guard names like `ascsubtag` get the `remote-rules AFFILIATE_PARAM_GUARD` label. Verified: **zero** guard/denylist params remain in `universal_high_confidence` (43).

## Third-source experiment dropped (on purpose)
This iteration does NOT include the uBlock/Brave/Firefox corroboration work explored earlier: uBlock overlaps AdGuard (only 13 low-quality corroborations), Brave now loads its list from a runtime remote JSON (no static array to parse), and Firefox's conservative list added zero net promotions. Stacking overlapping ABP lists yielded near-zero safe value, so the ~816 `needs_human` tail stays a manual/low-priority backlog rather than being auto-mined.

## Tests
Pins the guard gate (ascsubtag/campid -> review, never universal even with two-source agreement), the denylist gate (global -> reject, scoped -> domain_scoped), and vendor-label precedence (af_id -> AppsFlyer). `npm test` 5864 pass / 0 fail; lint + typecheck clean.