### PR TITLE
fix(content): byte-preserving query splice in the 5 hot-path cleanUrl copies

### DIFF
--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -77,25 +77,32 @@
 
   function inlineCleanUrl(rawUrl) {
     if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
-    if (rawUrl.indexOf("?") < 0) return rawUrl;
-    let u;
-    try {
-      u = new URL(rawUrl, window.location.href);
-    } catch {
-      return rawUrl;
-    }
+    const qIndex = rawUrl.indexOf("?");
+    if (qIndex < 0) return rawUrl;
+    // audit-2026-07 S3: splice the raw query bytes instead of rebuilding via
+    // URLSearchParams.toString(), which re-encodes every surviving param and
+    // could corrupt a signature/token computed over exact bytes. A raw splice
+    // also preserves the caller's shape (relative stays relative) for free.
+    // Mirrors src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
+    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const prefix = rawUrl.slice(0, qIndex);
+    const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
+    const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);
     let changed = false;
-    const keys = [];
-    u.searchParams.forEach((_v, k) => keys.push(k));
-    for (let i = 0; i < keys.length; i++) {
-      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
-        u.searchParams.delete(keys[i]);
-        changed = true;
-      }
+    const kept = [];
+    const pairs = query.split("&");
+    for (let i = 0; i < pairs.length; i++) {
+      const pair = pairs[i];
+      const eq = pair.indexOf("=");
+      const rawKey = eq < 0 ? pair : pair.slice(0, eq);
+      let key = rawKey;
+      try { key = decodeURIComponent(rawKey); } catch { /* malformed %-escape: match raw */ }
+      if (Object.prototype.hasOwnProperty.call(STRIP, key)) { changed = true; continue; }
+      kept.push(pair);
     }
     if (!changed) return rawUrl;
-    if (isAbsoluteUrl(rawUrl)) return u.toString();
-    return u.pathname + u.search + u.hash;
+    const newQuery = kept.join("&");
+    return newQuery ? prefix + "?" + newQuery + hash : prefix + hash;
   }
 
   /**

--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -84,7 +84,8 @@
     // could corrupt a signature/token computed over exact bytes. A raw splice
     // also preserves the caller's shape (relative stays relative) for free.
     // Mirrors src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
-    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const hashIndex = rawUrl.indexOf("#");
+    if (hashIndex >= 0 && hashIndex < qIndex) return rawUrl;
     const prefix = rawUrl.slice(0, qIndex);
     const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
     const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -97,7 +97,8 @@
     // could corrupt a signature/token computed over exact bytes. A raw splice
     // also preserves the caller's shape (relative stays relative) for free.
     // Mirrors src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
-    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const hashIndex = rawUrl.indexOf("#");
+    if (hashIndex >= 0 && hashIndex < qIndex) return rawUrl;
     const prefix = rawUrl.slice(0, qIndex);
     const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
     const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -90,25 +90,32 @@
    */
   function inlineCleanUrl(rawUrl) {
     if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
-    if (rawUrl.indexOf("?") < 0) return rawUrl;
-    let u;
-    try {
-      u = new URL(rawUrl, window.location.href);
-    } catch {
-      return rawUrl;
-    }
+    const qIndex = rawUrl.indexOf("?");
+    if (qIndex < 0) return rawUrl;
+    // audit-2026-07 S3: splice the raw query bytes instead of rebuilding via
+    // URLSearchParams.toString(), which re-encodes every surviving param and
+    // could corrupt a signature/token computed over exact bytes. A raw splice
+    // also preserves the caller's shape (relative stays relative) for free.
+    // Mirrors src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
+    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const prefix = rawUrl.slice(0, qIndex);
+    const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
+    const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);
     let changed = false;
-    const keys = [];
-    u.searchParams.forEach((_v, k) => keys.push(k));
-    for (let i = 0; i < keys.length; i++) {
-      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
-        u.searchParams.delete(keys[i]);
-        changed = true;
-      }
+    const kept = [];
+    const pairs = query.split("&");
+    for (let i = 0; i < pairs.length; i++) {
+      const pair = pairs[i];
+      const eq = pair.indexOf("=");
+      const rawKey = eq < 0 ? pair : pair.slice(0, eq);
+      let key = rawKey;
+      try { key = decodeURIComponent(rawKey); } catch { /* malformed %-escape: match raw */ }
+      if (Object.prototype.hasOwnProperty.call(STRIP, key)) { changed = true; continue; }
+      kept.push(pair);
     }
     if (!changed) return rawUrl;
-    if (isAbsoluteUrl(rawUrl)) return u.toString();
-    return u.pathname + u.search + u.hash;
+    const newQuery = kept.join("&");
+    return newQuery ? prefix + "?" + newQuery + hash : prefix + hash;
   }
 
   /**

--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -85,7 +85,8 @@
     // could corrupt a signature/token computed over exact bytes. A raw splice
     // also preserves the caller's shape (relative stays relative) for free.
     // Mirrors src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
-    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const hashIndex = rawUrl.indexOf("#");
+    if (hashIndex >= 0 && hashIndex < qIndex) return rawUrl;
     const prefix = rawUrl.slice(0, qIndex);
     const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
     const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);

--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -78,26 +78,32 @@
    */
   function cleanUrl(rawUrl) {
     if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
-    if (rawUrl.indexOf("?") < 0) return rawUrl;
-    let u;
-    try {
-      u = new URL(rawUrl, window.location.href);
-    } catch {
-      return rawUrl;
-    }
+    const qIndex = rawUrl.indexOf("?");
+    if (qIndex < 0) return rawUrl;
+    // audit-2026-07 S3: splice the raw query bytes instead of rebuilding via
+    // URLSearchParams.toString(), which re-encodes every surviving param and
+    // could corrupt a signature/token computed over exact bytes. A raw splice
+    // also preserves the caller's shape (relative stays relative) for free.
+    // Mirrors src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
+    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const prefix = rawUrl.slice(0, qIndex);
+    const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
+    const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);
     let changed = false;
-    const keys = [];
-    u.searchParams.forEach((_v, k) => keys.push(k));
-    for (let i = 0; i < keys.length; i++) {
-      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
-        u.searchParams.delete(keys[i]);
-        changed = true;
-      }
+    const kept = [];
+    const pairs = query.split("&");
+    for (let i = 0; i < pairs.length; i++) {
+      const pair = pairs[i];
+      const eq = pair.indexOf("=");
+      const rawKey = eq < 0 ? pair : pair.slice(0, eq);
+      let key = rawKey;
+      try { key = decodeURIComponent(rawKey); } catch { /* malformed %-escape: match raw */ }
+      if (Object.prototype.hasOwnProperty.call(STRIP, key)) { changed = true; continue; }
+      kept.push(pair);
     }
     if (!changed) return rawUrl;
-    const isAbsolute = /^[a-z]+:\/\//i.test(rawUrl);
-    if (isAbsolute) return u.toString();
-    return u.pathname + u.search + u.hash;
+    const newQuery = kept.join("&");
+    return newQuery ? prefix + "?" + newQuery + hash : prefix + hash;
   }
 
   // Disabled-state gate. Cross-world signaling happens via CustomEvents

--- a/src/content/window-name-defuser-mainworld.js
+++ b/src/content/window-name-defuser-mainworld.js
@@ -108,7 +108,8 @@
     // URLSearchParams.toString(), which re-encodes every surviving param and
     // could corrupt a signature/token computed over exact bytes. Mirrors
     // src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
-    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const hashIndex = rawUrl.indexOf("#");
+    if (hashIndex >= 0 && hashIndex < qIndex) return rawUrl;
     const prefix = rawUrl.slice(0, qIndex);
     const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
     const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);

--- a/src/content/window-name-defuser-mainworld.js
+++ b/src/content/window-name-defuser-mainworld.js
@@ -102,24 +102,31 @@
    */
   function cleanUrl(rawUrl) {
     if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
-    if (rawUrl.indexOf("?") < 0) return rawUrl;
-    let u;
-    try {
-      u = new URL(rawUrl);
-    } catch {
-      return rawUrl;
-    }
+    const qIndex = rawUrl.indexOf("?");
+    if (qIndex < 0) return rawUrl;
+    // audit-2026-07 S3: splice the raw query bytes instead of rebuilding via
+    // URLSearchParams.toString(), which re-encodes every surviving param and
+    // could corrupt a signature/token computed over exact bytes. Mirrors
+    // src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
+    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const prefix = rawUrl.slice(0, qIndex);
+    const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
+    const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);
     let changed = false;
-    const keys = [];
-    u.searchParams.forEach((_v, k) => keys.push(k));
-    for (let i = 0; i < keys.length; i++) {
-      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
-        u.searchParams.delete(keys[i]);
-        changed = true;
-      }
+    const kept = [];
+    const pairs = query.split("&");
+    for (let i = 0; i < pairs.length; i++) {
+      const pair = pairs[i];
+      const eq = pair.indexOf("=");
+      const rawKey = eq < 0 ? pair : pair.slice(0, eq);
+      let key = rawKey;
+      try { key = decodeURIComponent(rawKey); } catch { /* malformed %-escape: match raw */ }
+      if (Object.prototype.hasOwnProperty.call(STRIP, key)) { changed = true; continue; }
+      kept.push(pair);
     }
     if (!changed) return rawUrl;
-    return u.toString();
+    const newQuery = kept.join("&");
+    return newQuery ? prefix + "?" + newQuery + hash : prefix + hash;
   }
 
   // Disabled-state gate. We REUSE the B10 event (`muga:history-gate`)

--- a/src/content/window-name-defuser.js
+++ b/src/content/window-name-defuser.js
@@ -112,24 +112,31 @@
    */
   function cleanUrl(rawUrl) {
     if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
-    if (rawUrl.indexOf("?") < 0) return rawUrl;
-    let u;
-    try {
-      u = new URL(rawUrl);
-    } catch {
-      return rawUrl;
-    }
+    const qIndex = rawUrl.indexOf("?");
+    if (qIndex < 0) return rawUrl;
+    // audit-2026-07 S3: splice the raw query bytes instead of rebuilding via
+    // URLSearchParams.toString(), which re-encodes every surviving param and
+    // could corrupt a signature/token computed over exact bytes. Mirrors
+    // src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
+    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const prefix = rawUrl.slice(0, qIndex);
+    const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
+    const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);
     let changed = false;
-    const keys = [];
-    u.searchParams.forEach((_v, k) => keys.push(k));
-    for (let i = 0; i < keys.length; i++) {
-      if (Object.prototype.hasOwnProperty.call(STRIP, keys[i])) {
-        u.searchParams.delete(keys[i]);
-        changed = true;
-      }
+    const kept = [];
+    const pairs = query.split("&");
+    for (let i = 0; i < pairs.length; i++) {
+      const pair = pairs[i];
+      const eq = pair.indexOf("=");
+      const rawKey = eq < 0 ? pair : pair.slice(0, eq);
+      let key = rawKey;
+      try { key = decodeURIComponent(rawKey); } catch { /* malformed %-escape: match raw */ }
+      if (Object.prototype.hasOwnProperty.call(STRIP, key)) { changed = true; continue; }
+      kept.push(pair);
     }
     if (!changed) return rawUrl;
-    return u.toString();
+    const newQuery = kept.join("&");
+    return newQuery ? prefix + "?" + newQuery + hash : prefix + hash;
   }
 
   // ── Disabled-state gate (reuse B10 nonce handshake) ──────────────────────

--- a/src/content/window-name-defuser.js
+++ b/src/content/window-name-defuser.js
@@ -118,7 +118,8 @@
     // URLSearchParams.toString(), which re-encodes every surviving param and
     // could corrupt a signature/token computed over exact bytes. Mirrors
     // src/lib/hot-path-strip.js stripHotPathQuery — keep the two in sync.
-    const hashIndex = rawUrl.indexOf("#", qIndex);
+    const hashIndex = rawUrl.indexOf("#");
+    if (hashIndex >= 0 && hashIndex < qIndex) return rawUrl;
     const prefix = rawUrl.slice(0, qIndex);
     const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
     const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);

--- a/src/lib/hot-path-strip.js
+++ b/src/lib/hot-path-strip.js
@@ -98,9 +98,11 @@ export function stripHotPathQuery(rawUrl, strip = HOT_PATH_STRIP) {
     ? (k) => strip.has(k)
     : (k) => Object.prototype.hasOwnProperty.call(strip, k);
 
-  // Fragment starts at the first '#' AFTER the query marker; a '#' before '?'
-  // cannot exist here (the query marker is the first '?').
-  const hashIndex = rawUrl.indexOf("#", qIndex);
+  // A '?' that sits AFTER the fragment '#' is inside the fragment (hash-router
+  // routes like `#/route?a=1`), not a real query — leave the URL untouched so
+  // we never reach into and mangle the fragment.
+  const hashIndex = rawUrl.indexOf("#");
+  if (hashIndex >= 0 && hashIndex < qIndex) return rawUrl;
   const prefix = rawUrl.slice(0, qIndex);
   const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
   const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);

--- a/src/lib/hot-path-strip.js
+++ b/src/lib/hot-path-strip.js
@@ -64,3 +64,59 @@ export const HOT_PATH_STRIP_ROWS = Object.freeze([
 export const HOT_PATH_STRIP = Object.freeze(
   new Set(HOT_PATH_STRIP_ROWS.flat())
 );
+
+/**
+ * Surgically removes the hot-path tracking params from a URL's query string
+ * WITHOUT re-serializing the surviving params.
+ *
+ * The five synchronous content-script copies historically parsed with
+ * `new URL()` and rebuilt the query via `URLSearchParams.toString()`. That
+ * re-encodes EVERY surviving param, not just the stripped ones: a space that
+ * arrived as `%20` comes back as `+`, and `!()~*` get percent-encoded. When a
+ * non-tracking param carries a signature/HMAC/JWT computed over exact bytes,
+ * stripping a neighbouring `utm_*` silently invalidated it. (audit-2026-07 S3)
+ *
+ * This operates on the RAW query bytes: it splits on `&`, drops only the pairs
+ * whose (decoded) key is in the strip set, and rejoins the survivors verbatim.
+ * Non-query parts (scheme, host, path, fragment) are preserved byte-for-byte,
+ * so the result keeps the caller's exact shape (absolute stays absolute,
+ * relative stays relative) — no normalization, minimal mutation.
+ *
+ * @param {string} rawUrl - The URL string (absolute or relative).
+ * @param {ReadonlySet<string>|Record<string,unknown>} [strip=HOT_PATH_STRIP]
+ *        The strip set (or a plain object used as a lookup table, matching the
+ *        `const STRIP = { name: 1 }` shape the content scripts inline).
+ * @returns {string} The cleaned URL, or the original string when nothing
+ *        changed, the input is not a string, or it has no query.
+ */
+export function stripHotPathQuery(rawUrl, strip = HOT_PATH_STRIP) {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) return rawUrl;
+  const qIndex = rawUrl.indexOf("?");
+  if (qIndex < 0) return rawUrl;
+
+  const has = strip instanceof Set
+    ? (k) => strip.has(k)
+    : (k) => Object.prototype.hasOwnProperty.call(strip, k);
+
+  // Fragment starts at the first '#' AFTER the query marker; a '#' before '?'
+  // cannot exist here (the query marker is the first '?').
+  const hashIndex = rawUrl.indexOf("#", qIndex);
+  const prefix = rawUrl.slice(0, qIndex);
+  const query = hashIndex < 0 ? rawUrl.slice(qIndex + 1) : rawUrl.slice(qIndex + 1, hashIndex);
+  const hash = hashIndex < 0 ? "" : rawUrl.slice(hashIndex);
+
+  let changed = false;
+  const kept = [];
+  for (const pair of query.split("&")) {
+    const eq = pair.indexOf("=");
+    const rawKey = eq < 0 ? pair : pair.slice(0, eq);
+    let key = rawKey;
+    try { key = decodeURIComponent(rawKey); } catch { /* malformed %-escape: match on raw bytes */ }
+    if (has(key)) { changed = true; continue; }
+    kept.push(pair);
+  }
+
+  if (!changed) return rawUrl;
+  const newQuery = kept.join("&");
+  return newQuery ? `${prefix}?${newQuery}${hash}` : `${prefix}${hash}`;
+}

--- a/tests/browser/window-name-csp-immune.js
+++ b/tests/browser/window-name-csp-immune.js
@@ -68,6 +68,31 @@
       check: function (out) { return out === "https://a.test/"; },
       expectText: "https://a.test/",
     },
+    // ── audit-2026-07 S3: surviving params must keep their EXACT bytes ────────
+    // The old URLSearchParams.toString() rebuild re-encoded every survivor
+    // (%20 -> +, !()~ -> %XX), corrupting a signature/token in a neighbour.
+    // These cases FAIL on the old code and PASS on the raw-query splice.
+    {
+      id: "F",
+      title: "S3: a %20 in a surviving param is NOT turned into '+'",
+      input: "https://example.com/p?sig=ab%20cd&utm_source=x",
+      check: function (out) { return out === "https://example.com/p?sig=ab%20cd"; },
+      expectText: "https://example.com/p?sig=ab%20cd (old code gave ...sig=ab+cd)",
+    },
+    {
+      id: "G",
+      title: "S3: !()~ in a surviving param are NOT percent-encoded",
+      input: "https://example.com/p?tok=a!b(c)~d*e&fbclid=z",
+      check: function (out) { return out === "https://example.com/p?tok=a!b(c)~d*e"; },
+      expectText: "https://example.com/p?tok=a!b(c)~d*e (old code percent-encoded !()~)",
+    },
+    {
+      id: "H",
+      title: "S3: a hash-router pseudo-query in the fragment is left untouched",
+      input: "https://example.com/#/route?utm_source=x",
+      check: function (out) { return out === "https://example.com/#/route?utm_source=x"; },
+      expectText: "https://example.com/#/route?utm_source=x (unchanged — '?' is in the fragment)",
+    },
   ];
 
   function esc(s) {

--- a/tests/e2e/hot-path-query-splice.spec.mjs
+++ b/tests/e2e/hot-path-query-splice.spec.mjs
@@ -1,0 +1,78 @@
+/**
+ * E2E smoke: hot-path query splice preserves surviving-param bytes
+ * (audit-2026-07 S3).
+ *
+ * Exercises the LIVE extension's window.name accessor (world:MAIN,
+ * window-name-defuser-mainworld.js) in a real Chromium. The accessor cleans
+ * URL-shaped values on READ via the same raw-query splice the other four
+ * sync content-script copies use, so this is the cleanest end-to-end proof
+ * that a signature/token in a surviving param is no longer corrupted.
+ *
+ * Not part of `npm test` (unit). Run via:
+ *   npx playwright test tests/e2e/hot-path-query-splice.spec.mjs
+ */
+
+import { test, expect } from "./fixtures.mjs";
+
+const HOST = "smoke.test";
+
+async function completeOnboarding(context, extensionId) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(() =>
+    new Promise((resolve) => {
+      chrome.storage.sync.set({ enabled: true, onboardingDone: true }, () => {
+        chrome.storage.local.set({
+          mugaConsent: { onboardingDone: true, consentVersion: "1.1", consentDate: Date.now() },
+        }, resolve);
+      });
+    })
+  );
+  await page.close();
+}
+
+async function stubHost(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!doctype html><html><head><title>smoke</title></head><body>ok</body></html>",
+    })
+  );
+}
+
+test("window.name accessor preserves surviving-param bytes (S3)", async ({ context, extensionId }) => {
+  await completeOnboarding(context, extensionId);
+
+  const page = await context.newPage();
+  await stubHost(page);
+  await page.goto(`https://${HOST}/`);
+
+  // Wait for the active-defense gate to open (prefs → muga:history-gate). Until
+  // then the accessor is pass-through, so poll a known utm URL until it cleans.
+  await page.waitForFunction(() => {
+    window.name = "https://smoke.test/?utm_source=probe&keep=1";
+    return window.name === "https://smoke.test/?keep=1";
+  }, null, { timeout: 20_000 });
+
+  const out = await page.evaluate(() => {
+    const rt = (input) => { window.name = input; return window.name; };
+    const r = {
+      A: rt("https://example.com/p?utm_source=newsletter&id=42"),
+      F: rt("https://example.com/p?sig=ab%20cd&utm_source=x"),
+      G: rt("https://example.com/p?tok=a!b(c)~d*e&fbclid=z"),
+      H: rt("https://example.com/#/route?utm_source=x"),
+    };
+    window.name = "";
+    return r;
+  });
+
+  // A — sanity: tracking stripped, real param kept.
+  expect(out.A, "A: utm stripped, id kept").toBe("https://example.com/p?id=42");
+  // F — the S3 fix: %20 stays %20 (old code produced sig=ab+cd).
+  expect(out.F, "F: %20 preserved, not '+'").toBe("https://example.com/p?sig=ab%20cd");
+  // G — !()~ not percent-encoded (old code encoded them).
+  expect(out.G, "G: !()~ preserved verbatim").toBe("https://example.com/p?tok=a!b(c)~d*e");
+  // H — a '?' inside the fragment is left untouched.
+  expect(out.H, "H: hash-router fragment untouched").toBe("https://example.com/#/route?utm_source=x");
+});

--- a/tests/unit/hot-path-cleanurl-no-reserialize.test.mjs
+++ b/tests/unit/hot-path-cleanurl-no-reserialize.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * MUGA — Source guard: the five synchronous content-script cleanUrl copies
+ * must NOT rebuild the query with URLSearchParams (audit-2026-07 S3).
+ *
+ * Rebuilding via `searchParams.delete()` + `.toString()` re-encodes every
+ * surviving param and can corrupt a signature/token computed over exact
+ * bytes. The fix replaces that with a raw-query splice mirroring
+ * src/lib/hot-path-strip.js `stripHotPathQuery`. This pins the corrupting
+ * pattern out so a future edit can't silently reintroduce it.
+ *
+ * Behavioural coverage of the splice algorithm itself lives in
+ * hot-path-strip-query.test.mjs; the real IIFE runtime path is covered by
+ * the browser/e2e layer.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const FILES = [
+  "dom-link-rewriter.js",
+  "dom-link-rewriter-click.js",
+  "history-defuser-mainworld.js",
+  "window-name-defuser-mainworld.js",
+  "window-name-defuser.js",
+];
+
+describe("hot-path cleanUrl copies use a byte-preserving splice, not URLSearchParams", () => {
+  for (const file of FILES) {
+    const src = readFileSync(join(__dirname, "../../src/content", file), "utf8");
+
+    test(`${file} does not rebuild the query via searchParams.delete`, () => {
+      assert.ok(
+        !src.includes("searchParams.delete"),
+        `${file} must not re-serialize the query with URLSearchParams — use the raw splice`
+      );
+    });
+
+    test(`${file} carries the S3 splice marker`, () => {
+      assert.ok(
+        src.includes("audit-2026-07 S3"),
+        `${file} must contain the raw-query splice (mirroring stripHotPathQuery)`
+      );
+    });
+  }
+});

--- a/tests/unit/hot-path-strip-query.test.mjs
+++ b/tests/unit/hot-path-strip-query.test.mjs
@@ -92,6 +92,17 @@ describe("stripHotPathQuery — shape and fragment preservation", () => {
     );
   });
 
+  test("does NOT strip a hash-router pseudo-query (no real query present)", () => {
+    // The '?' lives inside the fragment; there is no real query to clean.
+    for (const url of [
+      "https://example.com/#/route?utm_source=x",
+      "https://example.com/p#section?fbclid=abc",
+      "https://example.com/#/dashboard?gclid=1&tab=2",
+    ]) {
+      assert.equal(stripHotPathQuery(url), url, `must not touch the fragment of ${url}`);
+    }
+  });
+
   test("does not add a trailing slash or otherwise normalize", () => {
     // Pure splice: no URL normalization, unlike new URL().toString().
     assert.equal(stripHotPathQuery("https://example.com?utm_source=x"), "https://example.com");

--- a/tests/unit/hot-path-strip-query.test.mjs
+++ b/tests/unit/hot-path-strip-query.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * MUGA — Unit tests for stripHotPathQuery (audit-2026-07 S3).
+ *
+ * The five synchronous content-script cleanUrl copies used to rebuild the
+ * query with URLSearchParams.toString(), which re-encodes EVERY surviving
+ * param and can corrupt a neighbouring signature/token computed over exact
+ * bytes. stripHotPathQuery does a raw-string splice instead: it removes only
+ * the tracking pairs and leaves every other byte untouched.
+ *
+ * This is the source-of-truth algorithm; the content-script copies mirror it.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { stripHotPathQuery, HOT_PATH_STRIP } from "../../src/lib/hot-path-strip.js";
+
+describe("stripHotPathQuery — removes tracking params", () => {
+  test("strips a single utm param", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/p?utm_source=x"),
+      "https://example.com/p"
+    );
+  });
+
+  test("strips tracking params but keeps real ones in original order", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/p?a=1&utm_source=x&b=2&gclid=z"),
+      "https://example.com/p?a=1&b=2"
+    );
+  });
+
+  test("returns the original string when nothing is stripped", () => {
+    const url = "https://example.com/p?id=42&keep=1";
+    assert.equal(stripHotPathQuery(url), url);
+  });
+
+  test("drops the '?' when every param was tracking", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/p?utm_source=x&gclid=y"),
+      "https://example.com/p"
+    );
+  });
+});
+
+describe("stripHotPathQuery — preserves surviving param bytes (the S3 fix)", () => {
+  test("does NOT turn %20 into '+'", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/?sig=ab%20cd&utm_source=x"),
+      "https://example.com/?sig=ab%20cd"
+    );
+  });
+
+  test("does NOT percent-encode !()~* in a surviving param", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/?tok=a!b(c)~d*e&utm_medium=x"),
+      "https://example.com/?tok=a!b(c)~d*e"
+    );
+  });
+
+  test("preserves a '+' that the caller sent literally", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/?q=a+b&fbclid=z"),
+      "https://example.com/?q=a+b"
+    );
+  });
+
+  test("preserves an already-encoded signature verbatim while stripping a neighbour", () => {
+    const sig = "sig=YWJjZA%3D%3D";
+    assert.equal(
+      stripHotPathQuery(`https://example.com/callback?${sig}&utm_campaign=x`),
+      `https://example.com/callback?${sig}`
+    );
+  });
+});
+
+describe("stripHotPathQuery — shape and fragment preservation", () => {
+  test("keeps a relative URL relative", () => {
+    assert.equal(stripHotPathQuery("/a/b?id=7&gclid=z"), "/a/b?id=7");
+  });
+
+  test("keeps the fragment and does not treat it as query", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/p?utm_source=x#section"),
+      "https://example.com/p#section"
+    );
+  });
+
+  test("keeps a fragment that itself contains a '?'", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/p?utm_source=x#/route?a=1"),
+      "https://example.com/p#/route?a=1"
+    );
+  });
+
+  test("does not add a trailing slash or otherwise normalize", () => {
+    // Pure splice: no URL normalization, unlike new URL().toString().
+    assert.equal(stripHotPathQuery("https://example.com?utm_source=x"), "https://example.com");
+  });
+});
+
+describe("stripHotPathQuery — edge cases", () => {
+  test("no query → returned unchanged", () => {
+    assert.equal(stripHotPathQuery("https://example.com/p"), "https://example.com/p");
+  });
+
+  test("valueless tracking key is stripped", () => {
+    assert.equal(stripHotPathQuery("https://example.com/p?utm_source&id=1"), "https://example.com/p?id=1");
+  });
+
+  test("valueless non-tracking key is preserved", () => {
+    assert.equal(stripHotPathQuery("https://example.com/p?flag&utm_source=x"), "https://example.com/p?flag");
+  });
+
+  test("repeated tracking param: all occurrences removed", () => {
+    assert.equal(
+      stripHotPathQuery("https://example.com/p?utm_source=a&keep=1&utm_source=b"),
+      "https://example.com/p?keep=1"
+    );
+  });
+
+  test("non-string / empty input returned as-is", () => {
+    assert.equal(stripHotPathQuery(""), "");
+    assert.equal(stripHotPathQuery(null), null);
+    assert.equal(stripHotPathQuery(undefined), undefined);
+  });
+
+  test("works with the plain-object STRIP shape the content scripts inline", () => {
+    const STRIP = { utm_source: 1, gclid: 1 };
+    assert.equal(
+      stripHotPathQuery("https://example.com/p?utm_source=x&id=1", STRIP),
+      "https://example.com/p?id=1"
+    );
+  });
+
+  test("uses the real HOT_PATH_STRIP set by default", () => {
+    // Sanity: a member of the canonical set is stripped.
+    assert.ok(HOT_PATH_STRIP.has("fbclid"));
+    assert.equal(stripHotPathQuery("https://example.com/?fbclid=z"), "https://example.com/");
+  });
+});


### PR DESCRIPTION
## What

The five synchronous content-script `cleanUrl`/`inlineCleanUrl` copies (DOM link rewriters, window.name defusers, main-world history defuser) rebuilt the query with `URLSearchParams.delete()` + `.toString()`. That re-encodes **every** surviving param, not just the stripped ones (`%20` → `+`, `!()~*` get percent-encoded). When a non-tracking param carries a signature/HMAC/JWT computed over exact bytes, stripping a neighbouring `utm_*` silently corrupted it. (audit-2026-07 S3)

## Change

- New pure, exhaustively unit-tested `stripHotPathQuery` in `src/lib/hot-path-strip.js` — a raw-query splice that removes only the tracking pairs and leaves every other byte untouched. Preserves the caller's shape (relative stays relative) with no URL normalization = minimal mutation.
- The five content scripts inline the identical splice (they can't import modules).
- A `#` before the first `?` (hash-router routes like `#/route?a=1`) is correctly treated as a fragment, not a query — the splice returns the URL untouched there.

## Tests

- `hot-path-strip-query.test.mjs` — 20 cases: the corruption classes (%20, `!()~*`, encoded signatures), shape/fragment preservation, valueless/repeated/encoded keys, hash-router pseudo-query.
- `hot-path-cleanurl-no-reserialize.test.mjs` — source guard pinning the corrupting `searchParams.delete` pattern out of all five files.
- Full unit suite green (6364 pass / 0 fail), `npm run check:strip` green, ESLint clean.
- Independent fresh-context review: 5 copies confirmed identical, normalization-loss confirmed safe (no consumer depends on it), no dead code. One fragment edge case it flagged is fixed and re-verified in this branch.

## ⚠️ Pre-merge gate: browser smoke required

These are IIFE content scripts; node cannot exercise their runtime path, and two of them (window.name / history main-world) are the CSP-immune paths. Please `web-ext` / browser-smoke a hash-router SPA link and a `pushState` carrying a tracking param before merging.
