### PR TITLE
fix(landing): revalidate /clean assets so deploys never serve stale JS (#1082)

### DIFF
--- a/landing-worker/worker.js
+++ b/landing-worker/worker.js
@@ -35,12 +35,52 @@ const SECURITY_HEADERS = {
   "Strict-Transport-Security": "max-age=31536000",
 };
 
+/**
+ * Decides the browser Cache-Control for a landing asset.
+ *
+ * The landing page and the inlined /clean tool form an HTML<->module contract:
+ * index.html (and /clean/index.html) load JS/CSS/JSON modules by fixed,
+ * unhashed names (./clean/ui.js, ./clean/engine/cleaner-bundle.js, the
+ * *.gen.mjs mirrors, etc.). Static Assets serves those with a multi-hour
+ * max-age, so after a deploy that changes the contract a returning visitor can
+ * get fresh HTML but a stale cached module and see a broken tool ("Cleaning is
+ * unavailable right now") until the module's cache expires.
+ *
+ * `no-cache` does NOT mean "don't cache" — it means the browser must
+ * revalidate with the edge before reusing the cached copy. With the ETag the
+ * asset already carries, an unchanged asset returns a cheap 304 and a changed
+ * one returns fresh bytes, so a deploy is picked up on the very next load with
+ * no stale window. Returns null for anything else (images, fonts, favicons),
+ * leaving the Static Assets default long-cache in place.
+ *
+ * @param {string} pathname URL pathname (e.g. "/clean/ui.js", "/", "/clean/").
+ * @returns {string|null} "no-cache" for contract assets, otherwise null.
+ */
+export function cacheControlFor(pathname) {
+  const path = typeof pathname === "string" ? pathname : "";
+  // A trailing "/" (or the root) resolves to an index.html document.
+  if (path === "/" || path.endsWith("/") || /\.(?:html|js|mjs|css|json)$/i.test(path)) {
+    return "no-cache";
+  }
+  return null;
+}
+
 export default {
   async fetch(request, env) {
     const response = await env.ASSETS.fetch(request);
     const newResponse = new Response(response.body, response);
     for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
       newResponse.headers.set(name, value);
+    }
+    let pathname = "/";
+    try {
+      pathname = new URL(request.url).pathname;
+    } catch {
+      pathname = "/";
+    }
+    const cacheControl = cacheControlFor(pathname);
+    if (cacheControl) {
+      newResponse.headers.set("Cache-Control", cacheControl);
     }
     return newResponse;
   },

--- a/tests/unit/landing-worker-cache.test.mjs
+++ b/tests/unit/landing-worker-cache.test.mjs
@@ -1,0 +1,46 @@
+/**
+ * MUGA: landing Worker cache-control policy guard.
+ *
+ * The landing page and the inlined /clean tool load unhashed JS/CSS/JSON
+ * modules by fixed name, so a stale cached module against fresh HTML breaks the
+ * tool for up to the asset's max-age after a deploy. `cacheControlFor` forces
+ * those contract assets to revalidate every load (no-cache + ETag => 304),
+ * closing the stale-window. This asserts the classification stays correct; the
+ * fetch() handler itself needs the Cloudflare runtime and is not unit-tested.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { cacheControlFor } from "../../landing-worker/worker.js";
+
+test("HTML documents (root, trailing slash, .html) revalidate", () => {
+  for (const p of ["/", "/index.html", "/clean/", "/clean/index.html"]) {
+    assert.equal(cacheControlFor(p), "no-cache", p);
+  }
+});
+
+test("every /clean tool module (js/mjs/css/json) revalidates", () => {
+  for (const p of [
+    "/clean/ui.js",
+    "/clean/ui-view.js",
+    "/clean/param-insight.js",
+    "/clean/engine/cleaner-bundle.js",
+    "/clean/engine/adapter.js",
+    "/clean/engine/domain-rules.gen.mjs",
+    "/clean/engine/domain-rules.json",
+    "/clean/engine/path-strip-rules.gen.mjs",
+  ]) {
+    assert.equal(cacheControlFor(p), "no-cache", p);
+  }
+});
+
+test("non-contract assets keep the Static Assets default (null)", () => {
+  for (const p of ["/favicon.ico", "/img/logo.png", "/fonts/inter.woff2", "/robots.txt"]) {
+    assert.equal(cacheControlFor(p), null, p);
+  }
+});
+
+test("non-string input is guarded", () => {
+  assert.equal(cacheControlFor(undefined), null);
+  assert.equal(cacheControlFor(null), null);
+});


### PR DESCRIPTION
Fixes #1082.

## Problem
After a deploy that changed the landing/`/clean` HTML<->module contract, a returning visitor could get fresh HTML but a **stale cached JS module** (served with `max-age=14400` by Static Assets, unhashed names), and the inline tool broke with "Cleaning is unavailable right now" for up to ~4h. This is the root cause behind the muga.app/clean unavailability you hit.

## Fix
The landing Worker already rewrites response headers; it now forces `Cache-Control: no-cache` on contract assets (html/js/mjs/css/json + index documents). `no-cache` means the browser revalidates every load — with the existing ETag, an unchanged asset returns a cheap 304 and a changed one returns fresh bytes, so a deploy is picked up on the next load with **no stale window**. Images/fonts keep the Static Assets default long cache.

- `cacheControlFor(pathname)` is a pure, unit-tested export; the `fetch` handler still needs the Cloudflare runtime.
- Deploy trigger already includes `landing-worker/**`, so this ships on merge.

## Why not content-hashing
Hashed filenames (immutable long-cache) are the higher-performance long-term option but need a build step to hash + rewrite the dynamic import paths (`./clean/ui.js`, the `*.gen.mjs` mirrors, ...). Deferred; the revalidation fix removes the bug with no build change.

## Testing
Full unit suite green: 6365 pass, 0 fail, 1 pre-existing skip. New: 4 tests asserting every contract asset revalidates and non-contract assets keep the default.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ
