### PR TITLE
feat(landing): relevant-only hero, inline morph cleaner, softened local narrative

### DIFF
--- a/landing/clean/index.html
+++ b/landing/clean/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>MUGA Clean: paste a URL, strip the tracking noise</title>
-<meta name="description" content="Paste any URL and MUGA Clean strips tracking parameters and unwraps known redirect wrappers, entirely in your browser. No server, no analytics, nothing about the URL ever leaves your device.">
+<meta name="description" content="Paste any URL and MUGA Clean strips tracking parameters and unwraps known redirect wrappers, right in the page. Open source, no analytics, no account.">
 <meta name="color-scheme" content="dark">
 <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDQgNjgiPjxwYXRoIGQ9Ik0gMTIgNTYgQyAxMiA4LCA0NiA4LCA1MiA0NiBMIDYyIDIyIEwgNzIgNTAgTCA4NCA1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjQTg4M0YwIiBzdHJva2Utd2lkdGg9IjEwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz48cGF0aCBkPSJNIDgwIDM3IEwgOTggNTAgTCA4MCA2MyBaIiBmaWxsPSIjQTg4M0YwIiBzdHJva2U9IiNBODgzRjAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPg==">
 
@@ -187,9 +187,9 @@
     <p class="lede">
       Paste any link below and MUGA strips tracking parameters (<code>utm_*</code>, <code>fbclid</code>,
       <code>gclid</code>, <code>mc_cid</code> and more) and unwraps known redirect wrappers. The cleaning
-      happens entirely in your browser and nothing about the URL is sent anywhere. If you choose to
-      report a bad result, that opens a prefilled GitHub issue you review and submit yourself. Existing
-      affiliate or creator referral tags are left untouched.
+      runs right here in the page. If you choose to report a bad result, that opens a
+      prefilled GitHub issue you review and submit yourself. Existing affiliate or creator referral
+      tags are left untouched.
     </p>
 
     <section class="panel" aria-labelledby="input-heading">
@@ -242,7 +242,7 @@
     </section>
 
     <footer class="trust">
-      <p>No analytics. No third-party requests. No account. Cleaning never contacts a server; reporting a result opens GitHub only if you click it.</p>
+      <p>No analytics. No third-party requests. No account. Reporting a result opens GitHub only if you click it.</p>
       <p><a href="https://github.com/yocreoquesi/muga">View source</a> &middot; <a href="https://muga.app/">Get the MUGA extension</a></p>
     </footer>
   </div>

--- a/landing/index.html
+++ b/landing/index.html
@@ -50,6 +50,7 @@
     --accent-ink: #A883F0;
     --accent-soft: #C9B2F5;
     --good: #4CC38A;
+    --bad: #E0665C;
     --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
     --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     --maxw: 1120px;
@@ -222,6 +223,7 @@
     .url-box.before .junk, .url-box.before .junk::after { animation: none; opacity: .35; }
     .url-box.before .junk { text-decoration: line-through; text-decoration-color: var(--accent-ink); }
     .eyebrow .dot { animation: none; }
+    .demo-live-row, .demo-output, .demo-foot { transition: none; }
   }
 
   .toast {
@@ -232,6 +234,55 @@
   }
   .toast::before { content: ""; width: 6px; height: 6px; border-radius: 999px; background: var(--good); }
   .demo-foot .tally { margin-left: auto; }
+
+  /* ---------- demo terminal: inline morph (JS-only, progressive enhancement) ---------- */
+  .demo-live-row {
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    gap: 10px;
+    align-items: center;
+    transition: max-height .32s ease, opacity .28s ease;
+  }
+  .demo.is-live .demo-live-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    max-height: 90px;
+    opacity: 1;
+    margin-bottom: 4px;
+  }
+  .demo-input {
+    font-family: var(--mono); font-size: 13px; color: var(--ink);
+    background: var(--bg); border: 1px solid var(--rule-soft); border-radius: 10px;
+    padding: 11px 13px; width: 100%; min-width: 0;
+  }
+  .demo-input::placeholder { color: var(--ink-3); }
+  .demo-clean-btn { padding: 11px 18px; font-size: 13.5px; border-radius: 10px; box-shadow: none; white-space: nowrap; }
+
+  .demo-output, .demo-foot { transition: opacity .25s ease; }
+  .demo.is-example .demo-output, .demo.is-example .demo-foot { opacity: .55; }
+
+  .demo.is-live .url-box.before .junk,
+  .demo.is-live .url-box.before .junk::after { animation: none; }
+  .demo.is-live .url-box.before .junk {
+    opacity: .55; text-decoration: line-through; text-decoration-color: var(--accent-ink);
+  }
+
+  .url-after-wrap { display: flex; align-items: center; gap: 10px; }
+  .url-after-wrap .url-box.after { flex: 1; min-width: 0; }
+  .demo-copy-btn {
+    flex: none; font-family: var(--sans); font-weight: 600; font-size: 12.5px;
+    color: var(--ink); background: var(--panel-2); border: 1px solid var(--rule-2);
+    border-radius: 8px; padding: 8px 12px; cursor: pointer;
+    transition: border-color .14s ease, background .14s ease;
+  }
+  .demo-copy-btn:hover { border-color: var(--accent); background: var(--panel-2); }
+
+  .url-box .error-text { color: var(--bad); }
+
+  .demo-destination { font-family: var(--mono); font-size: 11.5px; color: var(--ink-2); }
+  .demo-open-full { font-family: var(--mono); font-size: 11.5px; color: var(--accent-soft); text-decoration: none; }
+  .demo-open-full:hover { color: #E4D8FA; text-decoration: underline; }
 
   /* ---------- stats ---------- */
   .stats { margin-top: 64px; display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; }
@@ -522,25 +573,38 @@
         <span class="bk-text" id="bk">Making URLs Good Again.</span>
       </div>
 
-      <!-- live demo terminal -->
-      <div class="demo" aria-label="Before and after URL cleaning" style="width:100%;">
+      <!-- live demo terminal. Static by default; with JS, clicking "Clean a
+           link now" (#cta-web) morphs it in place into a working mini-cleaner
+           (see the inline script near the end of this file). -->
+      <div class="demo" id="demo" aria-label="Before and after URL cleaning" style="width:100%;">
         <div class="demo-head">
           <div class="lights"><span></span><span></span><span></span></div>
-          <span class="label">muga · live · before / after</span>
+          <span class="label" id="demo-label">muga · live · before / after</span>
         </div>
         <div class="demo-body">
-          <div class="url-row">
-            <span class="url-tag">Before</span>
-            <div class="url-box before"><span class="domain">shop.example.com</span><span class="path">/p/AZ12345?</span><span class="junk">utm_source=newsletter</span><span class="junk">&amp;utm_medium=email</span><span class="junk">&amp;utm_campaign=may26</span><span class="junk">&amp;fbclid=IwAR0xY2</span><span class="junk">&amp;gclid=Cj0KCQjw</span><span class="junk">&amp;ref_=nav_search</span><span class="junk">&amp;mc_cid=a1b2</span><span class="keep">&amp;ref=creator</span></div>
+          <div class="demo-live-row" id="demo-live-row" hidden>
+            <input type="url" id="hero-clean-input" class="demo-input" placeholder="https://example.com/p?utm_source=..." autocomplete="off" spellcheck="false">
+            <button type="button" id="hero-clean-btn" class="btn demo-clean-btn">Clean</button>
           </div>
-          <div class="url-row">
-            <span class="url-tag">After</span>
-            <div class="url-box after"><span class="domain">shop.example.com</span><span class="path">/p/AZ12345</span><span class="keep">?ref=creator</span></div>
+          <div class="demo-output" id="demo-output" aria-live="polite">
+            <div class="url-row">
+              <span class="url-tag">Before</span>
+              <div class="url-box before" id="demo-before"><span class="domain">shop.example.com</span><span class="path">/p/AZ12345?</span><span class="junk">utm_source=newsletter</span><span class="junk">&amp;utm_medium=email</span><span class="junk">&amp;utm_campaign=may26</span><span class="junk">&amp;fbclid=IwAR0xY2</span><span class="junk">&amp;gclid=Cj0KCQjw</span><span class="junk">&amp;ref_=nav_search</span><span class="junk">&amp;mc_cid=a1b2</span><span class="keep">&amp;ref=creator</span></div>
+            </div>
+            <div class="url-row">
+              <span class="url-tag">After</span>
+              <div class="url-after-wrap">
+                <div class="url-box after" id="demo-after"><span class="domain">shop.example.com</span><span class="path">/p/AZ12345</span><span class="keep">?ref=creator</span></div>
+                <button type="button" class="demo-copy-btn" id="demo-copy-btn" hidden>Copy</button>
+              </div>
+            </div>
           </div>
         </div>
-        <div class="demo-foot">
-          <span class="toast">Creator referral preserved · ref=creator</span>
-          <span class="tally">7 noise patterns quieted · 1 referral kept</span>
+        <div class="demo-foot" id="demo-foot" aria-live="polite">
+          <span class="toast" id="demo-toast">Creator referral preserved · ref=creator</span>
+          <span class="demo-destination" id="demo-destination" hidden></span>
+          <span class="tally" id="demo-tally">7 noise patterns quieted · 1 referral kept</span>
+          <a class="demo-open-full" id="demo-open-full" href="https://muga.app/clean" hidden target="_blank" rel="noopener">Open the full tool →</a>
         </div>
       </div>
     </div>
@@ -832,6 +896,227 @@
       badge.textContent = 'Best for your browser';
       card.appendChild(badge);
     }
+  })();
+
+  // Inline morph: clicking "Clean a link now" (#cta-web) turns the static
+  // demo terminal into a live, working mini-cleaner instead of navigating
+  // away. Progressive enhancement only: the anchor keeps its
+  // href="https://muga.app/clean" for no-JS visitors, and the cleaning
+  // engine is never fetched on page load, only on the first actual clean
+  // action (Clean button / Enter), same-origin, lazily, once, and cached.
+  //
+  // Security (AGENTS.md): addEventListener only, no inline handlers, the
+  // pasted URL is untrusted and is rendered via textContent/createElement
+  // only, never innerHTML with dynamic data.
+  (function () {
+    var ctaWeb = document.getElementById('cta-web');
+    var demo = document.getElementById('demo');
+    if (!ctaWeb || !demo) return;
+
+    var demoLabel = document.getElementById('demo-label');
+    var liveRow = document.getElementById('demo-live-row');
+    var input = document.getElementById('hero-clean-input');
+    var cleanBtn = document.getElementById('hero-clean-btn');
+    var beforeBox = document.getElementById('demo-before');
+    var afterBox = document.getElementById('demo-after');
+    var copyBtn = document.getElementById('demo-copy-btn');
+    var toastEl = document.getElementById('demo-toast');
+    var tallyEl = document.getElementById('demo-tally');
+    var destinationEl = document.getElementById('demo-destination');
+    var openFullLink = document.getElementById('demo-open-full');
+
+    var isLive = false;
+    var enginePromise = null;
+    var lastCleanUrl = null;
+
+    function reducedMotion() {
+      return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
+    function clearChildren(el) {
+      while (el.firstChild) el.removeChild(el.firstChild);
+    }
+
+    function textSpan(className, text) {
+      var span = document.createElement('span');
+      span.className = className;
+      span.textContent = text;
+      return span;
+    }
+
+    // Loads the cleaning engine same-origin, exactly once, lazily. Never
+    // called on page load. Falls back to the full tool link on any failure.
+    function loadEngine() {
+      if (enginePromise) return enginePromise;
+      enginePromise = new Promise(function (resolve, reject) {
+        var script = document.createElement('script');
+        script.src = './clean/engine/cleaner-bundle.js';
+        script.onload = function () {
+          import('./clean/engine/adapter.js').then(resolve, reject);
+        };
+        script.onerror = function () { reject(new Error('engine-load-failed')); };
+        document.body.appendChild(script);
+      });
+      // Drop the cached rejection on failure so a later click can retry the
+      // load instead of being stuck on the fallback for the rest of the session.
+      enginePromise.catch(function () { enginePromise = null; });
+      return enginePromise;
+    }
+
+    function enterLiveMode() {
+      if (isLive) { input.focus(); return; }
+      isLive = true;
+      demoLabel.textContent = 'muga · clean · try it';
+      liveRow.hidden = false;
+      openFullLink.hidden = false;
+      demo.classList.add('is-example');
+      var reveal = function () { demo.classList.add('is-live'); };
+      if (reducedMotion() || !window.requestAnimationFrame) reveal();
+      else window.requestAnimationFrame(reveal);
+
+      var rect = demo.getBoundingClientRect();
+      if (rect.top < 0 || rect.bottom > window.innerHeight) {
+        try {
+          demo.scrollIntoView({ behavior: reducedMotion() ? 'auto' : 'smooth', block: 'center' });
+        } catch (e) {
+          demo.scrollIntoView();
+        }
+      }
+      window.setTimeout(function () { input.focus(); }, 0);
+    }
+
+    // Renders the original pasted URL, striking through the params the
+    // engine actually removed. Best-effort: if the input doesn't parse as a
+    // URL (shouldn't happen once the adapter has validated it), it just
+    // shows the raw text.
+    function renderBefore(box, rawUrl, removed) {
+      clearChildren(box);
+      var parsed;
+      try { parsed = new URL(rawUrl); } catch (e) {
+        box.appendChild(textSpan('domain', rawUrl));
+        return;
+      }
+      box.appendChild(textSpan('domain', parsed.hostname));
+      box.appendChild(textSpan('path', parsed.pathname + (parsed.search ? '?' : '')));
+      if (parsed.search) {
+        var pairs = parsed.search.slice(1).split('&');
+        for (var i = 0; i < pairs.length; i++) {
+          var prefix = i === 0 ? '' : '&';
+          var key = pairs[i].split('=')[0];
+          var isJunk = removed.indexOf(key) !== -1;
+          box.appendChild(textSpan(isJunk ? 'junk' : 'keep', prefix + pairs[i]));
+        }
+      }
+    }
+
+    function renderAfter(box, cleanUrlStr) {
+      clearChildren(box);
+      var parsed;
+      try { parsed = new URL(cleanUrlStr); } catch (e) {
+        box.appendChild(textSpan('domain', cleanUrlStr));
+        return;
+      }
+      box.appendChild(textSpan('domain', parsed.hostname));
+      box.appendChild(textSpan('path', parsed.pathname));
+      if (parsed.search) box.appendChild(textSpan('keep', parsed.search));
+    }
+
+    function renderError(message) {
+      clearChildren(afterBox);
+      afterBox.appendChild(textSpan('error-text', message));
+      copyBtn.hidden = true;
+      lastCleanUrl = null;
+      toastEl.hidden = true;
+      destinationEl.hidden = true;
+      clearChildren(destinationEl);
+      tallyEl.textContent = '';
+      demo.classList.remove('is-example');
+    }
+
+    function renderResult(originalUrl, result) {
+      if (!result || !result.ok) {
+        renderBefore(beforeBox, originalUrl, []);
+        // Invalid-input errors from the adapter are already user-friendly;
+        // internal "error" tokens (engine-unavailable, processing-failed) are
+        // not, so they get a friendly fallback instead of leaking a code.
+        var message = (result && result.action === 'error')
+          ? 'Could not clean that link here. Open the full tool to try again.'
+          : ((result && result.error) || 'Could not clean that URL.');
+        renderError(message);
+        return;
+      }
+      var removedParams = Array.isArray(result.removed) ? result.removed : [];
+      renderBefore(beforeBox, originalUrl, removedParams);
+      renderAfter(afterBox, result.cleanUrl);
+      lastCleanUrl = result.cleanUrl;
+      copyBtn.hidden = false;
+
+      // The engine only tells us a referral was preserved, not which one, so
+      // the live toast stays generic and honest (the static example can name
+      // ref=creator because it is an illustration, not a real result).
+      if (result.affiliatePreserved) {
+        toastEl.textContent = 'Referral preserved';
+        toastEl.hidden = false;
+      } else {
+        toastEl.hidden = true;
+      }
+
+      if (result.unwrapped && result.destinationHost) {
+        clearChildren(destinationEl);
+        destinationEl.appendChild(document.createTextNode('Real destination: ' + result.destinationHost));
+        destinationEl.hidden = false;
+      } else {
+        destinationEl.hidden = true;
+        clearChildren(destinationEl);
+      }
+
+      var kept = result.affiliatePreserved ? 1 : 0;
+      tallyEl.textContent = removedParams.length + ' noise patterns quieted · ' + kept + ' referral kept';
+      demo.classList.remove('is-example');
+    }
+
+    function runClean() {
+      var value = input.value.trim();
+      if (!value) { input.focus(); return; }
+      var originalLabel = cleanBtn.textContent;
+      cleanBtn.disabled = true;
+      cleanBtn.textContent = 'Cleaning';
+      loadEngine().then(function (mod) {
+        cleanBtn.disabled = false;
+        cleanBtn.textContent = originalLabel;
+        var result = mod.cleanUrl(value);
+        renderResult(value, result);
+      }).catch(function () {
+        cleanBtn.disabled = false;
+        cleanBtn.textContent = originalLabel;
+        renderError('Could not load the cleaner here. Use the full tool below instead.');
+      });
+    }
+
+    ctaWeb.addEventListener('click', function (event) {
+      event.preventDefault();
+      enterLiveMode();
+    });
+
+    cleanBtn.addEventListener('click', runClean);
+    input.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        runClean();
+      }
+    });
+
+    copyBtn.addEventListener('click', function () {
+      if (!lastCleanUrl) return;
+      var originalLabel = copyBtn.textContent;
+      navigator.clipboard.writeText(lastCleanUrl).then(function () {
+        copyBtn.textContent = 'Copied';
+        window.setTimeout(function () { copyBtn.textContent = originalLabel; }, 1200);
+      }).catch(function () {
+        copyBtn.textContent = 'Copy failed';
+        window.setTimeout(function () { copyBtn.textContent = originalLabel; }, 1200);
+      });
+    });
   })();
 
   // Console easter egg

--- a/landing/index.html
+++ b/landing/index.html
@@ -490,9 +490,9 @@
       <h1>The web, <span class="mark">with the noise turned&nbsp;down.</span></h1>
 
       <p class="lede">
-        MUGA quiets the tracking noise from every link you open, locally in your browser,
-        without breaking pages. And unlike most URL cleaners, it tries to keep the referral of
-        whoever recommended you the link, and leaves you in control.
+        MUGA quiets the tracking noise from every link you open, without breaking pages.
+        And unlike most URL cleaners, it tries to keep the referral of whoever recommended
+        you the link, and leaves you in control.
       </p>
 
       <div class="install" id="hero-install">
@@ -504,20 +504,17 @@
           <svg class="ico" width="18" height="18" aria-hidden="true"><use href="#logo-firefox"/></svg>
           Add to Firefox
         </a>
-        <a class="btn" id="cta-web" href="https://muga.app/clean" hidden>
+        <a class="btn ghost" id="cta-web" href="https://muga.app/clean">
           <svg class="ico" viewBox="0 0 24 24" width="18" height="18" fill="none" aria-hidden="true">
             <path d="M9 15l6-6M8.5 9.5H7a4 4 0 100 8h1.5M15.5 14.5H17a4 4 0 100-8h-1.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
           </svg>
           Clean a link now
         </a>
-        <a class="btn bare" id="cta-desktop-hint" href="#get" hidden>Get the desktop extension →</a>
-        <a class="btn bare" href="https://github.com/yocreoquesi/muga">View source →</a>
+        <a class="btn bare" id="cta-all-ways" href="#get" hidden>See all ways to install →</a>
       </div>
 
       <div class="install-meta">
-        <span>Free · GPL v3</span><span class="sep">/</span>
-        <span>No telemetry</span><span class="sep">/</span>
-        <span>No requests about your browsing</span>
+        <span>Free · GPL v3</span>
       </div>
 
       <div class="bk-slot" aria-live="polite">
@@ -558,8 +555,8 @@
       </div>
       <div class="stat">
         <div class="num">100<span class="unit">%</span></div>
-        <div class="label">Local</div>
-        <div class="desc">Cleaning runs inside your browser. Nothing about your browsing is ever sent anywhere.</div>
+        <div class="label">Open source</div>
+        <div class="desc">Every line is public under GPL v3. Read it, audit it, or fork it. No build step to hide anything.</div>
       </div>
       <div class="stat">
         <div class="num">0</div>
@@ -610,8 +607,8 @@
         <h2>See where a link really goes.</h2>
         <p>
           On desktop, hover a link and hold still for a moment. MUGA shows you its real
-          destination, already cleaned, right there. No click, no page load, and nothing
-          about it leaves your browser.
+          destination, already cleaned, right there. No click, no page load: the real
+          destination shows up right where you are already looking.
         </p>
         <p>
           It only speaks up when it matters: links that bounce you through a redirect or a
@@ -784,10 +781,11 @@
   })();
 
   // Platform-aware install CTA — progressive enhancement, no analytics.
-  // Without JS the hero shows Chrome + Firefox and the section below shows
-  // ALL three options, so nothing is ever hidden from anyone. This only
-  // promotes the option the visitor can act on right now, and highlights
-  // the matching card down in the "three ways" grid; it hides nothing there.
+  // Without JS the hero shows every option (Chrome + Firefox + the web tool)
+  // so nothing is hidden from anyone. With JS it keeps only what the visitor
+  // can act on right now up top: the extension for their own browser plus the
+  // web tool, never the other browser's extension. The "three ways" grid below
+  // still lists all options for everyone.
   (function () {
     var ua = navigator.userAgent || '';
     var isFirefox = /firefox|fxios/i.test(ua);
@@ -795,28 +793,36 @@
     var isAndroid = /android/i.test(ua);
     var isMobile = isIOS || isAndroid || /Mobile/.test(ua);
 
-    var install = document.getElementById('hero-install');
     var chrome = document.getElementById('cta-chrome');
     var firefox = document.getElementById('cta-firefox');
     var web = document.getElementById('cta-web');
-    var hint = document.getElementById('cta-desktop-hint');
-    var youPlat = 'chrome';
+    var allWays = document.getElementById('cta-all-ways');
+    var youPlat;
 
-    if (isMobile && !isFirefox) {
-      // Chrome for Android, iOS, other mobile browsers: the extension cannot
-      // install here, so lead with the web tool they can use immediately.
-      if (chrome) chrome.hidden = true;
-      if (firefox) firefox.hidden = true;
-      if (web && install) { web.hidden = false; install.insertBefore(web, install.firstChild); }
-      if (hint) hint.hidden = false;
-      youPlat = 'web';
-    } else if (isFirefox) {
-      // Desktop Firefox or Firefox for Android — the extension installs on both.
-      if (firefox && install) { firefox.className = 'btn'; install.insertBefore(firefox, install.firstChild); }
-      if (chrome) chrome.className = 'btn ghost';
+    function hide(el) { if (el) el.hidden = true; }
+    function primary(el) { if (el) el.className = 'btn'; }
+    function secondary(el) { if (el) el.className = 'btn ghost'; }
+
+    if (isFirefox) {
+      // Firefox on desktop or Android — the extension installs on both. Lead
+      // with Firefox plus the web tool; Chrome's button is not relevant here.
+      hide(chrome);
+      primary(firefox); secondary(web);
       youPlat = 'firefox';
+    } else if (isMobile) {
+      // iOS, Chrome for Android, other mobile browsers: no installable
+      // extension here, so the web tool is the only thing to lead with.
+      hide(chrome); hide(firefox);
+      primary(web);
+      if (allWays) allWays.hidden = false;
+      youPlat = 'web';
+    } else {
+      // Desktop Chromium: lead with Chrome plus the web tool; Firefox's button
+      // is not relevant up top (it still lives in the "three ways" grid).
+      hide(firefox);
+      primary(chrome); secondary(web);
+      youPlat = 'chrome';
     }
-    // else desktop Chromium: keep the defaults.
 
     var card = document.querySelector('.way[data-plat="' + youPlat + '"]');
     if (card) {

--- a/tests/unit/landing-inline-morph-source-guard.test.mjs
+++ b/tests/unit/landing-inline-morph-source-guard.test.mjs
@@ -1,0 +1,171 @@
+/**
+ * MUGA: Landing inline morph — source guard.
+ *
+ * landing/index.html's morph script is browser-only (DOM/clipboard access)
+ * and cannot be exercised under node:test, mirroring the repo's existing
+ * `readFileSync` structural-test pattern (e.g. tests/unit/web-ui-source-
+ * guard.test.mjs, tests/unit/csp-inline-style-guard.test.mjs) for modules
+ * that cannot be imported in Node.
+ *
+ * Scope: these checks target ONLY the morph feature (the inline script
+ * block between the "// Inline morph:" and "// Console easter egg"
+ * comments, and the markup/copy added for it). They deliberately do not
+ * scan the rest of landing/index.html's pre-existing markup/scripts,
+ * which are out of scope for this change and covered elsewhere.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+
+const HTML = readFileSync(join(ROOT, "landing/index.html"), "utf8");
+
+/** Strips `//` and `/* *\/` comments so structural checks scan only
+ * executable code, not developer-facing doc comments. */
+function stripJsComments(js) {
+  return js.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+const MORPH_START = HTML.indexOf("// Inline morph:");
+const MORPH_END = HTML.indexOf("// Console easter egg");
+if (MORPH_START === -1 || MORPH_END === -1 || MORPH_END <= MORPH_START) {
+  throw new Error("Could not locate the inline-morph script block markers in landing/index.html");
+}
+const MORPH_SCRIPT = HTML.slice(MORPH_START, MORPH_END);
+const MORPH_SCRIPT_NO_COMMENTS = stripJsComments(MORPH_SCRIPT);
+
+describe("landing inline morph — progressive enhancement", () => {
+  test("#cta-web keeps its https://muga.app/clean href (no-JS fallback)", () => {
+    const ctaMatch = HTML.match(/<a[^>]*id\s*=\s*["']cta-web["'][^>]*>/i);
+    assert.ok(ctaMatch, "the #cta-web anchor must exist");
+    assert.ok(
+      /href\s*=\s*["']https:\/\/muga\.app\/clean["']/.test(ctaMatch[0]),
+      "#cta-web must keep href=\"https://muga.app/clean\" so JS-disabled visitors still navigate to the full tool",
+    );
+  });
+
+  test("the morph handler calls preventDefault() on the #cta-web click", () => {
+    assert.ok(
+      /ctaWeb\.addEventListener\(\s*['"]click['"]/.test(MORPH_SCRIPT),
+      "a click handler must be wired to ctaWeb via addEventListener",
+    );
+    assert.ok(
+      /ctaWeb\.addEventListener\(\s*['"]click['"][\s\S]{0,120}preventDefault\(\)/.test(MORPH_SCRIPT),
+      "the #cta-web click handler must call event.preventDefault() so JS-enabled visitors do not navigate away",
+    );
+  });
+
+  test("the engine is loaded from ./clean/engine/ only inside loadEngine(), not at the top level", () => {
+    const loadEngineMatch = MORPH_SCRIPT.match(/function loadEngine\s*\([^)]*\)\s*\{[\s\S]*?\n    \}/);
+    assert.ok(loadEngineMatch, "a loadEngine() function must exist");
+    assert.ok(
+      loadEngineMatch[0].includes("./clean/engine/cleaner-bundle.js"),
+      "loadEngine() must load the vendored engine bundle from ./clean/engine/cleaner-bundle.js",
+    );
+    assert.ok(
+      loadEngineMatch[0].includes("./clean/engine/adapter.js"),
+      "loadEngine() must import cleanUrl from ./clean/engine/adapter.js",
+    );
+
+    const outsideLoadEngine = MORPH_SCRIPT.replace(loadEngineMatch[0], "");
+    assert.ok(
+      !outsideLoadEngine.includes("cleaner-bundle.js") && !outsideLoadEngine.includes("./clean/engine/adapter.js"),
+      "the engine bundle/adapter must be referenced only inside loadEngine(), never elsewhere in the morph script",
+    );
+  });
+
+  test("loadEngine() is only invoked from runClean(), never eagerly at module scope or from enterLiveMode()", () => {
+    const enterLiveMode = MORPH_SCRIPT.match(/function enterLiveMode\s*\([^)]*\)\s*\{[\s\S]*?\n    \}/);
+    assert.ok(enterLiveMode, "an enterLiveMode() function must exist");
+    assert.ok(!enterLiveMode[0].includes("loadEngine("), "enterLiveMode() (the #cta-web morph step) must not call loadEngine() itself");
+
+    const runClean = MORPH_SCRIPT.match(/function runClean\s*\([^)]*\)\s*\{[\s\S]*?\n    \}/);
+    assert.ok(runClean, "a runClean() function must exist");
+    assert.ok(runClean[0].includes("loadEngine("), "runClean() (the Clean button / Enter handler) must call loadEngine()");
+  });
+});
+
+describe("landing inline morph — security (AGENTS.md)", () => {
+  test("never assigns innerHTML with dynamic data", () => {
+    assert.ok(!/\.innerHTML\s*=/.test(MORPH_SCRIPT), "the morph script must render via textContent/createElement, never innerHTML");
+  });
+
+  test("never calls eval or new Function", () => {
+    assert.ok(!/\beval\s*\(/.test(MORPH_SCRIPT), "the morph script must not call eval(");
+    assert.ok(!/new\s+Function\s*\(/.test(MORPH_SCRIPT), "the morph script must not construct new Function(");
+  });
+
+  test("wires events via addEventListener only", () => {
+    assert.ok(MORPH_SCRIPT.includes("addEventListener"), "the morph script must attach handlers via addEventListener");
+    assert.ok(!/\.on(click|keydown|keyup|submit)\s*=/.test(MORPH_SCRIPT), "the morph script must not assign .onclick/.onkeydown/... handlers directly");
+  });
+
+  test("the pasted URL is only ever rendered via textContent, never concatenated into markup", () => {
+    assert.ok(MORPH_SCRIPT.includes(".textContent = text"), "renderer helpers must assign untrusted text via .textContent");
+    assert.ok(!/[+`]\s*(rawUrl|cleanUrlStr|originalUrl|value)\b[\s\S]{0,20}(innerHTML|outerHTML)/.test(MORPH_SCRIPT), "user-controlled URL values must never be concatenated into innerHTML/outerHTML");
+  });
+
+  test("landing/index.html has no inline event handler attributes", () => {
+    assert.ok(
+      !/\bon[a-z]+\s*=\s*["']/i.test(HTML),
+      "index.html must not use inline event handler attributes (onclick=, onload=, ...)",
+    );
+  });
+
+  test("the dynamically injected engine <script> src is same-origin, not a CDN/external host", () => {
+    const scriptSrcMatch = MORPH_SCRIPT.match(/script\.src\s*=\s*['"][^'"]+['"]/);
+    assert.ok(scriptSrcMatch, "loadEngine() must set script.src");
+    assert.ok(!/https?:\/\//.test(scriptSrcMatch[0]), "script.src must not be an absolute/external URL");
+    assert.ok(scriptSrcMatch[0].includes("./clean/engine/"), "script.src must point at ./clean/engine/");
+  });
+});
+
+describe("landing inline morph — accessibility", () => {
+  test("the live result region announces changes to assistive tech", () => {
+    const outputMatch = HTML.match(/<div[^>]*id\s*=\s*["']demo-output["'][^>]*>/);
+    assert.ok(outputMatch, "#demo-output must exist");
+    assert.ok(/aria-live\s*=\s*["']polite["']/.test(outputMatch[0]), "#demo-output must have aria-live=\"polite\"");
+
+    const footMatch = HTML.match(/<div[^>]*id\s*=\s*["']demo-foot["'][^>]*>/);
+    assert.ok(footMatch, "#demo-foot must exist");
+    assert.ok(/aria-live\s*=\s*["']polite["']/.test(footMatch[0]), "#demo-foot must have aria-live=\"polite\"");
+  });
+
+  test("Clean and Copy controls are real <button> elements (keyboard-operable by default)", () => {
+    assert.ok(/<button[^>]*id\s*=\s*["']hero-clean-btn["']/.test(HTML), "hero-clean-btn must be a <button>");
+    assert.ok(/<button[^>]*id\s*=\s*["']demo-copy-btn["']/.test(HTML), "demo-copy-btn must be a <button>");
+  });
+});
+
+describe("landing inline morph — copy style constraints", () => {
+  test("no em-dash in the morph script's user-facing strings (comments excluded)", () => {
+    assert.ok(!MORPH_SCRIPT_NO_COMMENTS.includes("—"), "the morph script's copy strings must not contain an em-dash");
+  });
+
+  test("no double-hyphen dash in the morph script's user-facing strings (comments excluded)", () => {
+    assert.ok(!MORPH_SCRIPT_NO_COMMENTS.includes("--"), "the morph script's copy strings must not contain \"--\"");
+  });
+
+  test("added markup copy (placeholder, button labels, link text) has no em-dash", () => {
+    const addedIds = ["hero-clean-input", "hero-clean-btn", "demo-copy-btn", "demo-open-full"];
+    for (const id of addedIds) {
+      const tagMatch = HTML.match(new RegExp(`<[a-z]+[^>]*id\\s*=\\s*["']${id}["'][^>]*>([^<]*)`, "i"));
+      assert.ok(tagMatch, `element #${id} must exist`);
+      const text = tagMatch[0];
+      assert.ok(!text.includes("—"), `#${id} markup must not contain an em-dash`);
+    }
+  });
+
+  test("the full-tool fallback link points at https://muga.app/clean", () => {
+    const linkMatch = HTML.match(/<a[^>]*id\s*=\s*["']demo-open-full["'][^>]*>/);
+    assert.ok(linkMatch, "#demo-open-full must exist");
+    assert.ok(/href\s*=\s*["']https:\/\/muga\.app\/clean["']/.test(linkMatch[0]), "#demo-open-full must link to https://muga.app/clean");
+  });
+});

--- a/tests/unit/web-ui-source-guard.test.mjs
+++ b/tests/unit/web-ui-source-guard.test.mjs
@@ -198,11 +198,12 @@ describe("sdd/web-cleaning-insight (Slice 1) DOM wiring", () => {
     assert.ok(/unwrapCallout\.hidden/.test(UI_JS), "ui.js must toggle refs.unwrapCallout.hidden based on view.unwrapped");
   });
 
-  test("the rescoped lede and footer contain the exact honest-promise phrasing (design: Copy Rescope)", () => {
+  test("the lede and footer describe the report flow without an eternal local-only promise (design: Copy Rescope + narrative softening)", () => {
     const body = stripStyleBlocks(HTML);
-    assert.ok(body.includes("entirely in your browser"), "lede must state the cleaning happens entirely in your browser");
+    assert.ok(body.includes("runs right here in the page"), "lede must state the cleaning runs right here in the page (present-tense mechanism, not an eternal local promise)");
     assert.ok(body.includes("prefilled GitHub issue"), "lede must describe the report flow as a prefilled GitHub issue");
-    assert.ok(body.includes("Cleaning never contacts a server"), "footer must state cleaning never contacts a server");
+    assert.ok(body.includes("opens GitHub only if you click it"), "footer must state reporting opens GitHub only on click");
+    assert.ok(!/never contacts a server|nothing (about the URL )?ever leaves|entirely in your browser/i.test(body), "copy must not make an eternal local-only promise (product may add server features later)");
   });
 });
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>MUGA Clean: paste a URL, strip the tracking noise</title>
-<meta name="description" content="Paste any URL and MUGA Clean strips tracking parameters and unwraps known redirect wrappers, entirely in your browser. No server, no analytics, nothing about the URL ever leaves your device.">
+<meta name="description" content="Paste any URL and MUGA Clean strips tracking parameters and unwraps known redirect wrappers, right in the page. Open source, no analytics, no account.">
 <meta name="color-scheme" content="dark">
 <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDQgNjgiPjxwYXRoIGQ9Ik0gMTIgNTYgQyAxMiA4LCA0NiA4LCA1MiA0NiBMIDYyIDIyIEwgNzIgNTAgTCA4NCA1MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjQTg4M0YwIiBzdHJva2Utd2lkdGg9IjEwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz48cGF0aCBkPSJNIDgwIDM3IEwgOTggNTAgTCA4MCA2MyBaIiBmaWxsPSIjQTg4M0YwIiBzdHJva2U9IiNBODgzRjAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPg==">
 
@@ -187,9 +187,9 @@
     <p class="lede">
       Paste any link below and MUGA strips tracking parameters (<code>utm_*</code>, <code>fbclid</code>,
       <code>gclid</code>, <code>mc_cid</code> and more) and unwraps known redirect wrappers. The cleaning
-      happens entirely in your browser and nothing about the URL is sent anywhere. If you choose to
-      report a bad result, that opens a prefilled GitHub issue you review and submit yourself. Existing
-      affiliate or creator referral tags are left untouched.
+      runs right here in the page. If you choose to report a bad result, that opens a
+      prefilled GitHub issue you review and submit yourself. Existing affiliate or creator referral
+      tags are left untouched.
     </p>
 
     <section class="panel" aria-labelledby="input-heading">
@@ -242,7 +242,7 @@
     </section>
 
     <footer class="trust">
-      <p>No analytics. No third-party requests. No account. Cleaning never contacts a server; reporting a result opens GitHub only if you click it.</p>
+      <p>No analytics. No third-party requests. No account. Reporting a result opens GitHub only if you click it.</p>
       <p><a href="https://github.com/yocreoquesi/muga">View source</a> &middot; <a href="https://muga.app/">Get the MUGA extension</a></p>
     </footer>
   </div>


### PR DESCRIPTION
Landing + web-app design pass, in two commits.

## 1. Relevant-only hero CTAs + narrative softening
- Hero install matrix now shows only what the visitor can act on: their own browser's extension + the web tool, never the other browser's extension. Fixes a gap where Firefox mobile never surfaced the web tool.
- Removes redundant "Get the desktop extension" and "View source" from the hero (GitHub is in the header), and the repeated "No telemetry / No requests about your browsing" chips. The "three ways" grid below still lists everything; no-JS shows all options.
- Softens the local-only narrative so it is not promised as an eternal guarantee (room for future server-side features): "100% Local" repointed to "100% Open source"; drops "locally in your browser" / "nothing ever leaves" absolutes across hero, hover section, and the web tool meta/lede/footer, keeping truthful present-tense mechanism copy. The behavioral no-fetch guard stays.

## 2. Inline morph cleaner
- "Clean a link now" no longer navigates. With JS it morphs the static before/after demo terminal into a live mini-cleaner in place (natural transition from example to use). The full tool stays at /clean.
- Engine lazy-loads same-origin from `./clean/engine` only on the first clean, so page load stays request-free. No-JS fallback: the button still navigates to /clean (href preserved).
- Built with textContent/createElement only (no innerHTML with user data). Reuses the terminal's existing visual language and motion; respects prefers-reduced-motion.

## Reviewed (fresh context)
Two adversarial reviews. XSS / progressive-enhancement / lazy-load / scope: clean. Fixed two honest-copy findings before commit: generic "Referral preserved" toast (never claims ref=creator for an unrelated affiliate), and friendly mapping of internal engine error tokens. Retry-after-failed-load added.

## Tests
`npm test`: 6274 pass / 0 fail / 1 skipped (+ new `landing-inline-morph-source-guard.test.mjs`). `node tools/check-web-boundary.mjs`: OK. CSP (`landing-worker/worker.js`): `script-src 'self' 'unsafe-inline'` permits the same-origin lazy load.

## REQUIRED before merge: real browser pass
The morph is browser-only and could not be exercised in the dev env. Please verify on a real browser:
1. On load, no network request for `clean/engine/*` fires.
2. Click "Clean a link now" -> no navigation; terminal morphs in place; input focused. Click again while live -> just refocuses.
3. Paste a tracked URL -> engine loads once; before/after + tally update; Copy copies the clean URL; "Referral preserved" toast only when a referral was kept.
4. Paste garbage -> friendly error, no crash, Copy hidden.
5. JS disabled -> button still navigates to /clean.
6. prefers-reduced-motion -> transitions instant.

Merging deploys live to muga.app + muga.app/clean via deploy-landing.yml.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ