### PR TITLE
fix(firefox): clean URLs via blocking webRequest + CSP-immune history wrap

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -4,7 +4,7 @@
  * and maintains extension state.
  */
 
-import { processUrl, parseListEntry, getFullyExemptDomains } from "../lib/cleaner.js";
+import { processUrl, computeNavigationStrip, parseListEntry, getFullyExemptDomains } from "../lib/cleaner.js";
 import { getAffiliateDomains, resolveOurTag } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, migrateLegacyProxyPref, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules, getRemoteParams, incrementShortenerStat } from "../lib/storage.js";
 import { migrateConsentToLocal } from "../lib/sync-migration.js";
@@ -373,6 +373,114 @@ function getPrefsWithCache() {
     });
   }
   return prefsFetchPromise;
+}
+
+// --- Cleaned-URL stats/badge recording (shared) ---
+
+/**
+ * Records a clean into the badge + stats + session history. Extracted so the
+ * content-script BADGE_AND_STATS message handler and the Firefox blocking
+ * webRequest stripper (below) increment identical tallies — the counter must
+ * reflect network-layer strips on Firefox exactly as it reflects content-script
+ * strips. Stat-increment semantics mirror handleProcessUrl:
+ *   - urlsCleaned + junkRemoved fire only when action !== "untouched" AND
+ *     (the URL changed OR junkRemoved > 0);
+ *   - referralsSpotted fires when action === "detected_foreign";
+ *   - domainStats fires only when prefs.domainStats is on AND junk > 0.
+ *
+ * @param {number|undefined} tabId
+ * @param {string} originalUrl
+ * @param {{cleanUrl?:string, action?:string, removedTracking?:string[], junkRemoved?:number}} result
+ */
+function recordNetworkClean(tabId, originalUrl, result) {
+  const junkRemoved = Number(result?.junkRemoved) || 0;
+  const removedTracking = Array.isArray(result?.removedTracking) ? result.removedTracking : [];
+  const action = String(result?.action || "");
+  const cleanUrl = typeof result?.cleanUrl === "string" ? result.cleanUrl : "";
+  const urlChanged = cleanUrl && originalUrl && cleanUrl !== originalUrl;
+
+  if (junkRemoved > 0) updateTabBadge(tabId, junkRemoved);
+
+  if (action !== "untouched" && (urlChanged || junkRemoved > 0)) {
+    incrementStat("urlsCleaned");
+    if (junkRemoved > 0) incrementStat("junkRemoved", junkRemoved);
+    // Domain stats requires the user's pref. Best-effort read; failure skips the
+    // increment without affecting the rest.
+    getPrefsWithCache().then(prefs => {
+      if (prefs.domainStats && junkRemoved > 0) {
+        try {
+          const hostname = new URL(originalUrl).hostname.replace(/^www\./, "");
+          incrementDomainStat(hostname, junkRemoved);
+        } catch { /* invalid URL, skip */ }
+      }
+    }).catch(() => { /* prefs unavailable, skip */ });
+    if (originalUrl && cleanUrl) {
+      appendHistory(originalUrl, cleanUrl, removedTracking).catch(err => {
+        console.warn("[MUGA] recordNetworkClean appendHistory:", err);
+      });
+    }
+  }
+
+  if (action === "detected_foreign") {
+    incrementStat("referralsSpotted");
+  }
+}
+
+// --- Firefox network-layer stripper (blocking webRequest) ---
+//
+// Chrome MV3 removed blocking webRequest and cleans navigations via DNR. Firefox
+// MV2 KEEPS blocking webRequest, so on Firefox we use it as the network-layer
+// stripper — the true equivalent of Chrome's DNR: it strips tracking params from
+// the top-level navigation BEFORE the request goes out and, unlike DNR, can feed
+// the cleaned-URL counter (DNR emits no onRuleMatched signal). Chrome is
+// unaffected — it never registers this listener and keeps using DNR.
+//
+// Gate: MV2 manifest (only ever shipped to Firefox via with-firefox-manifest.sh)
+// AND a blocking-capable webRequest. `hasDNR` cannot distinguish the targets
+// (both expose declarativeNetRequest); the manifest version can.
+const isFirefoxMV2 =
+  chrome.runtime.getManifest().manifest_version === 2 &&
+  typeof chrome.webRequest?.onBeforeRequest?.addListener === "function";
+
+/**
+ * Blocking onBeforeRequest handler. MUST return synchronously (a BlockingResponse
+ * or undefined). Reads the warm prefs/rules caches synchronously and delegates the
+ * strip decision to computeNavigationStrip (the same pure logic a unit test
+ * exercises), so behavior never diverges from Chrome.
+ *
+ * @param {{url:string, tabId:number}} details
+ * @returns {{redirectUrl:string}|undefined}
+ */
+function onBeforeNavigateStrip(details) {
+  const prefs = cachedPrefs;
+  // Cold start (only the first navigation after browser start, since Firefox's
+  // background page is persistent): caches not warm yet. Kick the warm-up and let
+  // this request pass — the content-script self-clean is the fallback for this
+  // brief window.
+  if (!prefs) { getPrefsWithCache(); return; }
+
+  const decision = computeNavigationStrip(
+    details.url, prefs, domainRules, pathStripRules, pathAffiliateRules, frequencyTracker,
+  );
+  if (!decision) return;
+
+  // Fire-and-forget stats — keeps this listener's return synchronous.
+  recordNetworkClean(details.tabId, details.url, decision.result);
+  return { redirectUrl: decision.cleanUrl };
+}
+
+if (isFirefoxMV2) {
+  // Warm the caches the blocking listener reads synchronously. Firefox's
+  // background page is persistent, so this runs once at startup (the #629
+  // lazy-load cold-start concern is Chrome-MV3-specific and does not apply).
+  getPrefsWithCache();
+  if (_domainRulesReady === null) _domainRulesReady = _loadDomainRules();
+  if (_pathRulesReady === null) _pathRulesReady = _loadPathRules();
+  chrome.webRequest.onBeforeRequest.addListener(
+    onBeforeNavigateStrip,
+    { urls: ["<all_urls>"], types: ["main_frame"] },
+    ["blocking"],
+  );
 }
 
 // --- Remote-rules opportunistic fetch ---
@@ -1229,40 +1337,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   //   - referralsSpotted fires when action === "detected_foreign".
   //   - domainStats fires only when prefs.domainStats is on AND junk > 0.
   if (message.type === "BADGE_AND_STATS") {
-    const tabId = sender.tab?.id;
-    const junkRemoved = Number(message.junkRemoved) || 0;
-    const removedTracking = Array.isArray(message.removedTracking) ? message.removedTracking : [];
-    const action = String(message.action || "");
-    const cleanUrl = typeof message.cleanUrl === "string" ? message.cleanUrl : "";
     const originalUrl = typeof message.originalUrl === "string" ? message.originalUrl : "";
-    const urlChanged = cleanUrl && originalUrl && cleanUrl !== originalUrl;
-
-    if (junkRemoved > 0) updateTabBadge(tabId, junkRemoved);
-
-    if (action !== "untouched" && (urlChanged || junkRemoved > 0)) {
-      incrementStat("urlsCleaned");
-      if (junkRemoved > 0) incrementStat("junkRemoved", junkRemoved);
-      // Domain stats requires the user's pref. Best-effort read; failure
-      // skips the increment without affecting the rest.
-      getPrefsWithCache().then(prefs => {
-        if (prefs.domainStats && junkRemoved > 0) {
-          try {
-            const hostname = new URL(originalUrl).hostname.replace(/^www\./, "");
-            incrementDomainStat(hostname, junkRemoved);
-          } catch { /* invalid URL, skip */ }
-        }
-      }).catch(() => { /* prefs unavailable, skip */ });
-      if (originalUrl && cleanUrl) {
-        appendHistory(originalUrl, cleanUrl, removedTracking).catch(err => {
-          console.warn("[MUGA] BADGE_AND_STATS appendHistory:", err);
-        });
-      }
-    }
-
-    if (action === "detected_foreign") {
-      incrementStat("referralsSpotted");
-    }
-
+    recordNetworkClean(sender.tab?.id, originalUrl, {
+      cleanUrl: typeof message.cleanUrl === "string" ? message.cleanUrl : "",
+      action: message.action,
+      removedTracking: message.removedTracking,
+      junkRemoved: message.junkRemoved,
+    });
     try { sendResponse({ ok: true }); } catch { /* channel closed */ }
     return false;
   }

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -11,6 +11,7 @@ import { migrateConsentToLocal } from "../lib/sync-migration.js";
 import { evaluate as evaluateConsent } from "../lib/consent-policy.js";
 import { isValidListEntry } from "../lib/validation.js";
 import { DNR_CUSTOM_PARAMS_RULE_ID, DNR_REMOTE_PARAMS_RULE_ID, DNR_ALLOWLIST_RULE_ID_BASE, DNR_ALLOWLIST_MAX_RULES } from "../lib/dnr-ids.js";
+import { partitionRulesets } from "../lib/dnr-ruleset-state.js";
 import { t } from "../lib/i18n.js";
 import {
   runRemoteRulesFetch,
@@ -442,6 +443,14 @@ const isFirefoxMV2 =
   chrome.runtime.getManifest().manifest_version === 2 &&
   typeof chrome.webRequest?.onBeforeRequest?.addListener === "function";
 
+// Set true once prefs + domain/path rules have all settled (success or failure).
+// The blocking listener passes navigations through until then: stripping with an
+// empty domainRules would miss domain-specific rules AND could over-strip a
+// param that a domain's preserveParams would have kept. The content-script
+// self-clean covers this brief startup window (Firefox's bg page is persistent,
+// so it is effectively just the first navigation after browser start).
+let _fxStripperReady = false;
+
 /**
  * Blocking onBeforeRequest handler. MUST return synchronously (a BlockingResponse
  * or undefined). Reads the warm prefs/rules caches synchronously and delegates the
@@ -452,15 +461,12 @@ const isFirefoxMV2 =
  * @returns {{redirectUrl:string}|undefined}
  */
 function onBeforeNavigateStrip(details) {
-  const prefs = cachedPrefs;
-  // Cold start (only the first navigation after browser start, since Firefox's
-  // background page is persistent): caches not warm yet. Kick the warm-up and let
-  // this request pass — the content-script self-clean is the fallback for this
-  // brief window.
-  if (!prefs) { getPrefsWithCache(); return; }
+  // Pass through until prefs AND rules are warm (see _fxStripperReady). Kick the
+  // warm-up on the way past so it resolves as soon as possible.
+  if (!_fxStripperReady || !cachedPrefs) { getPrefsWithCache(); return; }
 
   const decision = computeNavigationStrip(
-    details.url, prefs, domainRules, pathStripRules, pathAffiliateRules, frequencyTracker,
+    details.url, cachedPrefs, domainRules, pathStripRules, pathAffiliateRules, frequencyTracker,
   );
   if (!decision) return;
 
@@ -470,12 +476,15 @@ function onBeforeNavigateStrip(details) {
 }
 
 if (isFirefoxMV2) {
-  // Warm the caches the blocking listener reads synchronously. Firefox's
-  // background page is persistent, so this runs once at startup (the #629
-  // lazy-load cold-start concern is Chrome-MV3-specific and does not apply).
-  getPrefsWithCache();
+  // Warm the caches the blocking listener reads synchronously, then arm it. Only
+  // strip once domain/path rules have settled so a startup navigation can never
+  // over-strip a preserve-domain param. Firefox's background page is persistent,
+  // so this warm-up runs once at startup.
   if (_domainRulesReady === null) _domainRulesReady = _loadDomainRules();
   if (_pathRulesReady === null) _pathRulesReady = _loadPathRules();
+  Promise.all([getPrefsWithCache(), _domainRulesReady, _pathRulesReady])
+    .catch(() => { /* best-effort warm; failures fall back to pass-through */ })
+    .finally(() => { _fxStripperReady = true; });
   chrome.webRequest.onBeforeRequest.addListener(
     onBeforeNavigateStrip,
     { urls: ["<all_urls>"], types: ["main_frame"] },
@@ -707,42 +716,15 @@ async function applyDnrState(prefs) {
   ).map(r => r.id);
 
   if (prefs.enabled && prefs.dnrEnabled && prefs.onboardingDone) {
-    // Gate open: selectively enable/disable based on per-feature prefs.
-    // The manifest defaults all three to enabled:true, so rulesets whose
-    // feature pref is OFF must be explicitly disabled — otherwise they
-    // stay active from the manifest default.
-    const enableRulesetIds = [];
-    const disableRulesetIds = [];
-
-    for (const id of declaredIds) {
-      if (id === "tracking_params") {
-        enableRulesetIds.push(id);
-      } else if (id === "amazon_path_canonical") {
-        // Amazon /dp/ SEO-slug strip (#903) — always-on when the consent
-        // gate is open, same as tracking_params. There is no dedicated
-        // feature pref for this yet; it is a Chrome-only DNR redirect
-        // (Firefox strips the slug via the in-page cleaner instead).
-        enableRulesetIds.push(id);
-      } else if (id === "amp_redirect") {
-        if (prefs.ampRedirect) {
-          enableRulesetIds.push(id);
-        } else {
-          disableRulesetIds.push(id);
-        }
-      } else if (id === "wrapper_unwrap") {
-        if (prefs.unwrapRedirects) {
-          enableRulesetIds.push(id);
-        } else {
-          disableRulesetIds.push(id);
-        }
-      } else {
-        // A manifest-declared ruleset this gate doesn't know about would
-        // keep its manifest default and silently bypass any feature pref.
-        // Enable it explicitly (matching the manifest default) and warn so
-        // the gap is visible the moment a fourth ruleset is added. (#810)
-        console.warn("[MUGA] applyDnrState: unmanaged ruleset id:", id);
-        enableRulesetIds.push(id);
-      }
+    // Gate open: selectively enable/disable based on per-feature prefs (pure
+    // decision in partitionRulesets). The manifest defaults every ruleset to
+    // enabled:true, so rulesets whose feature pref is OFF — or which a different
+    // mechanism now owns (tracking_params on Firefox, handled by the blocking
+    // webRequest stripper) — must be explicitly disabled here.
+    const { enableRulesetIds, disableRulesetIds, unmanaged } =
+      partitionRulesets(declaredIds, prefs, { isFirefoxMV2 });
+    for (const id of unmanaged) {
+      console.warn("[MUGA] applyDnrState: unmanaged ruleset id:", id);
     }
 
     await chrome.declarativeNetRequest.updateEnabledRulesets({

--- a/src/content/history-defuser.js
+++ b/src/content/history-defuser.js
@@ -19,6 +19,7 @@
  * surprising a not-yet-onboarded user with a mutated URL.
  */
 
+/* global exportFunction */
 (function () {
   "use strict";
 
@@ -69,37 +70,58 @@
   crypto.getRandomValues(_nonceBytes);
   const _nonce = Array.from(_nonceBytes, (b) => b.toString(16).padStart(2, "0")).join("");
 
-  // ── Firefox MV2 page-world bootstrap (#509 / B12) ────────────────────
+  // Firefox page-world history wrap reads this at call time to honor the same
+  // active-defense gate the CustomEvent path carries to Chrome's main world.
+  // Fail-closed until prefs land (see readPrefsAndGate).
+  let _fxGateOpen = false;
+
+  // ── Firefox MV2 page-world history wrap (CSP-immune) (#509 / B12) ─────
   //
-  // Chrome MV3 registers `history-defuser-mainworld.js` as a `world: "MAIN"`
-  // content script (see src/manifest.json) — the browser handles loading
-  // it into the page world automatically. Firefox MV2 has no `world: "MAIN"`
-  // support, so the same script must be injected from this isolated-world
-  // script as a `<script src=...>` element pointing at the extension's
-  // web-accessible resource. The injected `<script>` runs in the page world
-  // because that's where `<script>` tags execute by default; the extension
-  // origin and `web_accessible_resources` declaration in manifest.v2.json
-  // make the resource URL loadable cross-origin from the page.
+  // Chrome MV3 wraps history.pushState/replaceState via the `world:"MAIN"`
+  // content script history-defuser-mainworld.js. Firefox MV2 has no
+  // `world:"MAIN"`; the previous approach injected that script as a
+  // `<script src="moz-extension://...">` element, but a page's Content-
+  // Security-Policy (e.g. Amazon) silently blocks that injected script, so
+  // pushState "section" navigations were never detected and never cleaned.
   //
-  // MV3 detection is `manifest_version === 3`. We skip the inject in MV3 so
-  // we don't double-bootstrap.
+  // Firefox content scripts CAN reach the page's real objects via
+  // `window.wrappedJSObject` and inject callables with `exportFunction` — no
+  // `<script>` element is created, so the page CSP cannot block it. We wrap
+  // pushState/replaceState on the PAGE's history to trigger the full
+  // isolated-world reclean (`window.__mugaReclean`, set by cleaner.js in the
+  // same isolated world), exactly as the popstate/hashchange listeners below
+  // already do for those same-document navigation types. No CustomEvent bridge
+  // is needed on Firefox — the wrap and __mugaReclean share this world.
+  //
+  // Loop-safe: __mugaReclean calls the ISOLATED-world history.replaceState
+  // (a different binding than the PAGE object we wrap here), so cleaning does
+  // not re-enter this wrap; __mugaReclean's own _lastRecleanUrl guard is a
+  // second backstop.
   try {
     const mv = chrome.runtime.getManifest && chrome.runtime.getManifest().manifest_version;
-    if (mv === 2) {
-      const s = document.createElement("script");
-      s.src = chrome.runtime.getURL("content/history-defuser-mainworld.js");
-      // Synchronous so the wrap installs before the page's first script runs.
-      // Modern browsers honour async=false for in-document insertion.
-      s.async = false;
-      const target = document.head || document.documentElement;
-      if (target) {
-        target.appendChild(s);
-        // Detach from the DOM as soon as it's executed; the wrap lives on
-        // window.history regardless of whether the <script> node is present.
-        s.remove();
+    if (mv === 2 && typeof exportFunction === "function" && window.wrappedJSObject) {
+      const pageHistory = window.wrappedJSObject.history;
+      if (pageHistory) {
+        const wrapHistoryMethod = (methodName) => {
+          const orig = pageHistory[methodName];
+          if (typeof orig !== "function") return;
+          pageHistory[methodName] = exportFunction(function (state, title, url) {
+            const ret = orig.call(this, state, title, url);
+            if (_fxGateOpen) {
+              try {
+                if (typeof window.__mugaReclean === "function") {
+                  window.__mugaReclean(url == null ? window.location.href : String(url));
+                }
+              } catch { /* never let a reclean failure break navigation */ }
+            }
+            return ret;
+          }, window.wrappedJSObject);
+        };
+        wrapHistoryMethod("pushState");
+        wrapHistoryMethod("replaceState");
       }
     }
-  } catch { /* manifest unavailable / DOM not ready — leave the page-world wrap absent */ }
+  } catch { /* wrappedJSObject/exportFunction unavailable — leave the page-world wrap absent */ }
 
   // Broadcast the nonce once at document_start so all listeners (both worlds)
   // can capture it before any page script executes. This event is fired once
@@ -198,7 +220,10 @@
         // cleaning, window.name defusing, DOM link/click rewriting) if they break a site.
         // Default to ON when the pref key is absent (older installs / not yet synced).
         const activeDefenseOn = !(prefs && prefs.activeDefenseEnabled === false);
-        dispatchGate(prefsOk && activeDefenseOn && !exempt);
+        const gateOpen = prefsOk && activeDefenseOn && !exempt;
+        // Firefox page-world history wrap reads this synchronously at call time.
+        _fxGateOpen = gateOpen;
+        dispatchGate(gateOpen);
       });
     } catch {
       // Extension context invalidated. Leave the gate closed.

--- a/src/lib/cleaner.js
+++ b/src/lib/cleaner.js
@@ -660,6 +660,51 @@ export function processUrl(rawUrl, prefs, domainRules = [], canonicalBundle, fre
 }
 
 /**
+ * Decides how a top-level navigation should be rewritten by the Firefox blocking
+ * webRequest stripper (service-worker.js onBeforeNavigateStrip). Pure (no chrome.*
+ * access), so it is unit-testable in isolation and shares one code path with the
+ * listener (no divergence).
+ *
+ * Mirrors Chrome's DNR (STRIP only): affiliate injection and the foreign-affiliate
+ * toast are suppressed here so (a) network-layer behavior matches Chrome, where
+ * DNR cannot inject, leaving injection to the content-script self-clean on both
+ * browsers, and (b) the resulting redirect is idempotent: there is no injected
+ * tag for a re-entered clean URL to loop on. All strip/preserve/allowlist/
+ * affiliate guards are honored automatically because they live inside processUrl.
+ *
+ * @param {string} rawUrl
+ * @param {object} prefs the same materialized prefs snapshot the SW caches
+ * @param {Array} [domainRules=[]]
+ * @param {Array} [pathStripRules=[]]
+ * @param {Array} [pathAffiliateRules=[]]
+ * @param {object} [frequencyTracker] cross-site-frequency singleton (optional)
+ * @returns {{cleanUrl:string, result:object}|null} redirect target + full result,
+ *   or null when the navigation must pass through unchanged.
+ */
+export function computeNavigationStrip(rawUrl, prefs, domainRules = [], pathStripRules = [], pathAffiliateRules = [], frequencyTracker) {
+  if (typeof rawUrl !== "string" || (!rawUrl.startsWith("http://") && !rawUrl.startsWith("https://"))) {
+    return null;
+  }
+  if (!prefs || !prefs.enabled || !prefs.onboardingDone) return null;
+
+  const stripPrefs = (prefs.injectOwnAffiliate || prefs.notifyForeignAffiliate)
+    ? { ...prefs, injectOwnAffiliate: false, notifyForeignAffiliate: false }
+    : prefs;
+
+  let result;
+  try {
+    result = processUrl(rawUrl, stripPrefs, domainRules, undefined, frequencyTracker, "", pathStripRules, pathAffiliateRules);
+  } catch {
+    return null;
+  }
+
+  if (!result || result.action === "untouched" || !result.cleanUrl || result.cleanUrl === rawUrl) {
+    return null;
+  }
+  return { cleanUrl: result.cleanUrl, result };
+}
+
+/**
  * Fire-and-forget bridge from the cleaner to the cross-site-frequency
  * tracker (#446 / #495). One observe() call per stripped tracking param,
  * with the URL's hostname as the first-party domain and the param's

--- a/src/lib/dnr-ruleset-state.js
+++ b/src/lib/dnr-ruleset-state.js
@@ -1,0 +1,53 @@
+/**
+ * MUGA: DNR static-ruleset enable/disable decision (pure).
+ *
+ * Extracted from service-worker.js applyDnrState so the gate-open ruleset
+ * partition is unit-testable without the whole service worker. Given the
+ * manifest-declared ruleset ids and the current prefs, returns which rulesets to
+ * enable and which to disable when the consent gate is OPEN.
+ *
+ * The manifest defaults every ruleset to enabled:true, so any ruleset whose
+ * feature pref is OFF (or which a different mechanism now owns) MUST be listed in
+ * disableRulesetIds explicitly, or it stays active from the manifest default.
+ */
+
+/**
+ * @param {string[]} declaredIds  ruleset ids declared in the active manifest
+ * @param {object} prefs          materialized prefs (ampRedirect, unwrapRedirects, ...)
+ * @param {{isFirefoxMV2?: boolean}} [opts]
+ * @returns {{enableRulesetIds:string[], disableRulesetIds:string[], unmanaged:string[]}}
+ */
+export function partitionRulesets(declaredIds, prefs, { isFirefoxMV2 = false } = {}) {
+  const enableRulesetIds = [];
+  const disableRulesetIds = [];
+  const unmanaged = [];
+
+  for (const id of declaredIds) {
+    if (id === "tracking_params") {
+      // On Firefox MV2 the blocking webRequest stripper (onBeforeNavigateStrip in
+      // service-worker.js) is the SOLE network-layer tracking-param strip path: it
+      // increments the cleaned-URL counter (DNR emits no onRuleMatched signal) and
+      // avoids a redundant DNR+webRequest double-strip that would also hinge on an
+      // unverified webRequest-vs-DNR evaluation order. So disable this ruleset on
+      // Firefox. Chrome (no blocking webRequest) keeps DNR as its strip path.
+      (isFirefoxMV2 ? disableRulesetIds : enableRulesetIds).push(id);
+    } else if (id === "amazon_path_canonical") {
+      // Amazon /dp/ SEO-slug strip (#903): always-on when the gate is open. No
+      // dedicated feature pref; Chrome-only (not declared in the Firefox manifest).
+      enableRulesetIds.push(id);
+    } else if (id === "amp_redirect") {
+      (prefs.ampRedirect ? enableRulesetIds : disableRulesetIds).push(id);
+    } else if (id === "wrapper_unwrap") {
+      (prefs.unwrapRedirects ? enableRulesetIds : disableRulesetIds).push(id);
+    } else {
+      // A manifest-declared ruleset this partition doesn't know about would keep
+      // its manifest default and silently bypass any feature pref. Enable it
+      // (matching the default) and surface it so the gap is visible the moment a
+      // new ruleset is added. (#810)
+      unmanaged.push(id);
+      enableRulesetIds.push(id);
+    }
+  }
+
+  return { enableRulesetIds, disableRulesetIds, unmanaged };
+}

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -12,6 +12,8 @@
     "contextMenus",
     "clipboardWrite",
     "declarativeNetRequest",
+    "webRequest",
+    "webRequestBlocking",
     "<all_urls>"
   ],
 

--- a/tests/unit/config-integrity.test.mjs
+++ b/tests/unit/config-integrity.test.mjs
@@ -298,15 +298,24 @@ describe("manifest.json integrity", () => {
     }
   });
 
-  test("MV3 and MV2 declare the same permissions (excluding host_permissions and MV-specific equivalents)", () => {
+  test("MV3 and MV2 declare the same permissions (excluding host_permissions, MV-specific equivalents, and Firefox-only network permissions)", () => {
     // MV3 uses declarativeNetRequestWithHostAccess (required for redirect rules in MV3)
     // MV2 uses declarativeNetRequest (Firefox MV2 doesn't support the WithHostAccess variant)
     const MV_EQUIVALENTS = new Map([
       ["declarativeNetRequestWithHostAccess", "declarativeNetRequest"],
     ]);
+    // Firefox MV2 KEEPS blocking webRequest (removed in Chrome MV3) and uses it as
+    // its network-layer stripper — the equivalent of Chrome MV3's DNR redirect. So
+    // these permissions legitimately exist ONLY on MV2. See the Firefox
+    // onBeforeNavigateStrip listener in service-worker.js.
+    const MV2_ONLY = new Set(["webRequest", "webRequestBlocking"]);
     const normalize = (p) => MV_EQUIVALENTS.get(p) ?? p;
     const mv3Perms = new Set(mv3.permissions.map(normalize));
-    const mv2Perms = new Set(mv2.permissions.filter(p => p !== "<all_urls>").map(normalize));
+    const mv2Perms = new Set(
+      mv2.permissions
+        .filter(p => p !== "<all_urls>" && !MV2_ONLY.has(p))
+        .map(normalize)
+    );
     for (const p of mv3Perms) {
       assert.ok(mv2Perms.has(p), `Permission "${p}" in MV3 but missing from MV2`);
     }

--- a/tests/unit/dnr-consent-gate.test.mjs
+++ b/tests/unit/dnr-consent-gate.test.mjs
@@ -407,28 +407,35 @@ describe("service-worker.js source guards — #810 fix present", () => {
     );
   });
 
-  test("applyDnrState references ampRedirect pref", () => {
+  test("applyDnrState delegates the ruleset partition to partitionRulesets", () => {
+    // The per-feature gating (ampRedirect, unwrapRedirects) plus the Firefox
+    // tracking_params disable now live in the pure partitionRulesets helper
+    // (src/lib/dnr-ruleset-state.js), covered behaviorally in
+    // tests/unit/dnr-ruleset-state.test.mjs. Here we only guard that applyDnrState
+    // still delegates to it (a regression that inlined a divergent copy would
+    // bypass that coverage).
     const applyFnStart = swSource.indexOf("async function applyDnrState(");
     assert.ok(applyFnStart !== -1, "applyDnrState must exist in SW");
-    // Use 2600 chars — the function grew with comments after the #810 fix
-    // and the #903 amazon_path_canonical branch
     const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2600);
     assert.ok(
-      applyFnBlock.includes("ampRedirect"),
-      "applyDnrState must check prefs.ampRedirect to gate amp_redirect ruleset"
+      applyFnBlock.includes("partitionRulesets("),
+      "applyDnrState must call partitionRulesets() to decide enabled/disabled rulesets"
+    );
+    assert.ok(
+      applyFnBlock.includes("isFirefoxMV2"),
+      "applyDnrState must pass isFirefoxMV2 so tracking_params is disabled on Firefox"
     );
   });
 
-  test("applyDnrState references unwrapRedirects pref", () => {
-    const applyFnStart = swSource.indexOf("async function applyDnrState(");
-    assert.ok(applyFnStart !== -1, "applyDnrState must exist in SW");
-    // Use 2600 chars — the function grew with comments after the #810 fix
-    // and the #903 amazon_path_canonical branch
-    const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 2600);
-    assert.ok(
-      applyFnBlock.includes("unwrapRedirects"),
-      "applyDnrState must check prefs.unwrapRedirects to gate wrapper_unwrap ruleset"
+  test("partitionRulesets source gates on ampRedirect and unwrapRedirects prefs", () => {
+    const stateSource = readFileSync(
+      new URL("../../src/lib/dnr-ruleset-state.js", import.meta.url),
+      "utf8",
     );
+    assert.ok(stateSource.includes("ampRedirect"),
+      "partitionRulesets must gate amp_redirect on prefs.ampRedirect");
+    assert.ok(stateSource.includes("unwrapRedirects"),
+      "partitionRulesets must gate wrapper_unwrap on prefs.unwrapRedirects");
   });
 
   test("storage listener re-triggers applyDnrState on ampRedirect changes", () => {

--- a/tests/unit/dnr-ruleset-state.test.mjs
+++ b/tests/unit/dnr-ruleset-state.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * MUGA — partitionRulesets (gate-open DNR ruleset enable/disable decision).
+ *
+ * The load-bearing invariant this pins: on Firefox MV2 the `tracking_params`
+ * static ruleset is DISABLED, because the blocking webRequest stripper
+ * (service-worker.js onBeforeNavigateStrip) is the sole network-layer strip path
+ * there — it counts cleaned URLs and avoids a redundant, order-dependent
+ * DNR+webRequest double-strip. On Chrome it stays enabled (no blocking
+ * webRequest). Nothing else asserted this before; a regression here would
+ * silently zero the Firefox counter or double-strip.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { partitionRulesets } from "../../src/lib/dnr-ruleset-state.js";
+
+// Firefox MV2 declares exactly these two static rulesets (see manifest.v2.json).
+const FIREFOX_DECLARED = ["tracking_params", "wrapper_unwrap"];
+// Chrome MV3 declares more (tracking_params, wrapper_unwrap, amp_redirect,
+// amazon_path_canonical); the exact set doesn't matter for these unit cases.
+const CHROME_DECLARED = ["tracking_params", "wrapper_unwrap", "amp_redirect", "amazon_path_canonical"];
+
+const allPrefsOn = { ampRedirect: true, unwrapRedirects: true };
+const allPrefsOff = { ampRedirect: false, unwrapRedirects: false };
+
+describe("partitionRulesets — tracking_params ownership by browser", () => {
+  test("Firefox MV2 DISABLES tracking_params (webRequest stripper owns it)", () => {
+    const { enableRulesetIds, disableRulesetIds } =
+      partitionRulesets(FIREFOX_DECLARED, allPrefsOn, { isFirefoxMV2: true });
+    assert.ok(disableRulesetIds.includes("tracking_params"),
+      "tracking_params must be disabled on Firefox so the webRequest stripper is the sole strip path");
+    assert.ok(!enableRulesetIds.includes("tracking_params"),
+      "tracking_params must not also be enabled on Firefox");
+  });
+
+  test("Chrome ENABLES tracking_params (DNR is its strip path)", () => {
+    const { enableRulesetIds, disableRulesetIds } =
+      partitionRulesets(CHROME_DECLARED, allPrefsOn, { isFirefoxMV2: false });
+    assert.ok(enableRulesetIds.includes("tracking_params"));
+    assert.ok(!disableRulesetIds.includes("tracking_params"));
+  });
+
+  test("default opts (no isFirefoxMV2) treats as Chrome — enables tracking_params", () => {
+    const { enableRulesetIds } = partitionRulesets(CHROME_DECLARED, allPrefsOn);
+    assert.ok(enableRulesetIds.includes("tracking_params"));
+  });
+});
+
+describe("partitionRulesets — feature-pref gating", () => {
+  test("amp_redirect follows prefs.ampRedirect", () => {
+    assert.ok(partitionRulesets(CHROME_DECLARED, allPrefsOn).enableRulesetIds.includes("amp_redirect"));
+    assert.ok(partitionRulesets(CHROME_DECLARED, allPrefsOff).disableRulesetIds.includes("amp_redirect"));
+  });
+
+  test("wrapper_unwrap follows prefs.unwrapRedirects (both browsers)", () => {
+    assert.ok(partitionRulesets(FIREFOX_DECLARED, allPrefsOn, { isFirefoxMV2: true }).enableRulesetIds.includes("wrapper_unwrap"));
+    assert.ok(partitionRulesets(FIREFOX_DECLARED, allPrefsOff, { isFirefoxMV2: true }).disableRulesetIds.includes("wrapper_unwrap"));
+  });
+
+  test("amazon_path_canonical is always enabled when present", () => {
+    assert.ok(partitionRulesets(CHROME_DECLARED, allPrefsOff).enableRulesetIds.includes("amazon_path_canonical"));
+  });
+});
+
+describe("partitionRulesets — unmanaged rulesets surface, not silently dropped", () => {
+  test("an unknown ruleset id is enabled (manifest default) and reported in unmanaged", () => {
+    const { enableRulesetIds, unmanaged } =
+      partitionRulesets([...CHROME_DECLARED, "future_ruleset"], allPrefsOn);
+    assert.ok(enableRulesetIds.includes("future_ruleset"));
+    assert.deepEqual(unmanaged, ["future_ruleset"]);
+  });
+
+  test("no unmanaged ids for the known Firefox/Chrome sets", () => {
+    assert.deepEqual(partitionRulesets(FIREFOX_DECLARED, allPrefsOn, { isFirefoxMV2: true }).unmanaged, []);
+    assert.deepEqual(partitionRulesets(CHROME_DECLARED, allPrefsOn).unmanaged, []);
+  });
+});

--- a/tests/unit/firefox-history-wrap.test.mjs
+++ b/tests/unit/firefox-history-wrap.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * MUGA — Firefox CSP-immune history wrap (behavioral).
+ *
+ * history-defuser.js is an isolated-world IIFE. On Firefox MV2 it now wraps the
+ * PAGE's history.pushState/replaceState via window.wrappedJSObject +
+ * exportFunction (no injected <script>, so strict page CSPs like Amazon cannot
+ * block it) and calls window.__mugaReclean on a same-document navigation.
+ *
+ * This test loads the real source in a shimmed content-script environment and
+ * asserts: (1) a page pushState/replaceState triggers __mugaReclean when the
+ * active-defense gate is open, (2) it does NOT when the gate is closed, and
+ * (3) no <script> element is ever created (the CSP-immunity guarantee).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(resolve(__dirname, "../../src/content/history-defuser.js"), "utf8");
+
+/** Minimal EventTarget-ish stub that records createElement misuse. */
+function makeDocument() {
+  const listeners = new Map();
+  return {
+    createElementCalls: [],
+    addEventListener(type, fn) {
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type).push(fn);
+    },
+    removeEventListener() {},
+    dispatchEvent() { return true; },
+    createElement(tag) { this.createElementCalls.push(tag); return { set src(_v) {}, remove() {}, appendChild() {} }; },
+    head: null,
+    documentElement: null,
+  };
+}
+
+/**
+ * Loads history-defuser.js in a shimmed Firefox content-script world.
+ * `prefs` is what chrome.runtime.sendMessage("getPrefs") resolves to.
+ * Returns handles to assert against.
+ */
+function loadDefuser(prefs) {
+  const recleanCalls = [];
+  const pageHistory = {
+    pushCalls: [],
+    replaceCalls: [],
+    pushState(state, title, url) { this.pushCalls.push(url); },
+    replaceState(state, title, url) { this.replaceCalls.push(url); },
+  };
+  const pageWindow = { history: pageHistory };
+
+  const location = { href: "https://example.com/current", hostname: "example.com" };
+  const window = {
+    wrappedJSObject: pageWindow,
+    location,
+    __mugaReclean: (url) => recleanCalls.push(url),
+    addEventListener() {},
+  };
+  window.self = window;
+  window.top = window;
+
+  const document = makeDocument();
+  const chrome = {
+    runtime: {
+      getManifest: () => ({ manifest_version: 2 }),
+      sendMessage: (_msg, cb) => cb(prefs),
+      lastError: undefined,
+    },
+    storage: { onChanged: { addListener() {} } },
+  };
+  const exportFunction = (fn) => fn; // identity: exported fn is callable directly
+  const CustomEvent = class { constructor(type, opts) { this.type = type; this.detail = opts && opts.detail; } };
+  const consoleStub = { warn() {}, error() {}, log() {} };
+
+  // Run the real IIFE with our stubs shadowing the browser globals it reads.
+  const run = new Function(
+    "window", "document", "chrome", "crypto", "exportFunction", "location", "CustomEvent", "console",
+    SRC,
+  );
+  run(window, document, chrome, crypto, exportFunction, location, CustomEvent, consoleStub);
+
+  return { pageHistory, recleanCalls, document };
+}
+
+const OPEN_PREFS = { enabled: true, onboardingDone: true, activeDefenseEnabled: true };
+
+describe("Firefox history wrap — installs on the page world without a <script>", () => {
+  test("wraps pushState/replaceState on window.wrappedJSObject.history", () => {
+    const { pageHistory } = loadDefuser(OPEN_PREFS);
+    // The wrap replaces the methods; they are still functions and still record.
+    assert.equal(typeof pageHistory.pushState, "function");
+    assert.equal(typeof pageHistory.replaceState, "function");
+  });
+
+  test("creates NO <script> element (CSP-immunity guarantee)", () => {
+    const { document } = loadDefuser(OPEN_PREFS);
+    assert.deepEqual(document.createElementCalls, [], "no <script> (or any element) should be created");
+  });
+});
+
+describe("Firefox history wrap — triggers __mugaReclean on same-document navigation", () => {
+  test("page pushState with the gate OPEN calls __mugaReclean with the new URL", () => {
+    const { pageHistory, recleanCalls } = loadDefuser(OPEN_PREFS);
+    pageHistory.pushState({}, "", "https://example.com/section?utm_source=a");
+    assert.deepEqual(recleanCalls, ["https://example.com/section?utm_source=a"]);
+    // The original is still invoked so the page's navigation is preserved.
+    assert.deepEqual(pageHistory.pushCalls, ["https://example.com/section?utm_source=a"]);
+  });
+
+  test("page replaceState with the gate OPEN also triggers __mugaReclean", () => {
+    const { pageHistory, recleanCalls } = loadDefuser(OPEN_PREFS);
+    pageHistory.replaceState({}, "", "https://example.com/x?gclid=b");
+    assert.deepEqual(recleanCalls, ["https://example.com/x?gclid=b"]);
+  });
+
+  test("null url falls back to the current location href", () => {
+    const { pageHistory, recleanCalls } = loadDefuser(OPEN_PREFS);
+    pageHistory.pushState({}, "");
+    assert.deepEqual(recleanCalls, ["https://example.com/current"]);
+  });
+});
+
+describe("Firefox history wrap — respects the active-defense gate", () => {
+  test("gate CLOSED (MUGA disabled) does NOT call __mugaReclean, but still navigates", () => {
+    const { pageHistory, recleanCalls } = loadDefuser({ enabled: false, onboardingDone: true, activeDefenseEnabled: true });
+    pageHistory.pushState({}, "", "https://example.com/s?utm_source=a");
+    assert.deepEqual(recleanCalls, [], "closed gate must not reclean");
+    assert.deepEqual(pageHistory.pushCalls, ["https://example.com/s?utm_source=a"], "navigation must still happen");
+  });
+
+  test("gate CLOSED (active-defense turned off) does NOT call __mugaReclean", () => {
+    const { pageHistory, recleanCalls } = loadDefuser({ enabled: true, onboardingDone: true, activeDefenseEnabled: false });
+    pageHistory.pushState({}, "", "https://example.com/s?utm_source=a");
+    assert.deepEqual(recleanCalls, []);
+  });
+});

--- a/tests/unit/firefox-mv2-mainworld-injection.test.mjs
+++ b/tests/unit/firefox-mv2-mainworld-injection.test.mjs
@@ -1,30 +1,22 @@
 /**
- * MUGA — Firefox MV2 page-world injection contract (#509 / B12).
+ * MUGA — Firefox MV2 page-world wrap contract (#509 / B12).
  *
  * Chrome MV3 loads `history-defuser-mainworld.js` and
- * `window-name-defuser-mainworld.js` automatically via the
- * `world: "MAIN"` content-script directive in `src/manifest.json`.
- * Firefox MV2 (the manifest currently shipped to AMO) has no such
- * directive — the page-world wrap must be injected by the matching
- * isolated-world content script as a `<script src=...>` element
- * pointing at the extension's web-accessible resource.
+ * `window-name-defuser-mainworld.js` automatically via the `world: "MAIN"`
+ * content-script directive in `src/manifest.json`. Firefox MV2 has no such
+ * directive, so each isolated-world dispatcher must install the page-world
+ * wrap itself.
  *
- * This test pins three facts that must hold together for the
- * Firefox path to actually wrap the page world:
+ * HISTORY DEFUSER — CSP-immune wrap (fixed): the previous `<script src=...>`
+ * injection was silently blocked by strict page CSPs (e.g. Amazon), so
+ * pushState "section" navigations were never cleaned on Firefox. It now wraps
+ * `history.pushState`/`replaceState` directly from the isolated world via
+ * Firefox's `window.wrappedJSObject` + `exportFunction` — no `<script>`
+ * element, so no CSP can block it. This test pins that mechanism and, crucially,
+ * asserts NO `<script>` element is created for the history wrap.
  *
- *   1. The MV2 `web_accessible_resources` array exposes both
- *      mainworld scripts so the page can load them by URL.
- *   2. Each isolated-world dispatcher contains the inject helper
- *      gated on `manifest_version === 2` (so MV3 doesn't double-
- *      bootstrap).
- *   3. Each isolated-world dispatcher names the matching mainworld
- *      file in the `chrome.runtime.getURL` argument — typo-proofs
- *      the linkage between the two halves.
- *
- * If any of these break, Firefox users silently lose the active-
- * defense layer (B10/B11) — the unit tests stub the page world so
- * they don't catch this; only Playwright Firefox would, and that
- * spec is a follow-up to this slice.
+ * WINDOW-NAME DEFUSER — still uses the `<script src=...>` injection (its
+ * CSP-immune port is a follow-up). Its injection contract is still pinned here.
  */
 
 import { test, describe } from "node:test";
@@ -47,17 +39,10 @@ describe("Firefox MV2 web_accessible_resources expose the mainworld scripts (#50
       "MV2 web_accessible_resources must be an array");
   });
 
-  test("history-defuser-mainworld.js is web-accessible in MV2", () => {
-    assert.ok(
-      mv2Manifest.web_accessible_resources.includes("content/history-defuser-mainworld.js"),
-      "MV2 must expose history-defuser-mainworld.js so the isolated-world script can <script src> it",
-    );
-  });
-
-  test("window-name-defuser-mainworld.js is web-accessible in MV2", () => {
+  test("window-name-defuser-mainworld.js is web-accessible in MV2 (still <script src>'d)", () => {
     assert.ok(
       mv2Manifest.web_accessible_resources.includes("content/window-name-defuser-mainworld.js"),
-      "MV2 must expose window-name-defuser-mainworld.js for the same reason",
+      "MV2 must expose window-name-defuser-mainworld.js so its isolated-world dispatcher can <script src> it",
     );
   });
 
@@ -77,29 +62,45 @@ describe("Firefox MV2 web_accessible_resources expose the mainworld scripts (#50
   });
 });
 
-describe("Isolated-world dispatchers inject the mainworld script when running on MV2 (#509)", () => {
-  test("history-defuser.js gates the inject on manifest_version === 2", () => {
+describe("history-defuser.js wraps the page world CSP-immune on MV2 (#509)", () => {
+  test("gates the Firefox wrap on manifest_version === 2", () => {
     assert.match(
       histDefuserSrc,
       /manifest_version[^]*===[^]*2/,
-      "history-defuser.js must check manifest_version === 2 before injecting",
+      "history-defuser.js must check manifest_version === 2 before wrapping",
     );
   });
 
-  test("history-defuser.js injects the matching mainworld script via chrome.runtime.getURL", () => {
+  test("wraps pushState/replaceState via wrappedJSObject + exportFunction (not a <script>)", () => {
     assert.match(
       histDefuserSrc,
-      /chrome\.runtime\.getURL\(["'`]content\/history-defuser-mainworld\.js["'`]\)/,
-      "history-defuser.js must reference the mainworld resource by exact path",
+      /window\.wrappedJSObject/,
+      "history-defuser.js must reach the page world via window.wrappedJSObject",
     );
     assert.match(
+      histDefuserSrc,
+      /exportFunction/,
+      "history-defuser.js must inject the wrap via Firefox's exportFunction",
+    );
+    assert.match(histDefuserSrc, /pushState/, "history-defuser.js must wrap pushState");
+    assert.match(histDefuserSrc, /replaceState/, "history-defuser.js must wrap replaceState");
+  });
+
+  test("CSP-immunity guarantee — history-defuser.js creates NO <script> element", () => {
+    // The whole point of the fix: a strict page CSP (Amazon) blocks an injected
+    // <script src="moz-extension://...">. Wrapping via wrappedJSObject creates no
+    // <script>, so nothing for the CSP to block. This assertion is the regression
+    // guard against a future revert to the injection approach.
+    assert.doesNotMatch(
       histDefuserSrc,
       /document\.createElement\(["'`]script["'`]\)/,
-      "history-defuser.js must create a <script> element to inject the wrap",
+      "history-defuser.js must NOT create a <script> element — that reintroduces the CSP-block bug",
     );
   });
+});
 
-  test("window-name-defuser.js gates the inject on manifest_version === 2", () => {
+describe("window-name-defuser.js still injects the mainworld script on MV2 (pending CSP-immune port)", () => {
+  test("gates the inject on manifest_version === 2", () => {
     assert.match(
       winNameDefuserSrc,
       /manifest_version[^]*===[^]*2/,
@@ -107,7 +108,7 @@ describe("Isolated-world dispatchers inject the mainworld script when running on
     );
   });
 
-  test("window-name-defuser.js injects the matching mainworld script via chrome.runtime.getURL", () => {
+  test("injects the matching mainworld script via chrome.runtime.getURL", () => {
     assert.match(
       winNameDefuserSrc,
       /chrome\.runtime\.getURL\(["'`]content\/window-name-defuser-mainworld\.js["'`]\)/,
@@ -120,13 +121,11 @@ describe("Isolated-world dispatchers inject the mainworld script when running on
     );
   });
 
-  test("inject helpers append the script synchronously (async=false) so it runs before page scripts", () => {
-    for (const [name, src] of [["history-defuser.js", histDefuserSrc], ["window-name-defuser.js", winNameDefuserSrc]]) {
-      assert.match(
-        src,
-        /\.async\s*=\s*false/,
-        `${name} must set script.async=false so the page-world wrap installs before any page script runs`,
-      );
-    }
+  test("appends the script synchronously (async=false) so it runs before page scripts", () => {
+    assert.match(
+      winNameDefuserSrc,
+      /\.async\s*=\s*false/,
+      "window-name-defuser.js must set script.async=false so the page-world wrap installs before any page script runs",
+    );
   });
 });

--- a/tests/unit/firefox-mv2.test.mjs
+++ b/tests/unit/firefox-mv2.test.mjs
@@ -278,6 +278,18 @@ describe("Firefox MV2 manifest structure", () => {
     assert.equal(MANIFEST_V2.version, pkg.version,
       "manifest.v2.json version must match package.json");
   });
+
+  test("declares webRequest + webRequestBlocking (Firefox network-layer stripper)", () => {
+    // Firefox MV2 keeps blocking webRequest (removed in Chrome MV3) and uses it
+    // as its network-layer tracking-param stripper — the equivalent of Chrome's
+    // DNR redirect, and the source of the Firefox cleaned-URL counter. See the
+    // onBeforeNavigateStrip listener in service-worker.js. Without both
+    // permissions the listener silently never fires.
+    assert.ok(MANIFEST_V2.permissions.includes("webRequest"),
+      "manifest.v2.json must request webRequest");
+    assert.ok(MANIFEST_V2.permissions.includes("webRequestBlocking"),
+      "manifest.v2.json must request webRequestBlocking so onBeforeRequest can redirect");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/firefox-webrequest-stripper.test.mjs
+++ b/tests/unit/firefox-webrequest-stripper.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * MUGA — Firefox blocking-webRequest navigation stripper (computeNavigationStrip).
+ *
+ * On Firefox MV2, service-worker.js registers a blocking
+ * webRequest.onBeforeRequest listener (onBeforeNavigateStrip) that strips
+ * tracking params from top-level navigations by returning {redirectUrl} — the
+ * real equivalent of Chrome's DNR, and (unlike DNR) the source of the Firefox
+ * cleaned-URL counter. The listener delegates its decision to the pure,
+ * chrome-free computeNavigationStrip in cleaner.js, so these tests exercise the
+ * SAME code the listener runs (no divergence between test and production).
+ *
+ * They pin: (1) param parity with processUrl, (2) idempotency (the loop guard —
+ * a clean URL is never redirected again), (3) the enabled/onboarding/allowlist
+ * guards, (4) non-http pass-through, and (5) injection suppression (network layer
+ * strips only, matching Chrome's DNR).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { computeNavigationStrip, processUrl, parseListEntry } from "../../src/lib/cleaner.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+const DOMAIN_RULES = JSON.parse(readFileSync(join(ROOT, "src/rules/domain-rules.json"), "utf8"));
+
+/** Build a materialized prefs snapshot shaped like the SW's cachedPrefs. */
+function makePrefs(overrides = {}) {
+  const prefs = {
+    enabled: true,
+    onboardingDone: true,
+    blacklist: [],
+    whitelist: [],
+    customParams: [],
+    remoteParams: [],
+    disabledCategories: [],
+    stripAllAffiliates: false,
+    notifyForeignAffiliate: false,
+    injectOwnAffiliate: false,
+    ...overrides,
+  };
+  prefs._parsedBlacklist = (prefs.blacklist || []).map(parseListEntry);
+  prefs._parsedWhitelist = (prefs.whitelist || []).map(parseListEntry);
+  return prefs;
+}
+
+const strip = (url, prefs = makePrefs()) =>
+  computeNavigationStrip(url, prefs, DOMAIN_RULES, [], [], undefined);
+
+describe("Firefox webRequest stripper — param parity with processUrl", () => {
+  test("strips the same params processUrl would (single source of truth)", () => {
+    const url = "https://example.com/p?utm_source=nl&gclid=abc&keep=yes";
+    const prefs = makePrefs();
+    const decision = strip(url, prefs);
+    // The listener suppresses injection/notify — mirror that when computing the
+    // reference so the comparison is apples-to-apples.
+    const ref = processUrl(url, prefs, DOMAIN_RULES, undefined, undefined, "", [], []);
+    assert.ok(decision, "a dirty URL must yield a redirect decision");
+    assert.equal(decision.cleanUrl, ref.cleanUrl);
+    const params = new URL(decision.cleanUrl).searchParams;
+    assert.equal(params.has("utm_source"), false, "utm_source must be stripped");
+    assert.equal(params.has("gclid"), false, "gclid must be stripped");
+    assert.equal(params.get("keep"), "yes", "non-tracking params must survive");
+  });
+
+  test("strips multiple UTM params at once", () => {
+    const decision = strip("https://example.com/?utm_source=a&utm_medium=b&utm_campaign=c");
+    assert.ok(decision);
+    assert.equal(new URL(decision.cleanUrl).search, "");
+  });
+});
+
+describe("Firefox webRequest stripper — no redirect when nothing to strip", () => {
+  test("a clean URL returns null (no redirect issued)", () => {
+    assert.equal(strip("https://example.com/page?keep=yes&ok=1"), null);
+  });
+
+  test("a URL with no query returns null", () => {
+    assert.equal(strip("https://example.com/page"), null);
+  });
+});
+
+describe("Firefox webRequest stripper — idempotency (loop guard)", () => {
+  test("feeding the cleaned URL back returns null — Chrome's one-redirect-per-request is preserved without looping", () => {
+    const first = strip("https://example.com/?utm_source=a&gclid=b&keep=1");
+    assert.ok(first, "first pass strips");
+    const second = strip(first.cleanUrl);
+    assert.equal(second, null, "the clean URL must not be redirected again");
+  });
+});
+
+describe("Firefox webRequest stripper — guards", () => {
+  test("returns null when MUGA is disabled", () => {
+    assert.equal(strip("https://example.com/?utm_source=a", makePrefs({ enabled: false })), null);
+  });
+
+  test("returns null before onboarding is complete", () => {
+    assert.equal(strip("https://example.com/?utm_source=a", makePrefs({ onboardingDone: false })), null);
+  });
+
+  test("returns null on a fully-allowlisted (whitelisted) domain", () => {
+    // A domain-only whitelist entry fully exempts the site — the stripper must
+    // not touch it, mirroring the DNR allowlist "allow" rules on Chrome.
+    const prefs = makePrefs({ whitelist: ["example.com"] });
+    assert.equal(strip("https://example.com/?utm_source=a&gclid=b", prefs), null);
+  });
+});
+
+describe("Firefox webRequest stripper — non-http and malformed pass through", () => {
+  for (const url of ["chrome://extensions", "moz-extension://abc/x", "data:text/html,hi", "about:blank", "ftp://h/x"]) {
+    test(`returns null for non-http URL: ${url}`, () => {
+      assert.equal(strip(url), null);
+    });
+  }
+
+  test("returns null for a non-string url", () => {
+    assert.equal(computeNavigationStrip(undefined, makePrefs(), DOMAIN_RULES, [], [], undefined), null);
+  });
+});
+
+describe("Firefox webRequest stripper — injection is suppressed (network layer strips only, like DNR)", () => {
+  test("with injectOwnAffiliate on, the redirect target is the strip-only URL (no tag injected at the network layer)", () => {
+    const url = "https://example.com/?utm_source=a&keep=1";
+    const withInject = strip(url, makePrefs({ injectOwnAffiliate: true }));
+    const withoutInject = strip(url, makePrefs({ injectOwnAffiliate: false }));
+    assert.ok(withInject);
+    assert.ok(withoutInject);
+    // Suppressing injection means both produce the identical strip-only result.
+    assert.equal(withInject.cleanUrl, withoutInject.cleanUrl);
+    assert.equal(withInject.result.action !== "injected", true, "network strip must not be an injection");
+  });
+});


### PR DESCRIPTION
## Problem
On Firefox, MUGA did not clean URLs on navigation (clicks/sections) and the cleaned-URL counter stayed at 0. Root cause: Firefox relied entirely on the runtime cleaner, whose two paths fail on strict-CSP sites like Amazon:
- **Sections (pushState):** the main-world history wrap was injected as a `<script src="moz-extension://...">`, which the page CSP silently blocks.
- **Counter:** only ever fed by the content-script `BADGE_AND_STATS` message; DNR (Chrome's mechanism) emits no `onRuleMatched` signal, so nothing counted.

## Fix (Firefox MV2 only; Chrome MV3 provably untouched — everything gated on `manifest_version === 2`)
1. **Network layer:** a blocking `webRequest.onBeforeRequest` listener strips tracking params from `main_frame` navigations (the real equivalent of Chrome's DNR, and — unlike DNR — the source of the Firefox counter). It delegates to a new pure `computeNavigationStrip` (cleaner.js) so the test exercises the exact production logic. Strip-only (injection/toast suppressed) → parity with Chrome + idempotent redirect.
2. **`tracking_params` DNR ruleset is disabled on Firefox** (via the extracted pure `partitionRulesets`) so the webRequest listener is the SOLE strip path — it counts reliably and avoids a redundant, order-dependent DNR+webRequest double-strip.
3. **In-page layer:** the CSP-fragile `<script>` injection in `history-defuser.js` is replaced by a CSP-immune wrap of `pushState`/`replaceState` via Firefox `window.wrappedJSObject` + `exportFunction`, calling `__mugaReclean` directly.
4. Stats/badge recording factored into a shared `recordNetworkClean`.

Adds `webRequest` + `webRequestBlocking` to `manifest.v2.json` (Chrome `manifest.json` unchanged).

## Scope / follow-ups
- `window-name-defuser.js` keeps its `<script>` injection for now (its CSP-immune port is a follow-up; it is not URL cleaning).
- **A Playwright-Firefox e2e is not feasible in the chromium-only harness.** A live `web-ext run` smoke on Amazon is REQUIRED before the next Firefox/AMO release to confirm the X-ray wrap and blocking-webRequest redirect behave as designed (this cannot be validated in CI or from the dev environment).

## Tests
5950 pass / 0 fail, typecheck + lint clean. New: `firefox-webrequest-stripper` (param parity, idempotency, guards, non-http, injection suppression), `firefox-history-wrap` (behavioral: pushState triggers `__mugaReclean` gated; no `<script>` created), `dnr-ruleset-state` (Firefox disables / Chrome enables `tracking_params`). Rewrote the mainworld-injection assertions; added permission assertions.

Reviewed adversarially; HIGH (counter/DNR interaction) and MEDIUM (cold-start over-strip) findings fixed in the second commit.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ