### PR TITLE
fix(rules): domain-conditioned DNR strip instead of global drop

### DIFF
--- a/src/lib/dnr-ids.js
+++ b/src/lib/dnr-ids.js
@@ -15,6 +15,12 @@
  *              its own file-scoped namespace, distinct from tracking-params.json's 1/2)
  *   200      — static ruleset: Amazon /dp/ SEO-slug strip, Chrome-only DNR
  *              regexSubstitution redirect (amazon-path-canonical.json) — #903
+ *   300-799  — static ruleset: domain-conditioned tracking-param strip
+ *              (tracking-params.json). One rule per unique preserve-domain set:
+ *              strips a param everywhere EXCEPT the domains where it is
+ *              functional (excludedRequestDomains). Replaces the old behavior of
+ *              dropping the param from the global rule, which silently
+ *              un-stripped it network-wide.
  *   1000     — dynamic custom params rule (user-defined params, DNR redirect)
  *   1001     — dynamic remote params rule (signed remote payload, DNR redirect)
  *   2000-2499 — dynamic allowlist "allow" rules (#allowlist-full-inert), one
@@ -40,6 +46,23 @@ export const DNR_STATIC_RULE_ID = 1;
  * closing the gap where the in-page cleaner strips them but DNR did not.
  */
 export const DNR_AMAZON_PARAMS_RULE_ID = 2;
+
+/**
+ * Base ID for the static domain-conditioned tracking-param strip rules emitted
+ * into tracking-params.json. A param that is functional on specific domains
+ * (domain-rules preserveParams) is stripped everywhere EXCEPT those domains via
+ * `excludedRequestDomains`, instead of being dropped from the global rule (which
+ * silently un-stripped it network-wide). Rules are grouped by identical
+ * exclude-domain set; id = DNR_DOMAIN_PRESERVE_RULE_ID_BASE + group index.
+ */
+export const DNR_DOMAIN_PRESERVE_RULE_ID_BASE = 300;
+
+/**
+ * Cap on the number of domain-conditioned strip rule groups. Well under
+ * Chrome's static-rule ceiling; the generator fails loudly if exceeded so the
+ * 300-799 range can never overrun into DNR_CUSTOM_PARAMS_RULE_ID (1000).
+ */
+export const DNR_DOMAIN_PRESERVE_MAX_RULES = 500;
 
 /**
  * ID of the dynamic rule that removes user-defined custom params.

--- a/src/rules/tracking-params.json
+++ b/src/rules/tracking-params.json
@@ -463,6 +463,136 @@
     }
   },
   {
+    "id": 300,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "queryTransform": {
+            "removeParams": [
+              "cid"
+            ]
+          }
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "*",
+      "excludedRequestDomains": [
+        "aladin.co.kr",
+        "google.com",
+        "maps.google.com",
+        "sharepoint.com"
+      ],
+      "resourceTypes": [
+        "main_frame"
+      ]
+    }
+  },
+  {
+    "id": 301,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "queryTransform": {
+            "removeParams": [
+              "ie"
+            ]
+          }
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "*",
+      "excludedRequestDomains": [
+        "baidu.com",
+        "naver.com"
+      ],
+      "resourceTypes": [
+        "main_frame"
+      ]
+    }
+  },
+  {
+    "id": 302,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "queryTransform": {
+            "removeParams": [
+              "ref_"
+            ]
+          }
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "*",
+      "excludedRequestDomains": [
+        "imdb.com"
+      ],
+      "resourceTypes": [
+        "main_frame"
+      ]
+    }
+  },
+  {
+    "id": 303,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "queryTransform": {
+            "removeParams": [
+              "ei"
+            ]
+          }
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "*",
+      "excludedRequestDomains": [
+        "yahoo.co.jp",
+        "yahoo.com"
+      ],
+      "resourceTypes": [
+        "main_frame"
+      ]
+    }
+  },
+  {
+    "id": 304,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "queryTransform": {
+            "removeParams": [
+              "ab_channel"
+            ]
+          }
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "*",
+      "excludedRequestDomains": [
+        "youtube.com"
+      ],
+      "resourceTypes": [
+        "main_frame"
+      ]
+    }
+  },
+  {
     "id": 2,
     "priority": 1,
     "action": {

--- a/tests/unit/dnr-runtime-parity.test.mjs
+++ b/tests/unit/dnr-runtime-parity.test.mjs
@@ -4,15 +4,20 @@
  * Verifies that Chrome DNR's global strip and the runtime cleaner produce
  * the same set of stripped params for a 10-URL corpus.
  *
- * Two divergence cases are included where a param is in BOTH TRACKING_PARAMS
- * (so it IS in DNR's removeParams globally) AND in a domain's preserveParams
- * (so the generator EXCLUDED it from the DNR rule for that domain). Both DNR
- * and runtime cleaner correctly PRESERVE the param on those domains — the
- * "divergence" name refers to the MECHANISM being different, not the outcome.
+ * Divergence cases are included where a param is in BOTH TRACKING_PARAMS AND a
+ * domain's preserveParams. The generator emits such a param in a
+ * domain-conditioned DNR rule (excludedRequestDomains = its preserve domains),
+ * so DNR strips it everywhere EXCEPT those domains — matching the runtime
+ * cleaner, which preserves it via the domain rule on those hosts and strips it
+ * elsewhere. On the preserve host both PRESERVE (via different mechanisms); on
+ * any other host both STRIP. This is the fix for the old behavior that dropped
+ * a domain-preserved param from the global rule entirely, un-stripping it
+ * network-wide.
  *
- * Divergence pairs verified by one-liner on 2026-05-13:
- *   sharepoint.com -> cid  (in preserveParams + in TRACKING_PARAMS)
- *   aladin.co.kr   -> cid  (in preserveParams + in TRACKING_PARAMS)
+ * Divergence pairs (in preserveParams + in TRACKING_PARAMS):
+ *   sharepoint.com -> cid
+ *   aladin.co.kr   -> cid
+ *   www.youtube.com -> ab_channel
  *
  * Run with: node --test tests/unit/dnr-runtime-parity.test.mjs
  */
@@ -51,10 +56,13 @@ const PREFS = {
 
 // ── Corpus ────────────────────────────────────────────────────────────────────
 //
-// 8 "must agree" URLs: DNR and runtime strip set MUST be identical.
-// 2 "must diverge by design" URLs: param is in preserveParams for the domain
-//   so both DNR (excluded from removeParams) and runtime (domain rule) PRESERVE
-//   it — test asserts the param survives in BOTH output URLs.
+// "must agree" URLs: DNR and runtime strip set MUST be identical. Includes a
+//   conditioned param (cid) on a NON-preserve host, which must be stripped by
+//   BOTH the domain-conditioned DNR rule and the runtime cleaner — the
+//   regression guard for the old network-wide un-strip.
+// "must diverge" URLs: param is in preserveParams for the host, so both DNR
+//   (host in the rule's excludedRequestDomains) and runtime (domain rule)
+//   PRESERVE it — test asserts the param survives in BOTH output URLs.
 
 const CORPUS = [
   // ── 8 "DNR and runtime MUST agree" cases ─────────────────────────────────
@@ -93,11 +101,21 @@ const CORPUS = [
     url: "https://example.com/?cjevent=abc&irgwc=def&tduid=ghi",
     divergence: false,
   },
+  {
+    // Regression guard (#dnr-domain-preserve): cid is preserved on sharepoint/
+    // aladin/google, so it lives in a domain-conditioned DNR rule. On a host
+    // NOT in that rule's excludedRequestDomains it MUST still be stripped by
+    // DNR — exactly as the runtime cleaner strips it here. Previously cid was
+    // dropped from the global rule and leaked network-wide.
+    url: "https://example.com/?cid=strip_me&utm_source=strip_me",
+    divergence: false,
+  },
 
-  // ── 2 "DNR and runtime MUST DIVERGE by design" (preserveParams) ──────────
+  // ── "DNR and runtime MUST DIVERGE" (preserveParams) ──────────────────────
   // sharepoint.com has cid in preserveParams (domain-rules.json verified).
-  // cid is in TRACKING_PARAMS → excluded from removeParams for this domain.
-  // Both DNR and runtime PRESERVE cid here; utm_source is still stripped.
+  // cid is in TRACKING_PARAMS → emitted in a domain-conditioned rule whose
+  // excludedRequestDomains includes sharepoint.com. Both DNR and runtime
+  // PRESERVE cid here; utm_source is still stripped.
   {
     url: "https://sharepoint.com/page?cid=keep_me&utm_source=strip_me",
     divergence: true,
@@ -110,26 +128,48 @@ const CORPUS = [
     divergence: true,
     preservedParam: "cid",
   },
+  // www.youtube.com has ab_channel in preserveParams; the conditioned rule
+  // excludes youtube.com, so the subdomain www.youtube.com is excluded too.
+  // Both PRESERVE ab_channel; gclid is still stripped.
+  {
+    url: "https://www.youtube.com/watch?v=abc&ab_channel=SomeChannel&gclid=strip_me",
+    divergence: true,
+    preservedParam: "ab_channel",
+  },
 ];
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /**
- * Simulates Chrome DNR queryTransform.removeParams semantics.
- * Removes params by exact case-insensitive match — no prefix matching.
+ * True when a hostname is the domain or a subdomain of it — mirrors DNR
+ * requestDomains/excludedRequestDomains matching (domain + subdomains).
+ */
+function hostUnderAny(hostname, domains) {
+  return domains.some((d) => hostname === d || hostname.endsWith("." + d));
+}
+
+/**
+ * Simulates Chrome DNR queryTransform.removeParams semantics across ALL rules
+ * in tracking-params.json, honoring each rule's condition (requestDomains /
+ * excludedRequestDomains). Removes params by exact case-insensitive match — no
+ * prefix matching.
  *
  * @param {string} rawUrl
  * @param {Array}  trackingParamsJson — parsed tracking-params.json array
  * @returns {string} cleaned URL
  */
 function simulateDnr(rawUrl, trackingParamsJson) {
-  const rule = trackingParamsJson[0];
-  const removeParams = new Set(
-    rule.action.redirect.transform.queryTransform.removeParams.map((p) =>
-      p.toLowerCase()
-    )
-  );
   const u = new URL(rawUrl);
+  const host = u.hostname;
+  const removeParams = new Set();
+  for (const rule of trackingParamsJson) {
+    const c = rule.condition;
+    if (c.requestDomains && !hostUnderAny(host, c.requestDomains)) continue;
+    if (c.excludedRequestDomains && hostUnderAny(host, c.excludedRequestDomains)) continue;
+    for (const p of rule.action.redirect.transform.queryTransform.removeParams) {
+      removeParams.add(p.toLowerCase());
+    }
+  }
   const toDelete = [];
   for (const key of u.searchParams.keys()) {
     if (removeParams.has(key.toLowerCase())) toDelete.push(key);

--- a/tools/generate-rules.mjs
+++ b/tools/generate-rules.mjs
@@ -23,7 +23,12 @@ import {
   TRACKING_PREFIXES,
 } from "../src/lib/affiliates.js";
 import { AFFILIATE_PARAM_GUARD, REMOTE_PARAM_DENYLIST } from "../src/lib/remote-rules.js";
-import { DNR_STATIC_RULE_ID, DNR_AMAZON_PARAMS_RULE_ID } from "../src/lib/dnr-ids.js";
+import {
+  DNR_STATIC_RULE_ID,
+  DNR_AMAZON_PARAMS_RULE_ID,
+  DNR_DOMAIN_PRESERVE_RULE_ID_BASE,
+  DNR_DOMAIN_PRESERVE_MAX_RULES,
+} from "../src/lib/dnr-ids.js";
 
 /** Amazon marketplace hosts we scope the internal-nav strip rule to. */
 const AMAZON_HOST_RE = /(^|\.)amazon\./;
@@ -313,14 +318,40 @@ export function buildDnrRules() {
     process.exit(1);
   }
 
-  const preservedByDomain = new Set();
+  // Reverse index: param -> sorted unique domains where it is preserved.
+  const preservedOnDomains = new Map();
   for (const rule of domainRules) {
+    if (typeof rule.domain !== "string") continue;
     for (const p of rule.preserveParams ?? []) {
-      preservedByDomain.add(p);
+      if (!preservedOnDomains.has(p)) preservedOnDomains.set(p, new Set());
+      preservedOnDomains.get(p).add(rule.domain);
     }
   }
 
-  const filtered = TRACKING_PARAMS.filter((p) => !preservedByDomain.has(p));
+  // Split TRACKING_PARAMS: params preserved on no domain go in the global rule;
+  // params preserved on some domain go in a domain-conditioned rule that strips
+  // them everywhere EXCEPT those domains (excludedRequestDomains). This replaces
+  // the previous behavior of dropping a domain-preserved param from the global
+  // rule entirely, which silently un-stripped it network-wide.
+  //
+  // No guard/denylist filtering here (unlike buildAmazonParamsRule, which adds
+  // EXTRA params): the global + conditioned rules must mirror the runtime
+  // cleaner, which strips all of TRACKING_PARAMS. Filtering only the DNR side
+  // would break DNR<->runtime parity. Keeping an affiliate key out of the strip
+  // is the job of the #815 TRACKING_PARAMS/guard coherence invariant, not this
+  // generator.
+  const globalParams = [];
+  const conditioned = []; // { param, domains: string[] }
+  for (const param of TRACKING_PARAMS) {
+    const domains = preservedOnDomains.get(param);
+    if (domains && domains.size > 0) {
+      conditioned.push({ param, domains: [...domains].sort() });
+    } else {
+      globalParams.push(param);
+    }
+  }
+  // globalParams keeps TRACKING_PARAMS source order (as the previous filter did)
+  // so the generated global rule stays byte-stable except for the moved params.
 
   const rules = [
     {
@@ -331,7 +362,7 @@ export function buildDnrRules() {
         redirect: {
           transform: {
             queryTransform: {
-              removeParams: filtered,
+              removeParams: globalParams,
             },
           },
         },
@@ -343,7 +374,50 @@ export function buildDnrRules() {
     },
   ];
 
-  const amazonRule = buildAmazonParamsRule(domainRules, new Set(filtered));
+  // Group conditioned params by identical exclude-domain set so params that are
+  // preserved on the same domains share one rule, bounding total rule count.
+  const byDomainSet = new Map(); // JSON(domains) -> param[]
+  for (const { param, domains } of conditioned) {
+    const key = JSON.stringify(domains);
+    if (!byDomainSet.has(key)) byDomainSet.set(key, []);
+    byDomainSet.get(key).push(param);
+  }
+  const groups = [...byDomainSet.entries()]
+    .map(([key, params]) => ({ domains: JSON.parse(key), params: params.sort() }))
+    .sort((a, b) => JSON.stringify(a.domains).localeCompare(JSON.stringify(b.domains)));
+
+  if (groups.length > DNR_DOMAIN_PRESERVE_MAX_RULES) {
+    process.stderr.write(
+      `generate-rules.mjs: ${groups.length} domain-conditioned DNR rule groups exceeds ` +
+      `DNR_DOMAIN_PRESERVE_MAX_RULES (${DNR_DOMAIN_PRESERVE_MAX_RULES}). Raise the cap ` +
+      `(and its ID range in dnr-ids.js) or reduce distinct preserve-domain sets.\n`
+    );
+    process.exit(1);
+  }
+
+  groups.forEach((group, i) => {
+    rules.push({
+      id: DNR_DOMAIN_PRESERVE_RULE_ID_BASE + i,
+      priority: 1,
+      action: {
+        type: "redirect",
+        redirect: {
+          transform: {
+            queryTransform: {
+              removeParams: group.params,
+            },
+          },
+        },
+      },
+      condition: {
+        urlFilter: "*",
+        excludedRequestDomains: group.domains,
+        resourceTypes: ["main_frame"],
+      },
+    });
+  });
+
+  const amazonRule = buildAmazonParamsRule(domainRules, new Set(globalParams));
   if (amazonRule) rules.push(amazonRule);
 
   return rules;
@@ -422,7 +496,14 @@ function main() {
   const manifest = buildManifest();
   const dnrRules = buildDnrRules();
 
-  const excluded = TRACKING_PARAMS.length - dnrRules[0].action.redirect.transform.queryTransform.removeParams.length;
+  const globalCount = dnrRules[0].action.redirect.transform.queryTransform.removeParams.length;
+  const conditionedRules = dnrRules.filter(
+    (r) => r.id >= DNR_DOMAIN_PRESERVE_RULE_ID_BASE && r.id < DNR_DOMAIN_PRESERVE_RULE_ID_BASE + DNR_DOMAIN_PRESERVE_MAX_RULES
+  );
+  const conditionedParams = conditionedRules.reduce(
+    (n, r) => n + r.action.redirect.transform.queryTransform.removeParams.length,
+    0
+  );
   const amazonRule = dnrRules.find((r) => r.id === DNR_AMAZON_PARAMS_RULE_ID);
   const amazonCount = amazonRule
     ? amazonRule.action.redirect.transform.queryTransform.removeParams.length
@@ -432,7 +513,7 @@ function main() {
   writeFileSync(DNR_PATH, JSON.stringify(dnrRules, null, 2) + "\n", "utf8");
 
   console.log(
-    `Generated rules-manifest.json (${manifest.tracking.length} params, ${manifest.prefix_rules.length} prefixes) and tracking-params.json (${dnrRules[0].action.redirect.transform.queryTransform.removeParams.length} global DNR params, ${excluded} excluded; ${amazonCount} Amazon-scoped params)`
+    `Generated rules-manifest.json (${manifest.tracking.length} params, ${manifest.prefix_rules.length} prefixes) and tracking-params.json (${globalCount} global DNR params; ${conditionedParams} params across ${conditionedRules.length} domain-conditioned rules; ${amazonCount} Amazon-scoped params)`
   );
 }
 


### PR DESCRIPTION
## Problem
`generate-rules.mjs` dropped any param preserved on ANY domain from the **global** DNR strip rule entirely. A param functional on one site (`cid` on sharepoint, `ie` on baidu, `ab_channel` on youtube, `ei` on yahoo, `ref_` on imdb) was therefore **un-stripped network-wide** at the DNR layer, reaching analytics servers on the initial navigation to every *other* site. The runtime cleaner still stripped it, but only after the request had already gone out.

This was previously documented in the parity test as "diverge by design", acceptable when it affected 2 innocuous params. It is not acceptable for the crown-jewel trackers (`utm_*`), which is exactly what the AdGuard preserve-harvest would have triggered.

## Fix
`buildDnrRules` now emits a **domain-conditioned** rule per unique preserve-domain set: the param is stripped everywhere EXCEPT its preserve domains via `excludedRequestDomains` (id range 300-799), mirroring the existing Amazon-scoped `requestDomains` pattern. This:
- restores network-layer stripping for the 5 currently-affected params, and
- brings DNR into **tight parity** with the runtime cleaner (both strip except on the preserve host; both preserve on it).

No guard/denylist filtering is applied to these rules: they must mirror the runtime cleaner, which strips all of `TRACKING_PARAMS`. The global rule stays **byte-stable** (source order preserved); the only diff is the 5 appended rules.

## Why it matters
This is the **prerequisite** that unblocks harvesting AdGuard `@@removeparam` exceptions into domain `preserveParams` (previously impossible without leaking `utm_*` globally). The whole weekly preserve-harvest pillar depends on it.

## Tests
Parity test extended: `simulateDnr` now applies ALL rules honoring their conditions (`requestDomains`/`excludedRequestDomains`), plus a regression case asserting a conditioned param (`cid`) is stripped on a non-preserve host, and a youtube `ab_channel` divergence case. `npm test` 5879 pass / 0 fail; `lint:js` + `typecheck` clean; `compile:rules` output committed (CI #626 gate).