### PR TITLE
fix: high-severity pre-release audit findings (#1035, #1036, #1037, #1038)

### DIFF
--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -153,6 +153,30 @@
    */
   function urlCleaner(raw) {
     if (isAbsoluteUrl(raw)) return cleanAbsolute(raw);
+    // Protocol-relative hrefs (`//host/path`) are scheme-relative but
+    // ORIGIN-bearing. isAbsoluteUrl requires a scheme, so it misses them and
+    // they would fall into the relative branch below, which re-emits path-only
+    // against the CURRENT origin — silently repointing a cross-host link at
+    // this page (audit #1037). Clean here and re-emit in the SAME
+    // protocol-relative shape so the `//host` is preserved (and an unwrapped
+    // cross-origin destination stays expressible, unlike the path-only branch).
+    if (raw.startsWith("//")) {
+      if (raw.indexOf("?") < 0) return raw;
+      let resolvedPR;
+      try {
+        resolvedPR = new URL(raw, window.location.href).toString();
+      } catch {
+        return raw;
+      }
+      const cleanedPR = cleanAbsolute(resolvedPR);
+      if (cleanedPR === resolvedPR) return raw;
+      try {
+        const u = new URL(cleanedPR);
+        return "//" + u.host + u.pathname + u.search + u.hash;
+      } catch {
+        return raw;
+      }
+    }
     if (raw.indexOf("?") < 0) return raw;
 
     let resolved;

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -176,6 +176,30 @@
    */
   function urlCleaner(raw) {
     if (isAbsoluteUrl(raw)) return cleanAbsolute(raw);
+    // Protocol-relative hrefs (`//host/path`) are scheme-relative but
+    // ORIGIN-bearing. isAbsoluteUrl requires a scheme, so it misses them and
+    // they would fall into the relative branch below, which re-emits path-only
+    // against the CURRENT origin — silently repointing a cross-host link at
+    // this page (audit #1037). Clean here and re-emit in the SAME
+    // protocol-relative shape so the `//host` is preserved (and an unwrapped
+    // cross-origin destination stays expressible, unlike the path-only branch).
+    if (raw.startsWith("//")) {
+      if (raw.indexOf("?") < 0) return raw;
+      let resolvedPR;
+      try {
+        resolvedPR = new URL(raw, window.location.href).toString();
+      } catch {
+        return raw;
+      }
+      const cleanedPR = cleanAbsolute(resolvedPR);
+      if (cleanedPR === resolvedPR) return raw;
+      try {
+        const u = new URL(cleanedPR);
+        return "//" + u.host + u.pathname + u.search + u.hash;
+      } catch {
+        return raw;
+      }
+    }
     if (raw.indexOf("?") < 0) return raw;
 
     let resolved;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -100,7 +100,7 @@
   },
 
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app; style-src 'self'"
+    "extension_pages": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app https://bit.ly https://www.bit.ly https://tinyurl.com https://www.tinyurl.com https://t.co https://www.t.co https://link.medium.com https://www.link.medium.com https://lnkd.in https://www.lnkd.in https://fb.me https://www.fb.me https://ebay.to https://www.ebay.to; style-src 'self'"
   },
 
   "web_accessible_resources": [

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -108,7 +108,7 @@
     }
   },
 
-  "content_security_policy": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app; style-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'; worker-src 'self'; default-src 'self'; connect-src 'self' https://rules.muga.app https://bit.ly https://www.bit.ly https://tinyurl.com https://www.tinyurl.com https://t.co https://www.t.co https://link.medium.com https://www.link.medium.com https://lnkd.in https://www.lnkd.in https://fb.me https://www.fb.me https://ebay.to https://www.ebay.to; style-src 'self'",
 
   "icons": {
     "16": "icons/16.png",

--- a/src/onboarding/onboarding.js
+++ b/src/onboarding/onboarding.js
@@ -146,12 +146,21 @@ document.addEventListener("DOMContentLoaded", async () => {
     pendingConfirmations({ syncPrefs: rawGuardedSync, localConsent, overrides: existingOverrides })
   );
 
-  // Default the affiliate checkbox to the effective stored value. On a fresh
-  // install this is PREF_DEFAULTS.injectOwnAffiliate (now on by default), so new
-  // users see it enabled and can turn it off here or in Settings. On a
-  // re-onboard it is the user's existing choice, so a consent change never
-  // silently flips their setting (the completion write mirrors this state).
-  affiliateCheck.checked = !!syncPrefs.injectOwnAffiliate;
+  // Default the affiliate checkbox to the EFFECTIVE value on THIS device: a
+  // per-device override (#364) wins over the synced value. On a fresh install
+  // there is no override, so this is PREF_DEFAULTS.injectOwnAffiliate (on by
+  // default, #1032), which new users can turn off here or in Settings. On a
+  // re-onboard, reading the raw synced value while ignoring an existing
+  // override (audit #1038) both misrepresented this device's effective state
+  // AND — via the completion write below — clobbered another device's setting
+  // the user never touched here.
+  const hasAffiliateOverride = Object.prototype.hasOwnProperty.call(
+    existingOverrides, "injectOwnAffiliate"
+  );
+  const effectiveAffiliate = hasAffiliateOverride
+    ? !!existingOverrides.injectOwnAffiliate
+    : !!syncPrefs.injectOwnAffiliate;
+  affiliateCheck.checked = effectiveAffiliate;
 
   if (pending.has("injectOwnAffiliate")) {
     affiliateCheck.checked = true;
@@ -231,8 +240,17 @@ document.addEventListener("DOMContentLoaded", async () => {
         notifyForeignAffiliate: false,
         language: lang,
       };
+      // injectOwnAffiliate is a GUARDED per-device pref (#364): only a FRESH
+      // install establishes its shared synced value (#1032). On any re-onboard
+      // a change here is device-local and must be recorded as a per-device
+      // override, never pushed back to sync where it would flip other devices
+      // (audit #1038).
       if (!pending.has("injectOwnAffiliate")) {
-        syncWrites.injectOwnAffiliate = affiliateCheck.checked;
+        if (mode === "fresh") {
+          syncWrites.injectOwnAffiliate = affiliateCheck.checked;
+        } else if (affiliateCheck.checked !== effectiveAffiliate) {
+          overrideUpdates.injectOwnAffiliate = affiliateCheck.checked;
+        }
       }
 
       // #741: write sync prefs + per-device overrides FIRST, and only mark

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -7,7 +7,7 @@ import { getSupportedStores, TRACKING_PARAM_CATEGORIES } from "../lib/affiliates
 import { PREF_DEFAULTS, getPrefs, setPrefs, getDevMode, setDevMode, getShortenerStats } from "../lib/storage.js";
 import { getConsent } from "../lib/consent-storage.js";
 import { isFirefox as detectFirefox } from "../lib/browser-detect.js";
-import { isValidListEntry, IMPORT_LIST_CAPS } from "../lib/validation.js";
+import { isValidListEntry, isValidCustomParam, IMPORT_LIST_CAPS } from "../lib/validation.js";
 import { REMOTE_RULES_URL } from "../lib/remote-rules.js";
 import { planChangelogView } from "../lib/remote-rules-changelog-view.js";
 import {
@@ -881,7 +881,12 @@ function addEntry(listKey, inputId, containerId) {
   const value = input.value.trim();
   if (!value) return;
   if (listKey === "customParams") {
-    if (!/^[a-zA-Z0-9_.\-]+$/.test(value)) {
+    // Route the manual Add path through the SAME guard the import path uses
+    // (isValidCustomParam → REMOTE_PARAM_DENYLIST + AFFILIATE_PARAM_GUARD, 64-char
+    // cap). The old bare regex let a user hand-add an affiliate-attribution key
+    // (tag, ascsubtag…) to customParams and strip it globally — violating the
+    // never-strip-affiliate promise (ADR-0005 / #815). See audit #1036.
+    if (!isValidCustomParam(value)) {
       showToast(t("add_entry_invalid", _currentLang));
       return;
     }

--- a/tests/unit/dom-link-rewriter-relative-href.test.mjs
+++ b/tests/unit/dom-link-rewriter-relative-href.test.mjs
@@ -238,6 +238,44 @@ describe("#1012 — relative <a href> tracking params are stripped (bundle attac
         "no setAttribute must fire for a query-less relative href (idempotency)");
     });
 
+    // ── audit #1037: protocol-relative hrefs must keep their host ─────────
+
+    test(`${label}: protocol-relative cross-host href is cleaned and KEEPS its //host`, () => {
+      // `//other.example/p?utm_source=x` is scheme-relative but origin-bearing.
+      // The pre-fix code misread it as relative and re-emitted it path-only
+      // against the CURRENT origin, silently repointing a cross-host link at
+      // this page. It must stay protocol-relative with its own host.
+      const dirty = makeAnchor("//other.example/p?utm_source=x&id=1");
+      runContentScript(path, {
+        anchors: [dirty],
+        locationHref: "https://shop.example/category/",
+      });
+      assert.equal(dirty.__href, "//other.example/p?id=1",
+        "utm_source stripped, //other.example host preserved (NOT stripped to /p)");
+    });
+
+    test(`${label}: already-clean protocol-relative href triggers NO setAttribute`, () => {
+      const clean = makeAnchor("//other.example/p?id=9");
+      runContentScript(path, {
+        anchors: [clean],
+        locationHref: "https://shop.example/category/",
+      });
+      assert.equal(clean.__setCalls.length, 0,
+        "a protocol-relative href with no tracking params must not be rewritten");
+    });
+
+    test(`${label}: query-less protocol-relative href is UNCHANGED (no query of its own)`, () => {
+      const anchor = makeAnchor("//other.example/deal");
+      runContentScript(path, {
+        anchors: [anchor],
+        locationHref: "https://shop.example/landing?utm_source=ad",
+      });
+      assert.equal(anchor.__href, "//other.example/deal",
+        "must not inherit + strip the page's query, and must keep its host");
+      assert.equal(anchor.__setCalls.length, 0,
+        "no setAttribute must fire for a query-less protocol-relative href");
+    });
+
     test(`${label}: cross-origin unwrap must NOT be mis-relativized onto the current origin`, () => {
       // processUrl can UNWRAP a redirect wrapper and return a DIFFERENT-
       // origin absolute URL. Re-emitting pathname+search+hash would graft

--- a/tests/unit/native-shortener-permissions.test.mjs
+++ b/tests/unit/native-shortener-permissions.test.mjs
@@ -33,3 +33,50 @@ describe("ADR-0004 phase 2: shortener optional permissions", () => {
     }
   });
 });
+
+// audit #1035: an explicit, restrictive `connect-src` blocks fetch to any host
+// it does not list — independent of host_permissions. The native shortener
+// resolver (service-worker.js -> resolveShortener) fetch()es each allowlisted
+// shortener host, so every shortener origin MUST also appear in connect-src or
+// the whole ADR-0004 native-resolution path fails closed on both browsers.
+// Derived from GENERIC_SHORTENERS (single source of truth) so the manifest CSP
+// fails this test closed the moment it drifts from the resolver allowlist.
+function connectSrcSources(policyString) {
+  const directive = policyString
+    .split(";")
+    .map((s) => s.trim())
+    .find((d) => d === "connect-src" || d.startsWith("connect-src "));
+  return directive ? directive.split(/\s+/).slice(1) : [];
+}
+
+describe("audit #1035: connect-src covers every shortener the resolver fetches", () => {
+  // The resolver's gate (isGenericShortener -> matches() in opaque-networks.js)
+  // strips a leading `www.` before comparing, so `www.bit.ly` is ALSO treated as
+  // an allowlisted shortener and fetched. A CSP host-source matches the exact
+  // host only (no implicit www), so connect-src must carry BOTH the apex and the
+  // www. variant for each shortener or www-prefixed links fail closed.
+  const expectedConnect = GENERIC_SHORTENERS.flatMap((host) => [
+    `https://${host}`,
+    `https://www.${host}`,
+  ]);
+
+  test("MV3 extension_pages connect-src includes every shortener origin", () => {
+    const sources = connectSrcSources(mv3.content_security_policy.extension_pages);
+    for (const origin of expectedConnect) {
+      assert.ok(
+        sources.includes(origin),
+        `MV3 connect-src is missing ${origin} — resolveShortener fetch to it would be CSP-blocked`,
+      );
+    }
+  });
+
+  test("MV2 connect-src includes every shortener origin", () => {
+    const sources = connectSrcSources(mv2.content_security_policy);
+    for (const origin of expectedConnect) {
+      assert.ok(
+        sources.includes(origin),
+        `MV2 connect-src is missing ${origin} — resolveShortener fetch to it would be CSP-blocked`,
+      );
+    }
+  });
+});

--- a/tests/unit/onboarding.test.mjs
+++ b/tests/unit/onboarding.test.mjs
@@ -259,3 +259,42 @@ describe("#728 item 25 — gated-CTA flash + aria-live announcement", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// audit #1038 — re-onboard must honor the per-device override and must NOT
+// re-sync injectOwnAffiliate to shared sync.
+//
+// The affiliate checkbox was defaulted from the raw synced value, ignoring an
+// existing per-device override (#364), and the completion write pushed the
+// checkbox value back to chrome.storage.sync unconditionally. On a re-onboard
+// that both misrepresented THIS device's effective state and clobbered another
+// device's setting the user never touched. injectOwnAffiliate is a guarded
+// per-device pref: only a FRESH install establishes its synced value (#1032);
+// any re-onboard change must be recorded as a per-device override.
+// ---------------------------------------------------------------------------
+describe("#1038 — re-onboard honors per-device affiliate override, no sync clobber", () => {
+  test("the affiliate checkbox defaults from the effective (override-aware) value", () => {
+    assert.ok(
+      /existingOverrides\s*,\s*["']injectOwnAffiliate["']/.test(ONBOARDING_JS),
+      "onboarding must read injectOwnAffiliate from existingOverrides for the effective value",
+    );
+    assert.ok(
+      /affiliateCheck\.checked\s*=\s*effectiveAffiliate/.test(ONBOARDING_JS),
+      "the affiliate checkbox must be initialized from the effective (override-aware) value, not raw sync",
+    );
+  });
+
+  test("injectOwnAffiliate is written to SYNC only on a fresh install", () => {
+    assert.ok(
+      /mode\s*===\s*["']fresh["'][\s\S]{0,160}syncWrites\.injectOwnAffiliate\s*=/.test(ONBOARDING_JS),
+      "the sync write of injectOwnAffiliate must be gated behind mode === 'fresh'",
+    );
+  });
+
+  test("a re-onboard change is recorded as a per-device override, not a sync write", () => {
+    assert.ok(
+      /overrideUpdates\.injectOwnAffiliate\s*=\s*affiliateCheck\.checked/.test(ONBOARDING_JS),
+      "a re-onboard change to injectOwnAffiliate must be recorded as a per-device override",
+    );
+  });
+});

--- a/tests/unit/options-import-param-validation.test.mjs
+++ b/tests/unit/options-import-param-validation.test.mjs
@@ -302,3 +302,45 @@ describe("T5 i18n — import_params_skipped key exists", () => {
     );
   });
 });
+
+// ── T6: #1036 — manual "Add" path uses the SAME guard as import ───────────────
+//
+// The Advanced > Custom tracking params ADD box (addEntry) validated
+// customParams with a bare `/^[a-zA-Z0-9_.\-]+$/` regex that skipped the
+// affiliate-attribution + denylist guard. A user could hand-add an affiliate
+// key (tag, ascsubtag…) and strip it globally, breaking attribution (ADR-0005 /
+// #815) — while the IMPORT path (T4) correctly rejected the same string. Both
+// entry points for customParams must go through isValidCustomParam.
+
+describe("T6 #1036 — options.js manual Add path routes customParams through isValidCustomParam", () => {
+  test("the affiliate params blocked here are the ones a user could try to add manually", () => {
+    // Behavioral anchor: these are exactly the strings the manual Add box must
+    // now reject (previously it accepted them via the bare regex).
+    assert.ok(!isValidCustomParam("tag"), "affiliate key 'tag' must be rejected");
+    assert.ok(!isValidCustomParam("ascsubtag"), "affiliate key 'ascsubtag' must be rejected");
+    assert.ok(isValidCustomParam("utm_source"), "a genuine tracking param must still be accepted");
+  });
+
+  test("options.js imports isValidCustomParam from validation.js", () => {
+    assert.ok(
+      /import\s*\{[^}]*\bisValidCustomParam\b[^}]*\}\s*from\s*["'][^"']*validation\.js["']/.test(OPTIONS_SOURCE),
+      "options.js must import isValidCustomParam from validation.js"
+    );
+  });
+
+  test("addEntry validates customParams with isValidCustomParam, not a bare regex", () => {
+    const start = OPTIONS_SOURCE.indexOf("function addEntry(");
+    assert.ok(start !== -1, "addEntry must exist");
+    const end = OPTIONS_SOURCE.indexOf("\nfunction ", start + 1);
+    const body = OPTIONS_SOURCE.slice(start, end === -1 ? undefined : end);
+
+    assert.ok(
+      /isValidCustomParam\(\s*value\s*\)/.test(body),
+      "addEntry must validate customParams via isValidCustomParam(value)"
+    );
+    assert.ok(
+      !body.includes("[a-zA-Z0-9_.\\-]+$"),
+      "addEntry must not reintroduce the old bare /^[a-zA-Z0-9_.\\-]+$/ validator for customParams"
+    );
+  });
+});


### PR DESCRIPTION
Resolves the four HIGH-severity findings from the 2.5.0 pre-release audit. One PR, four atomic commits.

## Fixes

- **#1035 — CSP `connect-src` blocked the native shortener resolver.** The `extension_pages` CSP set an explicit, restrictive `connect-src`, which blocks `fetch()` to any unlisted host regardless of `host_permissions`. Every shortener resolution was CSP-refused, so the whole ADR-0004 native-resolution path failed closed on both browsers. Added the 7 shortener origins (apex **and** `www.` variants, since the resolver gate normalizes a leading `www.`) to `connect-src` in both manifests.
- **#1036 — Manual custom-param add bypassed the affiliate guard.** The Advanced > Custom tracking params "Add" box validated with a bare regex that skipped `REMOTE_PARAM_DENYLIST` / `AFFILIATE_PARAM_GUARD`, letting a user hand-add an affiliate-attribution key (`tag`, `ascsubtag`...) and strip it globally, breaking attribution (ADR-0005 / #815). Now routes through `isValidCustomParam`, the same guard the import path uses.
- **#1037 — Protocol-relative hrefs lost their host.** `//host/path` fell into the relative branch of `urlCleaner` and was re-emitted path-only against the current page origin, silently repointing a cross-host link at this site. Now handled explicitly and re-emitted in protocol-relative shape, preserving `//host`. Applied to both rewriters (B8 + B9).
- **#1038 — Re-onboard re-synced a stale affiliate value over the per-device override.** The checkbox defaulted from raw sync (ignoring the #364 per-device override) and the completion write pushed it back to shared sync unconditionally, which could clobber another device. Now initializes from the effective value (override wins) and, on any re-onboard, records changes as a per-device override; only a fresh install writes to sync (preserves #1032).

## Tests

Each fix ships a regression guard: behavioral tests for #1037 (both rewriters) and #1035 (connect-src derived from `GENERIC_SHORTENERS`, apex + www.), source guards for #1036 and #1038 following the repo convention for browser-only files.

## Verification

- Full unit suite: **6089 pass / 0 fail**.
- `eslint`, `tsc` typecheck, and `web-ext lint` (0 errors) all clean.
- Fresh-context adversarial review of the diff; it caught the `www.`-variant gap in the #1035 connect-src (gate normalizes `www.` but the CSP allowlist did not), now fixed and covered by the test.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ
