### PR TITLE
feat(consent): Didomi CMP adapter (Tier 1)

### DIFF
--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -72,6 +72,20 @@
   function canRejectCookiebot(signals) {
     return detectCookiebot(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  function detectDidomi(signals) {
+    if (!signals || signals.hasDidomiGlobal !== true || signals.hasSetUserDisagreeToAllFn !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasDidomiHostDom === true ? 1 : 0) +
+      (signals.hasGetCurrentUserStatusFn === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectDidomi(signals) {
+    return detectDidomi(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -128,6 +142,28 @@
     } catch {
       // ignore
     }
+    let hasDidomiGlobal = false;
+    let hasSetUserDisagreeToAllFn = false;
+    try {
+      hasDidomiGlobal = typeof window.Didomi === "object" && window.Didomi !== null;
+      hasSetUserDisagreeToAllFn =
+        hasDidomiGlobal && typeof window.Didomi.setUserDisagreeToAll === "function";
+    } catch {
+      // Leave both false — fail-closed.
+    }
+    let hasDidomiHostDom = false;
+    try {
+      hasDidomiHostDom = !!document.getElementById("didomi-host");
+    } catch {
+      // document not ready / detached — leave false.
+    }
+    let hasGetCurrentUserStatusFn = false;
+    try {
+      hasGetCurrentUserStatusFn =
+        hasDidomiGlobal && typeof window.Didomi.getCurrentUserStatus === "function";
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -139,6 +175,10 @@
       hasCybotDialogDom,
       hasConsentObjectGlobal,
       hasResponseBooleanGlobal,
+      hasDidomiGlobal,
+      hasSetUserDisagreeToAllFn,
+      hasDidomiHostDom,
+      hasGetCurrentUserStatusFn,
     };
   }
 
@@ -176,6 +216,19 @@
       _acted = true;
       try {
         window.Cookiebot.submitCustomConsent(false, false, false);
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: Didomi API adapter (#1119). Same zero-argument, synchronous
+    // reject-call shape as OneTrust.RejectAll() — setUserDisagreeToAll()
+    // takes no consent-granting parameter at all.
+    if (canRejectDidomi(signals)) {
+      _acted = true;
+      try {
+        window.Didomi.setUserDisagreeToAll();
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -255,6 +255,7 @@
         // A throwing page global must never break the page.
       }
       fxStopObserver();
+      return;
     }
   }
 

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -68,6 +68,20 @@
   function canRejectCookiebot(signals) {
     return detectCookiebot(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  function detectDidomi(signals) {
+    if (!signals || signals.hasDidomiGlobal !== true || signals.hasSetUserDisagreeToAllFn !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasDidomiHostDom === true ? 1 : 0) +
+      (signals.hasGetCurrentUserStatusFn === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectDidomi(signals) {
+    return detectDidomi(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -164,6 +178,30 @@
     } catch {
       // ignore
     }
+    let hasDidomiGlobal = false;
+    let hasSetUserDisagreeToAllFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const di = wrapped && wrapped.Didomi;
+      hasDidomiGlobal = typeof di === "object" && di !== null;
+      hasSetUserDisagreeToAllFn = hasDidomiGlobal && typeof di.setUserDisagreeToAll === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasDidomiHostDom = false;
+    try {
+      hasDidomiHostDom = !!document.getElementById("didomi-host");
+    } catch {
+      // ignore
+    }
+    let hasGetCurrentUserStatusFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const di = wrapped && wrapped.Didomi;
+      hasGetCurrentUserStatusFn = hasDidomiGlobal && typeof di.getCurrentUserStatus === "function";
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -175,6 +213,10 @@
       hasCybotDialogDom,
       hasConsentObjectGlobal,
       hasResponseBooleanGlobal,
+      hasDidomiGlobal,
+      hasSetUserDisagreeToAllFn,
+      hasDidomiHostDom,
+      hasGetCurrentUserStatusFn,
     };
   }
 
@@ -197,6 +239,18 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.Cookiebot.submitCustomConsent(false, false, false);
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: Didomi API adapter (#1119). Same zero-argument, synchronous
+    // reject-call shape as OneTrust.RejectAll() — see cookie-noise-mainworld.js.
+    if (canRejectDidomi(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.Didomi.setUserDisagreeToAll();
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -56,6 +56,13 @@
  *   Secondary/corroborating signal.
  * @property {boolean} [hasResponseBooleanGlobal] - `typeof window.Cookiebot.hasResponse === "boolean"`.
  *   Secondary/corroborating signal.
+ * @property {boolean} [hasDidomiGlobal] - `typeof window.Didomi === "object"`.
+ * @property {boolean} [hasSetUserDisagreeToAllFn] - `typeof window.Didomi.setUserDisagreeToAll === "function"`.
+ *   Mandatory signal: without this, no reject action can be confirmed.
+ * @property {boolean} [hasDidomiHostDom] - `#didomi-host` present in the DOM.
+ *   Secondary/corroborating signal.
+ * @property {boolean} [hasGetCurrentUserStatusFn] - `typeof window.Didomi.getCurrentUserStatus === "function"`.
+ *   Secondary/corroborating signal.
  */
 
 /**
@@ -86,7 +93,11 @@ export const ACTIONS = Object.freeze({
  *
  * The same shape (mandatory reject-function signal + >=1 corroborating
  * secondary signal) is reused verbatim for the Cookiebot adapter below
- * (#1118) — same fail-closed confidence gate, same threshold.
+ * (#1118) — same fail-closed confidence gate, same threshold. The Didomi
+ * adapter (#1119) reuses it again: like OneTrust, its reject call
+ * (`Didomi.setUserDisagreeToAll()`) is a direct zero-argument vendor-global
+ * method call, so it is modeled on the OneTrust detection shape rather than
+ * Cookiebot's literal-args guard.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -119,6 +130,20 @@ function detectCookiebot(signals) {
 
 function canRejectCookiebot(signals) {
   return detectCookiebot(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+function detectDidomi(signals) {
+  if (!signals || signals.hasDidomiGlobal !== true || signals.hasSetUserDisagreeToAllFn !== true) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasDidomiHostDom === true ? 1 : 0) +
+    (signals.hasGetCurrentUserStatusFn === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectDidomi(signals) {
+  return detectDidomi(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -169,8 +194,27 @@ export const cookiebotAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * Didomi Tier 1 adapter (#1119). The reject call
+ * (`Didomi.setUserDisagreeToAll()`) is invoked by the caller-supplied
+ * callback via the shared `reject()` helper above — this adapter
+ * definition never touches `window` itself. Same call shape as
+ * `oneTrustAdapter.RejectAll()`: synchronous, zero arguments, void return.
+ * Unlike Cookiebot's three positional booleans, this call has no
+ * consent-granting parameter at all — there is no argument surface a
+ * future edit could flip to grant broad consent.
+ * @type {Readonly<{id: "didomi", tier: 1, detect: typeof detectDidomi, canReject: typeof canRejectDidomi, reject: typeof reject}>}
+ */
+export const didomiAdapter = Object.freeze({
+  id: "didomi",
+  tier: 1,
+  detect: detectDidomi,
+  canReject: canRejectDidomi,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
-export const TIER1 = Object.freeze([oneTrustAdapter, cookiebotAdapter]);
+export const TIER1 = Object.freeze([oneTrustAdapter, cookiebotAdapter, didomiAdapter]);
 
 /**
  * Tier 2 registry: declarative click-rule adapters (Consent-O-Matic-style).
@@ -212,6 +256,9 @@ export function decideAction(signals) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   if (s.hasCookiebotGlobal === true && s.hasSubmitCustomConsentFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  if (s.hasDidomiGlobal === true && s.hasSetUserDisagreeToAllFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/e2e/cookie-consent-minimizer-didomi.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-didomi.spec.mjs
@@ -1,0 +1,155 @@
+/**
+ * E2E: Cookie Consent Minimizer — Didomi Tier 1 adapter (#1119)
+ *
+ * Verifies the Didomi reject path against a real Chromium with the
+ * extension loaded. The fixture page mimics a Didomi banner: a
+ * `window.Didomi` object with a `setUserDisagreeToAll()` method, the
+ * `#didomi-host` DOM anchor, and a `getCurrentUserStatus()` function — the
+ * multi-signal corroboration the dispatcher requires before acting
+ * (src/lib/cmp-adapters.js).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookiebot.spec.mjs's structure
+ * exactly (same onboarding helper shape, same feature pref).
+ *
+ * HONEST LIMIT (per design doc / exploration #1278): this is a REGRESSION
+ * oracle only — a snapshot of one fixture's behavior at write time. It
+ * proves the Chrome MAIN-world nonce handshake
+ * (content/cookie-noise-mainworld.js) and the never-auto-reject-the-other-
+ * way outcome on the fixture used here. It does NOT validate the Firefox
+ * `window.wrappedJSObject` reject path (content/cookie-noise.js) —
+ * Playwright's `chromium` fixture only exercises Chrome — and it does NOT
+ * prove real-vendor-script compatibility against a live Didomi CMP build.
+ * Per MUGA's Chrome DNR-regex memory-limit lesson: unit/Chromium-green does
+ * not guarantee real-env-green on every engine. A real-browser smoke test
+ * against at least one live Didomi-CMP site is required before considering
+ * the Didomi slice done — flagged for sdd-verify. Re-capture this fixture
+ * manually whenever the Didomi markup/API shape this test hardcodes changes
+ * upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-didomi.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMinimizerEnabled: enableFeature },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a Didomi banner offering a reject-all via
+ * `setUserDisagreeToAll()`. Both corroborating signals are present
+ * (`#didomi-host` DOM anchor, `getCurrentUserStatus` function) alongside
+ * the mandatory `setUserDisagreeToAll` function — the confidence gate in
+ * cmp-adapters.js requires the mandatory signal plus at least one of these.
+ */
+async function stubDidomiPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="didomi-host">
+          <button id="didomi-notice-agree-button">Agree</button>
+          <button id="didomi-notice-disagree-button">Disagree</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.Didomi = {
+            getCurrentUserStatus() {
+              return { purposes: {}, vendors: {} };
+            },
+            setUserDisagreeToAll() {
+              window.__consentState = "necessary-only";
+              document.getElementById("didomi-host").remove();
+            },
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — Didomi (#1119)", () => {
+  test("rejects a Didomi banner with setUserDisagreeToAll() when the feature is enabled", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubDidomiPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(() => document.getElementById("didomi-host") === null);
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubDidomiPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(() => document.getElementById("didomi-host") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -25,6 +25,7 @@ import {
   TIER2,
   oneTrustAdapter,
   cookiebotAdapter,
+  didomiAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -34,10 +35,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust and Cookiebot adapters, in order", () => {
-    assert.equal(TIER1.length, 2);
+  test("TIER1 contains exactly the OneTrust, Cookiebot and Didomi adapters, in order", () => {
+    assert.equal(TIER1.length, 3);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
+    assert.strictEqual(TIER1[2], didomiAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -64,6 +66,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof cookiebotAdapter.detect, "function");
     assert.equal(typeof cookiebotAdapter.canReject, "function");
     assert.equal(typeof cookiebotAdapter.reject, "function");
+  });
+
+  test("didomiAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(didomiAdapter.id, "didomi");
+    assert.equal(didomiAdapter.tier, 1);
+    assert.equal(typeof didomiAdapter.detect, "function");
+    assert.equal(typeof didomiAdapter.canReject, "function");
+    assert.equal(typeof didomiAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -159,6 +169,40 @@ describe("decideAction — truth table", () => {
       hasCybotDialogDom: false,
       hasConsentObjectGlobal: false,
       hasResponseBooleanGlobal: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("Didomi setUserDisagreeToAll present + corroborated -> reject", () => {
+    const r = decideAction({
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: true,
+      hasDidomiHostDom: true,
+      hasGetCurrentUserStatusFn: true,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "didomi");
+  });
+
+  test("Didomi global present but setUserDisagreeToAll absent (hard wall) -> NOOP", () => {
+    const r = decideAction({
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: false,
+      hasDidomiHostDom: true,
+      hasGetCurrentUserStatusFn: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("Didomi mandatory signal present but zero corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: true,
+      hasDidomiHostDom: false,
+      hasGetCurrentUserStatusFn: false,
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "uncertain");
@@ -273,6 +317,59 @@ describe("cookiebotAdapter.detect — confidence gate", () => {
   });
 });
 
+describe("didomiAdapter.detect — confidence gate", () => {
+  const FULL_DIDOMI_SIGNALS = Object.freeze({
+    hasDidomiGlobal: true,
+    hasSetUserDisagreeToAllFn: true,
+    hasDidomiHostDom: true,
+    hasGetCurrentUserStatusFn: true,
+  });
+
+  test("mandatory + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = didomiAdapter.detect(FULL_DIDOMI_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(didomiAdapter.canReject(FULL_DIDOMI_SIGNALS), true);
+  });
+
+  test("mandatory + exactly one secondary (#didomi-host DOM only) -> canReject true", () => {
+    const s = {
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: true,
+      hasDidomiHostDom: true,
+      hasGetCurrentUserStatusFn: false,
+    };
+    assert.equal(didomiAdapter.canReject(s), true);
+  });
+
+  test("global-only (mandatory present, zero secondary signals) -> uncertain, canReject false", () => {
+    const s = {
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: true,
+      hasDidomiHostDom: false,
+      hasGetCurrentUserStatusFn: false,
+    };
+    assert.equal(didomiAdapter.canReject(s), false);
+    assert.ok(didomiAdapter.detect(s) < 1);
+  });
+
+  test("DOM-only (mandatory setUserDisagreeToAll fn missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasDidomiGlobal: false,
+      hasSetUserDisagreeToAllFn: false,
+      hasDidomiHostDom: true,
+      hasGetCurrentUserStatusFn: true,
+    };
+    assert.equal(didomiAdapter.detect(s), 0);
+    assert.equal(didomiAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => didomiAdapter.detect(null));
+    assert.doesNotThrow(() => didomiAdapter.detect(undefined));
+    assert.equal(didomiAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -309,6 +406,25 @@ describe("cookiebotAdapter.reject — pure callback invocation", () => {
 
   test("non-function argument -> status noop, no call", () => {
     const r = cookiebotAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+describe("didomiAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = didomiAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = didomiAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = didomiAdapter.reject(undefined);
     assert.equal(r.status, "noop");
   });
 });
@@ -420,5 +536,11 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
   test("cookiebotAdapter is registered in TIER1 alongside oneTrustAdapter (#1118)", () => {
     assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must include cookiebotAdapter");
     assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+  });
+
+  test("didomiAdapter is registered in TIER1 alongside oneTrustAdapter and cookiebotAdapter (#1119)", () => {
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must include didomiAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -106,6 +106,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectCookiebot/.test(joined));
     assert.ok(/function canRejectCookiebot/.test(joined));
   });
+
+  test("sync block also defines detectDidomi and canRejectDidomi (#1119)", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectDidomi/.test(joined));
+    assert.ok(/function canRejectDidomi/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -300,6 +306,28 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       assert.ok(calls.length > 0, `${label} must call submitCustomConsent`);
       for (const args of calls) {
         assert.equal(args, "false, false, false", `${label} submitCustomConsent must be called with (false, false, false)`);
+      }
+    }
+  });
+
+  test("only window.Didomi.setUserDisagreeToAll (or wrappedJSObject equivalent) is invoked — no other Didomi method call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/Didomi\.(\w+)\s*\(/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call Didomi.setUserDisagreeToAll`);
+      for (const fn of calls) {
+        assert.equal(fn, "setUserDisagreeToAll", `${label} calls Didomi.${fn}() — only setUserDisagreeToAll is permitted`);
+      }
+    }
+  });
+
+  test("every setUserDisagreeToAll call passes zero arguments", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/setUserDisagreeToAll\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call setUserDisagreeToAll`);
+      for (const args of calls) {
+        assert.equal(args, "", `${label} setUserDisagreeToAll must be called with zero arguments`);
       }
     }
   });


### PR DESCRIPTION
Closes #1119
Related: #1123 (Sourcepoint follow-up, smoke-gated)

## Summary

Adds a **Didomi** Tier 1 adapter to the cookie-consent-minimizer module (third CMP, after OneTrust and Cookiebot). Clicks reject / deny-all on the user's behalf via Didomi's own API and never auto-accepts. Extends the existing two-tier dispatcher + `cmp-adapters.js` registry — no new UI, pref, manifest change, or permissions.

Targets **`develop`** (integration branch), not main.

## What it does

- **Reject API (verified)**: `window.Didomi.setUserDisagreeToAll()` — synchronous, zero-arg, denies consent + legitimate-interest for all purposes/vendors. No consent-granting parameter exists (safer than Cookiebot). Firefox mirror: `window.wrappedJSObject.Didomi.setUserDisagreeToAll()`. Same call shape as OneTrust's `RejectAll()`.
- **Detection (multi-signal, fail-closed)**: mandatory `window.Didomi` object + `setUserDisagreeToAll` function, plus ≥1 corroborating signal (`#didomi-host` element or `Didomi.getCurrentUserStatus` function). Below threshold → NOOP.
- **Never-auto-accept** stays structurally enforced: guards forbid any Didomi method other than `setUserDisagreeToAll` and require zero args. No accept/AllowAll token anywhere. `getCurrentUserStatus` is typeof-checked only, never invoked.
- Registered as the third TIER1 entry; OneTrust + Cookiebot paths byte-unchanged; one reject per page per world (idempotency intact).

## Changes

| File | Change |
|------|--------|
| `src/lib/cmp-adapters.js` | `didomiAdapter` added to TIER1, `@sync` block extended, `decideAction` Didomi hard-wall branch |
| `src/content/cookie-noise.js` / `cookie-noise-mainworld.js` | Didomi signals + reject wired (Chrome MAIN / Firefox wrappedJSObject); `@sync` block extended identically; symmetry fix (missing `return` in the FF dispatcher branch) |
| `tests/unit/cmp-adapters.test.mjs` | detection + decideAction truth tables, registry-shape (TIER1 length 3) |
| `tests/unit/cookie-noise-sync.test.mjs` | sync guard for the new block + never-accept guards (only setUserDisagreeToAll, zero args) |
| `tests/e2e/cookie-consent-minimizer-didomi.spec.mjs` | Chromium snapshot regression fixture |

## Test + review

- [x] `npm test` — 6603 pass / 0 fail (independently re-run in review)
- [x] `npm run check:i18n`, `npm run lint`, `build:content` drift gate — all clean
- [x] Adversarial review (independent verify + 6 focus areas) — 0 CRITICAL / 0 HIGH; decideAction three-branch logic, never-accept, @sync consistency, OneTrust/Cookiebot non-regression all confirmed clean

## Pre-ship gate (blocks store release, not this merge)

- [ ] Real-browser smoke: the Firefox `wrappedJSObject` path and live-Didomi compatibility are structurally tested only (Chromium e2e is a regression oracle). Run a `web-ext` + live-Didomi smoke before the next store release — same policy as OneTrust/Cookiebot (unit-green != real-env-green).
