### PR TITLE
fix(web): apply Amazon path-strip to the tag-free opt-out URL too

### DIFF
--- a/landing/clean/engine/adapter.js
+++ b/landing/clean/engine/adapter.js
@@ -184,7 +184,7 @@ export function cleanUrl(input, engine = resolveEngine()) {
   if (mugaReferralInjected) {
     const noInjectPrefs = buildPureCleanerPrefs(engine.PREF_DEFAULTS || {}, { injectMugaReferral: false });
     try {
-      const noInjectResult = engine.processUrl(input, noInjectPrefs, DOMAIN_RULES);
+      const noInjectResult = engine.processUrl(input, noInjectPrefs, DOMAIN_RULES, undefined, undefined, undefined, PATH_STRIP_RULES);
       if (noInjectResult && typeof noInjectResult.cleanUrl === "string") {
         cleanUrlNoMugaReferral = noInjectResult.cleanUrl;
       }

--- a/tests/unit/web-adapter-contract.test.mjs
+++ b/tests/unit/web-adapter-contract.test.mjs
@@ -125,6 +125,22 @@ describe("web adapter contract — naked-link MUGA referral injection (web-tool-
     assert.equal(optOut.pathname, injected.pathname);
   });
 
+  test("naked Amazon link WITH a product-name slug strips the slug in BOTH the injected and opt-out URLs", () => {
+    const out = cleanUrl("https://www.amazon.es/-/en/Sony-MDR-7506-Reduction-Closed-Headphones/dp/B000AJIF4E", engine);
+    assert.equal(out.ok, true);
+    assert.equal(out.mugaReferralInjected, true);
+    assert.ok(!out.cleanUrl.includes("Sony-MDR-7506"), "injected URL must strip the Amazon slug");
+    assert.ok(out.cleanUrlNoMugaReferral, "opt-out URL must be present when injected");
+    // Regression guard: the injection-off rerun once omitted path-strip, so
+    // the opt-out URL kept the slug the injected URL had already dropped.
+    assert.ok(!out.cleanUrlNoMugaReferral.includes("Sony-MDR-7506"), "opt-out URL must also strip the Amazon slug");
+    assert.equal(
+      new URL(out.cleanUrlNoMugaReferral).pathname,
+      new URL(out.cleanUrl).pathname,
+      "opt-out and injected URLs must share the same slug-stripped pathname",
+    );
+  });
+
   test("naked eBay link gets MUGA's own referral, same opt-out contract", () => {
     const out = cleanUrl("https://www.ebay.com/itm/123456789", engine);
     assert.equal(out.ok, true);

--- a/web/engine/adapter.js
+++ b/web/engine/adapter.js
@@ -184,7 +184,7 @@ export function cleanUrl(input, engine = resolveEngine()) {
   if (mugaReferralInjected) {
     const noInjectPrefs = buildPureCleanerPrefs(engine.PREF_DEFAULTS || {}, { injectMugaReferral: false });
     try {
-      const noInjectResult = engine.processUrl(input, noInjectPrefs, DOMAIN_RULES);
+      const noInjectResult = engine.processUrl(input, noInjectPrefs, DOMAIN_RULES, undefined, undefined, undefined, PATH_STRIP_RULES);
       if (noInjectResult && typeof noInjectResult.cleanUrl === "string") {
         cleanUrlNoMugaReferral = noInjectResult.cleanUrl;
       }


### PR DESCRIPTION
## Problem (live inconsistency after the #1065 + #1067 merge)
The web tool's "copy without MUGA's referral" variant (`cleanUrlNoMugaReferral`) is produced by a second, injection-off `processUrl` run in `web/engine/adapter.js`. That call omitted the 7th positional `pathStripRules` argument, so the opt-out URL kept the Amazon product-name slug that the main cleaned URL already stripped.

The gap appeared because the path-strip wiring (#1065) landed on the FIRST processUrl call, while the naked-link injection (#1067) added the SECOND call independently; the merge combined them without wiring path-strip into the second.

## Fix
Pass `PATH_STRIP_RULES` to the injection-off run so both URLs share the same slug-stripped pathname, differing only by MUGA's tag. Adds a contract test asserting slug parity across the injected and opt-out URLs (would fail before the fix).

## Tests
`npm test`: 6296 pass / 0 fail / 1 skipped. `npm run build:web` idempotent.

Merging deploys live to muga.app/clean.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ