### PR TITLE
fix(remote-rules): guard cjevent against remote-payload stripping

### DIFF
--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -151,6 +151,8 @@ export const AFFILIATE_PARAM_GUARD = Object.freeze(new Set([
   "awinaffid",
   // Commission Junction
   "cj_aid", "cj_pid",
+  // Commission Junction click identifier (attribution)
+  "cjevent",
   // Impact Radius
   "impact_ad_id", "impact_click_id", "impact_product_sku",
   // Partnerize

--- a/tests/unit/remote-rules.test.mjs
+++ b/tests/unit/remote-rules.test.mjs
@@ -203,6 +203,13 @@ describe("Constants — shape and values", () => {
     assert.ok(AFFILIATE_PARAM_GUARD.size >= 10, `must have >= 10 entries, got ${AFFILIATE_PARAM_GUARD.size}`);
   });
 
+  test("AFFILIATE_PARAM_GUARD contains 'cjevent' (Commission Junction click identifier)", () => {
+    assert.ok(
+      AFFILIATE_PARAM_GUARD.has("cjevent"),
+      "cjevent must be guarded so a compromised remote-rules endpoint can never strip it",
+    );
+  });
+
   test("PARAM_FORMAT_RE is the correct regex", () => {
     assert.ok(PARAM_FORMAT_RE instanceof RegExp);
     assert.ok(PARAM_FORMAT_RE.test("utm_source"));


### PR DESCRIPTION
## What
Adds `cjevent` (Commission Junction click identifier) to `AFFILIATE_PARAM_GUARD`.

## Why
CJ reads `cjevent` at the advertiser landing page to credit the publisher's commission. Stripping it silently destroys affiliate attribution (REQ-VALIDATE-5 / ADR-0005 class). It was neither guarded nor in `TRACKING_PARAMS`, so a compromised or buggy signed remote payload could have added it to the strip set with nothing to stop it. Guarding it makes `validateParams` reject any such payload.

## Safety
- `cjevent` stays OUT of `TRACKING_PARAMS`, so the #815 strip/guard coherence invariant holds.
- Runtime cleaning is unchanged (the guard gates remote payloads only, not the runtime cleaner).

## Scope note
This is the safe, isolated slice. The AdGuard `@@removeparam` preserve-harvest that was explored alongside this is deliberately NOT included: it drops globally-stripped params (utm_*, etc.) from the global DNR rule because `generate-rules.mjs` cannot yet emit domain-conditioned DNR (`excludedRequestDomains`). That generator enhancement is the prerequisite and is tracked as a separate increment.

## Tests
Adds an assertion that the guard contains `cjevent`. `npm test` 5877 pass / 0 fail; `lint:js` + `typecheck` clean.