### PR TITLE
fix(landing): run Worker for asset requests so cache/security headers apply

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,3 +19,10 @@ main = "landing-worker/worker.js"
 directory = "./landing"
 binding = "ASSETS"
 not_found_handling = "404-page"
+# Run the Worker for every request (including static-asset hits) so the
+# landing Worker's response transforms actually apply. Without this, Static
+# Assets serves files directly and the Worker is never invoked, so its
+# SECURITY_HEADERS and the Cache-Control revalidation policy (cacheControlFor)
+# silently never reach the browser. The Worker still serves bytes via
+# env.ASSETS.fetch(); this only inserts it into the request path.
+run_worker_first = true


### PR DESCRIPTION
## Why

#1083 tried to close the muga.app/clean stale-cache bug ("Cleaning is unavailable right now") by setting `Cache-Control: no-cache` on contract assets in the landing Worker. **I verified live after that deploy — it does nothing.**

Cloudflare Workers Static Assets serves static files **directly, without invoking the Worker**, by default. Evidence from prod:

- `/clean/ui.js` → `Cache-Control: public, max-age=14400` even on `Cf-Cache-Status: MISS` (fresh from origin, unchanged).
- **No** CSP / HSTS / X-Frame-Options from the Worker on *any* response, including the root.

So both the merged cache override **and** the Worker's `SECURITY_HEADERS` have been dead code in production.

## Fix

Set `run_worker_first = true` in `wrangler.toml`'s `[assets]`. The Worker now runs on every request and applies its response transforms; it still serves the actual bytes via `env.ASSETS.fetch()`. This activates:

1. **Cache revalidation** — `no-cache` + ETag ⇒ cheap 304 on unchanged assets, fresh bytes on changed ones, closing the stale-module window.
2. **Security headers** — CSP/HSTS/X-Frame-Options that were never reaching the browser.

## Verification plan

After deploy, confirm live: `curl -I https://muga.app/clean/ui.js` shows `Cache-Control: no-cache` **and** the CSP header is present. (I'll verify before declaring done — I did not do that adequately for #1083.)

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ