### PR TITLE
feat(consent): CookieYes CMP adapter (Tier 1)

### DIFF
--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -86,6 +86,25 @@
   function canRejectDidomi(signals) {
     return detectDidomi(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  function detectCookieYes(signals) {
+    if (
+      !signals ||
+      signals.hasGetCkyConsentFn !== true ||
+      signals.hasPerformBannerActionFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCkyConsentContainerDom === true ? 1 : 0) +
+      (signals.hasCkyOverlayDom === true ? 1 : 0) +
+      (signals.hasCkyConsentBarDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookieYes(signals) {
+    return detectCookieYes(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -164,6 +183,28 @@
     } catch {
       // ignore
     }
+    // CookieYes (#1120): unlike the three adapters above, the reject call
+    // is a BARE global (`window.performBannerAction`), not a method on a
+    // vendor-namespaced object. Both bare globals are checked directly —
+    // see the dual-mandatory-signal rationale on detectCookieYes above.
+    let hasGetCkyConsentFn = false;
+    let hasPerformBannerActionFn = false;
+    try {
+      hasGetCkyConsentFn = typeof window.getCkyConsent === "function";
+      hasPerformBannerActionFn = typeof window.performBannerAction === "function";
+    } catch {
+      // Leave both false — fail-closed.
+    }
+    let hasCkyConsentContainerDom = false;
+    let hasCkyOverlayDom = false;
+    let hasCkyConsentBarDom = false;
+    try {
+      hasCkyConsentContainerDom = !!document.querySelector(".cky-consent-container");
+      hasCkyOverlayDom = !!document.querySelector(".cky-overlay");
+      hasCkyConsentBarDom = !!document.querySelector(".cky-consent-bar");
+    } catch {
+      // document not ready / detached — leave all false.
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -179,6 +220,11 @@
       hasSetUserDisagreeToAllFn,
       hasDidomiHostDom,
       hasGetCurrentUserStatusFn,
+      hasGetCkyConsentFn,
+      hasPerformBannerActionFn,
+      hasCkyConsentContainerDom,
+      hasCkyOverlayDom,
+      hasCkyConsentBarDom,
     };
   }
 
@@ -229,6 +275,21 @@
       _acted = true;
       try {
         window.Didomi.setUserDisagreeToAll();
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: CookieYes API adapter (#1120). performBannerAction is a bare
+    // global function, not a vendor-namespaced method — the dual-mandatory
+    // detection gate (both getCkyConsent and performBannerAction present)
+    // is what makes this a confident CookieYes match. The literal string
+    // "reject" is the only argument this call site ever passes.
+    if (canRejectCookieYes(signals)) {
+      _acted = true;
+      try {
+        window.performBannerAction("reject");
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -82,6 +82,25 @@
   function canRejectDidomi(signals) {
     return detectDidomi(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  function detectCookieYes(signals) {
+    if (
+      !signals ||
+      signals.hasGetCkyConsentFn !== true ||
+      signals.hasPerformBannerActionFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCkyConsentContainerDom === true ? 1 : 0) +
+      (signals.hasCkyOverlayDom === true ? 1 : 0) +
+      (signals.hasCkyConsentBarDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookieYes(signals) {
+    return detectCookieYes(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -202,6 +221,30 @@
     } catch {
       // ignore
     }
+    // CookieYes (#1120): unlike the three adapters above, the reject call
+    // is a BARE global (`wrappedJSObject.performBannerAction`), not a
+    // method on a vendor-namespaced object. Both bare globals are checked
+    // directly — see the dual-mandatory-signal rationale on
+    // detectCookieYes in cookie-noise-mainworld.js / cmp-adapters.js.
+    let hasGetCkyConsentFn = false;
+    let hasPerformBannerActionFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      hasGetCkyConsentFn = wrapped && typeof wrapped.getCkyConsent === "function";
+      hasPerformBannerActionFn = wrapped && typeof wrapped.performBannerAction === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasCkyConsentContainerDom = false;
+    let hasCkyOverlayDom = false;
+    let hasCkyConsentBarDom = false;
+    try {
+      hasCkyConsentContainerDom = !!document.querySelector(".cky-consent-container");
+      hasCkyOverlayDom = !!document.querySelector(".cky-overlay");
+      hasCkyConsentBarDom = !!document.querySelector(".cky-consent-bar");
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -217,6 +260,11 @@
       hasSetUserDisagreeToAllFn,
       hasDidomiHostDom,
       hasGetCurrentUserStatusFn,
+      hasGetCkyConsentFn,
+      hasPerformBannerActionFn,
+      hasCkyConsentContainerDom,
+      hasCkyOverlayDom,
+      hasCkyConsentBarDom,
     };
   }
 
@@ -251,6 +299,19 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.Didomi.setUserDisagreeToAll();
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: CookieYes API adapter (#1120). Same dual-mandatory-signal
+    // detection and literal "reject"-only argument as the Chrome
+    // MAIN-world caller — see cookie-noise-mainworld.js.
+    if (canRejectCookieYes(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.performBannerAction("reject");
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -63,6 +63,19 @@
  *   Secondary/corroborating signal.
  * @property {boolean} [hasGetCurrentUserStatusFn] - `typeof window.Didomi.getCurrentUserStatus === "function"`.
  *   Secondary/corroborating signal.
+ * @property {boolean} [hasGetCkyConsentFn] - `typeof window.getCkyConsent === "function"`.
+ *   Mandatory signal (dual-mandatory with hasPerformBannerActionFn below):
+ *   both bare CookieYes globals are required together, since neither one
+ *   alone is a vendor-namespaced anchor like `window.OneTrust`.
+ * @property {boolean} [hasPerformBannerActionFn] - `typeof window.performBannerAction === "function"`.
+ *   Mandatory signal (dual-mandatory with hasGetCkyConsentFn above): without
+ *   both, no reject action can be confirmed.
+ * @property {boolean} [hasCkyConsentContainerDom] - `.cky-consent-container`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCkyOverlayDom] - `.cky-overlay` present in the DOM.
+ *   Secondary/corroborating signal.
+ * @property {boolean} [hasCkyConsentBarDom] - `.cky-consent-bar` present in
+ *   the DOM. Secondary/corroborating signal.
  */
 
 /**
@@ -98,6 +111,17 @@ export const ACTIONS = Object.freeze({
  * (`Didomi.setUserDisagreeToAll()`) is a direct zero-argument vendor-global
  * method call, so it is modeled on the OneTrust detection shape rather than
  * Cookiebot's literal-args guard.
+ *
+ * The CookieYes adapter (#1120) DEVIATES from this shape on purpose: its
+ * reject call (`performBannerAction("reject")`) is a BARE global function,
+ * not a method on a vendor-namespaced object like `window.OneTrust` /
+ * `window.Cookiebot` / `window.Didomi`. A single bare, generically-named
+ * global would be a weaker anchor than the other three (name-collision
+ * risk with an unrelated page script), so detectCookieYes strengthens the
+ * MANDATORY bar instead of weakening the corroboration bar: it requires
+ * BOTH `getCkyConsent` and `performBannerAction` bare globals present
+ * together, still gated by the same >=1 DOM secondary signal and the same
+ * CONFIDENCE_THRESHOLD.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -144,6 +168,25 @@ function detectDidomi(signals) {
 
 function canRejectDidomi(signals) {
   return detectDidomi(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+function detectCookieYes(signals) {
+  if (
+    !signals ||
+    signals.hasGetCkyConsentFn !== true ||
+    signals.hasPerformBannerActionFn !== true
+  ) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasCkyConsentContainerDom === true ? 1 : 0) +
+    (signals.hasCkyOverlayDom === true ? 1 : 0) +
+    (signals.hasCkyConsentBarDom === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectCookieYes(signals) {
+  return detectCookieYes(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -213,8 +256,35 @@ export const didomiAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * CookieYes Tier 1 adapter (#1120). The reject call
+ * (`performBannerAction("reject")`) is invoked by the caller-supplied
+ * callback via the shared `reject()` helper above — this adapter
+ * definition never touches `window` itself.
+ *
+ * Detection deviates from the other three adapters' shape ON PURPOSE: the
+ * reject call is a BARE global function (`window.performBannerAction`),
+ * not a method on a vendor-namespaced object like `window.OneTrust` /
+ * `window.Cookiebot` / `window.Didomi`. A single bare, generically-named
+ * global has a real name-collision risk (an unrelated page script could
+ * define its own `performBannerAction`), so this adapter requires BOTH
+ * CookieYes-specific bare globals (`getCkyConsent` AND
+ * `performBannerAction`) as the mandatory gate — strengthening the
+ * mandatory bar instead of weakening the corroboration bar — plus the
+ * usual >=1 DOM secondary signal before crossing the confidence
+ * threshold. See detectCookieYes above.
+ * @type {Readonly<{id: "cookieyes", tier: 1, detect: typeof detectCookieYes, canReject: typeof canRejectCookieYes, reject: typeof reject}>}
+ */
+export const cookieYesAdapter = Object.freeze({
+  id: "cookieyes",
+  tier: 1,
+  detect: detectCookieYes,
+  canReject: canRejectCookieYes,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
-export const TIER1 = Object.freeze([oneTrustAdapter, cookiebotAdapter, didomiAdapter]);
+export const TIER1 = Object.freeze([oneTrustAdapter, cookiebotAdapter, didomiAdapter, cookieYesAdapter]);
 
 /**
  * Tier 2 registry: declarative click-rule adapters (Consent-O-Matic-style).
@@ -259,6 +329,9 @@ export function decideAction(signals) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   if (s.hasDidomiGlobal === true && s.hasSetUserDisagreeToAllFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  if (s.hasGetCkyConsentFn === true && s.hasPerformBannerActionFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/e2e/cookie-consent-minimizer-cookieyes.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-cookieyes.spec.mjs
@@ -1,0 +1,176 @@
+/**
+ * E2E: Cookie Consent Minimizer — CookieYes Tier 1 adapter (#1120)
+ *
+ * Verifies the CookieYes reject path against a real Chromium with the
+ * extension loaded. The fixture page mimics a CookieYes banner: BARE page
+ * globals `window.getCkyConsent()` and `window.performBannerAction(action)`
+ * (unlike OneTrust/Cookiebot/Didomi, CookieYes does not namespace these
+ * under a vendor object), plus the `.cky-consent-container` DOM anchor —
+ * the dual-mandatory-signal + DOM corroboration the dispatcher requires
+ * before acting (src/lib/cmp-adapters.js).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookiebot.spec.mjs's structure
+ * exactly (same onboarding helper shape, same feature pref).
+ *
+ * HONEST LIMIT (per design doc / exploration #1280): this is a REGRESSION
+ * oracle only — a snapshot of one fixture's behavior at write time. It
+ * proves the Chrome MAIN-world nonce handshake
+ * (content/cookie-noise-mainworld.js) and the never-auto-reject-the-other-
+ * way outcome on the fixture used here. It does NOT validate the Firefox
+ * `window.wrappedJSObject` reject path (content/cookie-noise.js) —
+ * Playwright's `chromium` fixture only exercises Chrome — and it does NOT
+ * prove real-vendor-script compatibility against a live CookieYes CMP
+ * build. Per MUGA's Chrome DNR-regex memory-limit lesson: unit/Chromium-
+ * green does not guarantee real-env-green on every engine. A real-browser
+ * smoke test against at least one live CookieYes-CMP site is required
+ * before considering the CookieYes slice done — flagged for sdd-verify.
+ * In particular, `performBannerAction`'s exact availability timing
+ * (pre- vs post-banner-render) is UNDOCUMENTED upstream (unlike
+ * `getCkyConsent`, which CookieYes's own docs say is only available after
+ * the banner has fully loaded) — this fixture defines both globals
+ * up-front, which may not match real-world CookieYes script-load timing.
+ * Re-capture this fixture manually whenever the CookieYes markup/API shape
+ * this test hardcodes changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-cookieyes.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMinimizerEnabled: enableFeature },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a CookieYes banner offering reject via the bare global
+ * `performBannerAction("reject")`. Both mandatory bare globals
+ * (`getCkyConsent`, `performBannerAction`) are present alongside the
+ * `.cky-consent-container` DOM anchor — the confidence gate in
+ * cmp-adapters.js requires both mandatory globals plus at least one DOM
+ * secondary signal.
+ */
+async function stubCookieYesPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div class="cky-consent-container">
+          <div class="cky-consent-bar">
+            <button id="cky-btn-accept">Accept All</button>
+            <button id="cky-btn-reject">Reject All</button>
+          </div>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.getCkyConsent = function () {
+            return {
+              activeLaw: "gdpr",
+              categories: { necessary: true, functional: false, analytics: false, performance: false, advertisement: false },
+              isUserActionCompleted: false,
+              consentID: "test-consent-id",
+              languageCode: "en",
+            };
+          };
+          window.performBannerAction = function (action) {
+            if (action !== "reject") {
+              window.__consentState = "unexpected-consent";
+              return;
+            }
+            window.__consentState = "necessary-only";
+            document.querySelector(".cky-consent-container").remove();
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — CookieYes (#1120)", () => {
+  test('rejects a CookieYes banner with performBannerAction("reject") when the feature is enabled', async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubCookieYesPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(
+      () => document.querySelector(".cky-consent-container") === null
+    );
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubCookieYesPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(
+      () => document.querySelector(".cky-consent-container") !== null
+    );
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -26,6 +26,7 @@ import {
   oneTrustAdapter,
   cookiebotAdapter,
   didomiAdapter,
+  cookieYesAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -35,11 +36,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust, Cookiebot and Didomi adapters, in order", () => {
-    assert.equal(TIER1.length, 3);
+  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi and CookieYes adapters, in order", () => {
+    assert.equal(TIER1.length, 4);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
     assert.strictEqual(TIER1[2], didomiAdapter);
+    assert.strictEqual(TIER1[3], cookieYesAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -74,6 +76,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof didomiAdapter.detect, "function");
     assert.equal(typeof didomiAdapter.canReject, "function");
     assert.equal(typeof didomiAdapter.reject, "function");
+  });
+
+  test("cookieYesAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(cookieYesAdapter.id, "cookieyes");
+    assert.equal(cookieYesAdapter.tier, 1);
+    assert.equal(typeof cookieYesAdapter.detect, "function");
+    assert.equal(typeof cookieYesAdapter.canReject, "function");
+    assert.equal(typeof cookieYesAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -203,6 +213,55 @@ describe("decideAction — truth table", () => {
       hasSetUserDisagreeToAllFn: true,
       hasDidomiHostDom: false,
       hasGetCurrentUserStatusFn: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("CookieYes: both bare globals + corroborating DOM -> reject", () => {
+    const r = decideAction({
+      hasGetCkyConsentFn: true,
+      hasPerformBannerActionFn: true,
+      hasCkyConsentContainerDom: true,
+      hasCkyOverlayDom: true,
+      hasCkyConsentBarDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "cookieyes");
+  });
+
+  test("CookieYes: performBannerAction present but getCkyConsent missing (only one global) -> NOOP, uncertain", () => {
+    const r = decideAction({
+      hasGetCkyConsentFn: false,
+      hasPerformBannerActionFn: true,
+      hasCkyConsentContainerDom: true,
+      hasCkyOverlayDom: true,
+      hasCkyConsentBarDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("CookieYes: getCkyConsent present but performBannerAction missing (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasGetCkyConsentFn: true,
+      hasPerformBannerActionFn: false,
+      hasCkyConsentContainerDom: true,
+      hasCkyOverlayDom: true,
+      hasCkyConsentBarDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("CookieYes: both globals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasGetCkyConsentFn: true,
+      hasPerformBannerActionFn: true,
+      hasCkyConsentContainerDom: false,
+      hasCkyOverlayDom: false,
+      hasCkyConsentBarDom: false,
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "uncertain");
@@ -370,6 +429,87 @@ describe("didomiAdapter.detect — confidence gate", () => {
   });
 });
 
+describe("cookieYesAdapter.detect — dual-mandatory confidence gate", () => {
+  const FULL_COOKIEYES_SIGNALS = Object.freeze({
+    hasGetCkyConsentFn: true,
+    hasPerformBannerActionFn: true,
+    hasCkyConsentContainerDom: true,
+    hasCkyOverlayDom: true,
+    hasCkyConsentBarDom: true,
+  });
+
+  test("both mandatory globals + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = cookieYesAdapter.detect(FULL_COOKIEYES_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(cookieYesAdapter.canReject(FULL_COOKIEYES_SIGNALS), true);
+  });
+
+  test("both mandatory globals + exactly one secondary (.cky-consent-container only) -> canReject true", () => {
+    const s = {
+      hasGetCkyConsentFn: true,
+      hasPerformBannerActionFn: true,
+      hasCkyConsentContainerDom: true,
+      hasCkyOverlayDom: false,
+      hasCkyConsentBarDom: false,
+    };
+    assert.equal(cookieYesAdapter.canReject(s), true);
+  });
+
+  test("both mandatory globals present, zero DOM corroboration -> uncertain, canReject false", () => {
+    const s = {
+      hasGetCkyConsentFn: true,
+      hasPerformBannerActionFn: true,
+      hasCkyConsentContainerDom: false,
+      hasCkyOverlayDom: false,
+      hasCkyConsentBarDom: false,
+    };
+    assert.equal(cookieYesAdapter.canReject(s), false);
+    assert.ok(cookieYesAdapter.detect(s) < 1);
+  });
+
+  test("only getCkyConsent present (performBannerAction missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasGetCkyConsentFn: true,
+      hasPerformBannerActionFn: false,
+      hasCkyConsentContainerDom: true,
+      hasCkyOverlayDom: true,
+      hasCkyConsentBarDom: true,
+    };
+    assert.equal(cookieYesAdapter.detect(s), 0);
+    assert.equal(cookieYesAdapter.canReject(s), false);
+  });
+
+  test("only performBannerAction present (getCkyConsent missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasGetCkyConsentFn: false,
+      hasPerformBannerActionFn: true,
+      hasCkyConsentContainerDom: true,
+      hasCkyOverlayDom: true,
+      hasCkyConsentBarDom: true,
+    };
+    assert.equal(cookieYesAdapter.detect(s), 0);
+    assert.equal(cookieYesAdapter.canReject(s), false);
+  });
+
+  test("DOM-only (both mandatory globals missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasGetCkyConsentFn: false,
+      hasPerformBannerActionFn: false,
+      hasCkyConsentContainerDom: true,
+      hasCkyOverlayDom: true,
+      hasCkyConsentBarDom: true,
+    };
+    assert.equal(cookieYesAdapter.detect(s), 0);
+    assert.equal(cookieYesAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => cookieYesAdapter.detect(null));
+    assert.doesNotThrow(() => cookieYesAdapter.detect(undefined));
+    assert.equal(cookieYesAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -425,6 +565,25 @@ describe("didomiAdapter.reject — pure callback invocation", () => {
 
   test("non-function argument -> status noop, no call", () => {
     const r = didomiAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+describe("cookieYesAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = cookieYesAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = cookieYesAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = cookieYesAdapter.reject(undefined);
     assert.equal(r.status, "noop");
   });
 });
@@ -542,5 +701,12 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
     assert.ok(TIER1.includes(didomiAdapter), "TIER1 must include didomiAdapter");
     assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
     assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+  });
+
+  test("cookieYesAdapter is registered in TIER1 alongside the other three adapters (#1120)", () => {
+    assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must include cookieYesAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -112,6 +112,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectDidomi/.test(joined));
     assert.ok(/function canRejectDidomi/.test(joined));
   });
+
+  test("sync block also defines detectCookieYes and canRejectCookieYes (#1120)", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectCookieYes/.test(joined));
+    assert.ok(/function canRejectCookieYes/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -328,6 +334,25 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       assert.ok(calls.length > 0, `${label} must call setUserDisagreeToAll`);
       for (const args of calls) {
         assert.equal(args, "", `${label} setUserDisagreeToAll must be called with zero arguments`);
+      }
+    }
+  });
+
+  test("only performBannerAction (or wrappedJSObject equivalent) is invoked as the CookieYes reject call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/performBannerAction\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call performBannerAction`);
+    }
+  });
+
+  test('every performBannerAction call passes the literal "reject" argument — never accept_all/accept_partial, never a variable', () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/performBannerAction\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call performBannerAction`);
+      for (const args of calls) {
+        assert.equal(args, '"reject"', `${label} performBannerAction must be called with the literal string "reject"`);
       }
     }
   });


### PR DESCRIPTION
Closes #1120

## Summary

Adds a **CookieYes** Tier 1 adapter to the cookie-consent-minimizer module (fourth CMP, completing Phase 1 after OneTrust, Cookiebot, Didomi). Clicks reject on the user's behalf via CookieYes's own JS API and never auto-accepts. Extends the existing dispatcher + `cmp-adapters.js` registry — no new UI, pref, manifest change, or permissions.

Targets **`develop`** (integration branch), not main.

## What it does

- **Reject API (verified)**: `window.performBannerAction("reject")` — synchronous, and the argument is always the literal `"reject"`. Firefox mirror: `window.wrappedJSObject.performBannerAction("reject")`.
- **Detection — DUAL-MANDATORY (new, stronger gate)**: unlike the other three CMPs, CookieYes exposes BARE globals (`performBannerAction`, `getCkyConsent`) not namespaced under a vendor object. To avoid a wrong-target call on a page with a same-named global, detection requires BOTH functions present AND ≥1 CookieYes-proprietary DOM signal (`.cky-consent-container` / `.cky-overlay` / `.cky-consent-bar`). Below threshold → NOOP.
- **Never-auto-accept** stays structurally enforced: a guard asserts every `performBannerAction(` call site uses exactly `("reject")` — never `accept_all` / `accept_partial` / a variable. No accept/AllowAll token anywhere. Even a hypothetical detection misfire can only ever call reject (safe direction — structurally cannot grant consent).
- Registered as the fourth TIER1 entry; OneTrust/Cookiebot/Didomi paths byte-unchanged; one reject per page per world (idempotency intact; `return` present in both worlds).

## Changes

| File | Change |
|------|--------|
| `src/lib/cmp-adapters.js` | `cookieYesAdapter` added to TIER1 (now 4), `@sync` block extended, `decideAction` CookieYes hard-wall branch |
| `src/content/cookie-noise.js` / `cookie-noise-mainworld.js` | CookieYes signals + reject wired (Chrome MAIN / Firefox wrappedJSObject); `@sync` block extended identically |
| `tests/unit/cmp-adapters.test.mjs` | dual-mandatory detection + decideAction truth tables, registry-shape (TIER1 length 4) |
| `tests/unit/cookie-noise-sync.test.mjs` | sync guard for the new block + literal-`"reject"` never-accept guard |
| `tests/e2e/cookie-consent-minimizer-cookieyes.spec.mjs` | Chromium snapshot regression fixture |

## Test + review

- [x] `npm test` — 6625 pass / 0 fail (independently re-run in review)
- [x] `npm run check:i18n`, `npm run lint`, `build:content` drift gate — all clean
- [x] E2E — 8/8 across all four adapters, no regression
- [x] Adversarial review (independent verify + 7 focus areas) — 0 CRITICAL / HIGH / MEDIUM; dual-mandatory gate, literal-reject guard, @sync consistency, decideAction 4-branch, sibling non-regression all confirmed clean

## Pre-ship gate (blocks store release, not this merge)

- [ ] Real-browser smoke: the Firefox `wrappedJSObject` path AND `performBannerAction` load-timing (undocumented upstream) are structurally tested only. Run a `web-ext` + live-CookieYes smoke before the next store release — same policy as the other three adapters (unit-green != real-env-green).
