### PR TITLE
fix(web): offer copy-without-referral when a link already carries MUGA's tag

### DIFF
--- a/landing/clean/engine/adapter.js
+++ b/landing/clean/engine/adapter.js
@@ -65,6 +65,7 @@ function buildFailure(action, error, rawInput) {
     destinationHost: null,
     affiliatePreserved: false,
     mugaReferralInjected: false,
+    mugaReferralPresent: false,
     cleanUrlNoMugaReferral: null,
     action,
     error,
@@ -77,22 +78,24 @@ function buildFailure(action, error, rawInput) {
  * REAL defaults (`engine.PREF_DEFAULTS`) so behavioural defaults never
  * hand-drift from `src/lib/prefs.js`.
  *
- * `injectOwnAffiliate` is now conditional (design D1, web-tool-naked-link-injection
+ * `injectOwnAffiliate` stays on (design D1, web-tool-naked-link-injection
  * slice 2, ADR-1): the web tool injects MUGA's own tag on naked Amazon/eBay
- * links by default so the tool can fund itself, while every other web-tool
- * policy override (no notify, no honor-creator, no lists) stays in place.
- * Callers that need the tag-free variant pass `injectMugaReferral: false`.
+ * links so the tool can fund itself, while every other web-tool policy
+ * override (no notify, no honor-creator, no lists) stays in place. The
+ * tag-free variant is no longer produced by a second injection-off run; it
+ * is derived by surgically stripping MUGA's own tag from the cleaned URL
+ * (see detectOwnReferral), which also covers links that ALREADY carried our
+ * referral before cleaning.
  *
  * @param {object} prefDefaults
- * @param {{ injectMugaReferral?: boolean }} [options]
  * @returns {object}
  */
-function buildPureCleanerPrefs(prefDefaults, { injectMugaReferral = true } = {}) {
+function buildPureCleanerPrefs(prefDefaults) {
   return {
     ...prefDefaults,
     enabled: true,
     onboardingDone: true,
-    injectOwnAffiliate: injectMugaReferral,
+    injectOwnAffiliate: true,
     notifyForeignAffiliate: false,
     honorCreatorMode: false,
     blacklist: [],
@@ -100,6 +103,66 @@ function buildPureCleanerPrefs(prefDefaults, { injectMugaReferral = true } = {})
     customParams: [],
     userCustomRules: [],
   };
+}
+
+/**
+ * Resolves MUGA's own affiliate tag for an affiliate pattern + hostname.
+ * Adapter-local mirror of src/lib/affiliates.js `resolveOurTag`: the engine
+ * bundle exposes `AFFILIATE_PATTERNS` (each pattern carries its per-host
+ * `ourTag` map) and `getPatternsForHost`, but not `resolveOurTag` itself.
+ * Reading the already-exposed `ourTag` map keeps the tag VALUES single-
+ * sourced in the engine, so this adapter never hard-codes them.
+ *
+ * @param {{ourTag?: Object}|null|undefined} pattern
+ * @param {string} hostname
+ * @returns {string} the tag configured for this host, or "" when none.
+ */
+function resolveOurTag(pattern, hostname) {
+  if (!pattern || !pattern.ourTag || !hostname) return "";
+  const host = hostname.replace(/^www\./, "");
+  return pattern.ourTag[host] || pattern.ourTag[hostname] || "";
+}
+
+/**
+ * Detects whether a cleaned URL carries MUGA's OWN affiliate referral and,
+ * when it does, returns the URL with only that param removed.
+ *
+ * Matches our tag by VALUE against the engine's per-host affiliate patterns,
+ * so a foreign/creator referral (a different value on the same param, e.g.
+ * `tag=somecreator-20`) is never stripped: the preservation moat stays
+ * intact. Covers BOTH the just-injected case and a link the user pasted that
+ * already carried MUGA's tag (design "copy-without-referral parity"). Never
+ * throws: any failure degrades to "no own referral".
+ *
+ * @param {string} cleanUrl            The cleaned URL returned by the engine.
+ * @param {string|null} destinationHost  Its hostname (already parsed by the caller).
+ * @param {object} engine              The resolved engine handle.
+ * @returns {{ present: boolean, stripped: string|null }}
+ */
+function detectOwnReferral(cleanUrl, destinationHost, engine) {
+  const none = { present: false, stripped: null };
+  if (typeof cleanUrl !== "string" || !destinationHost) return none;
+  if (!engine || typeof engine.getPatternsForHost !== "function") return none;
+
+  let url;
+  try {
+    url = new URL(cleanUrl);
+  } catch {
+    return none;
+  }
+
+  const host = destinationHost.replace(/^www\./, "");
+  const patterns = engine.getPatternsForHost(host) || [];
+  let present = false;
+  for (const pattern of patterns) {
+    const ourTag = resolveOurTag(pattern, host);
+    if (!ourTag) continue;
+    if (url.searchParams.get(pattern.param) === ourTag) {
+      url.searchParams.delete(pattern.param);
+      present = true;
+    }
+  }
+  return present ? { present: true, stripped: url.toString() } : none;
 }
 
 /**
@@ -121,6 +184,7 @@ function buildPureCleanerPrefs(prefDefaults, { injectMugaReferral = true } = {})
  *   destinationHost: string|null,
  *   affiliatePreserved: boolean,
  *   mugaReferralInjected: boolean,
+ *   mugaReferralPresent: boolean,
  *   cleanUrlNoMugaReferral: string|null,
  *   action: string,
  *   error?: string,
@@ -171,27 +235,19 @@ export function cleanUrl(input, engine = resolveEngine()) {
   const unwrapped = destinationHost !== null && destinationHost !== inputUrl.hostname;
 
   // mugaReferralInjected (design D2): keyed off action === "injected", NOT
-  // affiliatePreserved. "injected" means MUGA added its own tag; a preserved
-  // creator/foreign referral means nothing MUGA-owned was added. The engine
-  // guard (D4) makes these mutually exclusive.
+  // affiliatePreserved. "injected" means MUGA added its own tag THIS run; a
+  // preserved creator/foreign referral means nothing MUGA-owned was added.
+  // It drives the disclosure WORDING (added vs already present).
   const mugaReferralInjected = result.action === "injected";
 
-  // cleanUrlNoMugaReferral (design D1): re-run the engine with injection OFF
-  // instead of string-stripping the known tag. Single source of truth —
-  // byte-exact to what the engine produces without injection, and this
-  // adapter never has to know MUGA's own param names.
-  let cleanUrlNoMugaReferral = null;
-  if (mugaReferralInjected) {
-    const noInjectPrefs = buildPureCleanerPrefs(engine.PREF_DEFAULTS || {}, { injectMugaReferral: false });
-    try {
-      const noInjectResult = engine.processUrl(input, noInjectPrefs, DOMAIN_RULES, undefined, undefined, undefined, PATH_STRIP_RULES);
-      if (noInjectResult && typeof noInjectResult.cleanUrl === "string") {
-        cleanUrlNoMugaReferral = noInjectResult.cleanUrl;
-      }
-    } catch {
-      cleanUrlNoMugaReferral = null;
-    }
-  }
+  // mugaReferralPresent + cleanUrlNoMugaReferral: the "copy without referral"
+  // opt-out must appear whenever the cleaned URL carries MUGA's OWN referral,
+  // whether MUGA injected it this run OR the pasted link already carried it
+  // (a MUGA-tagged link the user re-cleans). Detect our tag by value against
+  // the engine's per-host affiliate patterns and surgically remove only that
+  // param, so a foreign/creator referral is never stripped. This replaces the
+  // old injection-off rerun, which missed the already-present case entirely.
+  const ownReferral = detectOwnReferral(result.cleanUrl, destinationHost, engine);
 
   return {
     ok: true,
@@ -201,7 +257,8 @@ export function cleanUrl(input, engine = resolveEngine()) {
     destinationHost,
     affiliatePreserved: !!(result.preservedAffiliate || result.creatorReferralPreserved),
     mugaReferralInjected,
-    cleanUrlNoMugaReferral,
+    mugaReferralPresent: ownReferral.present,
+    cleanUrlNoMugaReferral: ownReferral.stripped,
     action: result.action,
   };
 }

--- a/landing/clean/ui-view.js
+++ b/landing/clean/ui-view.js
@@ -29,17 +29,26 @@
  * @property {boolean} affiliatePreserved
  * @property {boolean} noChanges
  * @property {boolean} mugaReferralInjected
+ * @property {boolean} mugaReferralPresent
  * @property {string|null} cleanUrlNoMugaReferral
  * @property {string|null} disclosure
  */
 
 /**
- * FTC-style disclosure shown only when MUGA injected its own referral
- * (design "Copy direction"; maintainer-approved verbatim copy).
+ * FTC-style disclosures shown when the cleaned URL carries MUGA's own
+ * referral. Two variants (maintainer-approved verbatim copy):
+ *  - INJECTED: MUGA added its tag to a link that had none this run.
+ *  - PRESENT:  the pasted link already carried MUGA's tag (re-cleaned).
+ * Both point at the opt-out without a directional phrase ("below"/"above"),
+ * because the opt-out button sits ABOVE this text in the DOM.
  */
-const REFERRAL_DISCLOSURE =
+const REFERRAL_DISCLOSURE_INJECTED =
   "This link had no referral of its own, so MUGA added one for a selected store " +
-  "to help keep the tool free. Prefer a clean link? Use the button below.";
+  "to help keep the tool free. Prefer a clean link? You can copy one without it too.";
+
+const REFERRAL_DISCLOSURE_PRESENT =
+  "This link already carries MUGA's referral, which helps keep the tool free. " +
+  "Prefer a clean link? You can copy one without it too.";
 
 /**
  * The view shown before the user has cleaned anything yet.
@@ -57,6 +66,7 @@ export function emptyStateView() {
     affiliatePreserved: false,
     noChanges: false,
     mugaReferralInjected: false,
+    mugaReferralPresent: false,
     cleanUrlNoMugaReferral: null,
     disclosure: null,
   };
@@ -138,6 +148,7 @@ export function computeLengthReduction(originalUrl, cleanUrl) {
  *   destinationHost?: string|null,
  *   affiliatePreserved?: boolean,
  *   mugaReferralInjected?: boolean,
+ *   mugaReferralPresent?: boolean,
  *   cleanUrlNoMugaReferral?: string|null,
  *   action?: string,
  *   error?: string,
@@ -160,6 +171,7 @@ export function formatCleanResult(result) {
       affiliatePreserved: false,
       noChanges: false,
       mugaReferralInjected: false,
+      mugaReferralPresent: false,
       cleanUrlNoMugaReferral: null,
       disclosure: null,
     };
@@ -169,6 +181,9 @@ export function formatCleanResult(result) {
   const unwrapped = !!result.unwrapped;
   const noChanges = removedList.length === 0 && !unwrapped;
   const mugaReferralInjected = !!result.mugaReferralInjected;
+  // A just-injected referral is always present in the output too, so treat
+  // "injected" as a superset of "present" even if the adapter only set one.
+  const mugaReferralPresent = !!result.mugaReferralPresent || mugaReferralInjected;
 
   return {
     state: "clean",
@@ -181,9 +196,14 @@ export function formatCleanResult(result) {
     affiliatePreserved: !!result.affiliatePreserved,
     noChanges,
     mugaReferralInjected,
-    cleanUrlNoMugaReferral: mugaReferralInjected && typeof result.cleanUrlNoMugaReferral === "string"
+    mugaReferralPresent,
+    cleanUrlNoMugaReferral: mugaReferralPresent && typeof result.cleanUrlNoMugaReferral === "string"
       ? result.cleanUrlNoMugaReferral
       : null,
-    disclosure: mugaReferralInjected ? REFERRAL_DISCLOSURE : null,
+    // Wording follows how the referral got there: added this run vs already
+    // on the pasted link. Both only show when our referral is present.
+    disclosure: mugaReferralInjected
+      ? REFERRAL_DISCLOSURE_INJECTED
+      : (mugaReferralPresent ? REFERRAL_DISCLOSURE_PRESENT : null),
   };
 }

--- a/landing/clean/ui.js
+++ b/landing/clean/ui.js
@@ -69,7 +69,7 @@ function render(refs, view, originalUrl) {
   refs.urlBox.textContent = hasCleanUrl ? view.cleanUrl : "";
   refs.copyBtn.disabled = !hasCleanUrl;
 
-  const showNoReferralBtn = hasCleanUrl && view.mugaReferralInjected && typeof view.cleanUrlNoMugaReferral === "string";
+  const showNoReferralBtn = hasCleanUrl && view.mugaReferralPresent && typeof view.cleanUrlNoMugaReferral === "string";
   refs.copyNoReferralBtn.hidden = !showNoReferralBtn;
   refs.copyNoReferralBtn.disabled = !showNoReferralBtn;
 

--- a/tests/unit/web-adapter-contract.test.mjs
+++ b/tests/unit/web-adapter-contract.test.mjs
@@ -117,6 +117,7 @@ describe("web adapter contract — naked-link MUGA referral injection (web-tool-
     assert.equal(out.ok, true);
     assert.equal(out.action, "injected");
     assert.equal(out.mugaReferralInjected, true);
+    assert.equal(out.mugaReferralPresent, true, "an injected tag is also present in the output");
     const injected = new URL(out.cleanUrl);
     assert.equal(injected.searchParams.get("tag"), "muga0b-20");
     assert.ok(out.cleanUrlNoMugaReferral, "cleanUrlNoMugaReferral must be present when injected");
@@ -156,14 +157,46 @@ describe("web adapter contract — naked-link MUGA referral injection (web-tool-
     assert.equal(out.ok, true);
     assert.equal(out.affiliatePreserved, true);
     assert.equal(out.mugaReferralInjected, false, "MUGA must not add anything when a referral already exists");
-    assert.equal(out.cleanUrlNoMugaReferral, null, "nothing to opt out of when MUGA injected nothing");
+    assert.equal(out.mugaReferralPresent, false, "a foreign referral is not MUGA's own — no opt-out");
+    assert.equal(out.cleanUrlNoMugaReferral, null, "nothing to opt out of when the referral is not MUGA's");
     assert.equal(new URL(out.cleanUrl).searchParams.get("tag"), "somecreator-20");
+  });
+
+  test("a pasted link that ALREADY carries MUGA's own tag surfaces the opt-out (not just the inject case)", () => {
+    // The bug this fixes: re-cleaning a link that already carries our tag left
+    // the referral on the output with no way to copy a tag-free variant, because
+    // the opt-out was gated on action === "injected".
+    const out = cleanUrl("https://www.amazon.com/dp/B000123456?tag=muga0b-20", engine);
+    assert.equal(out.ok, true);
+    assert.notEqual(out.action, "injected", "MUGA did not inject — the tag was already there");
+    assert.equal(out.mugaReferralInjected, false);
+    assert.equal(out.mugaReferralPresent, true, "our own tag is present in the output, so the opt-out must appear");
+    assert.ok(out.cleanUrlNoMugaReferral, "a tag-free variant must be offered");
+    assert.equal(
+      new URL(out.cleanUrlNoMugaReferral).searchParams.has("tag"),
+      false,
+      "the opt-out URL must carry no MUGA tag",
+    );
+    // The default (with-referral) URL still carries our tag.
+    assert.equal(new URL(out.cleanUrl).searchParams.get("tag"), "muga0b-20");
+  });
+
+  test("already-present tag with extra tracking: tracking is cleaned, our tag opt-out still offered", () => {
+    const out = cleanUrl("https://www.amazon.com/dp/B000123456?tag=muga0b-20&utm_source=news", engine);
+    assert.equal(out.ok, true);
+    assert.ok(out.removed.includes("utm_source"), "tracking params must still be removed");
+    assert.equal(out.mugaReferralPresent, true);
+    assert.ok(out.cleanUrlNoMugaReferral);
+    const optOut = new URL(out.cleanUrlNoMugaReferral);
+    assert.equal(optOut.searchParams.has("tag"), false, "opt-out drops our tag");
+    assert.equal(optOut.searchParams.has("utm_source"), false, "opt-out keeps the cleaned tracking removed");
   });
 
   test("non-supported program / plain link: no injection, no opt-out URL", () => {
     const out = cleanUrl("https://example.com/already-clean?id=42", engine);
     assert.equal(out.ok, true);
     assert.equal(out.mugaReferralInjected, false);
+    assert.equal(out.mugaReferralPresent, false);
     assert.equal(out.cleanUrlNoMugaReferral, null);
   });
 
@@ -178,6 +211,7 @@ describe("web adapter contract — naked-link MUGA referral injection (web-tool-
     assert.equal(out.affiliatePreserved, false);
     assert.equal(out.action, "cleaned");
     assert.equal(out.mugaReferralInjected, false);
+    assert.equal(out.mugaReferralPresent, false);
     assert.equal(out.cleanUrlNoMugaReferral, null);
   });
 });

--- a/tests/unit/web-ui-source-guard.test.mjs
+++ b/tests/unit/web-ui-source-guard.test.mjs
@@ -243,9 +243,12 @@ describe("MUGA referral opt-out and disclosure (web-tool-naked-link-injection)",
     assert.ok(HTML.includes('id="referral-disclosure"'), "a #referral-disclosure element must exist");
   });
 
-  test("ui.js toggles #copy-no-referral-btn on view.mugaReferralInjected and copies cleanUrlNoMugaReferral", () => {
+  test("ui.js toggles #copy-no-referral-btn on view.mugaReferralPresent and copies cleanUrlNoMugaReferral", () => {
     const code = stripJsComments(UI_JS);
-    assert.ok(/mugaReferralInjected/.test(code), "ui.js must reference view.mugaReferralInjected");
+    // The opt-out must show whenever OUR referral is present in the output
+    // (injected this run OR already on the pasted link), not only when we
+    // injected it — so the gate is mugaReferralPresent, not mugaReferralInjected.
+    assert.ok(/mugaReferralPresent/.test(code), "ui.js must reference view.mugaReferralPresent");
     assert.ok(/cleanUrlNoMugaReferral/.test(code), "ui.js must reference view.cleanUrlNoMugaReferral");
   });
 

--- a/tests/unit/web-ui-view.test.mjs
+++ b/tests/unit/web-ui-view.test.mjs
@@ -174,7 +174,7 @@ describe("formatCleanResult() — success paths", () => {
 });
 
 describe("formatCleanResult() — MUGA referral disclosure and opt-out (web-tool-naked-link-injection)", () => {
-  test("injected result surfaces mugaReferralInjected, the opt-out URL, and a disclosure line", () => {
+  test("injected result surfaces mugaReferralInjected/Present, the opt-out URL, and the ADDED disclosure line", () => {
     const result = {
       ok: true,
       cleanUrl: "https://www.amazon.com/dp/B000123456?tag=muga0b-20",
@@ -183,14 +183,43 @@ describe("formatCleanResult() — MUGA referral disclosure and opt-out (web-tool
       destinationHost: "amazon.com",
       affiliatePreserved: false,
       mugaReferralInjected: true,
+      mugaReferralPresent: true,
       cleanUrlNoMugaReferral: "https://www.amazon.com/dp/B000123456",
       action: "injected",
     };
     const view = formatCleanResult(result);
     assert.equal(view.mugaReferralInjected, true);
+    assert.equal(view.mugaReferralPresent, true);
     assert.equal(view.cleanUrlNoMugaReferral, "https://www.amazon.com/dp/B000123456");
     assert.equal(typeof view.disclosure, "string");
     assert.ok(view.disclosure.length > 0);
+    assert.ok(/added one/i.test(view.disclosure), "injected disclosure must say MUGA added the referral");
+    assert.ok(!/below|above/i.test(view.disclosure), "disclosure must not reference button direction");
+    assert.ok(!view.disclosure.includes("—"), "disclosure must not contain an em-dash");
+    assert.ok(!view.disclosure.includes("--"), "disclosure must not contain \"--\"");
+  });
+
+  test("already-present MUGA referral (not injected this run) still surfaces the opt-out with the ALREADY-CARRIES disclosure", () => {
+    const result = {
+      ok: true,
+      cleanUrl: "https://www.amazon.com/dp/B000123456?tag=muga0b-20",
+      removed: [],
+      unwrapped: false,
+      destinationHost: "amazon.com",
+      affiliatePreserved: false,
+      mugaReferralInjected: false,
+      mugaReferralPresent: true,
+      cleanUrlNoMugaReferral: "https://www.amazon.com/dp/B000123456",
+      action: "untouched",
+    };
+    const view = formatCleanResult(result);
+    assert.equal(view.mugaReferralInjected, false);
+    assert.equal(view.mugaReferralPresent, true);
+    assert.equal(view.cleanUrlNoMugaReferral, "https://www.amazon.com/dp/B000123456");
+    assert.equal(typeof view.disclosure, "string");
+    assert.ok(/already carries/i.test(view.disclosure), "present disclosure must say the link already carries the referral");
+    assert.ok(!/added one/i.test(view.disclosure), "present disclosure must NOT claim MUGA added the referral");
+    assert.ok(!/below|above/i.test(view.disclosure), "disclosure must not reference button direction");
     assert.ok(!view.disclosure.includes("—"), "disclosure must not contain an em-dash");
     assert.ok(!view.disclosure.includes("--"), "disclosure must not contain \"--\"");
   });
@@ -230,12 +259,14 @@ describe("formatCleanResult() — MUGA referral disclosure and opt-out (web-tool
     assert.equal(view.cleanUrlNoMugaReferral, null);
   });
 
-  test("empty and error states carry the same three fields with safe defaults", () => {
+  test("empty and error states carry the referral fields with safe defaults", () => {
     assert.equal(emptyStateView().mugaReferralInjected, false);
+    assert.equal(emptyStateView().mugaReferralPresent, false);
     assert.equal(emptyStateView().cleanUrlNoMugaReferral, null);
     assert.equal(emptyStateView().disclosure, null);
     const errorView = formatCleanResult(null);
     assert.equal(errorView.mugaReferralInjected, false);
+    assert.equal(errorView.mugaReferralPresent, false);
     assert.equal(errorView.cleanUrlNoMugaReferral, null);
     assert.equal(errorView.disclosure, null);
   });

--- a/web/engine/adapter.js
+++ b/web/engine/adapter.js
@@ -65,6 +65,7 @@ function buildFailure(action, error, rawInput) {
     destinationHost: null,
     affiliatePreserved: false,
     mugaReferralInjected: false,
+    mugaReferralPresent: false,
     cleanUrlNoMugaReferral: null,
     action,
     error,
@@ -77,22 +78,24 @@ function buildFailure(action, error, rawInput) {
  * REAL defaults (`engine.PREF_DEFAULTS`) so behavioural defaults never
  * hand-drift from `src/lib/prefs.js`.
  *
- * `injectOwnAffiliate` is now conditional (design D1, web-tool-naked-link-injection
+ * `injectOwnAffiliate` stays on (design D1, web-tool-naked-link-injection
  * slice 2, ADR-1): the web tool injects MUGA's own tag on naked Amazon/eBay
- * links by default so the tool can fund itself, while every other web-tool
- * policy override (no notify, no honor-creator, no lists) stays in place.
- * Callers that need the tag-free variant pass `injectMugaReferral: false`.
+ * links so the tool can fund itself, while every other web-tool policy
+ * override (no notify, no honor-creator, no lists) stays in place. The
+ * tag-free variant is no longer produced by a second injection-off run; it
+ * is derived by surgically stripping MUGA's own tag from the cleaned URL
+ * (see detectOwnReferral), which also covers links that ALREADY carried our
+ * referral before cleaning.
  *
  * @param {object} prefDefaults
- * @param {{ injectMugaReferral?: boolean }} [options]
  * @returns {object}
  */
-function buildPureCleanerPrefs(prefDefaults, { injectMugaReferral = true } = {}) {
+function buildPureCleanerPrefs(prefDefaults) {
   return {
     ...prefDefaults,
     enabled: true,
     onboardingDone: true,
-    injectOwnAffiliate: injectMugaReferral,
+    injectOwnAffiliate: true,
     notifyForeignAffiliate: false,
     honorCreatorMode: false,
     blacklist: [],
@@ -100,6 +103,66 @@ function buildPureCleanerPrefs(prefDefaults, { injectMugaReferral = true } = {})
     customParams: [],
     userCustomRules: [],
   };
+}
+
+/**
+ * Resolves MUGA's own affiliate tag for an affiliate pattern + hostname.
+ * Adapter-local mirror of src/lib/affiliates.js `resolveOurTag`: the engine
+ * bundle exposes `AFFILIATE_PATTERNS` (each pattern carries its per-host
+ * `ourTag` map) and `getPatternsForHost`, but not `resolveOurTag` itself.
+ * Reading the already-exposed `ourTag` map keeps the tag VALUES single-
+ * sourced in the engine, so this adapter never hard-codes them.
+ *
+ * @param {{ourTag?: Object}|null|undefined} pattern
+ * @param {string} hostname
+ * @returns {string} the tag configured for this host, or "" when none.
+ */
+function resolveOurTag(pattern, hostname) {
+  if (!pattern || !pattern.ourTag || !hostname) return "";
+  const host = hostname.replace(/^www\./, "");
+  return pattern.ourTag[host] || pattern.ourTag[hostname] || "";
+}
+
+/**
+ * Detects whether a cleaned URL carries MUGA's OWN affiliate referral and,
+ * when it does, returns the URL with only that param removed.
+ *
+ * Matches our tag by VALUE against the engine's per-host affiliate patterns,
+ * so a foreign/creator referral (a different value on the same param, e.g.
+ * `tag=somecreator-20`) is never stripped: the preservation moat stays
+ * intact. Covers BOTH the just-injected case and a link the user pasted that
+ * already carried MUGA's tag (design "copy-without-referral parity"). Never
+ * throws: any failure degrades to "no own referral".
+ *
+ * @param {string} cleanUrl            The cleaned URL returned by the engine.
+ * @param {string|null} destinationHost  Its hostname (already parsed by the caller).
+ * @param {object} engine              The resolved engine handle.
+ * @returns {{ present: boolean, stripped: string|null }}
+ */
+function detectOwnReferral(cleanUrl, destinationHost, engine) {
+  const none = { present: false, stripped: null };
+  if (typeof cleanUrl !== "string" || !destinationHost) return none;
+  if (!engine || typeof engine.getPatternsForHost !== "function") return none;
+
+  let url;
+  try {
+    url = new URL(cleanUrl);
+  } catch {
+    return none;
+  }
+
+  const host = destinationHost.replace(/^www\./, "");
+  const patterns = engine.getPatternsForHost(host) || [];
+  let present = false;
+  for (const pattern of patterns) {
+    const ourTag = resolveOurTag(pattern, host);
+    if (!ourTag) continue;
+    if (url.searchParams.get(pattern.param) === ourTag) {
+      url.searchParams.delete(pattern.param);
+      present = true;
+    }
+  }
+  return present ? { present: true, stripped: url.toString() } : none;
 }
 
 /**
@@ -121,6 +184,7 @@ function buildPureCleanerPrefs(prefDefaults, { injectMugaReferral = true } = {})
  *   destinationHost: string|null,
  *   affiliatePreserved: boolean,
  *   mugaReferralInjected: boolean,
+ *   mugaReferralPresent: boolean,
  *   cleanUrlNoMugaReferral: string|null,
  *   action: string,
  *   error?: string,
@@ -171,27 +235,19 @@ export function cleanUrl(input, engine = resolveEngine()) {
   const unwrapped = destinationHost !== null && destinationHost !== inputUrl.hostname;
 
   // mugaReferralInjected (design D2): keyed off action === "injected", NOT
-  // affiliatePreserved. "injected" means MUGA added its own tag; a preserved
-  // creator/foreign referral means nothing MUGA-owned was added. The engine
-  // guard (D4) makes these mutually exclusive.
+  // affiliatePreserved. "injected" means MUGA added its own tag THIS run; a
+  // preserved creator/foreign referral means nothing MUGA-owned was added.
+  // It drives the disclosure WORDING (added vs already present).
   const mugaReferralInjected = result.action === "injected";
 
-  // cleanUrlNoMugaReferral (design D1): re-run the engine with injection OFF
-  // instead of string-stripping the known tag. Single source of truth —
-  // byte-exact to what the engine produces without injection, and this
-  // adapter never has to know MUGA's own param names.
-  let cleanUrlNoMugaReferral = null;
-  if (mugaReferralInjected) {
-    const noInjectPrefs = buildPureCleanerPrefs(engine.PREF_DEFAULTS || {}, { injectMugaReferral: false });
-    try {
-      const noInjectResult = engine.processUrl(input, noInjectPrefs, DOMAIN_RULES, undefined, undefined, undefined, PATH_STRIP_RULES);
-      if (noInjectResult && typeof noInjectResult.cleanUrl === "string") {
-        cleanUrlNoMugaReferral = noInjectResult.cleanUrl;
-      }
-    } catch {
-      cleanUrlNoMugaReferral = null;
-    }
-  }
+  // mugaReferralPresent + cleanUrlNoMugaReferral: the "copy without referral"
+  // opt-out must appear whenever the cleaned URL carries MUGA's OWN referral,
+  // whether MUGA injected it this run OR the pasted link already carried it
+  // (a MUGA-tagged link the user re-cleans). Detect our tag by value against
+  // the engine's per-host affiliate patterns and surgically remove only that
+  // param, so a foreign/creator referral is never stripped. This replaces the
+  // old injection-off rerun, which missed the already-present case entirely.
+  const ownReferral = detectOwnReferral(result.cleanUrl, destinationHost, engine);
 
   return {
     ok: true,
@@ -201,7 +257,8 @@ export function cleanUrl(input, engine = resolveEngine()) {
     destinationHost,
     affiliatePreserved: !!(result.preservedAffiliate || result.creatorReferralPreserved),
     mugaReferralInjected,
-    cleanUrlNoMugaReferral,
+    mugaReferralPresent: ownReferral.present,
+    cleanUrlNoMugaReferral: ownReferral.stripped,
     action: result.action,
   };
 }

--- a/web/ui-view.js
+++ b/web/ui-view.js
@@ -29,17 +29,26 @@
  * @property {boolean} affiliatePreserved
  * @property {boolean} noChanges
  * @property {boolean} mugaReferralInjected
+ * @property {boolean} mugaReferralPresent
  * @property {string|null} cleanUrlNoMugaReferral
  * @property {string|null} disclosure
  */
 
 /**
- * FTC-style disclosure shown only when MUGA injected its own referral
- * (design "Copy direction"; maintainer-approved verbatim copy).
+ * FTC-style disclosures shown when the cleaned URL carries MUGA's own
+ * referral. Two variants (maintainer-approved verbatim copy):
+ *  - INJECTED: MUGA added its tag to a link that had none this run.
+ *  - PRESENT:  the pasted link already carried MUGA's tag (re-cleaned).
+ * Both point at the opt-out without a directional phrase ("below"/"above"),
+ * because the opt-out button sits ABOVE this text in the DOM.
  */
-const REFERRAL_DISCLOSURE =
+const REFERRAL_DISCLOSURE_INJECTED =
   "This link had no referral of its own, so MUGA added one for a selected store " +
-  "to help keep the tool free. Prefer a clean link? Use the button below.";
+  "to help keep the tool free. Prefer a clean link? You can copy one without it too.";
+
+const REFERRAL_DISCLOSURE_PRESENT =
+  "This link already carries MUGA's referral, which helps keep the tool free. " +
+  "Prefer a clean link? You can copy one without it too.";
 
 /**
  * The view shown before the user has cleaned anything yet.
@@ -57,6 +66,7 @@ export function emptyStateView() {
     affiliatePreserved: false,
     noChanges: false,
     mugaReferralInjected: false,
+    mugaReferralPresent: false,
     cleanUrlNoMugaReferral: null,
     disclosure: null,
   };
@@ -138,6 +148,7 @@ export function computeLengthReduction(originalUrl, cleanUrl) {
  *   destinationHost?: string|null,
  *   affiliatePreserved?: boolean,
  *   mugaReferralInjected?: boolean,
+ *   mugaReferralPresent?: boolean,
  *   cleanUrlNoMugaReferral?: string|null,
  *   action?: string,
  *   error?: string,
@@ -160,6 +171,7 @@ export function formatCleanResult(result) {
       affiliatePreserved: false,
       noChanges: false,
       mugaReferralInjected: false,
+      mugaReferralPresent: false,
       cleanUrlNoMugaReferral: null,
       disclosure: null,
     };
@@ -169,6 +181,9 @@ export function formatCleanResult(result) {
   const unwrapped = !!result.unwrapped;
   const noChanges = removedList.length === 0 && !unwrapped;
   const mugaReferralInjected = !!result.mugaReferralInjected;
+  // A just-injected referral is always present in the output too, so treat
+  // "injected" as a superset of "present" even if the adapter only set one.
+  const mugaReferralPresent = !!result.mugaReferralPresent || mugaReferralInjected;
 
   return {
     state: "clean",
@@ -181,9 +196,14 @@ export function formatCleanResult(result) {
     affiliatePreserved: !!result.affiliatePreserved,
     noChanges,
     mugaReferralInjected,
-    cleanUrlNoMugaReferral: mugaReferralInjected && typeof result.cleanUrlNoMugaReferral === "string"
+    mugaReferralPresent,
+    cleanUrlNoMugaReferral: mugaReferralPresent && typeof result.cleanUrlNoMugaReferral === "string"
       ? result.cleanUrlNoMugaReferral
       : null,
-    disclosure: mugaReferralInjected ? REFERRAL_DISCLOSURE : null,
+    // Wording follows how the referral got there: added this run vs already
+    // on the pasted link. Both only show when our referral is present.
+    disclosure: mugaReferralInjected
+      ? REFERRAL_DISCLOSURE_INJECTED
+      : (mugaReferralPresent ? REFERRAL_DISCLOSURE_PRESENT : null),
   };
 }

--- a/web/ui.js
+++ b/web/ui.js
@@ -69,7 +69,7 @@ function render(refs, view, originalUrl) {
   refs.urlBox.textContent = hasCleanUrl ? view.cleanUrl : "";
   refs.copyBtn.disabled = !hasCleanUrl;
 
-  const showNoReferralBtn = hasCleanUrl && view.mugaReferralInjected && typeof view.cleanUrlNoMugaReferral === "string";
+  const showNoReferralBtn = hasCleanUrl && view.mugaReferralPresent && typeof view.cleanUrlNoMugaReferral === "string";
   refs.copyNoReferralBtn.hidden = !showNoReferralBtn;
   refs.copyNoReferralBtn.disabled = !showNoReferralBtn;
 


### PR DESCRIPTION
Closes #1072

## Summary
- The "Copy without MUGA's referral" opt-out only appeared when MUGA **injected** its tag on a naked link. A pasted link that **already carried** our tag (`tag=muga0b-20`, eBay `campid`) kept the referral on the cleaned output with no tag-free copy.
- Now the opt-out appears whenever the cleaned URL carries MUGA's **own** referral (injected this run **or** already present). Foreign/creator referrals are never stripped, so preservation stays intact.
- Also fixes stale disclosure copy ("Use the button below" → "You can copy one without it too"; the button sits *above* the text in the DOM).

## Approach
Replaced the injection-off engine rerun with `detectOwnReferral()`: detect MUGA's own tag **by value** against `engine.getPatternsForHost` + `pattern.ourTag`, then surgically `URLSearchParams.delete` only that param. New field `mugaReferralPresent` (superset of `mugaReferralInjected`) gates the button; `mugaReferralInjected` now only selects the disclosure wording.

## Changes
| File | Change |
|------|--------|
| `web/engine/adapter.js` | `detectOwnReferral()` + `resolveOurTag()`; new `mugaReferralPresent`; drop injection-off rerun |
| `web/ui-view.js` | two disclosure variants (added vs already-carries); surface `mugaReferralPresent` |
| `web/ui.js` | button gated on `mugaReferralPresent` |
| `landing/clean/*` | regenerated mirror (`npm run build:web`) |
| `tests/unit/web-adapter-contract.test.mjs` | already-present + tracking cases; foreign stays no-opt-out |
| `tests/unit/web-ui-view.test.mjs` | injected + already-present disclosure coverage |
| `tests/unit/web-ui-source-guard.test.mjs` | gate assertion → `mugaReferralPresent` |

## Test plan
- [x] `node --test` web-tool suites — 114/114 green (adapter-contract, ui-view, source-guard, engine-mirror, boundary)
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] End-to-end with the real engine: naked-inject, already-our-tag, our-tag+tracking, foreign (no opt-out), eBay campid — all correct
- [x] Foreign/creator referral never stripped (moat intact)