### PR TITLE
feat(consent): Cookiebot CMP adapter (Tier 1)

### DIFF
--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -57,6 +57,21 @@
   function canRejectOneTrust(signals) {
     return detectOneTrust(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  function detectCookiebot(signals) {
+    if (!signals || signals.hasCookiebotGlobal !== true || signals.hasSubmitCustomConsentFn !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCybotDialogDom === true ? 1 : 0) +
+      (signals.hasConsentObjectGlobal === true ? 1 : 0) +
+      (signals.hasResponseBooleanGlobal === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookiebot(signals) {
+    return detectCookiebot(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -90,7 +105,41 @@
     } catch {
       // ignore
     }
-    return { hasOneTrustGlobal, hasRejectAllFn, hasBannerDom, hasActiveGroupsGlobal, hasRejectHandlerDom };
+    let hasCookiebotGlobal = false;
+    let hasSubmitCustomConsentFn = false;
+    try {
+      hasCookiebotGlobal = typeof window.Cookiebot === "object" && window.Cookiebot !== null;
+      hasSubmitCustomConsentFn =
+        hasCookiebotGlobal && typeof window.Cookiebot.submitCustomConsent === "function";
+    } catch {
+      // Leave both false — fail-closed.
+    }
+    let hasCybotDialogDom = false;
+    try {
+      hasCybotDialogDom = !!document.getElementById("CybotCookiebotDialog");
+    } catch {
+      // document not ready / detached — leave false.
+    }
+    let hasConsentObjectGlobal = false;
+    let hasResponseBooleanGlobal = false;
+    try {
+      hasConsentObjectGlobal = hasCookiebotGlobal && typeof window.Cookiebot.consent === "object";
+      hasResponseBooleanGlobal = hasCookiebotGlobal && typeof window.Cookiebot.hasResponse === "boolean";
+    } catch {
+      // ignore
+    }
+    return {
+      hasOneTrustGlobal,
+      hasRejectAllFn,
+      hasBannerDom,
+      hasActiveGroupsGlobal,
+      hasRejectHandlerDom,
+      hasCookiebotGlobal,
+      hasSubmitCustomConsentFn,
+      hasCybotDialogDom,
+      hasConsentObjectGlobal,
+      hasResponseBooleanGlobal,
+    };
   }
 
   // Idempotency guard (#1027): once a decisive reject has fired, never
@@ -112,6 +161,21 @@
       _acted = true;
       try {
         window.OneTrust.RejectAll();
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: Cookiebot API adapter (#1118). Necessary cookies are
+    // implicit/always-on in Cookiebot's model — the three positional
+    // booleans (preferences, statistics, marketing) are always literal
+    // `false`, never a variable, so this call structurally cannot grant
+    // broad consent.
+    if (canRejectCookiebot(signals)) {
+      _acted = true;
+      try {
+        window.Cookiebot.submitCustomConsent(false, false, false);
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -53,6 +53,21 @@
   function canRejectOneTrust(signals) {
     return detectOneTrust(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  function detectCookiebot(signals) {
+    if (!signals || signals.hasCookiebotGlobal !== true || signals.hasSubmitCustomConsentFn !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCybotDialogDom === true ? 1 : 0) +
+      (signals.hasConsentObjectGlobal === true ? 1 : 0) +
+      (signals.hasResponseBooleanGlobal === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookiebot(signals) {
+    return detectCookiebot(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -123,7 +138,44 @@
     } catch {
       // ignore
     }
-    return { hasOneTrustGlobal, hasRejectAllFn, hasBannerDom, hasActiveGroupsGlobal, hasRejectHandlerDom };
+    let hasCookiebotGlobal = false;
+    let hasSubmitCustomConsentFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const cb = wrapped && wrapped.Cookiebot;
+      hasCookiebotGlobal = typeof cb === "object" && cb !== null;
+      hasSubmitCustomConsentFn = hasCookiebotGlobal && typeof cb.submitCustomConsent === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasCybotDialogDom = false;
+    try {
+      hasCybotDialogDom = !!document.getElementById("CybotCookiebotDialog");
+    } catch {
+      // ignore
+    }
+    let hasConsentObjectGlobal = false;
+    let hasResponseBooleanGlobal = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const cb = wrapped && wrapped.Cookiebot;
+      hasConsentObjectGlobal = hasCookiebotGlobal && typeof cb.consent === "object";
+      hasResponseBooleanGlobal = hasCookiebotGlobal && typeof cb.hasResponse === "boolean";
+    } catch {
+      // ignore
+    }
+    return {
+      hasOneTrustGlobal,
+      hasRejectAllFn,
+      hasBannerDom,
+      hasActiveGroupsGlobal,
+      hasRejectHandlerDom,
+      hasCookiebotGlobal,
+      hasSubmitCustomConsentFn,
+      hasCybotDialogDom,
+      hasConsentObjectGlobal,
+      hasResponseBooleanGlobal,
+    };
   }
 
   function fxRunDispatcher() {
@@ -133,6 +185,18 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.OneTrust.RejectAll();
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: Cookiebot API adapter (#1118). Same literal-false-only reject
+    // call as the Chrome MAIN-world caller — see cookie-noise-mainworld.js.
+    if (canRejectCookiebot(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.Cookiebot.submitCustomConsent(false, false, false);
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -126,7 +126,8 @@ function canRejectCookiebot(signals) {
  * Invokes the caller-supplied reject call. Kept pure (no `window` access
  * here) by requiring the caller to inject the actual global call as a
  * zero-argument callback — the content-script shell is the one place that
- * touches `window.OneTrust.RejectAll` directly. Never throws.
+ * touches the vendor CMP global directly (e.g. `window.OneTrust.RejectAll`,
+ * `window.Cookiebot.submitCustomConsent`). Never throws.
  *
  * @param {() => void} [callRejectAll]
  * @returns {{status: "rejected"|"noop"}}

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -47,6 +47,15 @@
  *   Secondary/corroborating signal.
  * @property {boolean} [hasRejectHandlerDom] - `#onetrust-reject-all-handler`
  *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCookiebotGlobal] - `typeof window.Cookiebot === "object"`.
+ * @property {boolean} [hasSubmitCustomConsentFn] - `typeof window.Cookiebot.submitCustomConsent === "function"`.
+ *   Mandatory signal: without this, no reject action can be confirmed.
+ * @property {boolean} [hasCybotDialogDom] - `#CybotCookiebotDialog` present
+ *   in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasConsentObjectGlobal] - `typeof window.Cookiebot.consent === "object"`.
+ *   Secondary/corroborating signal.
+ * @property {boolean} [hasResponseBooleanGlobal] - `typeof window.Cookiebot.hasResponse === "boolean"`.
+ *   Secondary/corroborating signal.
  */
 
 /**
@@ -74,6 +83,10 @@ export const ACTIONS = Object.freeze({
  * content/cookie-noise-mainworld.js and content/cookie-noise.js. Do not
  * edit one copy without the other two — tests/unit/cookie-noise-sync.test.mjs
  * fails the build if they drift.
+ *
+ * The same shape (mandatory reject-function signal + >=1 corroborating
+ * secondary signal) is reused verbatim for the Cookiebot adapter below
+ * (#1118) — same fail-closed confidence gate, same threshold.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -91,6 +104,21 @@ function detectOneTrust(signals) {
 
 function canRejectOneTrust(signals) {
   return detectOneTrust(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+function detectCookiebot(signals) {
+  if (!signals || signals.hasCookiebotGlobal !== true || signals.hasSubmitCustomConsentFn !== true) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasCybotDialogDom === true ? 1 : 0) +
+    (signals.hasConsentObjectGlobal === true ? 1 : 0) +
+    (signals.hasResponseBooleanGlobal === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectCookiebot(signals) {
+  return detectCookiebot(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -122,8 +150,26 @@ export const oneTrustAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * Cookiebot Tier 1 adapter (#1118). The reject call
+ * (`Cookiebot.submitCustomConsent(false, false, false)`) is invoked by the
+ * caller-supplied callback via the shared `reject()` helper above — this
+ * adapter definition never touches `window` itself. Necessary cookies are
+ * implicit/always-on in Cookiebot's model and are not one of the three
+ * positional booleans, so this call has no code path that can grant broad
+ * consent.
+ * @type {Readonly<{id: "cookiebot", tier: 1, detect: typeof detectCookiebot, canReject: typeof canRejectCookiebot, reject: typeof reject}>}
+ */
+export const cookiebotAdapter = Object.freeze({
+  id: "cookiebot",
+  tier: 1,
+  detect: detectCookiebot,
+  canReject: canRejectCookiebot,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
-export const TIER1 = Object.freeze([oneTrustAdapter]);
+export const TIER1 = Object.freeze([oneTrustAdapter, cookiebotAdapter]);
 
 /**
  * Tier 2 registry: declarative click-rule adapters (Consent-O-Matic-style).
@@ -162,6 +208,9 @@ export function decideAction(signals) {
   }
 
   if (s.hasOneTrustGlobal === true && s.hasRejectAllFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  if (s.hasCookiebotGlobal === true && s.hasSubmitCustomConsentFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/e2e/cookie-consent-minimizer-cookiebot.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-cookiebot.spec.mjs
@@ -1,0 +1,158 @@
+/**
+ * E2E: Cookie Consent Minimizer — Cookiebot Tier 1 adapter (#1118)
+ *
+ * Verifies the Cookiebot reject path against a real Chromium with the
+ * extension loaded. The fixture page mimics a Cookiebot banner: a
+ * `window.Cookiebot` object with a `submitCustomConsent(preferences,
+ * statistics, marketing)` method, the `#CybotCookiebotDialog` DOM anchor,
+ * and a `Cookiebot.consent` object plus `Cookiebot.hasResponse` boolean —
+ * the multi-signal corroboration the dispatcher requires before acting
+ * (src/lib/cmp-adapters.js).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer.spec.mjs's structure exactly
+ * (same onboarding helper shape, same feature pref).
+ *
+ * HONEST LIMIT (per design doc / exploration #1275): this is a REGRESSION
+ * oracle only — a snapshot of one fixture's behavior at write time. It
+ * proves the Chrome MAIN-world nonce handshake
+ * (content/cookie-noise-mainworld.js) and the never-auto-reject-the-other-
+ * way outcome on the fixture used here. It does NOT validate the Firefox
+ * `window.wrappedJSObject` reject path (content/cookie-noise.js) —
+ * Playwright's `chromium` fixture only exercises Chrome — and it does NOT
+ * prove real-vendor-script compatibility against a live Cookiebot CMP
+ * build. Per MUGA's Chrome DNR-regex memory-limit lesson: unit/Chromium-
+ * green does not guarantee real-env-green on every engine. A real-browser
+ * smoke test against at least one live Cookiebot-CMP site is required
+ * before considering the Cookiebot slice done — flagged for sdd-verify.
+ * Re-capture this fixture manually whenever the Cookiebot markup/API shape
+ * this test hardcodes changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-cookiebot.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMinimizerEnabled: enableFeature },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a Cookiebot banner offering granular reject via
+ * `submitCustomConsent`. All three corroborating signals are present
+ * (Cybot dialog DOM, consent object global, hasResponse boolean) alongside
+ * the mandatory submitCustomConsent function — the confidence gate in
+ * cmp-adapters.js requires the mandatory signal plus at least one of these.
+ */
+async function stubCookiebotPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="CybotCookiebotDialog">
+          <button id="CybotCookiebotDialogBodyLevelButtonAccept">Allow all</button>
+          <button id="CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll">Allow all</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.Cookiebot = {
+            consent: { necessary: true, preferences: false, statistics: false, marketing: false },
+            hasResponse: false,
+            submitCustomConsent(preferences, statistics, marketing) {
+              window.__consentState =
+                preferences === false && statistics === false && marketing === false
+                  ? "necessary-only"
+                  : "unexpected-consent";
+              document.getElementById("CybotCookiebotDialog").remove();
+            },
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — Cookiebot (#1118)", () => {
+  test("rejects a Cookiebot banner with submitCustomConsent(false, false, false) when the feature is enabled", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubCookiebotPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(() => document.getElementById("CybotCookiebotDialog") === null);
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubCookiebotPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(() => document.getElementById("CybotCookiebotDialog") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -24,6 +24,7 @@ import {
   TIER1,
   TIER2,
   oneTrustAdapter,
+  cookiebotAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -33,9 +34,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust adapter", () => {
-    assert.equal(TIER1.length, 1);
+  test("TIER1 contains exactly the OneTrust and Cookiebot adapters, in order", () => {
+    assert.equal(TIER1.length, 2);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
+    assert.strictEqual(TIER1[1], cookiebotAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -54,6 +56,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof oneTrustAdapter.detect, "function");
     assert.equal(typeof oneTrustAdapter.canReject, "function");
     assert.equal(typeof oneTrustAdapter.reject, "function");
+  });
+
+  test("cookiebotAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(cookiebotAdapter.id, "cookiebot");
+    assert.equal(cookiebotAdapter.tier, 1);
+    assert.equal(typeof cookiebotAdapter.detect, "function");
+    assert.equal(typeof cookiebotAdapter.canReject, "function");
+    assert.equal(typeof cookiebotAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -116,6 +126,43 @@ describe("decideAction — truth table", () => {
     assert.equal(r.action, null);
     assert.equal(r.reason, "uncertain");
   });
+
+  test("Cookiebot submitCustomConsent present + corroborated -> reject", () => {
+    const r = decideAction({
+      hasCookiebotGlobal: true,
+      hasSubmitCustomConsentFn: true,
+      hasCybotDialogDom: true,
+      hasConsentObjectGlobal: true,
+      hasResponseBooleanGlobal: true,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "cookiebot");
+  });
+
+  test("Cookiebot global present but submitCustomConsent absent (hard wall) -> NOOP", () => {
+    const r = decideAction({
+      hasCookiebotGlobal: true,
+      hasSubmitCustomConsentFn: false,
+      hasCybotDialogDom: true,
+      hasConsentObjectGlobal: true,
+      hasResponseBooleanGlobal: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("Cookiebot mandatory signal present but zero corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasCookiebotGlobal: true,
+      hasSubmitCustomConsentFn: true,
+      hasCybotDialogDom: false,
+      hasConsentObjectGlobal: false,
+      hasResponseBooleanGlobal: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
 });
 
 // ── detect() / canReject() — multi-signal confidence gate ──────────────────
@@ -169,6 +216,63 @@ describe("oneTrustAdapter.detect — confidence gate", () => {
   });
 });
 
+describe("cookiebotAdapter.detect — confidence gate", () => {
+  const FULL_COOKIEBOT_SIGNALS = Object.freeze({
+    hasCookiebotGlobal: true,
+    hasSubmitCustomConsentFn: true,
+    hasCybotDialogDom: true,
+    hasConsentObjectGlobal: true,
+    hasResponseBooleanGlobal: true,
+  });
+
+  test("mandatory + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = cookiebotAdapter.detect(FULL_COOKIEBOT_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(cookiebotAdapter.canReject(FULL_COOKIEBOT_SIGNALS), true);
+  });
+
+  test("mandatory + exactly one secondary (Cybot dialog DOM only) -> canReject true", () => {
+    const s = {
+      hasCookiebotGlobal: true,
+      hasSubmitCustomConsentFn: true,
+      hasCybotDialogDom: true,
+      hasConsentObjectGlobal: false,
+      hasResponseBooleanGlobal: false,
+    };
+    assert.equal(cookiebotAdapter.canReject(s), true);
+  });
+
+  test("global-only (mandatory present, zero secondary signals) -> uncertain, canReject false", () => {
+    const s = {
+      hasCookiebotGlobal: true,
+      hasSubmitCustomConsentFn: true,
+      hasCybotDialogDom: false,
+      hasConsentObjectGlobal: false,
+      hasResponseBooleanGlobal: false,
+    };
+    assert.equal(cookiebotAdapter.canReject(s), false);
+    assert.ok(cookiebotAdapter.detect(s) < 1);
+  });
+
+  test("DOM-only (mandatory submitCustomConsent fn missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasCookiebotGlobal: false,
+      hasSubmitCustomConsentFn: false,
+      hasCybotDialogDom: true,
+      hasConsentObjectGlobal: true,
+      hasResponseBooleanGlobal: true,
+    };
+    assert.equal(cookiebotAdapter.detect(s), 0);
+    assert.equal(cookiebotAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => cookiebotAdapter.detect(null));
+    assert.doesNotThrow(() => cookiebotAdapter.detect(undefined));
+    assert.equal(cookiebotAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -186,6 +290,25 @@ describe("oneTrustAdapter.reject — pure callback invocation", () => {
 
   test("non-function argument -> status noop, no call", () => {
     const r = oneTrustAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+describe("cookiebotAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = cookiebotAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = cookiebotAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = cookiebotAdapter.reject(undefined);
     assert.equal(r.status, "noop");
   });
 });
@@ -292,5 +415,10 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
         assert.doesNotMatch(key, FORBIDDEN, `adapter "${adapter.id}" exposes a forbidden method: ${key}`);
       }
     }
+  });
+
+  test("cookiebotAdapter is registered in TIER1 alongside oneTrustAdapter (#1118)", () => {
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must include cookiebotAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -100,6 +100,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectOneTrust/.test(joined));
     assert.ok(/function canRejectOneTrust/.test(joined));
   });
+
+  test("sync block also defines detectCookiebot and canRejectCookiebot (#1118)", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectCookiebot/.test(joined));
+    assert.ok(/function canRejectCookiebot/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -272,6 +278,28 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       const calls = [...src.matchAll(/OneTrust\.(\w+)\s*\(/g)].map((m) => m[1]);
       for (const fn of calls) {
         assert.equal(fn, "RejectAll", `${label} calls OneTrust.${fn}() — only RejectAll is permitted`);
+      }
+    }
+  });
+
+  test("only window.Cookiebot.submitCustomConsent (or wrappedJSObject equivalent) is invoked — no other Cookiebot method call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/Cookiebot\.(\w+)\s*\(/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call Cookiebot.submitCustomConsent`);
+      for (const fn of calls) {
+        assert.equal(fn, "submitCustomConsent", `${label} calls Cookiebot.${fn}() — only submitCustomConsent is permitted`);
+      }
+    }
+  });
+
+  test("every submitCustomConsent call passes the literal (false, false, false) — never true, never a variable", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/submitCustomConsent\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call submitCustomConsent`);
+      for (const args of calls) {
+        assert.equal(args, "false, false, false", `${label} submitCustomConsent must be called with (false, false, false)`);
       }
     }
   });


### PR DESCRIPTION
Closes #1118
Related: #1121 (Usercentrics follow-up, verification-gated)

## Summary

Adds a **Cookiebot** Tier 1 adapter to the cookie-consent-minimizer module (second CMP after OneTrust). It clicks reject / necessary-only on the user's behalf via Cookiebot's own API and never auto-accepts. Extends the existing two-tier dispatcher + `cmp-adapters.js` registry — no new UI, no new pref, no manifest change, no new permissions.

Targets **`develop`** (integration branch), not main.

## What it does

- **Reject API (verified, 3 sources)**: `window.Cookiebot.submitCustomConsent(false, false, false)` (preferences / statistics / marketing; necessary is implicit). Synchronous. No callable `decline()` exists. Firefox mirror: `window.wrappedJSObject.Cookiebot.submitCustomConsent(false, false, false)`.
- **Detection (multi-signal, fail-closed)**: mandatory `window.Cookiebot` object + `submitCustomConsent` function, plus ≥1 corroborating signal (`#CybotCookiebotDialog`, `Cookiebot.consent`, or `Cookiebot.hasResponse`). Below threshold → NOOP.
- **Never-auto-accept** stays structurally enforced: two new static guards forbid any Cookiebot method other than `submitCustomConsent`, and require every `submitCustomConsent` call to use the exact literal `(false, false, false)` — never `true`, never a variable. No accept/AllowAll token anywhere.
- Registered as the second entry in `TIER1`; OneTrust path byte-unchanged; one reject per page per world (idempotency intact).

## Changes

| File | Change |
|------|--------|
| `src/lib/cmp-adapters.js` | `cookiebotAdapter` added to TIER1, `@sync` block extended, `decideAction` Cookiebot hard-wall branch |
| `src/content/cookie-noise.js` / `cookie-noise-mainworld.js` | Cookiebot signals + reject wired (Chrome MAIN / Firefox wrappedJSObject); `@sync` block extended identically |
| `tests/unit/cmp-adapters.test.mjs` | detection + decideAction truth tables, registry-shape, reject callback tests |
| `tests/unit/cookie-noise-sync.test.mjs` | sync guard for the new block + the literal-args never-accept guards |
| `tests/e2e/cookie-consent-minimizer-cookiebot.spec.mjs` | Chromium snapshot regression fixture |

## Test + review

- [x] `npm test` — 6584 pass / 0 fail (independently re-run in review)
- [x] `npm run check:i18n`, `npm run lint`, `build:content` drift gate — all clean
- [x] Adversarial review (independent verify + 7 focus areas) — 0 CRITICAL / 0 HIGH; never-accept, fail-closed, @sync consistency, OneTrust non-regression all confirmed clean

## Pre-ship gate (blocks store release, not this merge)

- [ ] Real-browser smoke: the Firefox `wrappedJSObject` reject path and live-Cookiebot compatibility are structurally tested only (Chromium e2e fixture is a regression oracle, not a real-vendor test). Run a `web-ext` + live-Cookiebot smoke before the next store release — same policy as OneTrust (unit-green != real-env-green).
