### PR TITLE
harden: reject IPv6 ULA in shortener filter + persist remote-rules rollback floor

### DIFF
--- a/src/lib/native-shortener-resolver.js
+++ b/src/lib/native-shortener-resolver.js
@@ -83,6 +83,10 @@ export function isPrivateHost(hostname) {
   // IPv6 link-local: fe80::/10
   if (/^fe[89ab][0-9a-f]:/i.test(h)) return true;
 
+  // IPv6 Unique Local Address: fc00::/7 (RFC 4193) — the IPv6 analogue of
+  // RFC 1918 private space (first hextet fc00–fdff). Never a valid destination.
+  if (/^f[cd][0-9a-f]{2}:/i.test(h)) return true;
+
   // IPv4-mapped IPv6 (::ffff:a.b.c.d, or the compact hex form ::ffff:7f00:1).
   const mapped = h.match(/^::ffff:(.+)$/i);
   if (mapped) {

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -632,7 +632,7 @@ export async function mergeIntoCache(accepted, meta, { storage, dnr }) {
   // mergeIntoCache calls. Only the single weekly alarm drives fetches and the
   // _remoteFetchInFlight guard drops any overlapping run, so there is never a
   // concurrent merge racing this get/set pair.
-  const prevCache = await storage.get({ remoteParams: [], remoteRulesMeta: null });
+  const prevCache = await storage.get({ remoteParams: [], remoteRulesMeta: null, remoteRulesVersionFloor: 0 });
   const prevParams = Array.isArray(prevCache.remoteParams) ? prevCache.remoteParams : [];
   const diff = diffRemoteParams(prevParams, accepted);
   const remoteRulesChangelog = {
@@ -641,10 +641,16 @@ export async function mergeIntoCache(accepted, meta, { storage, dnr }) {
     prevFetchedAt: prevCache.remoteRulesMeta?.fetchedAt ?? null,
   };
 
+  // Advance the persistent anti-rollback floor. This key deliberately survives
+  // clearRemoteCache so a disable → re-enable cycle cannot reset the version
+  // monotonicity floor. (audit-2026-07)
+  const remoteRulesVersionFloor = Math.max(prevCache.remoteRulesVersionFloor ?? 0, meta?.version ?? 0);
+
   await storage.set({
     remoteParams: accepted,
     remoteRulesMeta: meta,
     remoteRulesChangelog,
+    remoteRulesVersionFloor,
   });
 }
 
@@ -801,12 +807,20 @@ export async function runRemoteRulesFetch(deps = {}) {
     }
 
     // 5. Read stored meta and validate params
-    const stored = await storage.get({ remoteRulesMeta: { ...DEFAULT_META } });
+    const stored = await storage.get({ remoteRulesMeta: { ...DEFAULT_META }, remoteRulesVersionFloor: 0 });
     const storedMeta = stored.remoteRulesMeta ?? { ...DEFAULT_META };
+
+    // Anti-rollback floor: clearRemoteCache (user disable) deletes
+    // remoteRulesMeta, which would drop the version monotonicity floor to 0 and
+    // let a MITM/CDN replay an OLDER but validly-signed payload after a
+    // disable → re-enable cycle. remoteRulesVersionFloor is a persistent
+    // high-water mark that clearRemoteCache MUST NOT remove, so the floor is
+    // the max of the (possibly-cleared) meta version and that mark. (audit-2026-07)
+    const floorVersion = Math.max(storedMeta.version ?? 0, stored.remoteRulesVersionFloor ?? 0);
 
     const validResult = validateParams(
       obj.params,
-      { version: storedMeta.version, published: storedMeta.published },
+      { version: floorVersion, published: storedMeta.published },
       nowMs,
       { newVersion: obj.version, newPublished: obj.published }
     );

--- a/tests/unit/native-shortener-resolver.test.mjs
+++ b/tests/unit/native-shortener-resolver.test.mjs
@@ -107,6 +107,19 @@ describe("allowlist + private-host helpers", () => {
     assert.equal(isPrivateHost("192.88.98.1"), false,  "192.88.98.1 is not 6to4 relay");
     assert.equal(isPrivateHost("192.88.100.1"), false, "192.88.100.1 is not 6to4 relay");
   });
+
+  // ── IPv6 Unique Local Addresses fc00::/7 (RFC 4193) ─────────────────────────
+  // ULA is the IPv6 analogue of RFC 1918 private space and must never be a
+  // valid shortener destination. Covers both fc00::/8 and fd00::/8 halves, in
+  // bare and bracketed forms.
+  test("isPrivateHost blocks IPv6 ULA fc00::/7", () => {
+    for (const h of ["fd00::1", "fc00::1", "[fd00::1]", "[fc00::1]", "fdff:ffff::1", "fc12:3456::abcd"]) {
+      assert.equal(isPrivateHost(h), true, `${h} is IPv6 ULA (private)`);
+    }
+    // A global-unicast IPv6 address must still resolve (not ULA).
+    assert.equal(isPrivateHost("2606:4700::1111"), false, "2606:4700::1111 is global unicast");
+    assert.equal(isPrivateHost("[2606:4700::1111]"), false, "bracketed global unicast");
+  });
 });
 
 // ── happy paths ──────────────────────────────────────────────────────────────

--- a/tests/unit/remote-rules-integration.test.mjs
+++ b/tests/unit/remote-rules-integration.test.mjs
@@ -357,3 +357,51 @@ describe("SC-11 — Dedup guard: concurrent alarm fires drop the second trigger"
     assert.strictEqual(fetchCallCount, 1, "fetch count stays 1 after first completes");
   });
 });
+
+// ── SC-ROLLBACK: anti-rollback floor survives disable → re-enable ─────────────
+// Regression for the audit-2026-07 finding: clearRemoteCache used to delete
+// remoteRulesMeta, resetting the version floor to 0 so a MITM/CDN could serve
+// an OLDER but validly-signed payload after a disable → re-enable cycle. The
+// floor must persist across clearRemoteCache.
+describe("SC-ROLLBACK — version floor persists across clearRemoteCache", () => {
+  test("an older signed payload is rejected after disable → re-enable", async () => {
+    const storage = makeStorageFake({});
+    const dnr = makeDnrFake();
+    const trustedKeys = [testPubKeyBase64()];
+
+    // 1. Accept a high version (v20).
+    const high = makeSignedFetch(["remote_tracker_hi"], 20);
+    await runRemoteRulesFetch({ fetchImpl: high.fetchImpl, subtle: globalThis.crypto.subtle, trustedKeys, storage, dnr });
+    assert.deepEqual(storage._raw.remoteParams, ["remote_tracker_hi"], "v20 must be accepted");
+
+    // 2. User disables remote rules.
+    await clearRemoteCache({ storage, dnr });
+    assert.strictEqual(storage._raw.remoteParams, undefined, "params cleared on disable");
+    assert.strictEqual(storage._raw.remoteRulesMeta, undefined, "meta cleared on disable");
+
+    // 3. A validly-signed OLDER payload (v5) arrives on re-enable.
+    const old = makeSignedFetch(["remote_tracker_old"], 5);
+    await runRemoteRulesFetch({ fetchImpl: old.fetchImpl, subtle: globalThis.crypto.subtle, trustedKeys, storage, dnr });
+
+    // The floor persisted, so v5 must NOT be accepted.
+    assert.notDeepEqual(storage._raw.remoteParams, ["remote_tracker_old"], "an older signed payload must be rejected after re-enable");
+    assert.ok(
+      storage._raw.remoteParams === undefined || !storage._raw.remoteParams.includes("remote_tracker_old"),
+      "rolled-back params must never land in storage"
+    );
+  });
+
+  test("a newer signed payload is still accepted after disable → re-enable", async () => {
+    const storage = makeStorageFake({});
+    const dnr = makeDnrFake();
+    const trustedKeys = [testPubKeyBase64()];
+
+    const v10 = makeSignedFetch(["p10"], 10);
+    await runRemoteRulesFetch({ fetchImpl: v10.fetchImpl, subtle: globalThis.crypto.subtle, trustedKeys, storage, dnr });
+    await clearRemoteCache({ storage, dnr });
+
+    const v11 = makeSignedFetch(["p11"], 11);
+    await runRemoteRulesFetch({ fetchImpl: v11.fetchImpl, subtle: globalThis.crypto.subtle, trustedKeys, storage, dnr });
+    assert.deepEqual(storage._raw.remoteParams, ["p11"], "a newer version must still be accepted");
+  });
+});


### PR DESCRIPTION
## What

Two defense-in-depth hardening fixes from the pre-release audit (2026-07). Kept intentionally low on detail — full context is in the private security advisory **GHSA-q6j4-h3xx-4cqp**.

- **Shortener destination filter**: `isPrivateHost` now rejects IPv6 Unique Local Addresses (`fc00::/7`, RFC 4193), closing a gap alongside the existing loopback / link-local / RFC 1918 ranges.
- **Remote-rules version floor**: a persistent high-water version mark now survives a disable → re-enable cycle, so the anti-rollback floor can no longer be reset to zero. Never affects integrity — every param is still Ed25519-verified and deduped; this only prevents a downgrade to an older signed list.

## Tests

- New regression tests for both fixes (ULA bare/bracketed + global-unicast negative; v20 → disable → older v5 rejected while newer v11 still accepted).
- Full unit suite green (6335 pass / 0 fail), ESLint clean.
- Independent fresh-context review: both changes confirmed clean, tests non-tautological.

## Scope

Two remaining audit items (a query re-serialization fix touching the sync content scripts, and a low-priority hardening note) are tracked separately for their own tested slices.
