### PR TITLE
fix(hot-path): stop sync strip deleting redirect-network attribution params (#1092) — no release

### DIFF
--- a/src/content/dom-link-rewriter-click.js
+++ b/src/content/dom-link-rewriter-click.js
@@ -54,7 +54,6 @@
     mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
     _hsenc: 1, _hsmi: 1, mkt_tok: 1,
     yclid: 1, ysclid: 1, _openstat: 1,
-    irclickid: 1, cjevent: 1, awc: 1,
     ttclid: 1, sccid: 1, rdt_cid: 1,
     _branch_match_id: 1, _branch_referrer: 1,
     pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,

--- a/src/content/dom-link-rewriter.js
+++ b/src/content/dom-link-rewriter.js
@@ -59,7 +59,6 @@
     mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
     _hsenc: 1, _hsmi: 1, mkt_tok: 1,
     yclid: 1, ysclid: 1, _openstat: 1,
-    irclickid: 1, cjevent: 1, awc: 1,
     ttclid: 1, sccid: 1, rdt_cid: 1,
     _branch_match_id: 1, _branch_referrer: 1,
     pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,

--- a/src/content/history-defuser-mainworld.js
+++ b/src/content/history-defuser-mainworld.js
@@ -56,7 +56,6 @@
     mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
     _hsenc: 1, _hsmi: 1, mkt_tok: 1,
     yclid: 1, ysclid: 1, _openstat: 1,
-    irclickid: 1, cjevent: 1, awc: 1,
     ttclid: 1, sccid: 1, rdt_cid: 1,
     _branch_match_id: 1, _branch_referrer: 1,
     pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,

--- a/src/content/window-name-defuser-mainworld.js
+++ b/src/content/window-name-defuser-mainworld.js
@@ -65,7 +65,6 @@
     mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
     _hsenc: 1, _hsmi: 1, mkt_tok: 1,
     yclid: 1, ysclid: 1, _openstat: 1,
-    irclickid: 1, cjevent: 1, awc: 1,
     ttclid: 1, sccid: 1, rdt_cid: 1,
     _branch_match_id: 1, _branch_referrer: 1,
     pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,

--- a/src/content/window-name-defuser.js
+++ b/src/content/window-name-defuser.js
@@ -76,7 +76,6 @@
     mc_cid: 1, mc_eid: 1, igshid: 1, igsh: 1,
     _hsenc: 1, _hsmi: 1, mkt_tok: 1,
     yclid: 1, ysclid: 1, _openstat: 1,
-    irclickid: 1, cjevent: 1, awc: 1,
     ttclid: 1, sccid: 1, rdt_cid: 1,
     _branch_match_id: 1, _branch_referrer: 1,
     pk_campaign: 1, pk_kwd: 1, pk_source: 1, pk_medium: 1,

--- a/src/lib/hot-path-strip.js
+++ b/src/lib/hot-path-strip.js
@@ -42,7 +42,12 @@ export const HOT_PATH_STRIP_ROWS = Object.freeze([
   ["mc_cid", "mc_eid", "igshid", "igsh"],
   ["_hsenc", "_hsmi", "mkt_tok"],
   ["yclid", "ysclid", "_openstat"],
-  ["irclickid", "cjevent", "awc"],
+  // NOTE: redirect-network ATTRIBUTION params (irclickid/cjevent/awc and the
+  // rest of REDIRECT_NETWORK_PATTERNS.landingParams) are DELIBERATELY absent
+  // here. They are excluded from TRACKING_PARAMS and preserved by the async
+  // engine; the sync hot-path must match that (never destroy a creator's
+  // commission on the SPA-hydration race). Enforced by
+  // tests/unit/hot-path-preserves-landing-params-1092.test.mjs (#1092).
   ["ttclid", "sccid", "rdt_cid"],
   ["_branch_match_id", "_branch_referrer"],
   ["pk_campaign", "pk_kwd", "pk_source", "pk_medium"],

--- a/tests/unit/hot-path-preserves-landing-params-1092.test.mjs
+++ b/tests/unit/hot-path-preserves-landing-params-1092.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * MUGA — Regression + invariant guard for #1092 (audit-2026-07).
+ *
+ * The five synchronous content-script strip copies (main-world history
+ * defuser, DOM link rewriters, window.name defuser) share the HOT_PATH_STRIP
+ * subset. Three redirect-network ATTRIBUTION params — irclickid (Impact),
+ * cjevent (CJ), awc (Awin) — were in that subset, so the sync path deleted
+ * them with NO landing/referrer gate. But they are `landingParams` in
+ * REDIRECT_NETWORK_PATTERNS, are excluded from TRACKING_PARAMS, and the async
+ * engine (processUrl) PRESERVES them. A merchant SPA that calls
+ * history.replaceState during hydration — before the affiliate script reads
+ * location.search — would have its attribution destroyed by the sync copy,
+ * violating the never-strip-affiliate promise (ADR-0005 / #815).
+ *
+ * INVARIANT: the hot-path sync strip set must never contain a param the async
+ * engine treats as a preservable attribution param. This test pins that
+ * invariant against the SOURCE OF TRUTH (REDIRECT_NETWORK_PATTERNS), so a
+ * future network whose landingParams accidentally land in the strip table
+ * fails here instead of silently destroying commissions in the wild.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { HOT_PATH_STRIP, stripHotPathQuery } from "../../src/lib/hot-path-strip.js";
+import { REDIRECT_NETWORK_PATTERNS } from "../../src/lib/redirect-networks.js";
+
+const landingParamUnion = new Set(
+  REDIRECT_NETWORK_PATTERNS.flatMap((n) => n.landingParams).map((p) => p.toLowerCase()),
+);
+
+describe("#1092 — hot-path sync strip never deletes a preservable attribution param", () => {
+  test("HOT_PATH_STRIP is disjoint from the redirect-network landingParams union", () => {
+    const overlap = [...HOT_PATH_STRIP].filter((p) => landingParamUnion.has(p.toLowerCase()));
+    assert.deepEqual(
+      overlap,
+      [],
+      `hot-path sync strip must not contain attribution params the async engine preserves; found: ${JSON.stringify(overlap)}`,
+    );
+  });
+
+  test("stripHotPathQuery preserves irclickid/cjevent/awc while still stripping utm_source", () => {
+    for (const attribution of ["irclickid", "cjevent", "awc"]) {
+      const raw = `https://merchant.example/p?${attribution}=abc-123&utm_source=news`;
+      const cleaned = stripHotPathQuery(raw);
+      const params = new URL(cleaned).searchParams;
+      assert.equal(
+        params.get(attribution),
+        "abc-123",
+        `${attribution} (a redirect-network landing param) must survive the sync hot-path strip`,
+      );
+      assert.equal(params.has("utm_source"), false, "an actual tracking param must still be stripped");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1092 (P1, `audit:security`). The synchronous hot-path strip tables deleted three redirect-network **attribution** params the async engine preserves — destroying creator commission. **No version bump, no release** — accumulates on `main` as a patch.

## The bug

`irclickid` (Impact Radius), `cjevent` (CJ Affiliate), `awc` (Awin) are declared as `landingParams` in `REDIRECT_NETWORK_PATTERNS`, are excluded from `TRACKING_PARAMS`, and `processUrl` (the async engine) preserves them. But they were in `HOT_PATH_STRIP` — the subset codegen'd into the 5 synchronous content scripts (main-world history defuser, DOM link rewriters, window.name defusers) — which delete them with **no landing/referrer gate**.

Failure scenario (from the issue): land on a CJ affiliate link; the merchant SPA calls `history.replaceState` during hydration *before* CJ's script reads `location.search` → the main-world defuser strips `cjevent` → creator commission destroyed. Exactly what the never-strip-affiliate promise (ADR-0005 / #815) forbids.

## Fix

- Removed the `["irclickid","cjevent","awc"]` row from `HOT_PATH_STRIP_ROWS` (the single source of truth) and regenerated the 5 copies via `build:strip`. Both paths now agree: neither strips these attribution params.
- The right correction is *exclude*, not *gate*: these aren't tracking params, and the `document_start` main-world defusers can't reliably read `document.referrer` — so the async referrer gate is a no-op for them anyway. Removing divergence, not adding it.
- Added `tests/unit/hot-path-preserves-landing-params-1092.test.mjs`: an **invariant** guard asserting `HOT_PATH_STRIP` stays disjoint from the `REDIRECT_NETWORK_PATTERNS.landingParams` union, so a future network's landing param can't silently drift into the sync strip. Plus a behavioral test that `stripHotPathQuery` preserves the three while still stripping `utm_source`.

## Verification

- TDD: the invariant test was RED before the fix (reported exactly the three), GREEN after.
- `check:strip` drift guard passes; all 5 copies verified 0 occurrences.
- Full unit suite **6460 pass / 0 fail / 1 skipped**; `eslint` + `tsc` clean.
- Content-script e2e (dom-link-rewriter x2, history-defuser x2, hot-path-query-splice) **8/8 pass** in real Chromium.
- Fresh adversarial review (confirmed sound): no other sync strip list hardcodes these; `remote-rules.js` references them only in a *protection* list; the invariant correctly forbids ever adding any landing param (including dual-use ones) to the hot-path.
