### PR TITLE
feat(consent): Usercentrics CMP adapter (Tier 1)

### DIFF
--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -125,6 +125,25 @@
   function canRejectSourcepoint(signals) {
     return detectSourcepoint(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // Usercentrics (#1121): window.UC_UI is a vendor-namespaced global (like
+  // Didomi's window.Didomi), NOT a shared/generic surface like __tcfapi and
+  // NOT a bare global like CookieYes's — so this mirrors detectDidomi's
+  // shape (mandatory global + mandatory reject-fn signal, plus >=1
+  // corroborating secondary signal).
+  function detectUsercentrics(signals) {
+    if (!signals || signals.hasUcUiGlobal !== true || signals.hasDenyAllConsentsFn !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasUsercentricsRootDom === true ? 1 : 0) +
+      (signals.hasIsInitializedFn === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectUsercentrics(signals) {
+    return detectUsercentrics(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -247,6 +266,30 @@
     } catch {
       // document not ready / detached — leave all false.
     }
+    // Usercentrics (#1121): window.UC_UI is the drop-in banner's
+    // vendor-namespaced global. Do NOT key off __tcfapi or an __ucCmp
+    // global — those are the generic-TCF / headless-SDK surfaces (a
+    // separate, rarer Usercentrics integration mode), not this signal.
+    let hasUcUiGlobal = false;
+    let hasDenyAllConsentsFn = false;
+    try {
+      hasUcUiGlobal = typeof window.UC_UI === "object" && window.UC_UI !== null;
+      hasDenyAllConsentsFn = hasUcUiGlobal && typeof window.UC_UI.denyAllConsents === "function";
+    } catch {
+      // Leave both false — fail-closed.
+    }
+    let hasUsercentricsRootDom = false;
+    try {
+      hasUsercentricsRootDom = !!document.getElementById("usercentrics-root");
+    } catch {
+      // document not ready / detached — leave false.
+    }
+    let hasIsInitializedFn = false;
+    try {
+      hasIsInitializedFn = hasUcUiGlobal && typeof window.UC_UI.isInitialized === "function";
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -272,6 +315,10 @@
       hasSpPrivacyMgmtIframeDom,
       hasSpProdIframeDom,
       hasSpProdScriptDom,
+      hasUcUiGlobal,
+      hasDenyAllConsentsFn,
+      hasUsercentricsRootDom,
+      hasIsInitializedFn,
     };
   }
 
@@ -355,6 +402,21 @@
         window.__tcfapi("postRejectAll", 2, (success) => {
           void success; // fire-and-forget — log only, never gates control flow
         });
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: Usercentrics API adapter (#1121). denyAllConsents() returns a
+    // Promise (unlike every prior adapter here) — this call site is
+    // fire-and-forget: .catch(() => {}) swallows any floating rejection,
+    // and _acted + stopObserver() fire SYNCHRONOUSLY right after, never
+    // awaited, never gating control flow on the promise settling.
+    if (canRejectUsercentrics(signals)) {
+      _acted = true;
+      try {
+        window.UC_UI.denyAllConsents().catch(() => {});
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -121,6 +121,25 @@
   function canRejectSourcepoint(signals) {
     return detectSourcepoint(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // Usercentrics (#1121): window.UC_UI is a vendor-namespaced global (like
+  // Didomi's window.Didomi), NOT a shared/generic surface like __tcfapi and
+  // NOT a bare global like CookieYes's — so this mirrors detectDidomi's
+  // shape (mandatory global + mandatory reject-fn signal, plus >=1
+  // corroborating secondary signal).
+  function detectUsercentrics(signals) {
+    if (!signals || signals.hasUcUiGlobal !== true || signals.hasDenyAllConsentsFn !== true) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasUsercentricsRootDom === true ? 1 : 0) +
+      (signals.hasIsInitializedFn === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectUsercentrics(signals) {
+    return detectUsercentrics(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -288,6 +307,35 @@
     } catch {
       // ignore
     }
+    // Usercentrics (#1121): window.UC_UI is the drop-in banner's
+    // vendor-namespaced global, reached via wrappedJSObject — same
+    // Xray-safety pattern as the other Firefox signal reads above. Do NOT
+    // key off __tcfapi or an __ucCmp global — those are the generic-TCF /
+    // headless-SDK surfaces, not this signal.
+    let hasUcUiGlobal = false;
+    let hasDenyAllConsentsFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const uc = wrapped && wrapped.UC_UI;
+      hasUcUiGlobal = typeof uc === "object" && uc !== null;
+      hasDenyAllConsentsFn = hasUcUiGlobal && typeof uc.denyAllConsents === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasUsercentricsRootDom = false;
+    try {
+      hasUsercentricsRootDom = !!document.getElementById("usercentrics-root");
+    } catch {
+      // ignore
+    }
+    let hasIsInitializedFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const uc = wrapped && wrapped.UC_UI;
+      hasIsInitializedFn = hasUcUiGlobal && typeof uc.isInitialized === "function";
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -313,6 +361,10 @@
       hasSpPrivacyMgmtIframeDom,
       hasSpProdIframeDom,
       hasSpProdScriptDom,
+      hasUcUiGlobal,
+      hasDenyAllConsentsFn,
+      hasUsercentricsRootDom,
+      hasIsInitializedFn,
     };
   }
 
@@ -376,6 +428,21 @@
         window.wrappedJSObject.__tcfapi("postRejectAll", 2, (success) => {
           void success; // fire-and-forget — log only, never gates control flow
         });
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: Usercentrics API adapter (#1121). Same fire-and-forget,
+    // synchronous _fxActed + fxStopObserver() shape as the Chrome
+    // MAIN-world caller — see cookie-noise-mainworld.js. denyAllConsents()
+    // returns a Promise; .catch(() => {}) swallows any floating rejection
+    // and the promise is never awaited.
+    if (canRejectUsercentrics(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.UC_UI.denyAllConsents().catch(() => {});
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -91,6 +91,15 @@
  *   present in the DOM. Secondary/corroborating signal.
  * @property {boolean} [hasSpProdScriptDom] - `script[src*="sp-prod.net"]`
  *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasUcUiGlobal] - `typeof window.UC_UI === "object"`.
+ * @property {boolean} [hasDenyAllConsentsFn] - `typeof window.UC_UI.denyAllConsents === "function"`.
+ *   Mandatory signal: without this, no reject action can be confirmed.
+ * @property {boolean} [hasUsercentricsRootDom] - `#usercentrics-root`
+ *   present in the DOM (the drop-in banner's host element — its own markup
+ *   lives in an open Shadow DOM, but the host itself is always plain-DOM
+ *   queryable). Secondary/corroborating signal.
+ * @property {boolean} [hasIsInitializedFn] - `typeof window.UC_UI.isInitialized === "function"`.
+ *   Secondary/corroborating signal.
  */
 
 /**
@@ -152,6 +161,18 @@ export const ACTIONS = Object.freeze({
  * function signal + one vendor-specific DOM signal instead of two bare
  * globals. This is what lets Sourcepoint coexist with Didomi in the same
  * registry without misfiring on Didomi's (or any other TCF CMP's) pages.
+ *
+ * The Usercentrics adapter (#1121) reuses the OneTrust/Didomi shape again:
+ * `window.UC_UI` is a vendor-namespaced global (not a shared/generic
+ * surface like `__tcfapi`, and not a bare global like CookieYes's), so
+ * detectUsercentrics requires the mandatory `hasUcUiGlobal` +
+ * `hasDenyAllConsentsFn` pair plus >=1 corroborating signal
+ * (`hasUsercentricsRootDom` or `hasIsInitializedFn`) — same fail-closed
+ * confidence gate, same threshold. Do NOT key detection off `__tcfapi` or
+ * an `__ucCmp` global: those are the generic-TCF / headless-SDK surfaces
+ * (a separate, rarer Usercentrics integration mode) and would either
+ * collide with Sourcepoint/Didomi discrimination or fail to discriminate
+ * at all.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -237,6 +258,25 @@ function detectSourcepoint(signals) {
 
 function canRejectSourcepoint(signals) {
   return detectSourcepoint(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+// Usercentrics (#1121): window.UC_UI is a vendor-namespaced global (like
+// Didomi's window.Didomi), NOT a shared/generic surface like __tcfapi and
+// NOT a bare global like CookieYes's — so this mirrors detectDidomi's
+// shape (mandatory global + mandatory reject-fn signal, plus >=1
+// corroborating secondary signal).
+function detectUsercentrics(signals) {
+  if (!signals || signals.hasUcUiGlobal !== true || signals.hasDenyAllConsentsFn !== true) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasUsercentricsRootDom === true ? 1 : 0) +
+    (signals.hasIsInitializedFn === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectUsercentrics(signals) {
+  return detectUsercentrics(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -362,6 +402,36 @@ export const sourcepointAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * Usercentrics Tier 1 adapter (#1121). The reject call
+ * (`window.UC_UI.denyAllConsents()`) is invoked by the caller-supplied
+ * callback via the shared `reject()` helper above — this adapter
+ * definition never touches `window` itself.
+ *
+ * Async call shape, fire-and-forget: unlike every prior adapter here,
+ * `denyAllConsents()` returns a Promise. The content-script call site
+ * attaches `.catch(() => {})` to swallow any floating rejection, then
+ * returns SYNCHRONOUSLY right after — `_acted`/`_fxActed` and
+ * `stopObserver()`/`fxStopObserver()` fire immediately, never gated on the
+ * promise settling. `reject()` sees the exact same zero-arg, non-throwing
+ * callback shape as every other adapter here; the callback's returned
+ * promise (already `.catch`-guarded by the caller) is never awaited.
+ *
+ * Registered LAST in TIER1 (after sourcepointAdapter): `window.UC_UI` is a
+ * direct, unambiguous vendor-namespaced global (like Didomi's), so ordering
+ * relative to Sourcepoint (which rides the shared `__tcfapi` surface) is
+ * not safety-critical either way — appended at the end to keep the
+ * registry's history append-only.
+ * @type {Readonly<{id: "usercentrics", tier: 1, detect: typeof detectUsercentrics, canReject: typeof canRejectUsercentrics, reject: typeof reject}>}
+ */
+export const usercentricsAdapter = Object.freeze({
+  id: "usercentrics",
+  tier: 1,
+  detect: detectUsercentrics,
+  canReject: canRejectUsercentrics,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
 export const TIER1 = Object.freeze([
   oneTrustAdapter,
@@ -369,6 +439,7 @@ export const TIER1 = Object.freeze([
   didomiAdapter,
   cookieYesAdapter,
   sourcepointAdapter,
+  usercentricsAdapter,
 ]);
 
 /**
@@ -424,6 +495,11 @@ export function decideAction(signals) {
   // a bare hasTcfApiFn is true on every TCF CMP (Didomi included) and must
   // fall through to "uncertain" below, never claim Sourcepoint.
   if (s.hasSpMessageContainerDom === true && s.hasTcfApiFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  // Usercentrics (#1121) hard wall: same shape as the OneTrust/Didomi
+  // checks above (mandatory global present, mandatory reject fn absent).
+  if (s.hasUcUiGlobal === true && s.hasDenyAllConsentsFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/e2e/cookie-consent-minimizer-usercentrics.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-usercentrics.spec.mjs
@@ -1,0 +1,253 @@
+/**
+ * E2E: Cookie Consent Minimizer — Usercentrics Tier 1 adapter (#1121)
+ *
+ * Verifies the Usercentrics reject path against a real Chromium with the
+ * extension loaded. The fixture page mimics a Usercentrics drop-in banner:
+ * the vendor-namespaced global `window.UC_UI.denyAllConsents()` plus a
+ * `#usercentrics-root` DOM host — the dual-mandatory signal combination the
+ * dispatcher requires before acting (src/lib/cmp-adapters.js).
+ *
+ * NEW WRINKLE vs the other 5 adapters: `denyAllConsents()` returns a
+ * Promise. The fixture's stub models this explicitly so this spec exercises
+ * the async fire-and-forget path — the dispatcher must call the method,
+ * chain `.catch(() => {})`, and mark the reject as done (stopObserver)
+ * SYNCHRONOUSLY, without awaiting the promise.
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs's
+ * structure exactly (same onboarding helper shape, same feature pref).
+ *
+ * HONEST LIMIT (per sdd/usercentrics-adapter/explore, engram #1287): this is
+ * a REGRESSION oracle only — a snapshot of one fixture's behavior at write
+ * time. It proves the Chrome MAIN-world nonce handshake
+ * (content/cookie-noise-mainworld.js) and the never-auto-reject-the-other-
+ * way outcome on the fixture used here. It does NOT validate the Firefox
+ * `window.wrappedJSObject` reject path (content/cookie-noise.js) —
+ * Playwright's `chromium` fixture only exercises Chrome — and it does NOT
+ * prove real-vendor-script compatibility against a live Usercentrics CMP
+ * build. The Usercentrics API shape used here (denyAllConsents() returning
+ * a Promise, isInitialized()) was corroborated only via THIRD-PARTY
+ * integration docs — Usercentrics' own docs page for this exact method was
+ * unreachable during exploration — so a real-browser smoke against a live
+ * Usercentrics drop-in site carries EXTRA weight for this adapter
+ * specifically, beyond the usual residual risk already accepted for the
+ * other 5 adapters at ship time.
+ *
+ * REAL-BROWSER SMOKE PLAN required before considering this slice done
+ * (flagged for sdd-verify):
+ *   1. Live Usercentrics drop-in site — confirm both mandatory signals
+ *      (`UC_UI.denyAllConsents` fn + `#usercentrics-root` DOM) are detected
+ *      and `denyAllConsents()` actually clears the page's consent state.
+ *   2. Confirm `denyAllConsents()` is safe to call when no active prompt is
+ *      showing (already-consented page) — does not throw, does not have an
+ *      unexpected side effect.
+ *   3. Confirm `UC_UI.isInitialized()` reliably reflects whether a reject
+ *      call is safe to attempt (the headless/no-prompt gate).
+ *
+ * Re-capture this fixture manually whenever the Usercentrics markup/API
+ * shape this test hardcodes changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-usercentrics.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMinimizerEnabled: enableFeature },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a Usercentrics drop-in banner offering reject via
+ * `UC_UI.denyAllConsents()`. Both mandatory signals (`UC_UI` global,
+ * `denyAllConsents` function) are present, plus the `#usercentrics-root`
+ * DOM host as the corroborating secondary signal — the confidence gate in
+ * cmp-adapters.js requires both mandatory signals plus at least one
+ * secondary signal. `denyAllConsents` returns a real Promise (resolved on
+ * a macrotask delay) so this fixture exercises the fire-and-forget async
+ * path, not a synchronous stub.
+ */
+async function stubUsercentricsPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="usercentrics-root">
+          <button id="uc-btn-accept">Accept All</button>
+          <button id="uc-btn-deny">Deny All</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__ucCalls = [];
+          window.UC_UI = {
+            isInitialized: function () { return true; },
+            denyAllConsents: function () {
+              window.__ucCalls.push("denyAllConsents");
+              return new Promise(function (resolve) {
+                setTimeout(function () {
+                  window.__consentState = "necessary-only";
+                  document.getElementById("usercentrics-root").remove();
+                  resolve(true);
+                }, 0);
+              });
+            },
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — Usercentrics (#1121)", () => {
+  test("rejects a Usercentrics banner with UC_UI.denyAllConsents() when the feature is enabled", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubUsercentricsPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass. denyAllConsents() resolves the page's
+    // consent state asynchronously (macrotask) — poll for the outcome
+    // rather than asserting immediately, since the reject call site never
+    // awaits it either.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // denyAllConsents was actually invoked (not some other UC_UI method).
+    const ucCalls = await page.evaluate(() => window.__ucCalls);
+    expect(ucCalls).toEqual(["denyAllConsents"]);
+
+    // Banner host dismissed.
+    const bannerGone = await page.evaluate(
+      () => document.getElementById("usercentrics-root") === null
+    );
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    // The promise returned by denyAllConsents() was never awaited by the
+    // dispatcher itself (fire-and-forget) and its rejection path (if any)
+    // is swallowed — no unhandled rejection / page error surfaces.
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubUsercentricsPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(
+      () => document.getElementById("usercentrics-root") !== null
+    );
+    expect(bannerStillThere).toBe(true);
+
+    const ucCalls = await page.evaluate(() => window.__ucCalls);
+    expect(ucCalls).toEqual([]);
+
+    await page.close();
+  });
+
+  test("never misfires on a Didomi-only page (no UC_UI global present)", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    const DIDOMI_HOST = "muga-test-cookie-consent-usercentrics-didomi-guard.invalid";
+    await page.route(`**://${DIDOMI_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <div id="didomi-host"></div>
+          <p id="page-content">Real page content</p>
+          <script>
+            // A Didomi-shaped page: exposes window.Didomi.setUserDisagreeToAll
+            // but NO window.UC_UI global at all. The Usercentrics adapter
+            // must never act here.
+            window.__didomiCalls = [];
+            window.Didomi = {
+              getCurrentUserStatus: function () { return {}; },
+              setUserDisagreeToAll: function () {
+                window.__didomiCalls.push("setUserDisagreeToAll");
+              },
+            };
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${DIDOMI_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The Didomi adapter IS expected to fire here (it is a real Didomi
+    // page) — what this test guards is that the Usercentrics adapter never
+    // ALSO claims it / never references UC_UI on a page that has none.
+    await page.waitForFunction(
+      () => Array.isArray(window.__didomiCalls) && window.__didomiCalls.includes("setUserDisagreeToAll"),
+      { timeout: 10000 }
+    );
+
+    const ucGlobalPresent = await page.evaluate(() => typeof window.UC_UI !== "undefined");
+    expect(ucGlobalPresent).toBe(false);
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -28,6 +28,7 @@ import {
   didomiAdapter,
   cookieYesAdapter,
   sourcepointAdapter,
+  usercentricsAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -37,13 +38,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes and Sourcepoint adapters, in order", () => {
-    assert.equal(TIER1.length, 5);
+  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint and Usercentrics adapters, in order", () => {
+    assert.equal(TIER1.length, 6);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
     assert.strictEqual(TIER1[2], didomiAdapter);
     assert.strictEqual(TIER1[3], cookieYesAdapter);
     assert.strictEqual(TIER1[4], sourcepointAdapter);
+    assert.strictEqual(TIER1[5], usercentricsAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -94,6 +96,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof sourcepointAdapter.detect, "function");
     assert.equal(typeof sourcepointAdapter.canReject, "function");
     assert.equal(typeof sourcepointAdapter.reject, "function");
+  });
+
+  test("usercentricsAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(usercentricsAdapter.id, "usercentrics");
+    assert.equal(usercentricsAdapter.tier, 1);
+    assert.equal(typeof usercentricsAdapter.detect, "function");
+    assert.equal(typeof usercentricsAdapter.canReject, "function");
+    assert.equal(typeof usercentricsAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -336,6 +346,67 @@ describe("decideAction — truth table", () => {
     assert.equal(r.action, ACTIONS.REJECT_ALL);
     assert.equal(r.reason, "reject");
     assert.equal(r.adapterId, "didomi");
+  });
+
+  test("Usercentrics: UC_UI global + denyAllConsents fn + corroborating DOM host -> reject", () => {
+    const r = decideAction({
+      hasUcUiGlobal: true,
+      hasDenyAllConsentsFn: true,
+      hasUsercentricsRootDom: true,
+      hasIsInitializedFn: true,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "usercentrics");
+  });
+
+  test("Usercentrics: UC_UI global present but denyAllConsents absent (hard wall) -> NOOP", () => {
+    const r = decideAction({
+      hasUcUiGlobal: true,
+      hasDenyAllConsentsFn: false,
+      hasUsercentricsRootDom: true,
+      hasIsInitializedFn: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("Usercentrics mandatory signals present but zero corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasUcUiGlobal: true,
+      hasDenyAllConsentsFn: true,
+      hasUsercentricsRootDom: false,
+      hasIsInitializedFn: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("Didomi-shaped signals (window.Didomi, NO UC_UI) resolve to Didomi, never misfire as Usercentrics", () => {
+    const r = decideAction({
+      hasDidomiGlobal: true,
+      hasSetUserDisagreeToAllFn: true,
+      hasDidomiHostDom: true,
+      hasGetCurrentUserStatusFn: true,
+      hasUcUiGlobal: false,
+      hasDenyAllConsentsFn: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "didomi");
+  });
+
+  test("TCF-shaped signals (__tcfapi + sp_message_container, NO UC_UI) resolve to Sourcepoint, never misfire as Usercentrics", () => {
+    const r = decideAction({
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: true,
+      hasUcUiGlobal: false,
+      hasDenyAllConsentsFn: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "sourcepoint");
   });
 });
 
@@ -663,6 +734,69 @@ describe("sourcepointAdapter.detect — dual-mandatory TCF-generic-signal discri
   });
 });
 
+describe("usercentricsAdapter.detect — dual-mandatory confidence gate", () => {
+  const FULL_UC_SIGNALS = Object.freeze({
+    hasUcUiGlobal: true,
+    hasDenyAllConsentsFn: true,
+    hasUsercentricsRootDom: true,
+    hasIsInitializedFn: true,
+  });
+
+  test("both mandatory signals + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = usercentricsAdapter.detect(FULL_UC_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(usercentricsAdapter.canReject(FULL_UC_SIGNALS), true);
+  });
+
+  test("both mandatory signals + exactly one secondary (#usercentrics-root DOM only) -> canReject true", () => {
+    const s = {
+      hasUcUiGlobal: true,
+      hasDenyAllConsentsFn: true,
+      hasUsercentricsRootDom: true,
+      hasIsInitializedFn: false,
+    };
+    assert.equal(usercentricsAdapter.canReject(s), true);
+  });
+
+  test("both mandatory signals + exactly one secondary (isInitialized fn only) -> canReject true", () => {
+    const s = {
+      hasUcUiGlobal: true,
+      hasDenyAllConsentsFn: true,
+      hasUsercentricsRootDom: false,
+      hasIsInitializedFn: true,
+    };
+    assert.equal(usercentricsAdapter.canReject(s), true);
+  });
+
+  test("global-only (mandatory present, zero secondary signals) -> uncertain, canReject false", () => {
+    const s = {
+      hasUcUiGlobal: true,
+      hasDenyAllConsentsFn: true,
+      hasUsercentricsRootDom: false,
+      hasIsInitializedFn: false,
+    };
+    assert.equal(usercentricsAdapter.canReject(s), false);
+    assert.ok(usercentricsAdapter.detect(s) < 1);
+  });
+
+  test("DOM-only (mandatory denyAllConsents fn missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasUcUiGlobal: false,
+      hasDenyAllConsentsFn: false,
+      hasUsercentricsRootDom: true,
+      hasIsInitializedFn: true,
+    };
+    assert.equal(usercentricsAdapter.detect(s), 0);
+    assert.equal(usercentricsAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => usercentricsAdapter.detect(null));
+    assert.doesNotThrow(() => usercentricsAdapter.detect(undefined));
+    assert.equal(usercentricsAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -757,6 +891,47 @@ describe("sourcepointAdapter.reject — pure callback invocation", () => {
   test("non-function argument -> status noop, no call", () => {
     const r = sourcepointAdapter.reject(undefined);
     assert.equal(r.status, "noop");
+  });
+});
+
+describe("usercentricsAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = usercentricsAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = usercentricsAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = usercentricsAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+
+  test("a callback that returns a Promise is handled fire-and-forget: reject() reports rejected synchronously without awaiting, and a later rejection on that promise never surfaces as an unhandled rejection or a thrown error here", async () => {
+    let settleReject;
+    let called = false;
+    const promise = new Promise((_resolve, rej) => {
+      settleReject = rej;
+    });
+    const r = usercentricsAdapter.reject(() => {
+      called = true;
+      return promise.catch(() => {});
+    });
+    // Synchronous contract: reject() must report "rejected" immediately,
+    // without waiting for the returned promise to settle.
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+    // Now settle the floating promise with a rejection — this must never
+    // produce an unhandled-rejection warning (the .catch(() => {}) above,
+    // mirroring the real denyAllConsents().catch(() => {}) call-site shape,
+    // already swallowed it) and must not throw here.
+    settleReject(new Error("denyAllConsents rejected"));
+    await promise.catch(() => {});
   });
 });
 
@@ -888,5 +1063,14 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
     assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
     assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
     assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
+  });
+
+  test("usercentricsAdapter is registered in TIER1 alongside the other five adapters (#1121)", () => {
+    assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must include usercentricsAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
+    assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
+    assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -124,6 +124,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectSourcepoint/.test(joined));
     assert.ok(/function canRejectSourcepoint/.test(joined));
   });
+
+  test("sync block also defines detectUsercentrics and canRejectUsercentrics (#1121)", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectUsercentrics/.test(joined));
+    assert.ok(/function canRejectUsercentrics/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -379,6 +385,38 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       for (const firstArg of calls) {
         assert.equal(firstArg, "\"postRejectAll\"", `${label} __tcfapi's first argument must be the literal "postRejectAll"`);
       }
+    }
+  });
+
+  test("only UC_UI.denyAllConsents (or wrappedJSObject equivalent) is invoked — no other UC_UI method call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/UC_UI\.(\w+)\s*\(/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call UC_UI.denyAllConsents`);
+      for (const fn of calls) {
+        assert.equal(fn, "denyAllConsents", `${label} calls UC_UI.${fn}() — only denyAllConsents is permitted`);
+      }
+    }
+  });
+
+  test("every denyAllConsents call passes zero arguments — never a variable, never accept/allowAll", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/denyAllConsents\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call denyAllConsents`);
+      for (const args of calls) {
+        assert.equal(args, "", `${label} denyAllConsents must be called with zero arguments`);
+      }
+    }
+  });
+
+  test("every denyAllConsents() call is immediately followed by a .catch(...) to swallow the returned promise's rejection", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      assert.ok(
+        /denyAllConsents\(\)\s*\.catch\s*\(/.test(src),
+        `${label} must chain .catch(...) directly onto the denyAllConsents() call`,
+      );
     }
   });
 });


### PR DESCRIPTION
Closes #1121

## Summary

Adds a **Usercentrics** Tier 1 adapter to the cookie-consent-minimizer module (sixth CMP, and the **first with an async / Promise-returning reject API**). Rejects on the user's behalf via Usercentrics's own JS API and never auto-accepts. Extends the existing dispatcher + `cmp-adapters.js` registry — no new UI, pref, manifest change, or permissions.

Targets **`develop`** (integration branch), not main.

## What it does

- **Reject API (async, fire-and-forget)**: `window.UC_UI.denyAllConsents()` — zero-arg, vendor-namespaced (modeled on Didomi's shape). Unlike the 5 prior adapters, this call **returns a Promise**, so it is chained with `.catch(() => {})` to swallow any floating rejection. It is **never awaited**: `_acted = true` is set synchronously before the call and `stopObserver()` runs synchronously after, so control flow never depends on the promise. The whole call sits inside `try/catch` — if a real build returns `undefined` (not a Promise), the `undefined.catch` TypeError is caught and degrades to a no-op; a throwing/absent global can never break the page. Firefox mirror: `window.wrappedJSObject.UC_UI.denyAllConsents().catch(() => {})`.
- **Detection (dual-mandatory + corroborating, fail-closed)**: mandatory `typeof window.UC_UI === "object" && typeof window.UC_UI.denyAllConsents === "function"`, plus ≥1 corroborating signal (`#usercentrics-root` DOM host, or `typeof window.UC_UI.isInitialized === "function"`). Below `CONFIDENCE_THRESHOLD` → NOOP. Detection is **never** keyed off `__tcfapi`/`__ucCmp` (the generic-TCF / headless-SDK surfaces), so the existing Sourcepoint/Didomi/TCF discrimination boundary is byte-unchanged. Shadow DOM is a non-issue: we only need the queryable host element `#usercentrics-root`, never the shadow root (pure JS API call, no click simulation).
- **Never-auto-accept** stays structurally enforced: a guard scans BOTH content scripts and asserts the only method called on `UC_UI` is exactly `denyAllConsents`, zero args, with `.catch(` chained — never `acceptAllConsents`, never a non-zero arg, never a variable method name. Combined with the `/allowall|accept/i` full-source scan, a detection misfire can only ever deny.
- Registered as the sixth (last) TIER1 entry; the other five paths are **byte-unchanged** (the commit is purely additive — zero deletions in the three source files); one reject per page per world (idempotency intact; `return;` present in both worlds).

## Changes

| File | Change |
|------|--------|
| `src/lib/cmp-adapters.js` | `detectUsercentrics`/`canRejectUsercentrics` in `@sync` block, `usercentricsAdapter` added to TIER1 (now 6), `decideAction` Usercentrics hard-wall branch |
| `src/content/cookie-noise.js` / `cookie-noise-mainworld.js` | Usercentrics signals + async reject wired (`.catch()` inside `try/catch`, sync `_acted`/`stopObserver`); `@sync` block extended identically |
| `tests/unit/cmp-adapters.test.mjs` | dual-mandatory detection, confidence-gate, decideAction truth table, non-misfire (Didomi/TCF-shaped), registry-shape (TIER1 length 6), Promise fire-and-forget contract test |
| `tests/unit/cookie-noise-sync.test.mjs` | sync guard for the new block + never-accept guards (only `denyAllConsents`, zero args, mandatory `.catch(` chain) |
| `tests/e2e/cookie-consent-minimizer-usercentrics.spec.mjs` | Chromium fixture — async reject fires, OFF no-op, Didomi-only non-misfire |

## Test + review

- [x] `npm test` — 6672 pass / 0 fail / 1 pre-existing unrelated skip (+24 new; independently re-run in review)
- [x] `npm run check:i18n`, `npm run lint`, `npm run lint:js`, `build:content` drift gate — all clean
- [x] E2E — 3/3 on real Chromium (async reject / OFF no-op / Didomi non-misfire)
- [x] Adversarial review (independent verify — every gate RUN) — **MERGE-READY**, 0 findings above LOW; the highest-risk item (`.catch` on a non-Promise return) CONFIRMED handled by the enclosing `try/catch`; async fire-and-forget both worlds, non-misfire, literal-arg guard teeth, sibling non-regression (0-deletion diff) all confirmed

## Pre-ship gate (blocks store release, not this merge) — REINFORCED for this adapter

This gate carries **more weight than for the other five**: Usercentrics' own canonical API docs were unreachable during research, so the API shape was corroborated only via third-party integration docs. The smoke test therefore validates the API shape itself, not just real-env compatibility.

- [ ] **Live-Usercentrics smoke** on a real drop-in (`loader.js` / `UC_UI`) site: confirm `denyAllConsents()` exists, actually denies, and returns a Promise (if it returns void, the adapter already fails safe — a no-op, no page break — but confirm).
- [ ] **`isInitialized()` semantics**: the code only `typeof`-checks it as a corroborating signal, it does NOT call it as a runtime gate (consistent with the other five adapters, and deliberately so while its semantics are unverified). Confirm on a live site whether firing `denyAllConsents()` on an already-consented / not-yet-prompted page is safe/inert. Because we never accept, worst case is a redundant deny.
- [ ] **TCF-2.2-addon mode**: confirm whether that Usercentrics mode still exposes `window.UC_UI` or swaps it (ambiguous across third-party sources).
- [ ] Firefox `wrappedJSObject.UC_UI` path via `web-ext` smoke (structurally tested only) — same policy as the other five (unit-green != real-env-green).
