### PR TITLE
feat(landing): click-to-enlarge lightbox for the screenshots

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -333,6 +333,53 @@
     border: 1px solid var(--rule); backdrop-filter: blur(4px);
   }
 
+  /* ---------- screenshot lightbox (progressive enhancement, no deps) ---------- */
+  .shots.is-enhanced .shot { cursor: zoom-in; }
+  .shot::after {
+    content: "\2922"; position: absolute; top: 8px; right: 10px;
+    font-size: 13px; line-height: 1; color: var(--ink);
+    background: rgba(14,12,19,.7); border: 1px solid var(--rule);
+    border-radius: 6px; padding: 3px 6px; opacity: 0;
+    transition: opacity .18s; pointer-events: none;
+  }
+  .shots.is-enhanced .shot:hover::after,
+  .shots.is-enhanced .shot:focus-visible::after { opacity: 1; }
+  .shot:focus-visible { outline: 2px solid var(--accent-ink); outline-offset: 2px; }
+
+  .lightbox {
+    position: fixed; inset: 0; z-index: 1000;
+    display: none; align-items: center; justify-content: center;
+    padding: clamp(16px, 4vw, 48px);
+    background: rgba(14,12,19,.92); backdrop-filter: blur(8px);
+  }
+  .lightbox.open { display: flex; }
+  .lightbox-stage { position: relative; max-width: 1100px; width: 100%; text-align: center; }
+  .lightbox-figure { margin: 0; }
+  .lightbox-img {
+    max-width: 100%; max-height: 82vh; object-fit: contain;
+    border: 1px solid var(--rule-2); border-radius: 14px;
+    background: var(--panel-2); box-shadow: 0 24px 80px rgba(0,0,0,.5);
+  }
+  .lightbox-cap {
+    margin-top: 14px; font-family: var(--mono); font-size: 12px;
+    color: var(--ink-2); letter-spacing: .02em;
+  }
+  .lightbox-count { color: var(--ink-3); }
+  .lightbox-close, .lightbox-nav {
+    position: absolute; display: flex; align-items: center; justify-content: center;
+    border: 1px solid var(--rule-2); border-radius: 50%;
+    background: rgba(20,17,27,.85); color: var(--ink); cursor: pointer;
+    line-height: 1; transition: background .18s, border-color .18s;
+  }
+  .lightbox-nav { top: 50%; transform: translateY(-50%); width: 46px; height: 46px; font-size: 24px; }
+  .lightbox-close { top: -6px; right: 4px; width: 40px; height: 40px; font-size: 22px; }
+  .lightbox-prev { left: 6px; }
+  .lightbox-next { right: 6px; }
+  .lightbox-nav:hover, .lightbox-close:hover { background: var(--accent); border-color: var(--accent-hi); }
+  .lightbox-close:focus-visible, .lightbox-nav:focus-visible { outline: 2px solid var(--accent-ink); outline-offset: 2px; }
+  .lightbox[data-single="true"] .lightbox-nav { display: none; }
+  @media (prefers-reduced-motion: reduce) { .lightbox { backdrop-filter: none; } }
+
   /* ---------- final CTA ---------- */
   .cta-panel {
     position: relative; border: 1px solid var(--rule-2); border-radius: 20px;
@@ -649,6 +696,85 @@
     "background:#6A2BCF;color:#fff;padding:4px 8px;border-radius:4px;font-weight:600;",
     "color:#888;font-family:ui-monospace,monospace;font-size:12px;line-height:1.6;"
   );
+
+  // Screenshot lightbox — progressive enhancement, zero dependencies.
+  // If this fails, the thumbnails below stay fully functional and unchanged.
+  (function () {
+    var container = document.querySelector('.shots');
+    if (!container) return;
+    var shots = Array.prototype.slice.call(container.querySelectorAll('.shot'));
+    var items = shots.map(function (fig) {
+      var img = fig.querySelector('img');
+      var cap = fig.querySelector('figcaption');
+      return { el: fig, src: img ? img.src : '', alt: img ? img.alt : '', cap: cap ? cap.textContent : '' };
+    }).filter(function (it) { return it.src; });
+    if (!items.length) return;
+
+    container.classList.add('is-enhanced');
+
+    var box = document.createElement('div');
+    box.className = 'lightbox';
+    box.setAttribute('role', 'dialog');
+    box.setAttribute('aria-modal', 'true');
+    box.setAttribute('aria-label', 'Screenshot viewer');
+    if (items.length < 2) box.setAttribute('data-single', 'true');
+    box.innerHTML =
+      '<div class="lightbox-stage">' +
+        '<button class="lightbox-close" type="button" aria-label="Close">×</button>' +
+        '<button class="lightbox-nav lightbox-prev" type="button" aria-label="Previous screenshot">‹</button>' +
+        '<figure class="lightbox-figure">' +
+          '<img class="lightbox-img" alt="">' +
+          '<figcaption class="lightbox-cap"><span class="lightbox-cap-text"></span><span class="lightbox-count"></span></figcaption>' +
+        '</figure>' +
+        '<button class="lightbox-nav lightbox-next" type="button" aria-label="Next screenshot">›</button>' +
+      '</div>';
+    document.body.appendChild(box);
+
+    var imgEl = box.querySelector('.lightbox-img');
+    var capText = box.querySelector('.lightbox-cap-text');
+    var countEl = box.querySelector('.lightbox-count');
+    var cur = 0, lastFocus = null;
+
+    function render() {
+      var it = items[cur];
+      imgEl.src = it.src; imgEl.alt = it.alt;
+      capText.textContent = it.cap;
+      countEl.textContent = items.length > 1 ? ('  ·  ' + (cur + 1) + ' / ' + items.length) : '';
+    }
+    function open(i) {
+      cur = i; lastFocus = document.activeElement; render();
+      box.classList.add('open');
+      document.documentElement.style.overflow = 'hidden';
+      box.querySelector('.lightbox-close').focus();
+    }
+    function close() {
+      box.classList.remove('open');
+      document.documentElement.style.overflow = '';
+      if (lastFocus && lastFocus.focus) lastFocus.focus();
+    }
+    function go(d) { cur = (cur + d + items.length) % items.length; render(); }
+
+    items.forEach(function (it, i) {
+      it.el.setAttribute('tabindex', '0');
+      it.el.setAttribute('role', 'button');
+      it.el.setAttribute('aria-label', 'Enlarge screenshot: ' + it.cap);
+      it.el.addEventListener('click', function () { open(i); });
+      it.el.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(i); }
+      });
+    });
+
+    box.querySelector('.lightbox-close').addEventListener('click', close);
+    box.querySelector('.lightbox-prev').addEventListener('click', function () { go(-1); });
+    box.querySelector('.lightbox-next').addEventListener('click', function () { go(1); });
+    box.addEventListener('click', function (e) { if (e.target === box) close(); });
+    document.addEventListener('keydown', function (e) {
+      if (!box.classList.contains('open')) return;
+      if (e.key === 'Escape') close();
+      else if (e.key === 'ArrowLeft') go(-1);
+      else if (e.key === 'ArrowRight') go(1);
+    });
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Screenshots were cropped thumbnails (4/3 cover-crop), so the app UI wasn't visible at a usable size. Adds a click-to-enlarge lightbox: full-size uncropped image, prev/next navigation + counter (carousel), Esc/backdrop/close to dismiss.

- Progressive enhancement — overlay built in JS, screenshots markup untouched; thumbnails still work if the script fails. No external deps.
- On-brand: reuses existing design tokens (dark surfaces, purple accent, mono caption, backdrop blur).
- Accessible: role=dialog/aria-modal, focus management, keyboard nav, prefers-reduced-motion.

Previewed locally before merge.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ