### PR TITLE
feat(popup): unwrap indicator — show the real destination behind a redirect (#1062)

### DIFF
--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -224,6 +224,7 @@ export default Object.freeze({
   preview_count_other: "MUGA hat {n} Rauschen-Bits aus dieser URL entfernt",
   preview_count_clean: "Diese Seite ist sauber. MUGA bereinigt Links automatisch beim Surfen.",
   preview_shorter: "Dieser Link ist {n}% kürzer",
+  preview_unwrapped: "Echtes Ziel angezeigt: {host}",
   preview_preserved_creator: "Empfehlung des Creators erhalten",
   preview_preserved_creator_hint: "MUGA versucht, kein Affiliate-Tag anzufassen, das nicht uns gehört, damit die Person, die dir das empfohlen hat, die Anrechnung behält. Sollten wir uns einmal irren, melde es über den Link unten.",
   rate_muga_short: "MUGA bewerten",

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -224,6 +224,7 @@ export default Object.freeze({
   preview_count_other: "MUGA removed {n} bits of noise from this URL",
   preview_count_clean: "This page is clean. MUGA cleans links automatically as you browse.",
   preview_shorter: "This link is {n}% shorter",
+  preview_unwrapped: "Real destination revealed: {host}",
   preview_preserved_creator: "Creator referral preserved",
   preview_preserved_creator_hint: "MUGA tries not to touch any affiliate tag that isn't ours, so the creator who recommended this keeps the credit. If we ever get one wrong, report it with the link below.",
   rate_muga_short: "Rate MUGA",

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -224,6 +224,7 @@ export default Object.freeze({
   preview_count_other: "MUGA eliminó {n} bits de ruido de esta URL",
   preview_count_clean: "Esta página está limpia. MUGA limpia los enlaces automáticamente mientras navegas.",
   preview_shorter: "Este enlace es un {n}% más corto",
+  preview_unwrapped: "Destino real revelado: {host}",
   preview_preserved_creator: "Referido del creador preservado",
   preview_preserved_creator_hint: "MUGA procura no tocar ningún tag de afiliado que no sea el nuestro, para que quien te lo recomendó conserve su crédito. Si alguna vez nos equivocamos, puedes reportarlo con el enlace de abajo.",
   rate_muga_short: "Valorar MUGA",

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -224,6 +224,7 @@ export default Object.freeze({
   preview_count_other: "MUGA a supprimé {n} bits de bruit de cette URL",
   preview_count_clean: "Cette page est propre. MUGA nettoie les liens automatiquement pendant votre navigation.",
   preview_shorter: "Ce lien est {n}% plus court",
+  preview_unwrapped: "Destination réelle révélée : {host}",
   preview_preserved_creator: "Affiliation du créateur préservée",
   preview_preserved_creator_hint: "MUGA s'efforce de ne toucher aucun tag d'affiliation qui n'est pas le nôtre, afin que le créateur qui a recommandé ceci conserve son crédit. S'il nous arrive de nous tromper, signalez-le avec le lien ci-dessous.",
   rate_muga_short: "Évaluer MUGA",

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -224,6 +224,7 @@ export default Object.freeze({
   preview_count_other: "MUGA ha rimosso {n} bit di rumore da questo URL",
   preview_count_clean: "Questa pagina è pulita. MUGA pulisce i link automaticamente mentre navighi.",
   preview_shorter: "Questo link è più corto del {n}%",
+  preview_unwrapped: "Destinazione reale rivelata: {host}",
   preview_preserved_creator: "Affiliazione del creatore preservata",
   preview_preserved_creator_hint: "MUGA cerca di non toccare alcun tag di affiliazione che non sia il nostro, così il creator che ti ha consigliato questo mantiene il credito. Se dovessimo mai sbagliare, segnalalo con il link qui sotto.",
   rate_muga_short: "Valuta MUGA",

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -224,6 +224,7 @@ export default Object.freeze({
   preview_count_other: "MUGAはこのURLから{n}個のノイズを除去しました",
   preview_count_clean: "このページはクリーンです。MUGA は閲覧中に自動でリンクを整理します。",
   preview_shorter: "このリンクは{n}%短くなりました",
+  preview_unwrapped: "本当のリンク先: {host}",
   preview_preserved_creator: "クリエイターのリファラルを保持",
   preview_preserved_creator_hint: "MUGAは当方のものではないアフィリエイトタグにはできる限り触れないようにしています。そのため、これを推薦してくれたクリエイターはクレジットを保持できます。万が一間違えた場合は、下のリンクから報告してください。",
   rate_muga_short: "MUGAを評価",

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -224,6 +224,7 @@ export default Object.freeze({
   preview_count_other: "MUGA removeu {n} bits de ruído desta URL",
   preview_count_clean: "Esta página está limpa. O MUGA limpa os links automaticamente enquanto navegas.",
   preview_shorter: "Este link é {n}% mais curto",
+  preview_unwrapped: "Destino real revelado: {host}",
   preview_preserved_creator: "Indicação do criador preservada",
   preview_preserved_creator_hint: "O MUGA procura não tocar em nenhuma tag de afiliado que não seja nossa, para que quem recomendou isto continue com o crédito. Se algum dia errarmos, você pode reportar com o link abaixo.",
   rate_muga_short: "Avaliar MUGA",

--- a/src/lib/unwrap-view.js
+++ b/src/lib/unwrap-view.js
@@ -1,0 +1,43 @@
+/**
+ * MUGA: unwrap indicator for the popup preview (#1062 part 3).
+ *
+ * The popup already shows the "% shorter" line and the removed-parameter
+ * breakdown, but not the third receipt the issue asks for: whether MUGA
+ * UNWRAPPED a redirect. When the cleaner reveals the real destination behind a
+ * redirect wrapper (or resolves a shortener), the HOST changes — plain
+ * tracking-param cleaning never touches the host. So a host change IS the
+ * unwrap signal.
+ *
+ * This mirrors the shipped web tool exactly (web/engine/adapter.js:
+ * `unwrapped = destinationHost !== inputUrl.hostname`) so the extension and the
+ * muga.app/clean tool tell the user the same honest thing.
+ *
+ * Pure, DOM-free — content/popup can't ES-import cross-browser in the content
+ * layer, but the popup IS an extension page and imports this directly.
+ *
+ * @param {string} originalUrl The URL as the user sees it (pre-clean).
+ * @param {string} cleanUrl    The cleaned/unwrapped URL.
+ * @returns {{ unwrapped: boolean, destinationHost: string|null }}
+ *   unwrapped=true with the revealed host when the destination host differs
+ *   from the original; otherwise a no-op. Never throws.
+ */
+export function computeUnwrapView(originalUrl, cleanUrl) {
+  const none = { unwrapped: false, destinationHost: null };
+  if (typeof originalUrl !== "string" || typeof cleanUrl !== "string") return none;
+
+  let originalHost;
+  let destinationHost;
+  try {
+    originalHost = new URL(originalUrl).hostname;
+  } catch {
+    return none;
+  }
+  try {
+    destinationHost = new URL(cleanUrl).hostname;
+  } catch {
+    return none;
+  }
+
+  if (!destinationHost || destinationHost === originalHost) return none;
+  return { unwrapped: true, destinationHost };
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -100,6 +100,7 @@
         <div class="preview-length-removed" id="preview-length-removed"></div>
       </div>
     </div>
+    <p class="preview-unwrap" id="preview-unwrap" hidden aria-live="polite"></p>
     <div class="preview-removed" id="preview-removed" hidden aria-live="polite"></div>
     <div class="preview-preserved" id="preview-preserved" hidden aria-live="polite">
       <div class="preview-preserved-row">

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -20,6 +20,7 @@ import { presentLedger, DEFAULT_LEDGER_CAPACITY } from "../lib/attribution-ledge
 import { renderEntries as renderLedgerEntries } from "../lib/attribution-ledger-view.js";
 import { buildParamBreakdownView } from "../lib/param-breakdown-view.js";
 import { computeLengthReduction, computeLengthBar } from "../lib/length-reduction.js";
+import { computeUnwrapView } from "../lib/unwrap-view.js";
 
 /** Creates a clipboard SVG icon (12x12) via createElementNS. */
 function _createClipboardSvg() {
@@ -597,6 +598,13 @@ function _resetPreviewDom() {
   }
   const previewLengthBar = el("preview-length-bar");
   if (previewLengthBar) previewLengthBar.hidden = true;
+  // #1062 part 3: unwrap indicator, reset every render like the slots above so
+  // a prior navigation's revealed host never bleeds into a param-only clean.
+  const previewUnwrap = el("preview-unwrap");
+  if (previewUnwrap) {
+    previewUnwrap.hidden = true;
+    previewUnwrap.textContent = "";
+  }
   const previewLengthKept = el("preview-length-kept");
   if (previewLengthKept) previewLengthKept.style.width = "";
   const previewLengthRemoved = el("preview-length-removed");
@@ -767,6 +775,17 @@ async function showUrlPreview(prefs, lang) {
       lengthRemovedEl.style.width = `${bar.removedPercent}%`;
       lengthBarEl.hidden = false;
     }
+  }
+
+  // #1062 part 3: unwrap indicator. A host change means MUGA revealed the real
+  // destination behind a redirect wrapper / shortener (param cleaning never
+  // touches the host) — surface WHERE the link really goes. Mirrors the web
+  // tool's unwrap callout (src/lib/unwrap-view.js).
+  const unwrapView = computeUnwrapView(url, result.cleanUrl);
+  const unwrapEl = document.getElementById("preview-unwrap");
+  if (unwrapEl && unwrapView.unwrapped) {
+    unwrapEl.textContent = t("preview_unwrapped", lang).replace("{host}", unwrapView.destinationHost);
+    unwrapEl.hidden = false;
   }
 
   if (result.cleanUrl === url && result.action === "untouched") {

--- a/tests/unit/popup-length-bar-guard.test.mjs
+++ b/tests/unit/popup-length-bar-guard.test.mjs
@@ -17,7 +17,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const popupJs = readFileSync(join(ROOT, "src/popup/popup.js"), "utf8");
 const popupHtml = readFileSync(join(ROOT, "src/popup/popup.html"), "utf8");
 
-const SLOT_IDS = ["preview-shorter", "preview-length-bar", "preview-length-kept", "preview-length-removed"];
+const SLOT_IDS = ["preview-shorter", "preview-length-bar", "preview-length-kept", "preview-length-removed", "preview-unwrap"];
 
 test("popup.js imports the pure length-reduction module", () => {
   assert.match(popupJs, /from "\.\.\/lib\/length-reduction\.js"/);

--- a/tests/unit/unwrap-view.test.mjs
+++ b/tests/unit/unwrap-view.test.mjs
@@ -1,0 +1,57 @@
+/**
+ * MUGA: popup unwrap-indicator view (#1062 part 3).
+ *
+ * A host change between the original and cleaned URL means MUGA revealed the
+ * real destination behind a redirect wrapper / shortener — the only cleaning
+ * action that changes the host. Mirrors web/engine/adapter.js so the extension
+ * and muga.app/clean report the same thing.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeUnwrapView } from "../../src/lib/unwrap-view.js";
+
+test("host change => unwrapped, with the revealed destination host", () => {
+  const v = computeUnwrapView("https://t.co/abc123", "https://example.com/article");
+  assert.equal(v.unwrapped, true);
+  assert.equal(v.destinationHost, "example.com");
+});
+
+test("redirect wrapper carrying the destination in a param => unwrapped to that host", () => {
+  const v = computeUnwrapView("https://l.example.com/redir?url=https://dest.org/x", "https://dest.org/x");
+  assert.equal(v.unwrapped, true);
+  assert.equal(v.destinationHost, "dest.org");
+});
+
+test("same host, only params stripped => NOT unwrapped", () => {
+  const v = computeUnwrapView("https://shop.com/p?utm_source=x", "https://shop.com/p");
+  assert.equal(v.unwrapped, false);
+  assert.equal(v.destinationHost, null);
+});
+
+test("identical URL => not unwrapped", () => {
+  const v = computeUnwrapView("https://a.com/x", "https://a.com/x");
+  assert.equal(v.unwrapped, false);
+});
+
+test("a www difference counts as a host change (mirrors the web tool's raw compare)", () => {
+  // Documented parity with web/engine/adapter.js: it compares raw hostnames, so
+  // www.a.com -> a.com would read as unwrapped. MUGA never rewrites www during
+  // param cleaning, so this does not fire in practice; the test pins the parity.
+  const v = computeUnwrapView("https://www.a.com/x", "https://a.com/x");
+  assert.equal(v.unwrapped, true);
+  assert.equal(v.destinationHost, "a.com");
+});
+
+test("unparseable original => no-op (never throws)", () => {
+  assert.deepEqual(computeUnwrapView("::::bad", "https://a.com/"), { unwrapped: false, destinationHost: null });
+});
+
+test("unparseable clean => no-op", () => {
+  assert.deepEqual(computeUnwrapView("https://a.com/", "::::bad"), { unwrapped: false, destinationHost: null });
+});
+
+test("non-string inputs are guarded", () => {
+  assert.equal(computeUnwrapView(null, "https://a.com/").unwrapped, false);
+  assert.equal(computeUnwrapView("https://a.com/", undefined).unwrapped, false);
+});


### PR DESCRIPTION
Completes the last sub-item of **#1062 part 3**: the popup preview showed the `% shorter` line and the removed-parameter breakdown, but not whether MUGA **unwrapped a redirect**.

## Signal
When the cleaner reveals the real destination behind a redirect wrapper (or a resolved shortener), the **host changes** — plain tracking-param cleaning never touches the host. So a host change IS the unwrap signal.

Mirrors the shipped web tool exactly (`web/engine/adapter.js`: `unwrapped = destinationHost !== inputUrl.hostname`) so the extension and `muga.app/clean` tell the user the same honest thing.

## Change
- `src/lib/unwrap-view.js` — pure `computeUnwrapView(originalUrl, cleanUrl)` → `{ unwrapped, destinationHost }`.
- `#preview-unwrap` slot + render in the popup (reset every render like the other preview slots).
- `preview_unwrapped` in all 7 locales ("Real destination revealed: {host}", peninsular `es`, no em-dashes).

## Tests
- Unit: `unwrap-view` (8) — host change, wrapper-with-dest-param, param-only (not unwrapped), www parity note, unparseable guards.
- Structural: popup slot guard extended to `preview-unwrap`.
- Full unit suite green (6407/6408, 1 pre-existing skip).

Scopes #1062 to done: part 1 (% reduction, #1081) + part 3 (breakdown #986 + this unwrap line) shipped. Part 2 (global vs per-tab stats toggle) split to a separate issue — it needs a new per-tab stats data model, not just a toggle.

https://claude.ai/code/session_013Stjkga21r6aR2GXrMhYpJ