### PR TITLE
fix(web): apply Amazon path-strip (slug removal) in web cleaner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,16 @@ landing/clean/engine/cleaner-bundle.js     text eol=lf
 landing/clean/engine/domain-rules.json     text eol=lf
 landing/clean/engine/domain-rules.gen.mjs  text eol=lf
 
+# web-tool Amazon path-strip wiring fix: same LF discipline for the new
+# path-strip-rules mirrors (see build-web.mjs's header comment for why
+# they exist), so mirror-drift tests pass identically on Windows
+# (core.autocrlf=true) and Linux CI.
+src/rules/path-strip-rules.json                text eol=lf
+web/engine/path-strip-rules.json               text eol=lf
+web/engine/path-strip-rules.gen.mjs            text eol=lf
+landing/clean/engine/path-strip-rules.json     text eol=lf
+landing/clean/engine/path-strip-rules.gen.mjs  text eol=lf
+
 # web-cleaning-insight (#1058) generated taxonomy mirrors: same LF discipline
 # so the mirror-drift + deterministic-render tests pass identically on Windows
 # (core.autocrlf=true) and Linux CI, and `npm run build:web` stays idempotent.

--- a/landing/clean/engine/adapter.js
+++ b/landing/clean/engine/adapter.js
@@ -22,6 +22,14 @@
 // why this replaced a JSON `with { type: "json" }` import (Phase 4).
 import { DOMAIN_RULES } from "./domain-rules.gen.mjs";
 
+// web/engine/path-strip-rules.gen.mjs is a generated, drift-gated named-export
+// ES module mirror of src/rules/path-strip-rules.json (tools/build-web.mjs) —
+// gives the web tool the same Amazon-style path-strip (product-name slug
+// removal) behaviour as MUGA core. Wired as processUrl's 7th argument only;
+// pathAffiliateRules (8th argument) is deliberately deferred to a later
+// change.
+import { PATH_STRIP_RULES } from "./path-strip-rules.gen.mjs";
+
 /** Redirect-destination length cap, mirrored from AGENTS.md security rules. */
 const MAX_URL_LENGTH = 2000;
 
@@ -133,7 +141,7 @@ export function cleanUrl(input, engine = resolveEngine()) {
 
   let result;
   try {
-    result = engine.processUrl(input, prefs, DOMAIN_RULES);
+    result = engine.processUrl(input, prefs, DOMAIN_RULES, undefined, undefined, undefined, PATH_STRIP_RULES);
   } catch {
     return { ...buildFailure("error", "processing-failed", input) };
   }

--- a/landing/clean/engine/path-strip-rules.gen.mjs
+++ b/landing/clean/engine/path-strip-rules.gen.mjs
@@ -1,0 +1,36 @@
+/** MUGA: Generated ES module mirror of src/rules/path-strip-rules.json.
+ *
+ * A plain named-export copy of the path-strip rules used by
+ * web/engine/adapter.js, so the web tool can `import { PATH_STRIP_RULES }
+ * from "./path-strip-rules.gen.mjs"` instead of a JSON module import with
+ * an import attribute, which has limited support in older browsers.
+ *
+ * DO NOT EDIT BY HAND. Regenerate via `npm run build:web`
+ * (tools/build-web.mjs), sourced from src/rules/path-strip-rules.json.
+ */
+export const PATH_STRIP_RULES = [
+  {
+    "domain": "amazon",
+    "domainPattern": "(?:^|\\.)amazon\\.[a-z.]+$",
+    "pathPatterns": [
+      "\\/[^/]+\\/dp\\/([A-Za-z0-9]{10})",
+      "(\\/dp\\/[A-Za-z0-9]{10})\\/.+",
+      "(\\/gp\\/product\\/[A-Za-z0-9]{10})\\/.+",
+      "/ref=[^/]*$"
+    ],
+    "replacements": [
+      "/dp/$1",
+      "$1/",
+      "$1/",
+      ""
+    ],
+    "flags": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "fallbackPathname": "/",
+    "note": "Amazon path-strip — all TLDs. Migrated from cleanAmazonPath() in src/lib/cleaner.js:243-251 (issue #625). Pass 4: /ref=[^/]*$ anchored to pathname end — only trailing ref markers stripped, not mid-path /ref= segments (#831)."
+  }
+];

--- a/landing/clean/engine/path-strip-rules.json
+++ b/landing/clean/engine/path-strip-rules.json
@@ -1,0 +1,26 @@
+[
+  {
+    "domain": "amazon",
+    "domainPattern": "(?:^|\\.)amazon\\.[a-z.]+$",
+    "pathPatterns": [
+      "\\/[^/]+\\/dp\\/([A-Za-z0-9]{10})",
+      "(\\/dp\\/[A-Za-z0-9]{10})\\/.+",
+      "(\\/gp\\/product\\/[A-Za-z0-9]{10})\\/.+",
+      "/ref=[^/]*$"
+    ],
+    "replacements": [
+      "/dp/$1",
+      "$1/",
+      "$1/",
+      ""
+    ],
+    "flags": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "fallbackPathname": "/",
+    "note": "Amazon path-strip — all TLDs. Migrated from cleanAmazonPath() in src/lib/cleaner.js:243-251 (issue #625). Pass 4: /ref=[^/]*$ anchored to pathname end — only trailing ref markers stripped, not mid-path /ref= segments (#831)."
+  }
+]

--- a/tests/unit/web-adapter-contract.test.mjs
+++ b/tests/unit/web-adapter-contract.test.mjs
@@ -111,6 +111,22 @@ describe("web adapter contract — negative / invalid input handling", () => {
   });
 });
 
+describe("web adapter contract — path-strip-rules.json parity", () => {
+  test("strips the Amazon product-name slug (bug: web tool never applied path-strip)", () => {
+    const out = cleanUrl(
+      "https://www.amazon.es/-/en/Sony-MDR-7506-Reduction-Closed-Headphones/dp/B000AJIF4E/?th=1",
+      engine,
+    );
+    assert.equal(out.ok, true);
+    assert.ok(
+      !out.cleanUrl.includes("Sony-MDR-7506"),
+      "the Amazon product-name slug must be stripped from the cleaned URL",
+    );
+    const cleaned = new URL(out.cleanUrl);
+    assert.equal(cleaned.pathname, "/-/en/dp/B000AJIF4E/");
+  });
+});
+
 describe("web adapter contract — domain-rules.json parity", () => {
   test("preserves a domain-rule preserveParams entry that would otherwise be stripped as tracking", () => {
     // web/engine/domain-rules.json (mirrored from src/rules/domain-rules.json)

--- a/tests/unit/web-adapter.test.mjs
+++ b/tests/unit/web-adapter.test.mjs
@@ -13,6 +13,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
 import { cleanUrl, resolveEngine } from "../../web/engine/adapter.js";
+import { PATH_STRIP_RULES } from "../../web/engine/path-strip-rules.gen.mjs";
 
 const FAKE_PREF_DEFAULTS = {
   enabled: true,
@@ -30,8 +31,8 @@ const FAKE_PREF_DEFAULTS = {
 function makeFakeEngine({ result, throwError, capture } = {}) {
   return {
     PREF_DEFAULTS: FAKE_PREF_DEFAULTS,
-    processUrl(rawUrl, prefs, rules) {
-      if (capture) capture({ rawUrl, prefs, rules });
+    processUrl(rawUrl, prefs, rules, ...rest) {
+      if (capture) capture({ rawUrl, prefs, rules, rest });
       if (throwError) throw throwError;
       return result;
     },
@@ -135,6 +136,35 @@ describe("web adapter — pure-cleaner prefs", () => {
     assert.ok(Array.isArray(captured.rules), "domainRules must be an array");
     assert.ok(captured.rules.length > 0, "domainRules must not be empty");
     assert.ok("domain" in captured.rules[0]);
+  });
+});
+
+describe("web adapter — path-strip rules wiring", () => {
+  test("passes the mirrored path-strip-rules.json as processUrl's 7th argument (pathStripRules)", () => {
+    let captured;
+    const engine = makeFakeEngine({
+      result: {
+        cleanUrl: "https://example.com/",
+        action: "untouched",
+        removedTracking: [],
+        preservedAffiliate: null,
+        creatorReferralPreserved: false,
+      },
+      capture: (args) => { captured = args; },
+    });
+
+    cleanUrl("https://example.com/", engine);
+
+    assert.ok(captured, "processUrl must have been called");
+    // rest = [canonicalBundle, frequencyTracker, referrer, pathStripRules, pathAffiliateRules]
+    assert.equal(captured.rest[0], undefined, "canonicalBundle (4th arg) must stay undefined");
+    assert.equal(captured.rest[1], undefined, "frequencyTracker (5th arg) must stay undefined");
+    assert.equal(captured.rest[2], undefined, "referrer (6th arg) must stay undefined");
+    const pathStripRules = captured.rest[3];
+    assert.ok(Array.isArray(pathStripRules), "pathStripRules (7th arg) must be an array");
+    assert.ok(pathStripRules.length > 0, "pathStripRules must not be empty");
+    assert.deepEqual(pathStripRules, PATH_STRIP_RULES);
+    assert.equal(captured.rest[4], undefined, "pathAffiliateRules (8th arg) must stay unwired");
   });
 });
 

--- a/tests/unit/web-engine-mirror.test.mjs
+++ b/tests/unit/web-engine-mirror.test.mjs
@@ -27,7 +27,11 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 
-import { renderDomainRulesModule, renderParamCategoriesModule } from "../../tools/build-web.mjs";
+import {
+  renderDomainRulesModule,
+  renderParamCategoriesModule,
+  renderPathStripRulesModule,
+} from "../../tools/build-web.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..");
@@ -113,5 +117,43 @@ test("web/engine/param-breakdown-view.gen.mjs has zero import statements (self-c
   assert.ok(
     !/^\s*import /m.test(mirror),
     "web/engine/param-breakdown-view.gen.mjs must stay import-free — it is byte-copied verbatim, so its source (src/lib/param-breakdown-view.js) must never gain an import either",
+  );
+});
+
+test("web/engine/path-strip-rules.json is byte-identical to src/rules/path-strip-rules.json", () => {
+  const source = readFileSync(join(ROOT, "src/rules/path-strip-rules.json"));
+  const mirror = readFileSync(join(ROOT, "web/engine/path-strip-rules.json"));
+  assert.ok(
+    source.equals(mirror),
+    "web/engine/path-strip-rules.json is out of sync — run 'npm run build:web' and commit the result",
+  );
+});
+
+test("web/engine/path-strip-rules.gen.mjs matches the deterministic rendering of src/rules/path-strip-rules.json", () => {
+  const pathStripRules = JSON.parse(readFileSync(join(ROOT, "src/rules/path-strip-rules.json"), "utf8"));
+  const expected = renderPathStripRulesModule(pathStripRules);
+  const actual = readFileSync(join(ROOT, "web/engine/path-strip-rules.gen.mjs"), "utf8");
+  assert.equal(
+    actual,
+    expected,
+    "web/engine/path-strip-rules.gen.mjs is out of sync — run 'npm run build:web' and commit the result",
+  );
+});
+
+test("landing/clean/engine/path-strip-rules.json is byte-identical to web/engine/path-strip-rules.json", () => {
+  const source = readFileSync(join(ROOT, "web/engine/path-strip-rules.json"));
+  const mirror = readFileSync(join(ROOT, "landing/clean/engine/path-strip-rules.json"));
+  assert.ok(
+    source.equals(mirror),
+    "landing/clean/engine/path-strip-rules.json is out of sync — run 'npm run build:web' and commit the result",
+  );
+});
+
+test("landing/clean/engine/path-strip-rules.gen.mjs is byte-identical to web/engine/path-strip-rules.gen.mjs", () => {
+  const source = readFileSync(join(ROOT, "web/engine/path-strip-rules.gen.mjs"));
+  const mirror = readFileSync(join(ROOT, "landing/clean/engine/path-strip-rules.gen.mjs"));
+  assert.ok(
+    source.equals(mirror),
+    "landing/clean/engine/path-strip-rules.gen.mjs is out of sync — run 'npm run build:web' and commit the result",
   );
 });

--- a/tools/build-web.mjs
+++ b/tools/build-web.mjs
@@ -10,6 +10,17 @@
  *   4. src/lib/param-breakdown-view.js   -> web/engine/param-breakdown-view.gen.mjs
  *   5. src/lib/affiliates-data.js's
  *      TRACKING_PARAM_CATEGORIES         -> web/engine/param-categories.gen.mjs
+ *   6. src/rules/path-strip-rules.json   -> web/engine/path-strip-rules.json
+ *   7. src/rules/path-strip-rules.json   -> web/engine/path-strip-rules.gen.mjs
+ *
+ * (6) and (7) fix a bug where the web tool never applied Amazon-style
+ * path-strip (product-name slug removal): web/engine/adapter.js called
+ * processUrl() without a pathStripRules argument, so it silently
+ * defaulted to `[]`. They follow the exact (2)/(3) pattern (a byte-copy
+ * JSON mirror plus a named-export ES module mirror, `PATH_STRIP_RULES`),
+ * for the same import-attribute-compat reason (3) exists. Only
+ * pathStripRules is wired this way; pathAffiliateRules (processUrl's 8th
+ * argument) is deliberately out of scope here and stays deferred.
  *
  * (4) and (5), added for the web-cleaning-insight slice (Slice 1), let
  * web/param-insight.js build the same per-parameter what/why breakdown
@@ -59,6 +70,7 @@ const ROOT = join(__dir, "..");
 const SRC_BUNDLE = join(ROOT, "src/content/cleaner-bundle.js");
 const SRC_DOMAIN_RULES = join(ROOT, "src/rules/domain-rules.json");
 const SRC_PARAM_BREAKDOWN_VIEW = join(ROOT, "src/lib/param-breakdown-view.js");
+const SRC_PATH_STRIP_RULES = join(ROOT, "src/rules/path-strip-rules.json");
 
 const WEB_DIR = join(ROOT, "web");
 const WEB_ENGINE_DIR = join(WEB_DIR, "engine");
@@ -67,6 +79,8 @@ const WEB_DOMAIN_RULES = join(WEB_ENGINE_DIR, "domain-rules.json");
 const WEB_DOMAIN_RULES_MODULE = join(WEB_ENGINE_DIR, "domain-rules.gen.mjs");
 const WEB_PARAM_BREAKDOWN_VIEW_MODULE = join(WEB_ENGINE_DIR, "param-breakdown-view.gen.mjs");
 const WEB_PARAM_CATEGORIES_MODULE = join(WEB_ENGINE_DIR, "param-categories.gen.mjs");
+const WEB_PATH_STRIP_RULES = join(WEB_ENGINE_DIR, "path-strip-rules.json");
+const WEB_PATH_STRIP_RULES_MODULE = join(WEB_ENGINE_DIR, "path-strip-rules.gen.mjs");
 
 const LANDING_CLEAN_DIR = join(ROOT, "landing/clean");
 
@@ -123,16 +137,46 @@ export function renderParamCategoriesModule(categories) {
   );
 }
 
+/**
+ * Renders `web/engine/path-strip-rules.gen.mjs`'s deterministic content
+ * from the parsed path-strip rules array. Exported so tests can
+ * regenerate the expected content and byte-compare it against the
+ * committed file, mirroring `renderDomainRulesModule`'s drift-gate
+ * pattern.
+ *
+ * @param {Array<object>} pathStripRules Parsed src/rules/path-strip-rules.json.
+ * @returns {string} Full file contents, including the DO NOT EDIT header.
+ */
+export function renderPathStripRulesModule(pathStripRules) {
+  return (
+    "/** MUGA: Generated ES module mirror of src/rules/path-strip-rules.json.\n" +
+    " *\n" +
+    " * A plain named-export copy of the path-strip rules used by\n" +
+    " * web/engine/adapter.js, so the web tool can `import { PATH_STRIP_RULES }\n" +
+    " * from \"./path-strip-rules.gen.mjs\"` instead of a JSON module import with\n" +
+    " * an import attribute, which has limited support in older browsers.\n" +
+    " *\n" +
+    " * DO NOT EDIT BY HAND. Regenerate via `npm run build:web`\n" +
+    " * (tools/build-web.mjs), sourced from src/rules/path-strip-rules.json.\n" +
+    " */\n" +
+    `export const PATH_STRIP_RULES = ${JSON.stringify(pathStripRules, null, 2)};\n`
+  );
+}
+
 function main() {
   mkdirSync(WEB_ENGINE_DIR, { recursive: true });
 
   copyFileSync(SRC_BUNDLE, WEB_BUNDLE);
   copyFileSync(SRC_DOMAIN_RULES, WEB_DOMAIN_RULES);
   copyFileSync(SRC_PARAM_BREAKDOWN_VIEW, WEB_PARAM_BREAKDOWN_VIEW_MODULE);
+  copyFileSync(SRC_PATH_STRIP_RULES, WEB_PATH_STRIP_RULES);
 
   const domainRules = JSON.parse(readFileSync(SRC_DOMAIN_RULES, "utf8"));
   writeFileSync(WEB_DOMAIN_RULES_MODULE, renderDomainRulesModule(domainRules));
   writeFileSync(WEB_PARAM_CATEGORIES_MODULE, renderParamCategoriesModule(TRACKING_PARAM_CATEGORIES));
+
+  const pathStripRules = JSON.parse(readFileSync(SRC_PATH_STRIP_RULES, "utf8"));
+  writeFileSync(WEB_PATH_STRIP_RULES_MODULE, renderPathStripRulesModule(pathStripRules));
 
   // Mirror the whole authored+vendored web/ tree into landing/clean/ so
   // relative asset paths (./engine/cleaner-bundle.js, ./adapter.js, ...)
@@ -144,6 +188,8 @@ function main() {
   console.log(`[muga]                            ${WEB_DOMAIN_RULES_MODULE}`);
   console.log(`[muga]                            ${WEB_PARAM_BREAKDOWN_VIEW_MODULE}`);
   console.log(`[muga]                            ${WEB_PARAM_CATEGORIES_MODULE}`);
+  console.log(`[muga]                            ${WEB_PATH_STRIP_RULES}`);
+  console.log(`[muga]                            ${WEB_PATH_STRIP_RULES_MODULE}`);
   console.log(`[muga] landing mirror written: ${LANDING_CLEAN_DIR}`);
 }
 

--- a/web/engine/adapter.js
+++ b/web/engine/adapter.js
@@ -22,6 +22,14 @@
 // why this replaced a JSON `with { type: "json" }` import (Phase 4).
 import { DOMAIN_RULES } from "./domain-rules.gen.mjs";
 
+// web/engine/path-strip-rules.gen.mjs is a generated, drift-gated named-export
+// ES module mirror of src/rules/path-strip-rules.json (tools/build-web.mjs) —
+// gives the web tool the same Amazon-style path-strip (product-name slug
+// removal) behaviour as MUGA core. Wired as processUrl's 7th argument only;
+// pathAffiliateRules (8th argument) is deliberately deferred to a later
+// change.
+import { PATH_STRIP_RULES } from "./path-strip-rules.gen.mjs";
+
 /** Redirect-destination length cap, mirrored from AGENTS.md security rules. */
 const MAX_URL_LENGTH = 2000;
 
@@ -133,7 +141,7 @@ export function cleanUrl(input, engine = resolveEngine()) {
 
   let result;
   try {
-    result = engine.processUrl(input, prefs, DOMAIN_RULES);
+    result = engine.processUrl(input, prefs, DOMAIN_RULES, undefined, undefined, undefined, PATH_STRIP_RULES);
   } catch {
     return { ...buildFailure("error", "processing-failed", input) };
   }

--- a/web/engine/path-strip-rules.gen.mjs
+++ b/web/engine/path-strip-rules.gen.mjs
@@ -1,0 +1,36 @@
+/** MUGA: Generated ES module mirror of src/rules/path-strip-rules.json.
+ *
+ * A plain named-export copy of the path-strip rules used by
+ * web/engine/adapter.js, so the web tool can `import { PATH_STRIP_RULES }
+ * from "./path-strip-rules.gen.mjs"` instead of a JSON module import with
+ * an import attribute, which has limited support in older browsers.
+ *
+ * DO NOT EDIT BY HAND. Regenerate via `npm run build:web`
+ * (tools/build-web.mjs), sourced from src/rules/path-strip-rules.json.
+ */
+export const PATH_STRIP_RULES = [
+  {
+    "domain": "amazon",
+    "domainPattern": "(?:^|\\.)amazon\\.[a-z.]+$",
+    "pathPatterns": [
+      "\\/[^/]+\\/dp\\/([A-Za-z0-9]{10})",
+      "(\\/dp\\/[A-Za-z0-9]{10})\\/.+",
+      "(\\/gp\\/product\\/[A-Za-z0-9]{10})\\/.+",
+      "/ref=[^/]*$"
+    ],
+    "replacements": [
+      "/dp/$1",
+      "$1/",
+      "$1/",
+      ""
+    ],
+    "flags": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "fallbackPathname": "/",
+    "note": "Amazon path-strip — all TLDs. Migrated from cleanAmazonPath() in src/lib/cleaner.js:243-251 (issue #625). Pass 4: /ref=[^/]*$ anchored to pathname end — only trailing ref markers stripped, not mid-path /ref= segments (#831)."
+  }
+];

--- a/web/engine/path-strip-rules.json
+++ b/web/engine/path-strip-rules.json
@@ -1,0 +1,26 @@
+[
+  {
+    "domain": "amazon",
+    "domainPattern": "(?:^|\\.)amazon\\.[a-z.]+$",
+    "pathPatterns": [
+      "\\/[^/]+\\/dp\\/([A-Za-z0-9]{10})",
+      "(\\/dp\\/[A-Za-z0-9]{10})\\/.+",
+      "(\\/gp\\/product\\/[A-Za-z0-9]{10})\\/.+",
+      "/ref=[^/]*$"
+    ],
+    "replacements": [
+      "/dp/$1",
+      "$1/",
+      "$1/",
+      ""
+    ],
+    "flags": [
+      "",
+      "",
+      "",
+      ""
+    ],
+    "fallbackPathname": "/",
+    "note": "Amazon path-strip — all TLDs. Migrated from cleanAmazonPath() in src/lib/cleaner.js:243-251 (issue #625). Pass 4: /ref=[^/]*$ anchored to pathname end — only trailing ref markers stripped, not mid-path /ref= segments (#831)."
+  }
+]


### PR DESCRIPTION
## Problem

The web cleaner (muga.app/clean) never stripped Amazon product-name slugs, while the browser extension did. Reported live: `amazon.es/-/en/Sony-MDR-7506-Reduction-Closed-Headphones/dp/B000AJIF4E/?th=1` kept the `Sony-MDR-...` slug.

**Root cause:** `web/engine/adapter.js` called `processUrl(input, prefs, DOMAIN_RULES)` and stopped there. `processUrl`'s 7th positional arg `pathStripRules` defaulted to `[]`, so no path-strip rule ran. `tools/build-web.mjs` also never mirrored `src/rules/path-strip-rules.json` into the web engine bundle. The extension (`service-worker.js`) passes the rules; the web tool didn't.

## Fix

- `tools/build-web.mjs`: mirror `path-strip-rules.json` -> `web/engine/path-strip-rules.gen.mjs` (+ `.json`), same drift-gated pattern as `domain-rules.gen.mjs`.
- `web/engine/adapter.js`: pass `PATH_STRIP_RULES` as processUrl's 7th arg. `pathAffiliateRules` (8th arg) stays deferred to a later change.
- `.gitattributes`: `eol=lf` pins on both sides of every new byte-identity mirror (the #991 lesson).

Result: the URL above now cleans to `amazon.es/-/en/dp/B000AJIF4E/?th=1` (slug removed; `/-/en/` language prefix and functional `th` preserved), matching the extension.

## Tests

- `web-adapter-contract.test.mjs`: real-engine regression on the exact reported URL, asserts pathname becomes `/-/en/dp/B000AJIF4E/`.
- `web-adapter.test.mjs`: asserts the 7th positional arg is `PATH_STRIP_RULES` and args 4-6/8 stay `undefined`.
- `web-engine-mirror.test.mjs`: drift + deterministic-render gates for the new mirrors (web + landing/clean).
- `npm test`: 6263 pass / 0 fail. `npm run build:web` idempotent.

## Note

This branch is off `main` (pre Slice 2). The Slice 2 branch adds a second `processUrl` call (the tag-free re-run) that will also need `PATH_STRIP_RULES` passed when integrated.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ