### PR TITLE
fix(content): never hijack in-page fragment navigation on affiliate domains

### DIFF
--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -444,6 +444,31 @@
     return entry.count > 5;
   }
 
+  // Fragment-safe rewrite guard. Mirrors src/lib/reclean-target.js
+  // (unit-tested there; content scripts can't ES-import cross-browser — same
+  // pattern as dom-link-rewriter). Rewrite the address bar ONLY when the
+  // origin/path/query actually changed; a fragment-only difference (hashchange
+  // from a carousel arrow, hash router, in-page tab) must NEVER trigger a
+  // replaceState — that stomps the fragment the page just set and silently
+  // breaks in-page navigation (repro: amazon.es feed carousel `<a href="#">`).
+  // On a legitimate rewrite, preserve the EXACT live fragment (incl. a bare
+  // "#") by string-splice, since the URL `hash` setter normalizes "" away.
+  function computeRecleanTarget(currentHref, cleanUrl) {
+    if (typeof currentHref !== "string" || typeof cleanUrl !== "string") return null;
+    let cur, next;
+    try { cur = new URL(currentHref); } catch { return null; }
+    try { next = new URL(cleanUrl, currentHref); } catch { return null; }
+    if (cur.origin === next.origin && cur.pathname === next.pathname && cur.search === next.search) {
+      return null;
+    }
+    const liveHashAt = currentHref.indexOf("#");
+    const liveFragment = liveHashAt >= 0 ? currentHref.slice(liveHashAt) : "";
+    const nextStr = next.href;
+    const nextHashAt = nextStr.indexOf("#");
+    const nextWithoutFragment = nextHashAt >= 0 ? nextStr.slice(0, nextHashAt) : nextStr;
+    return nextWithoutFragment + liveFragment;
+  }
+
   window.__mugaReclean = function (rawUrl) {
     if (!_contentPrefs || !_contentPrefs.enabled || !_contentPrefs.onboardingDone) return;
     // Resolve to an absolute URL before anything else. `rawUrl` here is
@@ -497,10 +522,15 @@
       console.error("[MUGA] reclean failed:", err);
       return;
     }
-    if (!result || !result.cleanUrl || result.cleanUrl === window.location.href) return;
-    _lastRecleanUrl = result.cleanUrl;
+    if (!result || !result.cleanUrl) return;
+    // Fragment-safe: only rewrite on a real origin/path/query change, and carry
+    // the live fragment through untouched. A fragment-only diff => null => the
+    // page's hash navigation (carousels, tabs, hash routers) is never stomped.
+    const target = computeRecleanTarget(window.location.href, result.cleanUrl);
+    if (!target || target === _lastRecleanUrl) return;
+    _lastRecleanUrl = target;
     try {
-      history.replaceState(history.state, "", result.cleanUrl);
+      history.replaceState(history.state, "", target);
     } catch { /* cross-origin or sandboxed — ignore */ }
     // Fire-and-forget: tell the SW to update badge + stats. Failure here
     // doesn't roll back the URL change — the user's address bar already
@@ -589,6 +619,22 @@
       return;
     }
     if (!["http:", "https:"].includes(url.protocol)) return;
+
+    // In-page fragment navigation — carousel arrows (<a href="#">), tabs,
+    // accordions, "back to top", hash routers — MUST pass through untouched.
+    // If we preventDefault + navigate() one of these we hijack the click and
+    // the in-page control dies (repro: amazon.es feed carousel arrows, whose
+    // href="#" the page handles itself; the page just reloads instead of
+    // rotating). The `href.startsWith("#")` guard above is on `anchor.href` —
+    // the IDL PROPERTY, which RESOLVES a bare "#"/"#section" to an ABSOLUTE
+    // URL — so it never catches same-document anchors. Same document ==
+    // same origin+path+query, differing only by fragment. Mirrors the pure
+    // isSameDocumentNavigation() in src/lib/same-document-nav.js.
+    if (url.origin === location.origin &&
+        url.pathname === location.pathname &&
+        url.search === location.search) {
+      return;
+    }
 
     // Only intercept clicks to affiliate store domains. All other clicks
     // pass through unmodified: DNR (Chrome) and self-clean (Firefox) handle

--- a/src/content/cleaner.js
+++ b/src/content/cleaner.js
@@ -527,7 +527,14 @@
     // the live fragment through untouched. A fragment-only diff => null => the
     // page's hash navigation (carousels, tabs, hash routers) is never stomped.
     const target = computeRecleanTarget(window.location.href, result.cleanUrl);
-    if (!target || target === _lastRecleanUrl) return;
+    // computeRecleanTarget already returns null when nothing meaningful changed
+    // (same origin/path/search as the live URL). Do NOT also gate on
+    // `target === _lastRecleanUrl`: two DIFFERENT dirty URLs can clean to the
+    // SAME target (e.g. ?ref=a and ?ref=b both -> /product), and gating on the
+    // last-written target would skip the second clean and leak ?ref=b. Loop
+    // re-entrancy is handled by the INPUT guard above (`url === _lastRecleanUrl`)
+    // once we record the target below — not by suppressing distinct cleans.
+    if (!target) return;
     _lastRecleanUrl = target;
     try {
       history.replaceState(history.state, "", target);

--- a/src/lib/reclean-target.js
+++ b/src/lib/reclean-target.js
@@ -1,0 +1,79 @@
+/**
+ * MUGA: reclean-target guard (#951 follow-up — fragment-safe rewrite).
+ *
+ * Decides whether — and to what — `__mugaReclean` should rewrite the address
+ * bar via `history.replaceState`. Pure, DOM-free, no globals, so the whole
+ * decision is unit-testable; content/cleaner.js mirrors this logic inline
+ * (content scripts can't ES-import cross-browser — same pattern as
+ * dom-link-rewriter).
+ *
+ * WHY THIS EXISTS
+ * The reclean pipeline runs on every same-document navigation MUGA can see:
+ * pushState/replaceState (via muga:history-committed), popstate, and
+ * hashchange. Its old guard rewrote whenever `cleanUrl !== location.href` — a
+ * raw string compare. A `hashchange` changes ONLY the fragment (tracking
+ * params live in the query, which is untouched), yet the string compare saw a
+ * difference and fired `replaceState`, overwriting the fragment the page had
+ * just set. That silently broke every hash-driven in-page control on the web
+ * (carousels, tabs, hash routers) — reported live on the amazon.es feed
+ * carousel, whose arrows are `<a href="#">`.
+ *
+ * THE INVARIANT
+ *   1. Rewrite ONLY when origin+pathname+search actually changed — i.e. real
+ *      tracking was removed or our affiliate tag was injected. A fragment-only
+ *      difference (or no difference at all) returns null: leave the URL alone.
+ *   2. On a legitimate rewrite, carry over the EXACT live fragment, including a
+ *      bare "#". MUGA cleans query/path, never the fragment, so the fragment
+ *      the page is currently on must survive verbatim. The URL `hash` setter
+ *      normalizes an empty fragment away (`url.hash = ""` drops the "#"), so
+ *      the fragment is spliced by string, not through the URL API.
+ *
+ * @param {string} currentHref The live `window.location.href` at reclean time.
+ * @param {string} cleanUrl    The cleaner's proposed URL (may be relative to
+ *                             currentHref; may or may not carry a fragment).
+ * @returns {string|null} The URL to write with `replaceState`, or null when
+ *                        nothing meaningful changed (fragment-only / identical
+ *                        / unparseable). Never throws.
+ */
+export function computeRecleanTarget(currentHref, cleanUrl) {
+  if (typeof currentHref !== "string" || typeof cleanUrl !== "string") return null;
+
+  let cur;
+  let next;
+  try {
+    cur = new URL(currentHref);
+  } catch {
+    return null;
+  }
+  try {
+    // cleanUrl may be relative (SPA routers push relative URLs); resolve it
+    // against the live URL exactly as the reclean caller does.
+    next = new URL(cleanUrl, currentHref);
+  } catch {
+    return null;
+  }
+
+  // Only the query/path matter. A fragment-only difference must never trigger
+  // a rewrite — that is the whole bug. Comparing origin+pathname+search also
+  // means an already-clean URL (no change) returns null.
+  if (
+    cur.origin === next.origin &&
+    cur.pathname === next.pathname &&
+    cur.search === next.search
+  ) {
+    return null;
+  }
+
+  // A real query/path change. Reconstruct the target from the cleaned
+  // origin/path/query, then graft the LIVE fragment back on verbatim so the
+  // page's in-page hash state is preserved. String-splice both fragments to
+  // survive the empty-"#" normalization the URL API would otherwise apply.
+  const liveHashAt = currentHref.indexOf("#");
+  const liveFragment = liveHashAt >= 0 ? currentHref.slice(liveHashAt) : "";
+
+  const nextStr = next.href;
+  const nextHashAt = nextStr.indexOf("#");
+  const nextWithoutFragment = nextHashAt >= 0 ? nextStr.slice(0, nextHashAt) : nextStr;
+
+  return nextWithoutFragment + liveFragment;
+}

--- a/src/lib/same-document-nav.js
+++ b/src/lib/same-document-nav.js
@@ -1,0 +1,52 @@
+/**
+ * MUGA: same-document (in-page fragment) navigation detector.
+ *
+ * The affiliate click interceptor in content/cleaner.js calls
+ * `e.preventDefault()` + `navigate()` on clicks bound for affiliate store
+ * domains (Amazon, etc.) so it can clean/inject before navigating. But a click
+ * on an IN-PAGE control — a carousel arrow `<a href="#">`, a tab, an accordion,
+ * a "back to top" anchor, a hash router — is NOT a navigation to intercept: the
+ * page handles it itself. Hijacking it makes the page reload/navigate instead
+ * of advancing the control (repro: amazon.es feed carousel arrows).
+ *
+ * The interceptor's original `href.startsWith("#")` guard reads `anchor.href` —
+ * the IDL PROPERTY — which RESOLVES a bare "#" or "#section" to the current
+ * document's ABSOLUTE URL, so it never begins with "#" and the guard misses
+ * every same-document anchor. This predicate closes that gap by comparing the
+ * resolved destination to the current document.
+ *
+ * Same document == identical origin + pathname + search; only the fragment
+ * differs (or nothing differs). content/cleaner.js mirrors this check inline
+ * (content scripts can't ES-import cross-browser — same pattern as
+ * reclean-target / dom-link-rewriter); this pure copy is the unit-tested one.
+ *
+ * @param {string} currentHref The live `location.href`.
+ * @param {string} targetHref  The click destination (`anchor.href`; may be a
+ *                             resolved absolute URL or a relative href).
+ * @returns {boolean} true when the target is same-document (fragment-only)
+ *                    navigation that must NOT be intercepted. Never throws;
+ *                    returns false on unparseable input (fail toward the
+ *                    existing interception behaviour).
+ */
+export function isSameDocumentNavigation(currentHref, targetHref) {
+  if (typeof currentHref !== "string" || typeof targetHref !== "string") return false;
+
+  let cur;
+  let next;
+  try {
+    cur = new URL(currentHref);
+  } catch {
+    return false;
+  }
+  try {
+    next = new URL(targetHref, currentHref);
+  } catch {
+    return false;
+  }
+
+  return (
+    cur.origin === next.origin &&
+    cur.pathname === next.pathname &&
+    cur.search === next.search
+  );
+}

--- a/tests/e2e/affiliate-inpage-nav.spec.mjs
+++ b/tests/e2e/affiliate-inpage-nav.spec.mjs
@@ -1,0 +1,111 @@
+/**
+ * E2E: MUGA must not hijack in-page fragment navigation on affiliate domains.
+ *
+ * Regression guard for the amazon.es feed-carousel bug. MUGA's affiliate click
+ * interceptor (content/cleaner.js) preventDefault+navigate()s clicks bound for
+ * affiliate store domains so it can clean/inject. But an in-page control — a
+ * carousel arrow `<a href="#">`, a tab, a hash router — is same-document
+ * navigation the page handles itself; hijacking it reloads the page instead of
+ * advancing the control. The interceptor's old `anchor.href.startsWith("#")`
+ * guard never matched because `anchor.href` (the IDL property) resolves "#" to
+ * an absolute URL. The fix skips same-document navigation (same
+ * origin+path+query, only the fragment differs).
+ *
+ * These run on a STUBBED www.amazon.com so the interceptor's affiliate-domain
+ * branch is exercised in a real Chrome, exactly as it is on the live site — and
+ * the same guard protects every other site with hash-based in-page navigation.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { seedStorage, waitForDnrPropagation } from "./helpers/index.mjs";
+
+async function activateOnAffiliateDomain(context, extensionId) {
+  // Onboarded + enabled so the click interceptor is armed. Injection OFF to
+  // isolate the click behaviour from load-time tag replaceState noise — the
+  // interceptor still fires on affiliate domains regardless of injection.
+  await seedStorage(context, extensionId, {
+    sync: {
+      injectOwnAffiliate: false,
+      notifyForeignAffiliate: false,
+      stripAllAffiliates: false,
+      language: "en",
+    },
+    local: {
+      mugaConsent: {
+        onboardingDone: true,
+        consentVersion: "1.1",
+        consentDate: Date.now(),
+      },
+    },
+  });
+  await waitForDnrPropagation(context, extensionId);
+}
+
+// A minimal hash-router "carousel": clicking the arrow changes the fragment and
+// a hashchange handler advances the slide — the exact pattern MUGA was breaking.
+async function stubCarousel(page) {
+  await page.route("**://www.amazon.com/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="current">start</div>
+        <a id="next" class="feed-carousel-control" href="#slide2">next</a>
+        <a id="prod" href="https://www.amazon.com/dp/B0044R881I?utm_source=x">product</a>
+        <script>
+          window.addEventListener("hashchange", function () {
+            document.getElementById("current").textContent = location.hash || "start";
+          });
+        </script>
+      </body></html>`,
+    }),
+  );
+}
+
+test.describe("Affiliate-domain in-page fragment navigation (carousel regression)", () => {
+  test("a carousel arrow <a href='#slide2'> performs the fragment nav — MUGA does not hijack it", async ({ context, extensionId }) => {
+    await activateOnAffiliateDomain(context, extensionId);
+    const page = await context.newPage();
+    await stubCarousel(page);
+
+    await page.goto("https://www.amazon.com/");
+    // Sanity: on an affiliate domain, cleanly loaded, no fragment yet.
+    expect(await page.evaluate(() => location.hash)).toBe("");
+
+    await page.click("#next");
+
+    // The fragment navigation must have happened. This is the deterministic
+    // proof the click was NOT hijacked: if MUGA had preventDefault()'d the
+    // affiliate-domain click, the browser would never set the fragment, so
+    // location.hash would stay "". The page's own hashchange handler then runs
+    // (a reload would reset #current AND drop us off "/"), which we assert to
+    // confirm we stayed on the same document.
+    await expect
+      .poll(() => page.evaluate(() => location.hash), { timeout: 3000 })
+      .toBe("#slide2");
+    // Same document — no reload/navigate away.
+    expect(await page.evaluate(() => location.pathname)).toBe("/");
+    // The page's hashchange handler ran (poll to absorb the async handler tick;
+    // if MUGA had reloaded the page this would reset to "start" and never reach
+    // "#slide2").
+    await expect
+      .poll(() => page.evaluate(() => document.getElementById("current").textContent), { timeout: 3000 })
+      .toBe("#slide2");
+  });
+
+  test("a real cross-path affiliate link IS still intercepted and cleaned (guard not over-broadened)", async ({ context, extensionId }) => {
+    await activateOnAffiliateDomain(context, extensionId);
+    const page = await context.newPage();
+    await stubCarousel(page);
+
+    await page.goto("https://www.amazon.com/");
+    await page.click("#prod");
+
+    // A genuine navigation to a DIFFERENT path must still be intercepted and
+    // cleaned: the tracking param is gone after MUGA rewrites the destination.
+    await expect
+      .poll(() => page.evaluate(() => location.pathname), { timeout: 5000 })
+      .toBe("/dp/B0044R881I");
+    expect(await page.evaluate(() => new URL(location.href).searchParams.get("utm_source"))).toBeNull();
+  });
+});

--- a/tests/e2e/history-defuser-reclean.spec.mjs
+++ b/tests/e2e/history-defuser-reclean.spec.mjs
@@ -78,6 +78,7 @@ async function stubAmazonHost(page) {
       contentType: "text/html",
       body: `<!doctype html><html><body>
         <button id="muga-push-btn">on-site banner link</button>
+        <button id="muga-push-btn-2">on-site banner link 2</button>
         <script>
           // Count replaceState calls at the page-world level (same world as
           // history-defuser-mainworld.js, since it runs with world: MAIN).
@@ -97,6 +98,15 @@ async function stubAmazonHost(page) {
           document.getElementById("muga-push-btn").addEventListener("click", () => {
             history.pushState({ tag: "muga-test" }, "Product",
               "/Some-Product-Name/dp/B0044R881I/ref=sr_1_1?aref=abc123&th=1");
+          });
+
+          // A SECOND dirty variant of the SAME product: different /ref= marker
+          // and different aref value, so it cleans to the SAME target as the
+          // first button. Used to prove the reclean does not skip a genuine
+          // clean just because its target matches the previously-written one.
+          document.getElementById("muga-push-btn-2").addEventListener("click", () => {
+            history.pushState({ tag: "muga-test" }, "Product",
+              "/Some-Product-Name/dp/B0044R881I/ref=sr_2_9?aref=zzz999&th=1");
           });
         </script>
       </body></html>`,
@@ -195,6 +205,45 @@ test.describe("SPA reclean on pushState (#951 Layer B)", () => {
     // URL stayed stable after settling (no oscillation).
     const settledUrl = await page.evaluate(() => window.location.href);
     expect(settledUrl).toBe(finalUrl);
+
+    await page.close();
+  });
+
+  test("two different dirty URLs that clean to the SAME target are BOTH cleaned (no output-history skip)", async ({ context }) => {
+    // Regression guard: the reclean rewrite must NOT be gated on
+    // `target === _lastRecleanUrl`. Two distinct dirty navigations can clean to
+    // the same target (here: same product, different /ref= + aref values). If
+    // the guard compared the computed target against the LAST WRITTEN target it
+    // would skip the second clean and leak the second URL's tracking. The loop
+    // guard lives on the INPUT (url === _lastRecleanUrl), not the output.
+    const page = await context.newPage();
+    await stubAmazonHost(page);
+    await page.goto(`https://${HOST}/index.html`);
+    await page.waitForFunction(() => window.__mugaHistoryDefused === true, { timeout: 10000 });
+
+    // First dirty nav -> cleans to target T, records _lastRecleanUrl = T.
+    await page.locator("#muga-push-btn").click();
+    await page.waitForFunction(
+      () => !window.location.pathname.includes("/ref=") && !window.location.search.includes("aref"),
+      { timeout: 10000 }
+    );
+
+    // Second dirty nav -> DIFFERENT dirty URL, SAME clean target T. Must still
+    // be cleaned. With the buggy output-history guard this would leave
+    // /ref=sr_2_9 and aref=zzz999 in the address bar (target === _lastRecleanUrl
+    // bails), so the wait below would time out.
+    await page.locator("#muga-push-btn-2").click();
+    await page.waitForFunction(
+      () => !window.location.pathname.includes("/ref=") && !window.location.search.includes("aref"),
+      { timeout: 10000 }
+    );
+
+    const finalPath = await page.evaluate(() => window.location.pathname);
+    const finalSearch = await page.evaluate(() => window.location.search);
+    expect(finalPath).not.toContain("/ref=");
+    expect(finalPath).toContain("/dp/B0044R881I");
+    expect(finalSearch).not.toContain("aref");
+    expect(finalSearch).toContain("th=1");
 
     await page.close();
   });

--- a/tests/unit/content-script.test.mjs
+++ b/tests/unit/content-script.test.mjs
@@ -371,6 +371,35 @@ describe("Content script — affiliate-only click interception", () => {
       "click handler must return early for non-affiliate domains"
     );
   });
+
+  test("click handler returns early for same-document (in-page fragment) navigation BEFORE preventDefault", () => {
+    // Regression guard for the carousel bug: `<a href="#">` arrows, tabs and
+    // hash routers on affiliate domains (amazon.es) were hijacked because the
+    // `anchor.href` startsWith("#") guard reads the RESOLVED absolute URL and
+    // never matches. The interceptor MUST detect same-document navigation
+    // (same origin+path+query, only fragment differs) and return BEFORE
+    // e.preventDefault(), or it reloads the page instead of letting the
+    // in-page control run. See src/lib/same-document-nav.js.
+    const clickHandler = contentSource.match(
+      /document\.addEventListener\("click"[\s\S]*?\}, true\)/
+    )[0];
+
+    // Must compare origin + pathname + search against the live location.
+    assert.ok(/url\.origin === location\.origin/.test(clickHandler),
+      "click handler must compare url.origin === location.origin");
+    assert.ok(/url\.pathname === location\.pathname/.test(clickHandler),
+      "click handler must compare url.pathname === location.pathname");
+    assert.ok(/url\.search === location\.search/.test(clickHandler),
+      "click handler must compare url.search === location.search");
+
+    // The same-document early return MUST run before preventDefault, or the
+    // in-page click is already hijacked by the time we notice.
+    const sameDocIdx = clickHandler.indexOf("url.pathname === location.pathname");
+    const preventIdx = clickHandler.indexOf("e.preventDefault()");
+    assert.ok(sameDocIdx !== -1 && preventIdx !== -1, "both markers must exist");
+    assert.ok(sameDocIdx < preventIdx,
+      "the same-document guard must return BEFORE e.preventDefault()");
+  });
 });
 
 // ── getAffiliateDomains helper ──────────────────────────────────────────────

--- a/tests/unit/history-defuser.test.mjs
+++ b/tests/unit/history-defuser.test.mjs
@@ -498,11 +498,28 @@ describe("content/cleaner.js — window.__mugaReclean wiring (#951 Layer B)", ()
     assert.ok(guardIdx !== -1, "must compare url === _lastRecleanUrl");
     assert.ok(guardIdx < processIdx,
       "the loop-guard check must run before processUrl() is invoked");
-    // _lastRecleanUrl must be updated with the cleaned result so a
-    // subsequent re-entrant call (triggered by our own replaceState) is
-    // recognized and short-circuited.
-    assert.ok(/_lastRecleanUrl\s*=\s*result\.cleanUrl/.test(body),
-      "_lastRecleanUrl must be set to the cleaned URL after a successful clean");
+    // _lastRecleanUrl must be updated with the URL we actually WROTE (the
+    // fragment-safe target), so a re-entrant call triggered by our own
+    // replaceState is recognized and short-circuited.
+    assert.ok(/_lastRecleanUrl\s*=\s*target/.test(body),
+      "_lastRecleanUrl must be set to the written target after a successful clean");
+  });
+
+  test("__mugaReclean is fragment-safe: rewrites via computeRecleanTarget, not a raw cleanUrl string compare", () => {
+    const body = recleanBody();
+    // The rewrite decision MUST go through the fragment-safe guard so a
+    // hashchange (carousel arrow, hash router, in-page tab) never triggers a
+    // replaceState that stomps the page's fragment (repro: amazon.es carousel).
+    assert.ok(/computeRecleanTarget\(\s*window\.location\.href\s*,\s*result\.cleanUrl\s*\)/.test(body),
+      "__mugaReclean must compute the rewrite target via computeRecleanTarget(window.location.href, result.cleanUrl)");
+    // The address bar must be written with the fragment-preserving target,
+    // NOT the raw result.cleanUrl (which can drop/normalize the fragment).
+    assert.ok(/replaceState\(\s*history\.state\s*,\s*""\s*,\s*target\s*\)/.test(body),
+      "replaceState must write the fragment-safe target, not result.cleanUrl");
+    // Guard against a regression back to the raw string compare that caused
+    // the bug: `result.cleanUrl === window.location.href`.
+    assert.equal(/result\.cleanUrl\s*===\s*window\.location\.href/.test(body), false,
+      "must not gate the rewrite on a raw result.cleanUrl === location.href compare (fragment-blind)");
   });
 
   test("__mugaReclean bails when prefs are missing/disabled/not onboarded", () => {

--- a/tests/unit/reclean-target.test.mjs
+++ b/tests/unit/reclean-target.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * MUGA: reclean-target guard — fragment-safe address-bar rewrite decision.
+ *
+ * `__mugaReclean` (content/cleaner.js) rewrites the address bar via
+ * history.replaceState whenever the local cleaner produces a cleanUrl that
+ * differs from the live URL. The OLD guard was a raw string compare, so ANY
+ * cosmetic difference — most importantly a normalized URL fragment — fired a
+ * rewrite. On a `hashchange` (carousel arrows, hash routers, in-page tabs)
+ * that rewrite stomped the fragment the page had just set, silently breaking
+ * in-page navigation across the whole web (repro: amazon.es feed carousel).
+ *
+ * The invariant this module enforces:
+ *   1. Rewrite ONLY when origin+path+query actually changed (real tracking
+ *      removed, or our affiliate tag injected). A fragment-only difference —
+ *      or no difference — returns null (do not touch the URL).
+ *   2. On a legitimate rewrite, PRESERVE the exact live fragment, including a
+ *      bare "#". The URL `hash` setter normalizes an empty fragment away, so
+ *      the fragment is spliced by string, not via the URL API.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeRecleanTarget } from "../../src/lib/reclean-target.js";
+
+test("fragment-only change (hash router / carousel) => null, never rewrites", () => {
+  // Same query, page only advanced the fragment. Must NOT rewrite.
+  const cur = "https://www.amazon.es/?tag=muga0b-21#feed";
+  const clean = "https://www.amazon.es/?tag=muga0b-21";
+  assert.equal(computeRecleanTarget(cur, clean), null);
+});
+
+test("bare trailing '#' (the amazon.es carousel case) => null", () => {
+  // The exact reported URL: a bare '#' the arrow appended. cleanUrl drops it
+  // via URL normalization, but query is identical => no rewrite, '#' survives.
+  const cur = "https://www.amazon.es/?tag=muga0b-21#";
+  const clean = "https://www.amazon.es/?tag=muga0b-21";
+  assert.equal(computeRecleanTarget(cur, clean), null);
+});
+
+test("identical URLs => null", () => {
+  const u = "https://example.com/p?a=1";
+  assert.equal(computeRecleanTarget(u, u), null);
+});
+
+test("query changed (tracking removed) => rewrites, preserving the live fragment", () => {
+  const cur = "https://example.com/p?utm_source=x&a=1#section";
+  const clean = "https://example.com/p?a=1#section";
+  assert.equal(computeRecleanTarget(cur, clean), "https://example.com/p?a=1#section");
+});
+
+test("query changed but cleanUrl lost the fragment => live fragment is re-attached", () => {
+  // cleanUrl came back WITHOUT the fragment (common: processUrl re-serializes);
+  // we must graft the live fragment back on so the page's hash state survives.
+  const cur = "https://example.com/p?utm_source=x#section";
+  const clean = "https://example.com/p"; // no query, no fragment
+  assert.equal(computeRecleanTarget(cur, clean), "https://example.com/p#section");
+});
+
+test("tag injection on a fragmentless page => rewrites with no spurious '#'", () => {
+  const cur = "https://www.amazon.es/";
+  const clean = "https://www.amazon.es/?tag=muga0b-21";
+  assert.equal(computeRecleanTarget(cur, clean), "https://www.amazon.es/?tag=muga0b-21");
+});
+
+test("query changed AND live URL has a bare '#' => rewrite keeps the bare '#'", () => {
+  const cur = "https://example.com/p?utm_source=x#";
+  const clean = "https://example.com/p";
+  assert.equal(computeRecleanTarget(cur, clean), "https://example.com/p#");
+});
+
+test("path changed (path-strip rule) with a fragment => rewrites, fragment preserved", () => {
+  const cur = "https://www.amazon.es/dp/B00/ref=sr_1_1#reviews";
+  const clean = "https://www.amazon.es/dp/B00#reviews";
+  assert.equal(computeRecleanTarget(cur, clean), "https://www.amazon.es/dp/B00#reviews");
+});
+
+test("unparseable current href => null (never throws)", () => {
+  assert.equal(computeRecleanTarget("::::not a url::::", "https://example.com/"), null);
+});
+
+test("a relative cleanUrl is resolved against the live URL (SPA routers push relative)", () => {
+  // cleanUrl may be relative; it resolves against currentHref just like the
+  // reclean caller does. Query differs => rewrite, fragment ("" here) preserved.
+  const cur = "https://example.com/old?utm_source=x";
+  const clean = "/new?a=1";
+  assert.equal(computeRecleanTarget(cur, clean), "https://example.com/new?a=1");
+});
+
+test("an absolute but invalid cleanUrl => null (never throws)", () => {
+  // Space in the authority makes this an invalid ABSOLUTE URL, so it hits the
+  // catch branch instead of being treated as relative.
+  assert.equal(computeRecleanTarget("https://example.com/", "https://exa mple.com/"), null);
+});
+
+test("non-string inputs are guarded", () => {
+  assert.equal(computeRecleanTarget(null, "https://example.com/"), null);
+  assert.equal(computeRecleanTarget("https://example.com/", undefined), null);
+});

--- a/tests/unit/same-document-nav.test.mjs
+++ b/tests/unit/same-document-nav.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * MUGA: same-document navigation guard for the affiliate click interceptor.
+ *
+ * The interceptor preventDefault+navigate()s clicks on affiliate domains. An
+ * in-page fragment click (`<a href="#">` carousel arrow, tab, hash router) must
+ * be recognised as same-document so it is NOT hijacked — otherwise the page
+ * reloads instead of the control advancing (repro: amazon.es feed carousel).
+ * The old `anchor.href.startsWith("#")` guard failed because `anchor.href`
+ * resolves "#" to an absolute URL; this predicate compares origin+path+query.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isSameDocumentNavigation } from "../../src/lib/same-document-nav.js";
+
+test("bare '#' arrow (resolved to absolute) is same-document", () => {
+  // This is the exact carousel case: anchor.href resolves href="#" to the
+  // full page URL WITH a trailing '#'. Must be recognised as in-page nav.
+  const cur = "https://www.amazon.es/?tag=muga0b-21";
+  const target = "https://www.amazon.es/?tag=muga0b-21#";
+  assert.equal(isSameDocumentNavigation(cur, target), true);
+});
+
+test("'#section' anchor is same-document", () => {
+  const cur = "https://www.amazon.es/?tag=muga0b-21";
+  const target = "https://www.amazon.es/?tag=muga0b-21#section";
+  assert.equal(isSameDocumentNavigation(cur, target), true);
+});
+
+test("a relative bare '#' href resolves to same-document", () => {
+  assert.equal(isSameDocumentNavigation("https://www.amazon.es/?tag=x", "#"), true);
+});
+
+test("identical URL (no fragment either) is same-document", () => {
+  const u = "https://www.amazon.es/dp/B00";
+  assert.equal(isSameDocumentNavigation(u, u), true);
+});
+
+test("different PATH is NOT same-document (real product link => intercept)", () => {
+  const cur = "https://www.amazon.es/";
+  const target = "https://www.amazon.es/dp/B00?tag=foreign-21";
+  assert.equal(isSameDocumentNavigation(cur, target), false);
+});
+
+test("different QUERY on same path is NOT same-document (real navigation)", () => {
+  const cur = "https://www.amazon.es/s?k=a";
+  const target = "https://www.amazon.es/s?k=b";
+  assert.equal(isSameDocumentNavigation(cur, target), false);
+});
+
+test("different ORIGIN is NOT same-document", () => {
+  const cur = "https://www.amazon.es/";
+  const target = "https://www.amazon.de/#x";
+  assert.equal(isSameDocumentNavigation(cur, target), false);
+});
+
+test("unparseable current href => false (fail toward interception)", () => {
+  assert.equal(isSameDocumentNavigation("::::bad", "https://www.amazon.es/#x"), false);
+});
+
+test("unparseable absolute target => false", () => {
+  assert.equal(isSameDocumentNavigation("https://www.amazon.es/", "https://exa mple.com/#x"), false);
+});
+
+test("non-string inputs are guarded", () => {
+  assert.equal(isSameDocumentNavigation(null, "https://www.amazon.es/"), false);
+  assert.equal(isSameDocumentNavigation("https://www.amazon.es/", undefined), false);
+});

--- a/tests/unit/source-grep-ratchet.test.mjs
+++ b/tests/unit/source-grep-ratchet.test.mjs
@@ -126,7 +126,7 @@ const BASELINE = {
   "shortener-stats-sw.test.mjs": 40,        // SW + storage; behavioral migration deferred (#824). +1 for #922 egress-gate guard (SW not importable)
   "misc-regression.test.mjs": 29,           // mixed bag; partial migration possible (#824)
   "content-cleaner-patterns.test.mjs": 34,  // content script not importable (#824). +7 for #allowlist-full-inert: ping-blocking, runRedirectUnwrap, and click-interception isSiteFullyExempt guards
-  "content-script.test.mjs": 19,            // content script not importable (#824)
+  "content-script.test.mjs": 20,            // content script not importable (#824); +1: same-document click-guard mirror (carousel regression)
   "dnr-ids.test.mjs": 8,                    // verifies SW + remote-rules import the ids module (#824)
   "dnr-consent-gate.test.mjs": 8,           // SW not importable; mixed with behavioral tests (#824). +1 for #921 rule-1001 gate guard
   "allowlist-dnr.test.mjs": 7,               // SW not importable; syncAllowlistDNR/applyDnrState wiring guards, mostly behavioral (fake-DNR-facade tests) with a handful of source-region extractions mirroring dnr-consent-gate.test.mjs's pattern (#allowlist-full-inert, #824). +2 for the resourceTypes/main_frame fix (post fresh-context review Finding 1)


### PR DESCRIPTION
## The bug

On `amazon.es` (and any affiliate store domain), MUGA broke **all hash-based in-page navigation** — feed-carousel arrows, tabs, anchors, hash routers. Clicking a carousel arrow reloaded/navigated the page instead of rotating. User-reported and reproduced reliably in a real Chrome with a live Amazon session.

## Root cause

The affiliate click interceptor in `content/cleaner.js` `preventDefault()` + `navigate()`s clicks on affiliate domains to clean/inject. Its skip-guard was:

```js
const href = anchor.href;                       // ← IDL PROPERTY, not attribute
if (href.startsWith("#")) return;               // never true for <a href="#">
```

`anchor.href` (the property) **resolves** a bare `href="#"` / `href="#section"` to the page's **absolute** URL, so `startsWith("#")` is always false. Amazon is an affiliate domain → the arrow click was intercepted, `preventDefault`'d, and the page navigated.

## Fix

Skip interception for **same-document navigation** — same `origin+pathname+search`, only the fragment differs. Pure helper `src/lib/same-document-nav.js` (unit-tested), mirrored inline in the content script (content scripts can't ES-import cross-browser).

Plus a **defensive** hardening (separate from this repro): `__mugaReclean` now rewrites via a fragment-safe `computeRecleanTarget` (`src/lib/reclean-target.js`) that never `replaceState`s on a fragment-only diff and preserves the live `#` — so `hashchange`/`popstate` can't stomp in-page hash state either.

## Tests (3 layers)

- **Unit**: `same-document-nav` (10) + `reclean-target` (12) — logic incl. bare `#`, resolved-to-absolute, different path/query/origin, empty-fragment edge.
- **Structural**: guard stays before `preventDefault` in the interceptor (catches mirror drift; content IIFE isn't Node-importable, hence the +1 to the #824 source-grep baseline).
- **E2E** (`affiliate-inpage-nav.spec.mjs`): reproduces the carousel on a stubbed `www.amazon.com`, asserts the fragment nav is **not** hijacked, and confirms a real cross-path affiliate link **is** still cleaned (guard not over-broadened).

**Green**: unit 6394/6395 (1 pre-existing skip), new e2e 2/2 (x2, not flaky), 15/15 related e2e (history-defuser, inject-affiliate, dom-link-rewriter-click, amazon-path-canonical, local-cleaning).

## Validation

Controlled A/B in real Chrome + live Amazon session: **prod build → carousel broken; this build → carousel works.** Same environment, only variable changed = this fix.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ