### PR TITLE
feat(consent): Sourcepoint CMP adapter (Tier 1)

### DIFF
--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -105,6 +105,26 @@
   function canRejectCookieYes(signals) {
     return detectCookieYes(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // Sourcepoint (#1123): __tcfapi is generic to ALL TCF-compliant CMPs
+  // (including Didomi above), so it can never be the sole mandatory anchor.
+  // Both hasTcfApiFn AND the Sourcepoint-specific DOM signal
+  // (div[id^="sp_message_container"]) are mandatory together — see the
+  // TCF-generic-signal discrimination rationale above detectCookieYes.
+  function detectSourcepoint(signals) {
+    if (!signals || signals.hasTcfApiFn !== true || signals.hasSpMessageContainerDom !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasSpPrivacyMgmtIframeDom === true ? 1 : 0) +
+      (signals.hasSpProdIframeDom === true ? 1 : 0) +
+      (signals.hasSpProdScriptDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectSourcepoint(signals) {
+    return detectSourcepoint(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -205,6 +225,28 @@
     } catch {
       // document not ready / detached — leave all false.
     }
+    // Sourcepoint (#1123): __tcfapi is the generic IAB TCF surface every
+    // TCF-compliant CMP exposes (including Didomi above), so it can never
+    // be the sole mandatory anchor on its own — see the dual-mandatory
+    // rationale on detectSourcepoint above.
+    let hasTcfApiFn = false;
+    try {
+      hasTcfApiFn = typeof window.__tcfapi === "function";
+    } catch {
+      // Leave false — fail-closed.
+    }
+    let hasSpMessageContainerDom = false;
+    let hasSpPrivacyMgmtIframeDom = false;
+    let hasSpProdIframeDom = false;
+    let hasSpProdScriptDom = false;
+    try {
+      hasSpMessageContainerDom = !!document.querySelector('div[id^="sp_message_container"]');
+      hasSpPrivacyMgmtIframeDom = !!document.querySelector('iframe[src*="privacy-mgmt.com"]');
+      hasSpProdIframeDom = !!document.querySelector('iframe[src*="sp-prod.net"]');
+      hasSpProdScriptDom = !!document.querySelector('script[src*="sp-prod.net"]');
+    } catch {
+      // document not ready / detached — leave all false.
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -225,6 +267,11 @@
       hasCkyConsentContainerDom,
       hasCkyOverlayDom,
       hasCkyConsentBarDom,
+      hasTcfApiFn,
+      hasSpMessageContainerDom,
+      hasSpPrivacyMgmtIframeDom,
+      hasSpProdIframeDom,
+      hasSpProdScriptDom,
     };
   }
 
@@ -290,6 +337,24 @@
       _acted = true;
       try {
         window.performBannerAction("reject");
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: Sourcepoint API adapter (#1123). postRejectAll is async
+    // (callback-based), but this call site is fire-and-forget: the arrow
+    // function below returns SYNCHRONOUSLY right after queuing the call —
+    // _acted and stopObserver() fire synchronously right here, never gated
+    // on the async callback's later result. The callback is optional-log-
+    // only and must never re-trigger dispatch or flip _acted back.
+    if (canRejectSourcepoint(signals)) {
+      _acted = true;
+      try {
+        window.__tcfapi("postRejectAll", 2, (success) => {
+          void success; // fire-and-forget — log only, never gates control flow
+        });
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -101,6 +101,26 @@
   function canRejectCookieYes(signals) {
     return detectCookieYes(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // Sourcepoint (#1123): __tcfapi is generic to ALL TCF-compliant CMPs
+  // (including Didomi above), so it can never be the sole mandatory anchor.
+  // Both hasTcfApiFn AND the Sourcepoint-specific DOM signal
+  // (div[id^="sp_message_container"]) are mandatory together — see the
+  // TCF-generic-signal discrimination rationale above detectCookieYes.
+  function detectSourcepoint(signals) {
+    if (!signals || signals.hasTcfApiFn !== true || signals.hasSpMessageContainerDom !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasSpPrivacyMgmtIframeDom === true ? 1 : 0) +
+      (signals.hasSpProdIframeDom === true ? 1 : 0) +
+      (signals.hasSpProdScriptDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectSourcepoint(signals) {
+    return detectSourcepoint(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -245,6 +265,29 @@
     } catch {
       // ignore
     }
+    // Sourcepoint (#1123): __tcfapi is the generic IAB TCF surface every
+    // TCF-compliant CMP exposes (including Didomi above), so it can never
+    // be the sole mandatory anchor on its own — see the dual-mandatory
+    // rationale on detectSourcepoint above. Reached via wrappedJSObject,
+    // same Xray-safety pattern as the other Firefox signal reads above.
+    let hasTcfApiFn = false;
+    try {
+      hasTcfApiFn = typeof window.wrappedJSObject.__tcfapi === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasSpMessageContainerDom = false;
+    let hasSpPrivacyMgmtIframeDom = false;
+    let hasSpProdIframeDom = false;
+    let hasSpProdScriptDom = false;
+    try {
+      hasSpMessageContainerDom = !!document.querySelector('div[id^="sp_message_container"]');
+      hasSpPrivacyMgmtIframeDom = !!document.querySelector('iframe[src*="privacy-mgmt.com"]');
+      hasSpProdIframeDom = !!document.querySelector('iframe[src*="sp-prod.net"]');
+      hasSpProdScriptDom = !!document.querySelector('script[src*="sp-prod.net"]');
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -265,6 +308,11 @@
       hasCkyConsentContainerDom,
       hasCkyOverlayDom,
       hasCkyConsentBarDom,
+      hasTcfApiFn,
+      hasSpMessageContainerDom,
+      hasSpPrivacyMgmtIframeDom,
+      hasSpProdIframeDom,
+      hasSpProdScriptDom,
     };
   }
 
@@ -312,6 +360,22 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.performBannerAction("reject");
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: Sourcepoint API adapter (#1123). Same fire-and-forget,
+    // synchronous _fxActed + fxStopObserver() shape as the Chrome
+    // MAIN-world caller — see cookie-noise-mainworld.js. postRejectAll's
+    // async callback is optional-log-only and never gates control flow.
+    if (canRejectSourcepoint(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.__tcfapi("postRejectAll", 2, (success) => {
+          void success; // fire-and-forget — log only, never gates control flow
+        });
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -76,6 +76,21 @@
  *   Secondary/corroborating signal.
  * @property {boolean} [hasCkyConsentBarDom] - `.cky-consent-bar` present in
  *   the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasTcfApiFn] - `typeof window.__tcfapi === "function"`.
+ *   Mandatory signal (dual-mandatory with hasSpMessageContainerDom below):
+ *   `__tcfapi` is the generic IAB TCF surface every TCF-compliant CMP
+ *   exposes (including Didomi, already handled above), so it can never be
+ *   a sole mandatory anchor on its own.
+ * @property {boolean} [hasSpMessageContainerDom] - `div[id^="sp_message_container"]`
+ *   present in the DOM. Mandatory signal (dual-mandatory with hasTcfApiFn
+ *   above): the Sourcepoint-specific anchor that discriminates this CMP
+ *   from every other `__tcfapi`-exposing vendor.
+ * @property {boolean} [hasSpPrivacyMgmtIframeDom] - `iframe[src*="privacy-mgmt.com"]`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasSpProdIframeDom] - `iframe[src*="sp-prod.net"]`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasSpProdScriptDom] - `script[src*="sp-prod.net"]`
+ *   present in the DOM. Secondary/corroborating signal.
  */
 
 /**
@@ -122,6 +137,21 @@ export const ACTIONS = Object.freeze({
  * BOTH `getCkyConsent` and `performBannerAction` bare globals present
  * together, still gated by the same >=1 DOM secondary signal and the same
  * CONFIDENCE_THRESHOLD.
+ *
+ * The Sourcepoint adapter (#1123) DEVIATES from every prior adapter's
+ * discrimination shape on purpose (TCF-generic-signal discrimination): its
+ * reject call rides `window.__tcfapi`, the generic IAB TCF surface that
+ * EVERY TCF-compliant CMP exposes — including Didomi, already handled
+ * above. Unlike OneTrust/Cookiebot/Didomi's vendor-namespaced anchor or
+ * CookieYes's dual-bare-global anchor, `hasTcfApiFn` alone is true on any
+ * TCF CMP's page and can never be a safe mandatory anchor by itself.
+ * detectSourcepoint therefore requires BOTH `hasTcfApiFn` AND the
+ * Sourcepoint-specific DOM signal `hasSpMessageContainerDom`
+ * (`div[id^="sp_message_container"]`) as dual-mandatory, mirroring
+ * detectCookieYes's dual-mandatory shape but anchored on one generic
+ * function signal + one vendor-specific DOM signal instead of two bare
+ * globals. This is what lets Sourcepoint coexist with Didomi in the same
+ * registry without misfiring on Didomi's (or any other TCF CMP's) pages.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -187,6 +217,26 @@ function detectCookieYes(signals) {
 
 function canRejectCookieYes(signals) {
   return detectCookieYes(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+// Sourcepoint (#1123): __tcfapi is generic to ALL TCF-compliant CMPs
+// (including Didomi above), so it can never be the sole mandatory anchor.
+// Both hasTcfApiFn AND the Sourcepoint-specific DOM signal
+// (div[id^="sp_message_container"]) are mandatory together — see the
+// TCF-generic-signal discrimination rationale above detectCookieYes.
+function detectSourcepoint(signals) {
+  if (!signals || signals.hasTcfApiFn !== true || signals.hasSpMessageContainerDom !== true) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasSpPrivacyMgmtIframeDom === true ? 1 : 0) +
+    (signals.hasSpProdIframeDom === true ? 1 : 0) +
+    (signals.hasSpProdScriptDom === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectSourcepoint(signals) {
+  return detectSourcepoint(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -283,8 +333,43 @@ export const cookieYesAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * Sourcepoint Tier 1 adapter (#1123). The reject call
+ * (`window.__tcfapi("postRejectAll", 2, callback)`) is invoked by the
+ * caller-supplied callback via the shared `reject()` helper above — this
+ * adapter definition never touches `window` itself.
+ *
+ * Async call shape, fire-and-forget: `__tcfapi` is callback-based (its
+ * second-argument callback fires later, asynchronously), but the injected
+ * callback the content-script call site supplies is a zero-argument arrow
+ * that just invokes `__tcfapi(...)` and returns SYNCHRONOUSLY right after —
+ * the async callback passed to `postRejectAll` is optional-log-only and
+ * never gates `reject()`'s control flow. `reject()` sees the exact same
+ * zero-arg, non-throwing shape as every other adapter here.
+ *
+ * Registered LAST in TIER1 (after didomiAdapter): Didomi's reject call is a
+ * direct, unambiguous vendor-global method, while Sourcepoint rides the
+ * shared/generic `__tcfapi` surface — on a hypothetical dual-CMP page,
+ * more-certain adapters should get first refusal. See detectSourcepoint's
+ * TCF-generic-signal discrimination rationale above.
+ * @type {Readonly<{id: "sourcepoint", tier: 1, detect: typeof detectSourcepoint, canReject: typeof canRejectSourcepoint, reject: typeof reject}>}
+ */
+export const sourcepointAdapter = Object.freeze({
+  id: "sourcepoint",
+  tier: 1,
+  detect: detectSourcepoint,
+  canReject: canRejectSourcepoint,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
-export const TIER1 = Object.freeze([oneTrustAdapter, cookiebotAdapter, didomiAdapter, cookieYesAdapter]);
+export const TIER1 = Object.freeze([
+  oneTrustAdapter,
+  cookiebotAdapter,
+  didomiAdapter,
+  cookieYesAdapter,
+  sourcepointAdapter,
+]);
 
 /**
  * Tier 2 registry: declarative click-rule adapters (Consent-O-Matic-style).
@@ -332,6 +417,13 @@ export function decideAction(signals) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   if (s.hasGetCkyConsentFn === true && s.hasPerformBannerActionFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  // Sourcepoint (#1123) hard wall is the MIRROR IMAGE of the checks above:
+  // keyed off the Sourcepoint-specific DOM signal, NOT hasTcfApiFn alone —
+  // a bare hasTcfApiFn is true on every TCF CMP (Didomi included) and must
+  // fall through to "uncertain" below, never claim Sourcepoint.
+  if (s.hasSpMessageContainerDom === true && s.hasTcfApiFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs
@@ -217,8 +217,9 @@ test.describe("Cookie Consent Minimizer — Sourcepoint (#1123)", () => {
 
     await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
 
-    // Negative assertion: no positive signal to wait on — fixed settle
-    // window, same pattern as the disabled-feature test above.
+    // REASON: negative assertion (no misfire) has no positive signal to
+    // wait on — fixed settle window, same pattern as the disabled-feature
+    // test above.
     await page.waitForTimeout(1500);
 
     const tcfCalls = await page.evaluate(() => window.__tcfapiCalls);

--- a/tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs
@@ -1,0 +1,234 @@
+/**
+ * E2E: Cookie Consent Minimizer — Sourcepoint Tier 1 adapter (#1123)
+ *
+ * Verifies the Sourcepoint reject path against a real Chromium with the
+ * extension loaded. The fixture page mimics a Sourcepoint banner: the
+ * generic IAB TCF surface `window.__tcfapi(command, version, callback)`
+ * plus a `div[id^="sp_message_container"]` DOM anchor — the dual-mandatory
+ * signal combination the dispatcher requires before acting
+ * (src/lib/cmp-adapters.js), since `__tcfapi` alone is exposed by every
+ * TCF-compliant CMP (including Didomi, already shipped in this extension).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookieyes.spec.mjs's structure
+ * exactly (same onboarding helper shape, same feature pref).
+ *
+ * HONEST LIMIT (per design doc / exploration #1283): this is a REGRESSION
+ * oracle only — a snapshot of one fixture's behavior at write time. It
+ * proves the Chrome MAIN-world nonce handshake
+ * (content/cookie-noise-mainworld.js) and the never-auto-reject-the-other-
+ * way outcome on the fixture used here. It does NOT validate the Firefox
+ * `window.wrappedJSObject` reject path (content/cookie-noise.js) —
+ * Playwright's `chromium` fixture only exercises Chrome — and it does NOT
+ * prove real-vendor-script compatibility against a live Sourcepoint CMP
+ * build. Per MUGA's Chrome DNR-regex memory-limit lesson: unit/Chromium-
+ * green does not guarantee real-env-green on every engine.
+ *
+ * REAL-BROWSER SMOKE PLAN required before considering this slice done
+ * (flagged for sdd-verify — this is the riskiest unknown in the design,
+ * since `__tcfapi` is a generic TCF surface unit tests cannot fully
+ * validate against a real vendor stub):
+ *   1. Live Sourcepoint site — confirm both mandatory signals
+ *      (`__tcfapi` fn + `sp_message_container` DOM) are detected and
+ *      `postRejectAll` actually clears the page's consent state.
+ *   2. Live Didomi-only site (no Sourcepoint) — confirm zero misfire: the
+ *      Sourcepoint adapter must never claim a Didomi-only TCF page.
+ *   3. Calling `postRejectAll` against a foreign (e.g. Didomi's) `__tcfapi`
+ *      stub is inert — no console error, no page breakage, no accidental
+ *      grant. Cannot be verified against a real Didomi stub without a live
+ *      dual-CMP fixture; this fixture only proves the fire-and-forget
+ *      shape is safe against a throwing/foreign stub in isolation.
+ *
+ * Re-capture this fixture manually whenever the Sourcepoint markup/API
+ * shape this test hardcodes changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-sourcepoint.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMinimizerEnabled: enableFeature },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a Sourcepoint banner offering reject via the generic IAB
+ * TCF surface `__tcfapi("postRejectAll", 2, callback)`. Both mandatory
+ * signals (`__tcfapi` function, `sp_message_container` DOM anchor) are
+ * present, plus one corroborating iframe — the confidence gate in
+ * cmp-adapters.js requires both mandatory signals plus at least one DOM
+ * secondary signal.
+ */
+async function stubSourcepointPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="sp_message_container_1234">
+          <iframe src="https://some-account.privacy-mgmt.com/consent/some-message" title="consent"></iframe>
+          <button id="sp-btn-accept">Accept All</button>
+          <button id="sp-btn-reject">Reject All</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__tcfapiCalls = [];
+          window.__tcfapi = function (command, version, callback) {
+            window.__tcfapiCalls.push(command);
+            if (command !== "postRejectAll") {
+              if (typeof callback === "function") callback(false, false);
+              return;
+            }
+            window.__consentState = "necessary-only";
+            document.getElementById("sp_message_container_1234").remove();
+            if (typeof callback === "function") {
+              setTimeout(() => callback(true, true), 0);
+            }
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — Sourcepoint (#1123)", () => {
+  test('rejects a Sourcepoint banner with __tcfapi("postRejectAll", ...) when the feature is enabled', async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubSourcepointPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // postRejectAll was actually invoked (not some other TCF command).
+    const tcfCalls = await page.evaluate(() => window.__tcfapiCalls);
+    expect(tcfCalls).toContain("postRejectAll");
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(
+      () => document.querySelector('div[id^="sp_message_container"]') === null
+    );
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubSourcepointPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(
+      () => document.querySelector('div[id^="sp_message_container"]') !== null
+    );
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+
+  test("never misfires on a Didomi-only TCF page (no sp_message_container DOM anchor)", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    const DIDOMI_HOST = "muga-test-cookie-consent-sourcepoint-didomi-guard.invalid";
+    await page.route(`**://${DIDOMI_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <p id="page-content">Real page content</p>
+          <script>
+            // A Didomi-shaped page: exposes the generic __tcfapi surface
+            // (as any TCF-compliant CMP does) but WITHOUT the
+            // Sourcepoint-specific sp_message_container DOM anchor. The
+            // Sourcepoint adapter must never act here.
+            window.__tcfapiCalls = [];
+            window.__tcfapi = function (command, version, callback) {
+              window.__tcfapiCalls.push(command);
+              if (typeof callback === "function") callback(false, false);
+            };
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${DIDOMI_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // Negative assertion: no positive signal to wait on — fixed settle
+    // window, same pattern as the disabled-feature test above.
+    await page.waitForTimeout(1500);
+
+    const tcfCalls = await page.evaluate(() => window.__tcfapiCalls);
+    expect(tcfCalls).not.toContain("postRejectAll");
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -27,6 +27,7 @@ import {
   cookiebotAdapter,
   didomiAdapter,
   cookieYesAdapter,
+  sourcepointAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -36,12 +37,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi and CookieYes adapters, in order", () => {
-    assert.equal(TIER1.length, 4);
+  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes and Sourcepoint adapters, in order", () => {
+    assert.equal(TIER1.length, 5);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
     assert.strictEqual(TIER1[2], didomiAdapter);
     assert.strictEqual(TIER1[3], cookieYesAdapter);
+    assert.strictEqual(TIER1[4], sourcepointAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -84,6 +86,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof cookieYesAdapter.detect, "function");
     assert.equal(typeof cookieYesAdapter.canReject, "function");
     assert.equal(typeof cookieYesAdapter.reject, "function");
+  });
+
+  test("sourcepointAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(sourcepointAdapter.id, "sourcepoint");
+    assert.equal(sourcepointAdapter.tier, 1);
+    assert.equal(typeof sourcepointAdapter.detect, "function");
+    assert.equal(typeof sourcepointAdapter.canReject, "function");
+    assert.equal(typeof sourcepointAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -265,6 +275,67 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "uncertain");
+  });
+
+  test("Sourcepoint: __tcfapi fn + sp_message_container DOM + corroboration -> reject", () => {
+    const r = decideAction({
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: true,
+      hasSpProdIframeDom: false,
+      hasSpProdScriptDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "sourcepoint");
+  });
+
+  test("Sourcepoint: sp_message_container DOM present but __tcfapi missing (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasTcfApiFn: false,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("Sourcepoint: __tcfapi present but sp_message_container DOM missing -> NOOP, uncertain (generic TCF CMP, not Sourcepoint)", () => {
+    const r = decideAction({
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: false,
+      hasSpPrivacyMgmtIframeDom: true,
+      hasSpProdIframeDom: true,
+      hasSpProdScriptDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("Sourcepoint: both mandatory signals present but zero corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: false,
+      hasSpProdIframeDom: false,
+      hasSpProdScriptDom: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("Didomi-shaped signals (window.Didomi + __tcfapi, NO sp_message_container) resolve to Didomi, never misfire as Sourcepoint", () => {
+    const r = decideAction({
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: true,
+      hasDidomiHostDom: true,
+      hasGetCurrentUserStatusFn: true,
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "didomi");
   });
 });
 
@@ -510,6 +581,88 @@ describe("cookieYesAdapter.detect — dual-mandatory confidence gate", () => {
   });
 });
 
+describe("sourcepointAdapter.detect — dual-mandatory TCF-generic-signal discrimination", () => {
+  const FULL_SP_SIGNALS = Object.freeze({
+    hasTcfApiFn: true,
+    hasSpMessageContainerDom: true,
+    hasSpPrivacyMgmtIframeDom: true,
+    hasSpProdIframeDom: true,
+    hasSpProdScriptDom: true,
+  });
+
+  test("both mandatory signals + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = sourcepointAdapter.detect(FULL_SP_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(sourcepointAdapter.canReject(FULL_SP_SIGNALS), true);
+  });
+
+  test("both mandatory signals + exactly one secondary (privacy-mgmt.com iframe only) -> canReject true", () => {
+    const s = {
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: true,
+      hasSpProdIframeDom: false,
+      hasSpProdScriptDom: false,
+    };
+    assert.equal(sourcepointAdapter.canReject(s), true);
+  });
+
+  test("both mandatory signals present, zero DOM corroboration -> uncertain, canReject false (fail-closed)", () => {
+    const s = {
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: false,
+      hasSpProdIframeDom: false,
+      hasSpProdScriptDom: false,
+    };
+    assert.equal(sourcepointAdapter.canReject(s), false);
+    assert.ok(sourcepointAdapter.detect(s) < 1);
+  });
+
+  test("__tcfapi present but sp_message_container DOM missing -> confidence 0 (generic TCF CMP, e.g. Didomi)", () => {
+    const s = {
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: false,
+      hasSpPrivacyMgmtIframeDom: true,
+      hasSpProdIframeDom: true,
+      hasSpProdScriptDom: true,
+    };
+    assert.equal(sourcepointAdapter.detect(s), 0);
+    assert.equal(sourcepointAdapter.canReject(s), false);
+  });
+
+  test("sp_message_container DOM present but __tcfapi missing -> confidence 0, canReject false", () => {
+    const s = {
+      hasTcfApiFn: false,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: true,
+      hasSpProdIframeDom: true,
+      hasSpProdScriptDom: true,
+    };
+    assert.equal(sourcepointAdapter.detect(s), 0);
+    assert.equal(sourcepointAdapter.canReject(s), false);
+  });
+
+  test("Didomi-shaped signal set (window.Didomi + __tcfapi, NO sp_message_container) yields NOOP (confidence 0) for the Sourcepoint adapter", () => {
+    const s = {
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: true,
+      hasDidomiHostDom: true,
+      hasGetCurrentUserStatusFn: true,
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: false,
+    };
+    assert.equal(sourcepointAdapter.detect(s), 0);
+    assert.equal(sourcepointAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => sourcepointAdapter.detect(null));
+    assert.doesNotThrow(() => sourcepointAdapter.detect(undefined));
+    assert.equal(sourcepointAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -584,6 +737,25 @@ describe("cookieYesAdapter.reject — pure callback invocation", () => {
 
   test("non-function argument -> status noop, no call", () => {
     const r = cookieYesAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+describe("sourcepointAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = sourcepointAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = sourcepointAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = sourcepointAdapter.reject(undefined);
     assert.equal(r.status, "noop");
   });
 });
@@ -708,5 +880,13 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
     assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
     assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
     assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
+  });
+
+  test("sourcepointAdapter is registered in TIER1 alongside the other four adapters (#1123)", () => {
+    assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must include sourcepointAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
+    assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -118,6 +118,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectCookieYes/.test(joined));
     assert.ok(/function canRejectCookieYes/.test(joined));
   });
+
+  test("sync block also defines detectSourcepoint and canRejectSourcepoint (#1123)", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectSourcepoint/.test(joined));
+    assert.ok(/function canRejectSourcepoint/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -353,6 +359,25 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       assert.ok(calls.length > 0, `${label} must call performBannerAction`);
       for (const args of calls) {
         assert.equal(args, '"reject"', `${label} performBannerAction must be called with the literal string "reject"`);
+      }
+    }
+  });
+
+  test("only __tcfapi (or wrappedJSObject equivalent) is invoked as the Sourcepoint reject call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/__tcfapi\s*\(([^)]*)/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call __tcfapi`);
+    }
+  });
+
+  test("every __tcfapi call's first argument is exactly the literal 'postRejectAll' — never another command, never a variable", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/__tcfapi\s*\(([^,]*),/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call __tcfapi`);
+      for (const firstArg of calls) {
+        assert.equal(firstArg, "\"postRejectAll\"", `${label} __tcfapi's first argument must be the literal "postRejectAll"`);
       }
     }
   });


### PR DESCRIPTION
Closes #1123

## Summary

Adds a **Sourcepoint** Tier 1 adapter to the cookie-consent-minimizer module (fifth CMP, completing Phase 1 after OneTrust, Cookiebot, Didomi, CookieYes). Rejects on the user's behalf via the IAB TCF `__tcfapi` command and never auto-accepts. Extends the existing dispatcher + `cmp-adapters.js` registry — no new UI, pref, manifest change, or permissions.

Targets **`develop`** (integration branch), not main.

## What it does

- **Reject API (new call-shape)**: `window.__tcfapi("postRejectAll", 2, cb)` — **fire-and-forget**. `_acted = true` and `stopObserver()` fire synchronously right after the call; the async callback is log-only (`void success`) and never gates control flow. Firefox mirror: `window.wrappedJSObject.__tcfapi("postRejectAll", 2, cb)`. `try/catch` wraps the call so a throwing page global can never break the page.
- **Detection — DUAL-MANDATORY (TCF discrimination)**: `__tcfapi` is the generic IAB TCF entrypoint that Didomi ALSO exposes, so presence of `__tcfapi` alone is not enough. Detection requires BOTH `hasTcfApiFn === true` AND `hasSpMessageContainerDom === true` (the `sp_message_container` DOM anchor), plus ≥1 Sourcepoint-proprietary secondary signal (`privacy-mgmt.com` / `sp-prod.net` iframe or script) for full confidence. A Didomi-only page (`__tcfapi` present, no `sp_message_container`) yields Sourcepoint confidence 0 and resolves to Didomi — never fires `postRejectAll`.
- **Ambiguous-CMP resolution**: on a page exposing both Didomi globals and `sp_message_container`, the TIER1 loop resolves **Didomi first** (index 2 < Sourcepoint index 5) and fires `setUserDisagreeToAll()` — both are reject actions, so the outcome is safe and matches intent.
- **Never-auto-accept** stays structurally enforced: a guard scans BOTH content scripts and asserts every `__tcfapi(` call's first argument is exactly the literal `"postRejectAll"` — never `postAcceptAll`, never a variable. Combined with the `/allowall|accept/i` full-source scan, a detection misfire can only ever reject (structurally cannot grant consent).
- Registered as the fifth (last) TIER1 entry; OneTrust/Cookiebot/Didomi/CookieYes paths byte-unchanged; one reject per page per world (idempotency intact; `return;` present in both worlds).

## Changes

| File | Change |
|------|--------|
| `src/lib/cmp-adapters.js` | `detectSourcepoint`/`canRejectSourcepoint` in `@sync` block, `sourcepointAdapter` added to TIER1 (now 5), `decideAction` Sourcepoint hard-wall branch |
| `src/content/cookie-noise.js` / `cookie-noise-mainworld.js` | Sourcepoint signals + reject wired (Chrome MAIN `__tcfapi` / Firefox `wrappedJSObject.__tcfapi`); `@sync` block extended identically |
| `tests/unit/cmp-adapters.test.mjs` | dual-mandatory detection, confidence-gate, decideAction truth table, Didomi-non-misfire, registry-shape (TIER1 length 5) |
| `tests/unit/cookie-noise-sync.test.mjs` | sync guard for the new block + literal-`"postRejectAll"` never-accept guard (regex-scans both sources) |
| `tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs` | Chromium regression fixture (reject fires, OFF no-op, Didomi-shaped non-misfire) |

## Test + review

- [x] `npm test` — 6648 pass / 0 fail / 1 pre-existing unrelated skip (independently re-run in review)
- [x] `npm run check:i18n`, `npm run lint`, `npm run lint:js`, `build:content` drift gate — all clean
- [x] E2E — 3/3 on real Chromium (reject / OFF no-op / Didomi non-misfire)
- [x] Adversarial review (independent verify — every gate RUN, not reasoned) — **MERGE-READY**, 0 findings above LOW; TCF discrimination, ambiguous-CMP resolution, literal-arg guard teeth (defeat attempts failed), fire-and-forget both worlds, `return;` present both worlds, sibling non-regression all CONFIRMED

## Pre-ship gate (blocks store release, not this merge)

- [ ] Real-browser smoke: the Firefox `wrappedJSObject.__tcfapi` path, live-Sourcepoint compatibility, and `postRejectAll` against a live Didomi-only page (non-misfire) are structurally tested only (Chromium e2e is a regression oracle). Run a `web-ext` + live-Sourcepoint smoke before the next store release — same policy as the other four adapters (unit-green != real-env-green).
- [ ] Known fail-closed coverage gap: a self-hosted/proxied Sourcepoint "native message" loader that omits the `privacy-mgmt.com`/`sp-prod.net` secondary signals yields confidence 0.4 and is missed (never misfires). Deliberate, consistent with the other adapters; revisit with a real sample if reported.
