### PR TITLE
test: pre-release guards — cleaner property tests + MV2/MV3 parity (#988, #989)

### DIFF
--- a/tests/unit/cleaner-property.test.mjs
+++ b/tests/unit/cleaner-property.test.mjs
@@ -1,0 +1,432 @@
+/**
+ * MUGA — Property-based tests for the cleaner pipeline (issue #988).
+ *
+ * Generates a deterministic corpus of synthetic URLs from a small grammar
+ * (scheme + affiliate/plain host + path + a mix of tracking params,
+ * functional params, MUGA's own affiliate tag, and a third-party creator
+ * tag) using a seeded mulberry32 PRNG, then asserts three invariants that
+ * must hold across the WHOLE corpus:
+ *
+ *   1. Idempotence — cleaning an already-cleaned URL is a no-op.
+ *   2. Copy-safe no-leak (#946) — the copy/share prefs shape
+ *      (injectOwnAffiliate: false, notifyForeignAffiliate: false) must
+ *      never cause MUGA's own affiliate tag to appear on the output unless
+ *      it was already present on the input.
+ *   3. Affiliate preservation — a third-party creator's affiliate tag
+ *      survives under default (non-strip-all) prefs and is removed only
+ *      when the user opts into stripAllAffiliates. MUGA's own tag is
+ *      injected only when injectOwnAffiliate is on and no affiliate tag
+ *      is already present.
+ *
+ * The real `processUrl()` pipeline is exercised directly (same call shape
+ * used by tests/unit/content-copy-safe-injection.test.mjs and
+ * tests/unit/cleaner-affiliate-pipeline.test.mjs):
+ *
+ *   processUrl(rawUrl, prefs, domainRules, canonicalBundle, frequencyTracker,
+ *              referrer, pathStripRules, pathAffiliateRules)
+ *
+ * This file is TEST-ONLY. If a generated case reveals a real invariant
+ * violation, that is a genuine cleaner bug — the assertion must NOT be
+ * weakened and production code must NOT be touched to make it pass.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+import { processUrl } from "../../src/lib/cleaner.js";
+import { TRACKING_PARAMS } from "../../src/lib/affiliates.js";
+
+const require = createRequire(import.meta.url);
+const domainRules = require("../../src/rules/domain-rules.json");
+
+// ── Deterministic seeded PRNG (mulberry32) ───────────────────────────────
+// No Math.random anywhere in this file — every run with the same SEED
+// produces the exact same corpus, so a CI failure is always reproducible.
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function rng() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const SEED = 988;
+const rng = mulberry32(SEED);
+
+function pick(arr) {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+function pickN(arr, n) {
+  // Sample n distinct entries via Fisher-Yates partial shuffle.
+  const pool = arr.slice();
+  const out = [];
+  const count = Math.min(n, pool.length);
+  for (let i = 0; i < count; i++) {
+    const idx = Math.floor(rng() * pool.length);
+    out.push(pool[idx]);
+    pool.splice(idx, 1);
+  }
+  return out;
+}
+
+function shuffle(arr) {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+// ── Grammar data — sourced from the real ruleset, not invented ──────────
+
+// Affiliate hosts + MUGA's own tag values, taken directly from OUR_TAGS in
+// src/lib/affiliates.js (amazon-associates + ebay-partner-network programs).
+const AFFILIATE_HOSTS = [
+  { host: "amazon.com", param: "tag", ourTag: "muga0b-20" },
+  { host: "amazon.es", param: "tag", ourTag: "muga0b-21" },
+  { host: "amazon.de", param: "tag", ourTag: "muga0f-21" },
+  { host: "amazon.fr", param: "tag", ourTag: "muga08a-21" },
+  { host: "amazon.it", param: "tag", ourTag: "muga04f-21" },
+  { host: "amazon.co.uk", param: "tag", ourTag: "muga0a-21" },
+  { host: "ebay.com", param: "campid", ourTag: "5339147108" },
+  { host: "ebay.es", param: "campid", ourTag: "5339147108" },
+];
+
+// Plain, non-affiliate hosts. Fictional/fixture-only names so they can
+// never accidentally collide with a real entry in domain-rules.json.
+const PLAIN_HOSTS = [
+  "blog.cleaner-fixture.example",
+  "news.cleaner-fixture.example",
+  "recipes.cleaner-fixture.example",
+];
+
+// Third-party creator affiliate tag values. None of these may equal any
+// ourTag value above (that would silently turn a "creator tag" case into
+// an "already our tag" case and break the copy-safe invariant's premise).
+const CREATOR_TAGS = ["creator-alpha-19", "youtuber-diego-21", "streamer-mika-07"];
+
+// Functional params that MUST be preserved: none of these are tracking
+// params (verified against TRACKING_PARAMS/TRACKING_PREFIXES) and "page"
+// is additionally an explicit preserveParams entry for amazon.*/ebay.* in
+// domain-rules.json.
+const FUNCTIONAL_PARAMS = ["q", "id", "page", "sort"];
+
+// Safe path segments — none match AUTH_PATH_RE
+// (/(oauth|oauth2|authorize|callback|auth|signin|login|sso|saml|checkout|payment|pay)(\/|$)/)
+// so every generated URL actually reaches the tracking/affiliate pipeline
+// instead of short-circuiting to "untouched".
+const PATHS = [
+  "/",
+  "/dp/B08N5WRWNW",
+  "/product/12345",
+  "/item/abc-123",
+  "/shop/electronics",
+  "/deals/today",
+  "/search-results",
+];
+
+const SCHEMES = ["http", "https"];
+
+// Sanity check on the grammar's own premise — fail loudly here rather than
+// producing a confusing property-test failure downstream.
+for (const tag of CREATOR_TAGS) {
+  for (const h of AFFILIATE_HOSTS) {
+    if (tag === h.ourTag) {
+      throw new Error(`Grammar bug: creator tag "${tag}" collides with ourTag for ${h.host}`);
+    }
+  }
+}
+
+// ── Prefs variants ────────────────────────────────────────────────────────
+
+const NAV_PREFS = Object.freeze({
+  enabled: true,
+  onboardingDone: true,
+  injectOwnAffiliate: true,
+  notifyForeignAffiliate: true,
+  stripAllAffiliates: false,
+  blacklist: [],
+  whitelist: [],
+  disabledCategories: [],
+});
+
+// The copy/share prefs shape (#946): the content-script copy paths and
+// background handleProcessUrl's skipNotify branch both force these two
+// toggles off regardless of the user's live navigation prefs.
+const COPY_PREFS = Object.freeze({
+  enabled: true,
+  onboardingDone: true,
+  injectOwnAffiliate: false,
+  notifyForeignAffiliate: false,
+  stripAllAffiliates: false,
+  blacklist: [],
+  whitelist: [],
+  disabledCategories: [],
+});
+
+const STRIP_ALL_PREFS = Object.freeze({
+  ...NAV_PREFS,
+  stripAllAffiliates: true,
+  // notifyForeignAffiliate detection is gated off automatically when
+  // stripAllAffiliates is on (see handleAffiliatePipeline Step 3), kept
+  // here only for readability of the fixture.
+  notifyForeignAffiliate: false,
+});
+
+const NO_INJECT_PREFS = Object.freeze({
+  ...NAV_PREFS,
+  injectOwnAffiliate: false,
+  notifyForeignAffiliate: false,
+});
+
+// ── Case generation ───────────────────────────────────────────────────────
+
+/**
+ * @typedef {object} GeneratedCase
+ * @property {string} rawUrl
+ * @property {{host:string, param:string, ourTag:string}|null} affiliateHost
+ * @property {"none"|"ourTag"|"creatorTag"} tagState
+ * @property {string|null} creatorTagValue
+ */
+
+function generateCase(index) {
+  const scheme = pick(SCHEMES);
+  const useAffiliateHost = rng() < 0.7;
+  const affiliateHost = useAffiliateHost ? pick(AFFILIATE_HOSTS) : null;
+  const bareHost = affiliateHost ? affiliateHost.host : pick(PLAIN_HOSTS);
+  const host = rng() < 0.3 ? `www.${bareHost}` : bareHost;
+  const path = pick(PATHS);
+
+  const params = [];
+
+  // 1-4 real tracking params from the ruleset, with deterministic values.
+  const trackingSample = pickN(TRACKING_PARAMS, 1 + Math.floor(rng() * 4));
+  trackingSample.forEach((name, i) => params.push([name, `v${index}_${i}`]));
+
+  // 0-2 functional params that must survive cleaning untouched.
+  const functionalSample = pickN(FUNCTIONAL_PARAMS, Math.floor(rng() * 3));
+  functionalSample.forEach((name) => params.push([name, `${name}val${index}`]));
+
+  // Affiliate tag state, only meaningful on affiliate hosts.
+  let tagState = "none";
+  let creatorTagValue = null;
+  if (affiliateHost) {
+    const roll = rng();
+    if (roll < 0.34) {
+      tagState = "none";
+    } else if (roll < 0.67) {
+      tagState = "ourTag";
+      params.push([affiliateHost.param, affiliateHost.ourTag]);
+    } else {
+      tagState = "creatorTag";
+      creatorTagValue = pick(CREATOR_TAGS);
+      params.push([affiliateHost.param, creatorTagValue]);
+    }
+  }
+
+  const orderedParams = shuffle(params);
+  const query = orderedParams.map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join("&");
+  const rawUrl = `${scheme}://${host}${path}${query ? `?${query}` : ""}`;
+
+  return { rawUrl, affiliateHost, tagState, creatorTagValue };
+}
+
+const CASE_COUNT = 300;
+const CORPUS = Array.from({ length: CASE_COUNT }, (_, i) => generateCase(i));
+
+// ── Shared processUrl call helper ────────────────────────────────────────
+// Matches the real call shape from content-copy-safe-injection.test.mjs /
+// cleaner-affiliate-pipeline.test.mjs: (rawUrl, prefs, domainRules,
+// canonicalBundle, frequencyTracker, referrer, pathStripRules, pathAffiliateRules).
+function clean(rawUrl, prefs) {
+  return processUrl(rawUrl, prefs, domainRules, undefined, undefined, "", [], []);
+}
+
+function tagValueOf(url, param) {
+  try {
+    return new URL(url).searchParams.get(param);
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Invariant 1: Idempotence ──────────────────────────────────────────────
+
+describe("cleaner property: idempotence (processUrl(processUrl(x)) === processUrl(x))", () => {
+  test(`holds across ${CASE_COUNT} generated cases under default navigation prefs`, () => {
+    const failures = [];
+    for (const c of CORPUS) {
+      const first = clean(c.rawUrl, NAV_PREFS);
+      const second = clean(first.cleanUrl, NAV_PREFS);
+      if (second.cleanUrl !== first.cleanUrl) {
+        failures.push({
+          invariant: "idempotence",
+          rawUrl: c.rawUrl,
+          firstPass: first.cleanUrl,
+          secondPass: second.cleanUrl,
+        });
+      }
+    }
+    assert.equal(
+      failures.length,
+      0,
+      `Idempotence violated in ${failures.length}/${CASE_COUNT} case(s). ` +
+        `First offender: ${JSON.stringify(failures[0], null, 2)}`,
+    );
+  });
+});
+
+// ── Invariant 2: Copy-safe never leaks our own tag ────────────────────────
+
+describe("cleaner property: copy-safe cleaning never injects MUGA's own affiliate tag (#946)", () => {
+  test(`holds across every affiliate-host case where the input did not already carry our tag`, () => {
+    const failures = [];
+    for (const c of CORPUS) {
+      if (!c.affiliateHost) continue;
+      const { param, ourTag } = c.affiliateHost;
+      const inputHadOurTag = tagValueOf(c.rawUrl, param) === ourTag;
+      const result = clean(c.rawUrl, COPY_PREFS);
+      const outputTagValue = tagValueOf(result.cleanUrl, param);
+
+      if (!inputHadOurTag && outputTagValue === ourTag) {
+        failures.push({
+          invariant: "copy-safe-no-leak",
+          rawUrl: c.rawUrl,
+          cleanUrl: result.cleanUrl,
+          action: result.action,
+          reason: "our own tag appeared on copy-safe output even though the input never had it",
+        });
+      }
+      if (!inputHadOurTag && result.action === "injected") {
+        failures.push({
+          invariant: "copy-safe-no-injected-action",
+          rawUrl: c.rawUrl,
+          cleanUrl: result.cleanUrl,
+          action: result.action,
+          reason: 'copy-safe prefs must never report action "injected"',
+        });
+      }
+    }
+    assert.equal(
+      failures.length,
+      0,
+      `Copy-safe leak in ${failures.length} case(s). First offender: ${JSON.stringify(failures[0], null, 2)}`,
+    );
+  });
+});
+
+// ── Invariant 3: Third-party affiliate preservation ───────────────────────
+
+describe("cleaner property: third-party creator affiliate tag preservation", () => {
+  test("a creator tag survives under default (non-strip-all) prefs", () => {
+    const failures = [];
+    for (const c of CORPUS) {
+      if (!c.affiliateHost || c.tagState !== "creatorTag") continue;
+      const { param } = c.affiliateHost;
+      const result = clean(c.rawUrl, NAV_PREFS);
+      const outputTagValue = tagValueOf(result.cleanUrl, param);
+      if (outputTagValue !== c.creatorTagValue) {
+        failures.push({
+          invariant: "creator-tag-preserved-default",
+          rawUrl: c.rawUrl,
+          cleanUrl: result.cleanUrl,
+          expectedCreatorTag: c.creatorTagValue,
+          actualTagValue: outputTagValue,
+        });
+      }
+    }
+    assert.equal(
+      failures.length,
+      0,
+      `Creator tag not preserved in ${failures.length} case(s). ` +
+        `First offender: ${JSON.stringify(failures[0], null, 2)}`,
+    );
+  });
+
+  test("a creator tag is removed once the user opts into stripAllAffiliates", () => {
+    const failures = [];
+    for (const c of CORPUS) {
+      if (!c.affiliateHost || c.tagState !== "creatorTag") continue;
+      const { param } = c.affiliateHost;
+      const result = clean(c.rawUrl, STRIP_ALL_PREFS);
+      const outputTagValue = tagValueOf(result.cleanUrl, param);
+      if (outputTagValue === c.creatorTagValue) {
+        failures.push({
+          invariant: "creator-tag-stripped-under-strip-all",
+          rawUrl: c.rawUrl,
+          cleanUrl: result.cleanUrl,
+          creatorTagValue: c.creatorTagValue,
+        });
+      }
+    }
+    assert.equal(
+      failures.length,
+      0,
+      `stripAllAffiliates failed to remove the creator tag in ${failures.length} case(s). ` +
+        `First offender: ${JSON.stringify(failures[0], null, 2)}`,
+    );
+  });
+
+  test("MUGA's own tag is injected only when injectOwnAffiliate is on and no tag is already present", () => {
+    const failures = [];
+    for (const c of CORPUS) {
+      if (!c.affiliateHost || c.tagState !== "none") continue;
+      const { param, ourTag } = c.affiliateHost;
+
+      const withInject = clean(c.rawUrl, NAV_PREFS); // injectOwnAffiliate: true
+      const withInjectTag = tagValueOf(withInject.cleanUrl, param);
+      if (withInjectTag !== ourTag || withInject.action !== "injected") {
+        failures.push({
+          invariant: "own-tag-injected-when-enabled",
+          rawUrl: c.rawUrl,
+          cleanUrl: withInject.cleanUrl,
+          action: withInject.action,
+          expectedOurTag: ourTag,
+          actualTagValue: withInjectTag,
+        });
+      }
+
+      const withoutInject = clean(c.rawUrl, NO_INJECT_PREFS); // injectOwnAffiliate: false
+      const withoutInjectTag = tagValueOf(withoutInject.cleanUrl, param);
+      if (withoutInjectTag) {
+        failures.push({
+          invariant: "own-tag-not-injected-when-disabled",
+          rawUrl: c.rawUrl,
+          cleanUrl: withoutInject.cleanUrl,
+          unexpectedTagValue: withoutInjectTag,
+        });
+      }
+    }
+    assert.equal(
+      failures.length,
+      0,
+      `Own-tag injection behavior violated in ${failures.length} case(s). ` +
+        `First offender: ${JSON.stringify(failures[0], null, 2)}`,
+    );
+  });
+});
+
+// ── Corpus sanity (guards the generator itself, not the cleaner) ─────────
+
+describe("cleaner property: corpus sanity", () => {
+  test("generates the expected number of cases with a mix of affiliate and plain hosts", () => {
+    assert.equal(CORPUS.length, CASE_COUNT);
+    const affiliateCount = CORPUS.filter((c) => c.affiliateHost).length;
+    const plainCount = CASE_COUNT - affiliateCount;
+    assert.ok(affiliateCount > 0, "corpus must include affiliate-host cases");
+    assert.ok(plainCount > 0, "corpus must include plain-host cases");
+  });
+
+  test("is fully deterministic across two independent generator runs with the same seed", () => {
+    const rngA = mulberry32(SEED);
+    const rngB = mulberry32(SEED);
+    const samplesA = Array.from({ length: 20 }, () => rngA());
+    const samplesB = Array.from({ length: 20 }, () => rngB());
+    assert.deepEqual(samplesA, samplesB, "mulberry32 must produce identical sequences for the same seed");
+  });
+});

--- a/tests/unit/mv-parity.test.mjs
+++ b/tests/unit/mv-parity.test.mjs
@@ -1,0 +1,294 @@
+/**
+ * MUGA — MV2/MV3 parity guard (#989).
+ *
+ * Past parity gaps between the Chrome MV3 build (src/manifest.json) and the
+ * Firefox MV2 build (src/manifest.v2.json) were caught late in review instead
+ * of at CI time: a DNR rule (#820), the onboarding trigger (#888 follow-up),
+ * and most recently a leftover content-script registration (#1026). Each of
+ * those existing gaps now has its own dedicated regression test (see
+ * firefox-mv2.test.mjs's "DNR ruleset MV2 parity" describe block and
+ * firefox-mv2-mainworld-injection.test.mjs). This file adds the two
+ * dimensions those tests do NOT cover end-to-end:
+ *
+ *   1. Runtime message-TYPE parity: the set of `message.type` values the
+ *      background handles must be identical for both builds, because both
+ *      builds load the exact same background source file. This test pins
+ *      that single-source-of-truth wiring AND the message-type roster, so a
+ *      future MV-conditional branch around a message type (or a second,
+ *      build-specific background file) fails loudly instead of silently
+ *      diverging.
+ *
+ *   2. Content-script registration parity: the flattened set of content
+ *      scripts declared by each manifest must be identical except for the
+ *      two already-documented MV-specific differences below. Adding or
+ *      removing a shared content script in only one manifest — or changing
+ *      its world/run_at in only one manifest — now fails here instead of
+ *      waiting for a live-browser bug report.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * LEGITIMATE MV-specific differences encoded below (NOT parity gaps):
+ *
+ *   - content/history-defuser-mainworld.js and
+ *     content/window-name-defuser-mainworld.js are CHROME-MV3-ONLY. MV3 loads
+ *     them via the `world: "MAIN"` content_scripts group. Firefox MV2 has no
+ *     `world: "MAIN"` support; the isolated-world companions
+ *     (history-defuser.js / window-name-defuser.js) install the page-world
+ *     wrap themselves via `window.wrappedJSObject` + `exportFunction`
+ *     instead (#1026, pinned by firefox-mv2-mainworld-injection.test.mjs).
+ *
+ *   - content/amp-redirect.js is FIREFOX-MV2-ONLY. Chrome MV3 handles AMP
+ *     canonicalization via the `amp_redirect` DNR ruleset (declarative,
+ *     network-layer); Firefox MV2 has no equivalent so it runs this content
+ *     script as a document_end fallback instead (#820, partially pinned by
+ *     firefox-mv2.test.mjs's "DNR ruleset MV2 parity" describe block, which
+ *     covers the ruleset ID but not the content-script registration itself —
+ *     this file closes that gap).
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "../..");
+
+const mv3Manifest = JSON.parse(readFileSync(resolve(ROOT, "src/manifest.json"), "utf8"));
+const mv2Manifest = JSON.parse(readFileSync(resolve(ROOT, "src/manifest.v2.json"), "utf8"));
+const backgroundHtml = readFileSync(resolve(ROOT, "src/background/background.html"), "utf8");
+const serviceWorkerSrc = readFileSync(resolve(ROOT, "src/background/service-worker.js"), "utf8");
+
+// ---------------------------------------------------------------------------
+// 1. Message-TYPE parity — single shared background source
+// ---------------------------------------------------------------------------
+
+// Pinned roster of production `message.type` values the main
+// chrome.runtime.onMessage listener in service-worker.js handles (excludes
+// the __TEST__* dispatch, which is a separate, explicitly test-mode-gated
+// mechanism inside the same shared file and therefore trivially in parity).
+// If a message type is added or removed, update this list — that is the
+// point of the guard: the change gets reviewed instead of silently drifting
+// between builds.
+const EXPECTED_MESSAGE_TYPES = [
+  "getPrefs",
+  "PROCESS_URL",
+  "BADGE_AND_STATS",
+  "ADD_TO_WHITELIST",
+  "ADD_TO_BLACKLIST",
+  "GET_DEBUG_LOG",
+  "INCREMENT_STAT",
+  "CLEAR_DEBUG_LOG",
+  "ENABLE_REMOTE_RULES",
+  "DISABLE_REMOTE_RULES",
+  "GET_REMOTE_RULES_STATUS",
+  "FORCE_FETCH_REMOTE_RULES",
+  "RESOLVE_SHORTENER",
+];
+
+/**
+ * Extract every literal `message.type === "..."` (or '...') check from the
+ * given source. Used both to pin the production roster above and to prove
+ * no message type is checked more than once under a different MV-specific
+ * guard elsewhere in the file.
+ */
+function extractMessageTypes(src) {
+  // Excludes `typeof message.type === "string"` (a type-of guard, not a
+  // literal message-type comparison) via the negative lookbehind on "typeof ".
+  const re = /(?<!typeof )message\.type\s*===\s*["']([^"']+)["']/g;
+  const types = new Set();
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    types.add(m[1]);
+  }
+  return types;
+}
+
+describe("MV parity — background message-type handlers share one source file (#989)", () => {
+  test("MV3 manifest points its background at background/service-worker.js", () => {
+    assert.equal(
+      mv3Manifest.background?.service_worker,
+      "background/service-worker.js",
+      "MV3 manifest.json must declare background/service-worker.js as the service worker",
+    );
+  });
+
+  test("MV2 manifest points its background page at background/background.html", () => {
+    assert.equal(
+      mv2Manifest.background?.page,
+      "background/background.html",
+      "MV2 manifest.v2.json must declare background/background.html as the background page",
+    );
+  });
+
+  test("background.html loads the SAME service-worker.js file MV3 uses directly", () => {
+    // This is the load-bearing assertion for message-type parity: as long as
+    // both builds execute this one file, the set of message.type handlers is
+    // structurally identical by construction. If a future change points
+    // background.html at a different (e.g. MV2-specific) script, this fails.
+    assert.match(
+      backgroundHtml,
+      /<script\s+type="module"\s+src="service-worker\.js"><\/script>/,
+      "background.html must load service-worker.js as a module — the exact same file MV3's " +
+      "background.service_worker points to (background/service-worker.js)",
+    );
+  });
+
+  test("exactly one chrome.runtime.onMessage.addListener registration exists in service-worker.js", () => {
+    // Guards against a future second, MV-specific listener being added
+    // alongside the shared one — that would let message-type handling
+    // silently diverge between builds despite both loading this file.
+    const matches = serviceWorkerSrc.match(/chrome\.runtime\.onMessage\.addListener\(/g) || [];
+    assert.equal(
+      matches.length,
+      1,
+      "service-worker.js must register exactly one runtime.onMessage listener " +
+      `(found ${matches.length}) — a second listener could gate message types per build`,
+    );
+  });
+
+  test("no message.type check is gated behind an MV-specific conditional", () => {
+    // isFirefoxMV2 / manifest_version are used elsewhere in service-worker.js
+    // (e.g. DNR ruleset partitioning at startup), which is legitimate runtime
+    // capability branching, not message-type registration. The listener body
+    // itself (from the addListener call to its closing paren before the next
+    // top-level function) must never reference either token, or a message
+    // type could become reachable on only one build.
+    const listenerStart = serviceWorkerSrc.indexOf("chrome.runtime.onMessage.addListener(");
+    assert.ok(listenerStart >= 0, "onMessage.addListener call not found");
+    const nextFunctionIdx = serviceWorkerSrc.indexOf("\nasync function", listenerStart);
+    assert.ok(nextFunctionIdx > listenerStart, "could not locate end of the onMessage listener body");
+    const listenerBody = serviceWorkerSrc.slice(listenerStart, nextFunctionIdx);
+    assert.doesNotMatch(
+      listenerBody,
+      /isFirefoxMV2|manifest_version/,
+      "the shared onMessage listener body must not branch on isFirefoxMV2 or manifest_version — " +
+      "that would let a message type be handled on only one build",
+    );
+  });
+
+  test("production message-type roster matches the pinned EXPECTED_MESSAGE_TYPES list", () => {
+    const found = extractMessageTypes(serviceWorkerSrc);
+    const foundSorted = [...found].sort();
+    const expectedSorted = [...EXPECTED_MESSAGE_TYPES].sort();
+    assert.deepStrictEqual(
+      foundSorted,
+      expectedSorted,
+      "message-type roster drifted from EXPECTED_MESSAGE_TYPES — since both manifests load this " +
+      "same file, update the pinned list above after confirming the new/removed type is intentional",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Content-script registration parity
+// ---------------------------------------------------------------------------
+
+// Chrome-MV3-only content scripts (world: "MAIN"), see file header (#1026).
+const ALLOWED_MV3_ONLY_SCRIPTS = [
+  "content/history-defuser-mainworld.js",
+  "content/window-name-defuser-mainworld.js",
+];
+
+// Firefox-MV2-only content script (document_end fallback), see file header (#820).
+const ALLOWED_MV2_ONLY_SCRIPTS = ["content/amp-redirect.js"];
+
+function flattenContentScripts(manifest) {
+  const groups = manifest.content_scripts || [];
+  /** @type {Map<string, { world: string, run_at: string, matches: string[] }>} */
+  const byFile = new Map();
+  for (const group of groups) {
+    const world = group.world || "ISOLATED";
+    const run_at = group.run_at || "document_idle";
+    const matches = group.matches || [];
+    for (const js of group.js || []) {
+      assert.ok(
+        !byFile.has(js),
+        `content script ${js} appears in more than one content_scripts group in the same manifest`,
+      );
+      byFile.set(js, { world, run_at, matches });
+    }
+  }
+  return byFile;
+}
+
+describe("MV parity — content-script registration (#989)", () => {
+  const mv3Scripts = flattenContentScripts(mv3Manifest);
+  const mv2Scripts = flattenContentScripts(mv2Manifest);
+
+  test("no unexpected content script is MV3-only", () => {
+    const onlyMv3 = [...mv3Scripts.keys()].filter((f) => !mv2Scripts.has(f));
+    assert.deepStrictEqual(
+      onlyMv3.sort(),
+      [...ALLOWED_MV3_ONLY_SCRIPTS].sort(),
+      "content scripts present in manifest.json but missing from manifest.v2.json must exactly " +
+      "match ALLOWED_MV3_ONLY_SCRIPTS — if this fails, either add the script to manifest.v2.json " +
+      "or, if it is intentionally Chrome-only, document why and add it to the allowed list:\n  " +
+      onlyMv3.join("\n  "),
+    );
+  });
+
+  test("no unexpected content script is MV2-only", () => {
+    const onlyMv2 = [...mv2Scripts.keys()].filter((f) => !mv3Scripts.has(f));
+    assert.deepStrictEqual(
+      onlyMv2.sort(),
+      [...ALLOWED_MV2_ONLY_SCRIPTS].sort(),
+      "content scripts present in manifest.v2.json but missing from manifest.json must exactly " +
+      "match ALLOWED_MV2_ONLY_SCRIPTS — if this fails, either add the script to manifest.json " +
+      "or, if it is intentionally Firefox-only, document why and add it to the allowed list:\n  " +
+      onlyMv2.join("\n  "),
+    );
+  });
+
+  test("shared content scripts have identical world/run_at/matches in both manifests", () => {
+    const shared = [...mv3Scripts.keys()].filter((f) => mv2Scripts.has(f));
+    assert.ok(shared.length > 0, "expected at least one content script shared by both manifests");
+    for (const file of shared) {
+      const a = mv3Scripts.get(file);
+      const b = mv2Scripts.get(file);
+      assert.deepStrictEqual(
+        a,
+        b,
+        `content script ${file} has drifted between manifests (world/run_at/matches must match): ` +
+        `MV3=${JSON.stringify(a)} MV2=${JSON.stringify(b)}`,
+      );
+    }
+  });
+
+  test("the shared isolated content-script set is non-empty and includes the core cleaner pipeline", () => {
+    // Regression guard: if this ever comes back empty, the two sets above
+    // (world/run_at/matches) could still pass vacuously.
+    const shared = [...mv3Scripts.keys()].filter((f) => mv2Scripts.has(f));
+    for (const required of [
+      "content/cleaner-bundle.js",
+      "content/cleaner.js",
+      "content/history-defuser.js",
+      "content/window-name-defuser.js",
+    ]) {
+      assert.ok(
+        shared.includes(required),
+        `expected ${required} to be a shared (non-MV-specific) content script in both manifests`,
+      );
+    }
+  });
+
+  test("ALLOWED_MV3_ONLY_SCRIPTS are declared with world: 'MAIN' in manifest.json", () => {
+    for (const file of ALLOWED_MV3_ONLY_SCRIPTS) {
+      const entry = mv3Scripts.get(file);
+      assert.ok(entry, `${file} must be declared in manifest.json`);
+      assert.equal(
+        entry.world,
+        "MAIN",
+        `${file} is documented as Chrome-MV3-only via world: "MAIN" — found world: "${entry.world}"`,
+      );
+    }
+  });
+
+  test("ALLOWED_MV2_ONLY_SCRIPTS are declared in manifest.v2.json only (not MV3)", () => {
+    for (const file of ALLOWED_MV2_ONLY_SCRIPTS) {
+      assert.ok(mv2Scripts.has(file), `${file} must be declared in manifest.v2.json`);
+      assert.ok(!mv3Scripts.has(file), `${file} must NOT be declared in manifest.json`);
+    }
+  });
+});


### PR DESCRIPTION
Test-only, no production code touched. Both landed green with no bug/gap found, adding regression coverage before the 2.5.0 tag.

- **#988** `tests/unit/cleaner-property.test.mjs`: deterministic seeded property tests over the real `processUrl` pipeline — idempotence, copy-safe no-tag-leak (#946), third-party affiliate preservation vs stripAllAffiliates/injectOwnAffiliate. Grammar sourced from the real ruleset; avoids the AUTH_PATH_RE short-circuit so cases reach the pipeline.
- **#989** `tests/unit/mv-parity.test.mjs`: MV2/MV3 parity guard — both builds load the same service-worker.js, pinned 13-entry message-type roster, single onMessage listener with no MV branch, content-script registration parity (world/run_at/matches). Only documented differences allowed: Chrome-only mainworld (#1026), Firefox-only amp-redirect (#820).

Local: full suite 6075 pass / 0 fail / 1 pre-existing skip; typecheck clean.

Closes #988
Closes #989