### PR TITLE
test(cmp): nightly real-site canary + TCF spec-contract tests (#1129)

### DIFF
--- a/.github/workflows/cmp-canary.yml
+++ b/.github/workflows/cmp-canary.yml
@@ -1,0 +1,69 @@
+name: CMP canary — nightly real-site drift alarm
+
+# NON-BLOCKING drift alarm (#1129): runs the Cookie Consent Minimizer's
+# Tier 1 adapters (src/lib/cmp-adapters.js) against a small candidate list
+# of real, publicly-reachable sites per CMP (tests/canary/cmp-sites.json)
+# and reports whether each CMP's banner still gets rejected. This workflow
+# NEVER gates a PR or a release — it only files/updates a tracking issue
+# per drifting CMP for a maintainer to triage. See tests/canary/cmp-canary.spec.mjs
+# and tools/canary-report.mjs for the full honest-limits rationale (real
+# sites are flaky/geo-variant/CMP-migrating; the canary self-validates its
+# own candidate list on every run).
+
+on:
+  schedule:
+    # Nightly at 05:00 UTC — off-peak, ahead of the weekly maintenance jobs
+    # (import-upstream Sun 04:00 UTC, moat-expansion Sun 06:00 UTC).
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bundle content script (#356)
+        # The canary loads the real extension (--load-extension=src/), same
+        # as the e2e suite — needs the content bundle present.
+        run: npm run build:content
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run CMP canary against real sites (xvfb, non-blocking)
+        # continue-on-error: true — a flaky real site (or several) must
+        # never fail this job. Drift decisions are made downstream by
+        # tools/canary-report.mjs's threshold logic, not by this step's
+        # own exit code.
+        continue-on-error: true
+        run: xvfb-run npm run test:canary
+
+      - name: Upload canary results (debugging aid)
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        with:
+          name: cmp-canary-results
+          path: test-results/canary-results.json
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: File or update drift-tracking issues
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node tools/canary-report.mjs "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:dnr": "node scripts/generate-dnr-rules.mjs",
     "add-rule": "node tools/add-rule.mjs",
     "test:e2e": "npx playwright test",
+    "test:canary": "playwright test --config playwright.canary.config.mjs",
     "typecheck": "tsc -p jsconfig.json",
     "lint:js": "eslint .",
     "moat:report": "node tools/moat-expansion/cli.mjs",

--- a/playwright.canary.config.mjs
+++ b/playwright.canary.config.mjs
@@ -1,0 +1,50 @@
+/**
+ * MUGA — nightly real-site CMP canary Playwright config (#1129).
+ *
+ * Deliberately SEPARATE from playwright.config.mjs (the normal `npm run
+ * test:e2e` config, testDir "tests/e2e"): this config's testDir is
+ * "tests/canary", so the two suites never collide and the canary — which
+ * hits real, uncontrolled third-party websites — can never be picked up by
+ * the local/CI e2e gate.
+ *
+ * NON-BLOCKING BY DESIGN: this suite exists to raise a nightly drift alarm
+ * (see tests/canary/cmp-canary.spec.mjs and tools/canary-report.mjs), never
+ * to gate a PR or a release build. `retries: 2` absorbs real-world
+ * navigation flakiness (DNS blips, slow real sites) — see
+ * cmp-canary.spec.mjs for which failures are retry-worthy vs. recorded as
+ * "inconclusive"/"fail" data.
+ */
+
+import { defineConfig } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const extensionPath = path.resolve(__dirname, "src");
+
+export default defineConfig({
+  testDir: "tests/canary",
+  timeout: 120_000,
+  retries: 2,
+  workers: 1, // extensions require serial execution (same constraint as playwright.config.mjs)
+  reporter: [["list"]],
+  use: {
+    headless: false, // Chrome extensions require headed mode
+    viewport: { width: 1280, height: 900 },
+  },
+  projects: [
+    {
+      name: "cmp-canary",
+      use: {
+        launchOptions: {
+          args: [
+            `--disable-extensions-except=${extensionPath}`,
+            `--load-extension=${extensionPath}`,
+            "--no-first-run",
+            "--disable-search-engine-choice-screen",
+          ],
+        },
+      },
+    },
+  ],
+});

--- a/tests/canary/cmp-canary.spec.mjs
+++ b/tests/canary/cmp-canary.spec.mjs
@@ -1,0 +1,176 @@
+/**
+ * MUGA — Cookie Consent Minimizer: nightly real-site CMP canary (#1129)
+ *
+ * ── Honest limits (read before treating a red run as a bug) ────────────────
+ *
+ * This is a NON-BLOCKING DRIFT ALARM, never a merge/CI gate. The site list
+ * in cmp-sites.json is a CANDIDATE list, not a verified ground truth: it was
+ * assembled from vendor case studies and third-party sources (see each
+ * entry's `note` field), not from live script inspection of every site (see
+ * that file's docblock-equivalent notes for the two lower-confidence
+ * entries). Real sites are flaky, geo-variant (a banner may not appear at
+ * all for an EU-exit-node run, or may already be pre-consented via a
+ * previously-set cookie), and may switch CMP vendors without notice. This
+ * spec therefore self-validates the list on every run:
+ *   - If a site's banner never appears at all, that is recorded as
+ *     "inconclusive" (NOT "fail") — it does not mean MUGA is broken, it
+ *     usually means the banner didn't fire for this run/region/session.
+ *   - Only a banner that DEMONSTRABLY APPEARED and then stayed visible
+ *     after MUGA's reject window is recorded as "fail" — a real signal
+ *     that the CMP's DOM/API surface may have drifted from the adapter in
+ *     src/lib/cmp-adapters.js.
+ *   - tools/canary-report.mjs additionally requires >=2 "fail" results for
+ *     the SAME CMP (across its 2 candidate sites) before treating it as
+ *     drift and opening a tracking issue — a single flaky site never
+ *     triggers an alert.
+ *
+ * This file is NOT picked up by the normal `npm run test:e2e` run —
+ * playwright.config.mjs's testDir is "tests/e2e", not "tests/canary". It
+ * runs only via `npm run test:canary` (playwright.canary.config.mjs) or the
+ * scheduled .github/workflows/cmp-canary.yml.
+ *
+ * Reuses the same extension-loading mechanism as tests/e2e/fixtures.mjs
+ * (chromium.launchPersistentContext + --load-extension, headed) by
+ * importing its `test`/`expect` directly rather than duplicating the
+ * launch config.
+ */
+
+import { test, expect } from "../e2e/fixtures.mjs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const sites = JSON.parse(readFileSync(join(__dirname, "cmp-sites.json"), "utf8"));
+
+const BANNER_APPEAR_TIMEOUT_MS = 15_000;
+const BANNER_DISAPPEAR_TIMEOUT_MS = 15_000;
+const NAV_TIMEOUT_MS = 30_000;
+
+const RESULTS_PATH = join(__dirname, "../../test-results/canary-results.json");
+
+/** @type {Map<string, {cmp: string, url: string, status: "pass"|"fail"|"inconclusive", detail: string}>} */
+const results = new Map();
+
+function recordResult(site, status, detail) {
+  results.set(`${site.cmp}::${site.url}`, { cmp: site.cmp, url: site.url, status, detail });
+}
+
+/**
+ * Completes onboarding and turns on cookieConsentMinimizerEnabled directly
+ * via chrome.storage — mirrors tests/e2e/fixtures.mjs's completeOnboarding()
+ * but additionally flips the feature pref, which defaults OFF (see
+ * src/content/cookie-noise-mainworld.js's docblock) and is not touched by
+ * the shared e2e fixture.
+ *
+ * @param {import("@playwright/test").BrowserContext} context
+ * @param {string} extensionId
+ */
+async function enableCookieConsentMinimizer(context, extensionId) {
+  const extOrigin = `chrome-extension://${extensionId}`;
+  let extPage = context.pages().find((p) => p.url().startsWith(extOrigin));
+  if (!extPage) {
+    extPage = await context.newPage();
+    await extPage.goto(`${extOrigin}/onboarding/onboarding.html`);
+  }
+
+  await extPage.evaluate(() => {
+    return new Promise((resolve) => {
+      const syncWrite = new Promise((r) =>
+        chrome.storage.sync.set(
+          {
+            injectOwnAffiliate: false,
+            notifyForeignAffiliate: false,
+            language: "en",
+            cookieConsentMinimizerEnabled: true,
+          },
+          r,
+        ),
+      );
+      const localWrite = new Promise((r) =>
+        chrome.storage.local.set(
+          {
+            mugaConsent: {
+              onboardingDone: true,
+              consentVersion: "1.2",
+              consentDate: Date.now(),
+            },
+          },
+          r,
+        ),
+      );
+      Promise.all([syncWrite, localWrite]).then(() => resolve());
+    });
+  });
+
+  for (const p of context.pages()) {
+    if (p.url().includes("/onboarding/")) await p.close();
+  }
+}
+
+test.describe("CMP canary — nightly real-site drift alarm (#1129, non-blocking)", () => {
+  for (const site of sites) {
+    test(`${site.cmp} — ${site.url}`, async ({ context, extensionId }) => {
+      test.setTimeout(120_000);
+
+      await enableCookieConsentMinimizer(context, extensionId);
+
+      const page = await context.newPage();
+
+      try {
+        await page.goto(site.url, { waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+      } catch (err) {
+        await page.close();
+        // A genuine navigation failure (DNS, timeout, connection refused) is
+        // exactly the kind of transient real-world flakiness
+        // playwright.canary.config.mjs's retries:2 exists to absorb —
+        // rethrow so Playwright retries this site before giving up.
+        throw err;
+      }
+
+      let bannerAppeared = true;
+      try {
+        await page.waitForSelector(site.bannerSelector, { state: "visible", timeout: BANNER_APPEAR_TIMEOUT_MS });
+      } catch {
+        bannerAppeared = false;
+      }
+
+      if (!bannerAppeared) {
+        recordResult(
+          site,
+          "inconclusive",
+          "banner never appeared within the wait window (already-consented cookie, geo-variant CMP config, or the site no longer uses this CMP) — not treated as a MUGA failure",
+        );
+        await page.close();
+        return;
+      }
+
+      let status;
+      let detail;
+      try {
+        await page.waitForSelector(site.bannerSelector, { state: "hidden", timeout: BANNER_DISAPPEAR_TIMEOUT_MS });
+        status = "pass";
+        detail = "banner appeared and was hidden/removed after MUGA's reject action";
+      } catch {
+        status = "fail";
+        detail = "banner appeared and remained visible after the wait window — MUGA did not reject it (possible CMP/adapter drift)";
+      }
+
+      recordResult(site, status, detail);
+      await page.close();
+
+      // Soft signal only: a per-site "fail" is real information (surfaced in
+      // the JSON + Playwright's own report) but must never hard-fail this
+      // spec file in a way that would block a future blocking pipeline —
+      // drift decisions belong to tools/canary-report.mjs's threshold logic,
+      // not to a single site's assertion here.
+      expect(status, detail).not.toBe(undefined);
+    });
+  }
+
+  test.afterAll(() => {
+    mkdirSync(dirname(RESULTS_PATH), { recursive: true });
+    writeFileSync(RESULTS_PATH, JSON.stringify(Array.from(results.values()), null, 2), "utf8");
+  });
+});

--- a/tests/canary/cmp-sites.json
+++ b/tests/canary/cmp-sites.json
@@ -1,0 +1,74 @@
+[
+  {
+    "cmp": "onetrust",
+    "url": "https://www.aircanada.com",
+    "bannerSelector": "#onetrust-banner-sdk",
+    "note": "Air Canada is named as a OneTrust customer on OneTrust's own customers page (https://www.onetrust.com/customers/). Not independently confirmed via script inspection (see limitations note in cmp-canary.spec.mjs) — the canary self-validates on first real run."
+  },
+  {
+    "cmp": "onetrust",
+    "url": "https://www.bertelsmann.com",
+    "bannerSelector": "#onetrust-banner-sdk",
+    "note": "Bertelsmann is named as a OneTrust customer on OneTrust's own customers page (https://www.onetrust.com/customers/). Same confidence caveat as the Air Canada entry above."
+  },
+  {
+    "cmp": "cookiebot",
+    "url": "https://www.clece.es",
+    "bannerSelector": "#CybotCookiebotDialog",
+    "note": "Clece is named in Usercentrics' \"All Around\" Cookiebot case study (https://usercentrics.com/resources/all-around-cookiebot-case-study/) as a company whose ~34 domains are governed under Cookiebot CMP via reseller partner All Around."
+  },
+  {
+    "cmp": "cookiebot",
+    "url": "https://www.cookiebot.com",
+    "bannerSelector": "#CybotCookiebotDialog",
+    "note": "LOWER CONFIDENCE: Cookiebot's own marketing site — inferred from the industry-standard practice of CMP vendors running their own product on their own site (\"dogfooding\"), not from an independent citation. A direct WebFetch script-tag check was inconclusive because HTML-to-markdown conversion strips <script> tags before analysis; only one confidently-sourced Cookiebot site (clece.es above) was found via search. The canary's self-validation (inconclusive vs fail) covers this if wrong."
+  },
+  {
+    "cmp": "didomi",
+    "url": "https://www.orange.fr",
+    "bannerSelector": "#didomi-host",
+    "note": "Orange is a long-standing named Didomi customer per Didomi's own case studies (https://www.didomi.io/blog/didomi-x-orange and https://www.didomi.io/blog/client-testimonial-orange-cookie-compliance), using Didomi across web, app, and TV."
+  },
+  {
+    "cmp": "didomi",
+    "url": "https://www.europcar.com",
+    "bannerSelector": "#didomi-host",
+    "note": "Europcar is named in Didomi's own case study (https://www.didomi.io/blog/europcar-case-study) covering ~20 Europcar-brand websites using Didomi."
+  },
+  {
+    "cmp": "cookieyes",
+    "url": "https://ahrefs.com",
+    "bannerSelector": ".cky-consent-container, .cky-consent-bar",
+    "note": "Ahrefs is named explicitly as a CookieYes example in CookieYes's own blog post (https://www.cookieyes.com/blog/cookieyes-cookie-banner-examples/)."
+  },
+  {
+    "cmp": "cookieyes",
+    "url": "https://www.dominos.gr",
+    "bannerSelector": ".cky-consent-container, .cky-consent-bar",
+    "note": "Domino's (Greece) is named in the same CookieYes blog post (https://www.cookieyes.com/blog/cookieyes-cookie-banner-examples/) as a CookieYes example."
+  },
+  {
+    "cmp": "sourcepoint",
+    "url": "https://9gag.com",
+    "bannerSelector": "div[id^=\"sp_message_container\"]",
+    "note": "Sourcepoint's own case study (https://sourcepoint.com/case-studies/how-9gag-successfully-migrated-consent-management-platforms/) explicitly states Sourcepoint is live on 9gag.com."
+  },
+  {
+    "cmp": "sourcepoint",
+    "url": "https://www.heraldscotland.com",
+    "bannerSelector": "div[id^=\"sp_message_container\"]",
+    "note": "LOWER CONFIDENCE: heraldscotland.com is a masthead of Newsquest, and Sourcepoint's own case-studies page (https://sourcepoint.com/case-studies/) names Newsquest as running Sourcepoint's \"Consent or Pay\" across 200+ Newsquest sites — the specific masthead itself is not individually named in the case study."
+  },
+  {
+    "cmp": "usercentrics",
+    "url": "https://www.dish.com",
+    "bannerSelector": "#usercentrics-root",
+    "note": "DISH is named as a Usercentrics case study customer (https://usercentrics.com/case-studies/, \"DISH — Consent experience streamlining\")."
+  },
+  {
+    "cmp": "usercentrics",
+    "url": "https://www.conrad.de",
+    "bannerSelector": "#usercentrics-root",
+    "note": "Conrad Electronic is named as a Usercentrics case study customer (https://usercentrics.com/case-studies/, \"Conrad Electronic — Privacy compliance at scale\")."
+  }
+]

--- a/tests/unit/canary-report.test.mjs
+++ b/tests/unit/canary-report.test.mjs
@@ -1,0 +1,193 @@
+/**
+ * MUGA — tools/canary-report.mjs pure-logic unit tests (#1129).
+ *
+ * Covers decideDrift's threshold behavior (below/at/above, inconclusive
+ * always ignored, multiple CMPs tracked independently) and
+ * formatIssueBody's deterministic rendering. Importing tools/canary-report.mjs
+ * must never execute its CLI (no gh/network calls) — see the entry-guard
+ * smoke test at the bottom, which is what makes this file safe to run in
+ * the normal `npm test` gate.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { decideDrift, formatIssueBody } from "../../tools/canary-report.mjs";
+
+// ── decideDrift — threshold behavior ──────────────────────────────────────
+
+describe("canary-report — decideDrift threshold behavior", () => {
+  test("below threshold: 1 fail (default threshold 2) is not drift", () => {
+    const results = [
+      { cmp: "onetrust", url: "https://a.example", status: "fail" },
+      { cmp: "onetrust", url: "https://b.example", status: "pass" },
+    ];
+    const drift = decideDrift(results);
+    assert.equal(drift.onetrust.inDrift, false);
+    assert.equal(drift.onetrust.failCount, 1);
+  });
+
+  test("at threshold: exactly 2 fails (default threshold 2) IS drift", () => {
+    const results = [
+      { cmp: "onetrust", url: "https://a.example", status: "fail" },
+      { cmp: "onetrust", url: "https://b.example", status: "fail" },
+    ];
+    const drift = decideDrift(results);
+    assert.equal(drift.onetrust.inDrift, true);
+    assert.equal(drift.onetrust.failCount, 2);
+  });
+
+  test("above threshold: 3 fails is drift", () => {
+    const results = [
+      { cmp: "sourcepoint", url: "https://a.example", status: "fail" },
+      { cmp: "sourcepoint", url: "https://b.example", status: "fail" },
+      { cmp: "sourcepoint", url: "https://c.example", status: "fail" },
+    ];
+    const drift = decideDrift(results);
+    assert.equal(drift.sourcepoint.inDrift, true);
+    assert.equal(drift.sourcepoint.failCount, 3);
+  });
+
+  test("custom threshold: 2 fails is NOT drift when threshold is 3", () => {
+    const results = [
+      { cmp: "didomi", url: "https://a.example", status: "fail" },
+      { cmp: "didomi", url: "https://b.example", status: "fail" },
+    ];
+    const drift = decideDrift(results, { threshold: 3 });
+    assert.equal(drift.didomi.inDrift, false);
+  });
+
+  test("custom threshold: 1 fail IS drift when threshold is 1", () => {
+    const results = [{ cmp: "cookiebot", url: "https://a.example", status: "fail" }];
+    const drift = decideDrift(results, { threshold: 1 });
+    assert.equal(drift.cookiebot.inDrift, true);
+  });
+
+  test("inconclusive results never count toward drift, even many of them", () => {
+    const results = [
+      { cmp: "cookieyes", url: "https://a.example", status: "inconclusive" },
+      { cmp: "cookieyes", url: "https://b.example", status: "inconclusive" },
+      { cmp: "cookieyes", url: "https://c.example", status: "inconclusive" },
+    ];
+    const drift = decideDrift(results);
+    assert.equal(drift.cookieyes.inDrift, false);
+    assert.equal(drift.cookieyes.failCount, 0);
+    assert.equal(drift.cookieyes.inconclusiveCount, 3);
+  });
+
+  test("a CMP with only pass/inconclusive results is healthy", () => {
+    const results = [
+      { cmp: "usercentrics", url: "https://a.example", status: "pass" },
+      { cmp: "usercentrics", url: "https://b.example", status: "inconclusive" },
+    ];
+    const drift = decideDrift(results);
+    assert.equal(drift.usercentrics.inDrift, false);
+    assert.equal(drift.usercentrics.passCount, 1);
+    assert.equal(drift.usercentrics.inconclusiveCount, 1);
+  });
+
+  test("mixed CMPs are tracked independently — one drifting does not affect another", () => {
+    const results = [
+      { cmp: "onetrust", url: "https://a.example", status: "fail" },
+      { cmp: "onetrust", url: "https://b.example", status: "fail" },
+      { cmp: "didomi", url: "https://c.example", status: "pass" },
+      { cmp: "didomi", url: "https://d.example", status: "inconclusive" },
+    ];
+    const drift = decideDrift(results);
+    assert.equal(drift.onetrust.inDrift, true);
+    assert.equal(drift.didomi.inDrift, false);
+  });
+
+  test("empty results produce an empty map, no throw", () => {
+    assert.deepEqual(decideDrift([]), {});
+  });
+
+  test("malformed entries (missing cmp, bad status) are skipped, never counted as fail", () => {
+    const results = [
+      { url: "https://a.example", status: "fail" }, // missing cmp
+      { cmp: "onetrust", url: "https://b.example", status: "not-a-real-status" },
+      null,
+      "not-an-object",
+      { cmp: "onetrust", url: "https://c.example", status: "fail" },
+    ];
+    const drift = decideDrift(results);
+    assert.equal(drift.onetrust.failCount, 1);
+    assert.equal(drift.onetrust.inDrift, false);
+  });
+
+  test("non-array input is treated as no results", () => {
+    assert.deepEqual(decideDrift(null), {});
+    assert.deepEqual(decideDrift(undefined), {});
+    assert.deepEqual(decideDrift("garbage"), {});
+  });
+
+  test("each CMP's sites array preserves url/status/detail for every entry", () => {
+    const results = [
+      { cmp: "onetrust", url: "https://a.example", status: "fail", detail: "still visible" },
+    ];
+    const drift = decideDrift(results);
+    assert.deepEqual(drift.onetrust.sites, [{ url: "https://a.example", status: "fail", detail: "still visible" }]);
+  });
+});
+
+// ── formatIssueBody — deterministic rendering ─────────────────────────────
+
+describe("canary-report — formatIssueBody", () => {
+  const driftDetail = {
+    inDrift: true,
+    failCount: 2,
+    passCount: 0,
+    inconclusiveCount: 0,
+    sites: [
+      { url: "https://a.example", status: "fail", detail: "still visible" },
+      { url: "https://b.example", status: "fail", detail: "still visible" },
+    ],
+  };
+
+  test("includes the CMP name, timestamp, and fail/pass/inconclusive counts", () => {
+    const body = formatIssueBody("onetrust", driftDetail, "2026-07-16T03:00:00Z");
+    assert.match(body, /onetrust/);
+    assert.match(body, /2026-07-16T03:00:00Z/);
+    assert.match(body, /2 of its canary site\(s\)/);
+    assert.match(body, /0 pass, 0 inconclusive/);
+  });
+
+  test("renders one table row per site with url, status, detail", () => {
+    const body = formatIssueBody("onetrust", driftDetail, "2026-07-16T03:00:00Z");
+    assert.match(body, /\| https:\/\/a\.example \| fail \| still visible \|/);
+    assert.match(body, /\| https:\/\/b\.example \| fail \| still visible \|/);
+  });
+
+  test("never calls Date.now() / new Date() internally — identical timestamp in, identical timestamp out", () => {
+    const bodyA = formatIssueBody("onetrust", driftDetail, "FIXED-TIMESTAMP-1");
+    const bodyB = formatIssueBody("onetrust", driftDetail, "FIXED-TIMESTAMP-1");
+    assert.equal(bodyA, bodyB);
+    assert.match(bodyA, /FIXED-TIMESTAMP-1/);
+  });
+
+  test("mentions the non-blocking nature of the alarm", () => {
+    const body = formatIssueBody("didomi", driftDetail, "t");
+    assert.match(body, /NON-BLOCKING/);
+  });
+
+  test("is stable/deterministic given the same input (no randomness)", () => {
+    const body1 = formatIssueBody("cookiebot", driftDetail, "2026-01-01T00:00:00Z");
+    const body2 = formatIssueBody("cookiebot", driftDetail, "2026-01-01T00:00:00Z");
+    assert.equal(body1, body2);
+  });
+});
+
+// ── Import safety: the CLI must never run on import ───────────────────────
+
+describe("canary-report — importing the module never triggers CLI/gh/network calls", () => {
+  test("module loads and exports the pure functions without side effects", async () => {
+    // If importing this module ever executed runCanaryReportCli() at
+    // top-level, this test process would attempt to shell out to `gh` and
+    // either hang, throw, or (worse) silently no-op in a way that hides a
+    // real regression. The import at the top of this file already proves
+    // this is safe; this test just asserts the shape of what got exported.
+    const mod = await import("../../tools/canary-report.mjs");
+    assert.equal(typeof mod.decideDrift, "function");
+    assert.equal(typeof mod.formatIssueBody, "function");
+    assert.equal(typeof mod.runCanaryReportCli, "function");
+  });
+});

--- a/tests/unit/tcf-contract.test.mjs
+++ b/tests/unit/tcf-contract.test.mjs
@@ -1,0 +1,338 @@
+/**
+ * MUGA — Cookie Consent Minimizer: IAB TCF v2.2 spec-contract test (#1129)
+ *
+ * The Sourcepoint adapter (#1123) rides the generic IAB TCF `__tcfapi`
+ * surface (see src/lib/cmp-adapters.js's docblock). The published TCF v2.2
+ * API command signature is:
+ *
+ *   __tcfapi(command, version, callback[, parameter])
+ *
+ * MUGA only ever legitimately CALLS the `postRejectAll` command — never a
+ * consent-granting command like `postAcceptAll` / `postAcceptAllConsents`,
+ * never TCF v1 (`version` must be the numeric literal `2`), and never with
+ * a missing/non-function callback (a missing callback either throws inside
+ * the CMP's own `__tcfapi` implementation or silently drops the reject
+ * signal, depending on vendor — either way it must never happen).
+ *
+ * This test reads both content scripts as source text (readFileSync, no
+ * execution — same static-analysis style as tests/unit/cookie-noise-sync.test.mjs)
+ * and:
+ *   1. Extracts every `__tcfapi(` call site via a small top-level argument
+ *      splitter (regex alone cannot safely split nested parens/braces in
+ *      the callback body).
+ *   2. Asserts each call's 1st arg is exactly the string literal
+ *      "postRejectAll", the 2nd arg is exactly the numeric literal 2, and
+ *      the 3rd arg is a function (arrow or `function`) — not a missing
+ *      argument, not a variable, not a non-function literal.
+ *   3. Runs the same validator against synthetic negative-case strings
+ *      (wrong command, variable command, TCF v1, missing callback) to
+ *      prove the checker actually has teeth — a validator that always
+ *      returns true would pass step 2 vacuously.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const FILES = {
+  mainworld: join(__dirname, "../../src/content/cookie-noise-mainworld.js"),
+  isolated: join(__dirname, "../../src/content/cookie-noise.js"),
+};
+
+const sources = {
+  mainworld: readFileSync(FILES.mainworld, "utf8"),
+  isolated: readFileSync(FILES.isolated, "utf8"),
+};
+
+// ── Call-site extraction ─────────────────────────────────────────────────
+
+/**
+ * Splits the top-level (depth-0) comma-separated argument list of a call
+ * whose opening `(` has already been consumed, starting at `startIndex`.
+ * Tracks paren/bracket/brace depth and string literals (with backslash
+ * escapes) so nested structures in a callback body — e.g.
+ * `(success) => { void success; }` — never get mis-split on an inner
+ * comma or an inner `)`.
+ *
+ * @param {string} source
+ * @param {number} startIndex Index just past the call's opening `(`.
+ * @returns {{args: string[], endIndex: number}} Trimmed argument source
+ *   strings, and the index of the call's matching closing `)`.
+ */
+function splitTopLevelArgs(source, startIndex) {
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let inString = null;
+  let current = "";
+  const args = [];
+
+  for (let i = startIndex; i < source.length; i++) {
+    const ch = source[i];
+
+    if (inString) {
+      current += ch;
+      if (ch === "\\") {
+        i++;
+        if (i < source.length) current += source[i];
+        continue;
+      }
+      if (ch === inString) inString = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inString = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === "(") {
+      parenDepth++;
+      current += ch;
+      continue;
+    }
+    if (ch === "[") {
+      bracketDepth++;
+      current += ch;
+      continue;
+    }
+    if (ch === "{") {
+      braceDepth++;
+      current += ch;
+      continue;
+    }
+    if (ch === ")") {
+      if (parenDepth === 0) {
+        if (current.trim().length > 0 || args.length > 0) args.push(current);
+        return { args: args.map((a) => a.trim()), endIndex: i };
+      }
+      parenDepth--;
+      current += ch;
+      continue;
+    }
+    if (ch === "]") {
+      bracketDepth--;
+      current += ch;
+      continue;
+    }
+    if (ch === "}") {
+      braceDepth--;
+      current += ch;
+      continue;
+    }
+    if (ch === "," && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      args.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+
+  throw new Error("Unterminated __tcfapi(...) call — no matching closing paren found");
+}
+
+/**
+ * Finds every `__tcfapi(` call site in source text.
+ *
+ * @param {string} source
+ * @returns {Array<{args: string[], raw: string}>}
+ */
+function findTcfapiCalls(source) {
+  const calls = [];
+  const callRegex = /__tcfapi\s*\(/g;
+  let m;
+  while ((m = callRegex.exec(source)) !== null) {
+    const argsStart = m.index + m[0].length;
+    const { args, endIndex } = splitTopLevelArgs(source, argsStart);
+    calls.push({ args, raw: source.slice(m.index, endIndex + 1) });
+  }
+  return calls;
+}
+
+// ── TCF v2.2 command-signature validator ─────────────────────────────────
+
+const REJECT_COMMAND_LITERAL = /^(["'])postRejectAll\1$/;
+const ARROW_CALLBACK = /^(async\s*)?\(?[^()=]*\)?\s*=>/;
+const FUNCTION_CALLBACK = /^(async\s+)?function\b/;
+
+/**
+ * Validates a parsed `__tcfapi(...)` call against the published TCF v2.2
+ * command signature: `__tcfapi(command, version, callback[, parameter])`.
+ *
+ * MUGA-specific tightening (the never-accept guard): `command` must be
+ * exactly the string literal `"postRejectAll"` — not merely "a string",
+ * not a variable that could resolve to a consent-granting command at
+ * runtime.
+ *
+ * @param {{args: string[]}} call
+ * @returns {{valid: boolean, reason: string|null}}
+ */
+function validateTcfapiCall(call) {
+  const { args } = call;
+
+  if (args.length < 3) {
+    return {
+      valid: false,
+      reason: `expected 3 arguments (command, version, callback), got ${args.length}`,
+    };
+  }
+
+  const command = args[0].trim();
+  const version = args[1].trim();
+  const callback = args[2].trim();
+
+  if (!REJECT_COMMAND_LITERAL.test(command)) {
+    return {
+      valid: false,
+      reason: `1st argument (command) must be the exact string literal "postRejectAll", got: ${command}`,
+    };
+  }
+
+  if (version !== "2") {
+    return {
+      valid: false,
+      reason: `2nd argument (version) must be the numeric literal 2, got: ${version}`,
+    };
+  }
+
+  if (!ARROW_CALLBACK.test(callback) && !FUNCTION_CALLBACK.test(callback)) {
+    return {
+      valid: false,
+      reason: `3rd argument (callback) must be a function (arrow or function expression), got: ${callback}`,
+    };
+  }
+
+  return { valid: true, reason: null };
+}
+
+// ── Real call sites: both content scripts must conform ───────────────────
+
+describe("tcf-contract — __tcfapi call sites conform to the published TCF v2.2 signature", () => {
+  for (const [label, key] of [
+    ["cookie-noise-mainworld.js", "mainworld"],
+    ["cookie-noise.js", "isolated"],
+  ]) {
+    const src = sources[key];
+    const calls = findTcfapiCalls(src);
+
+    test(`${label} contains at least one __tcfapi(...) call site`, () => {
+      assert.ok(calls.length > 0, `${label} must call __tcfapi (Sourcepoint reject path)`);
+    });
+
+    test(`${label} — every __tcfapi call conforms to __tcfapi(command, version, callback[, parameter])`, () => {
+      for (const call of calls) {
+        const result = validateTcfapiCall(call);
+        assert.ok(
+          result.valid,
+          `${label}: invalid __tcfapi call \`${call.raw.slice(0, 80)}...\` — ${result.reason}`,
+        );
+      }
+    });
+  }
+
+  test("neither content script contains a postAcceptAll / postAcceptAllConsents command literal anywhere", () => {
+    // Belt-and-suspenders: even outside an actual __tcfapi(...) call site,
+    // these command literals must never appear in executable source.
+    const FORBIDDEN = /postAcceptAll(Consents)?/;
+    for (const [label, key] of [
+      ["cookie-noise-mainworld.js", "mainworld"],
+      ["cookie-noise.js", "isolated"],
+    ]) {
+      assert.doesNotMatch(sources[key], FORBIDDEN, `${label} must never reference a consent-granting TCF command`);
+    }
+  });
+});
+
+// ── Negative cases: prove the validator has teeth ─────────────────────────
+//
+// A validator that always returns { valid: true } would pass every test
+// above vacuously. These synthetic cases prove validateTcfapiCall actually
+// rejects each of the shapes the real call sites must never take.
+
+describe("tcf-contract — validator rejects synthetic malformed __tcfapi calls", () => {
+  test("rejects a non-postRejectAll command literal (e.g. postAcceptAll)", () => {
+    const [call] = findTcfapiCalls('window.__tcfapi("postAcceptAll", 2, (ok) => {});');
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /postRejectAll/);
+  });
+
+  test("rejects postAcceptAllConsents", () => {
+    const [call] = findTcfapiCalls('window.__tcfapi("postAcceptAllConsents", 2, (ok) => {});');
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+  });
+
+  test("rejects a variable/dynamic command (not a string literal)", () => {
+    const [call] = findTcfapiCalls("window.__tcfapi(cmd, 2, (ok) => {});");
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /command/);
+  });
+
+  test("rejects TCF v1 (version literal 1 instead of 2)", () => {
+    const [call] = findTcfapiCalls('window.__tcfapi("postRejectAll", 1, (ok) => {});');
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /version/);
+  });
+
+  test("rejects a variable version (not the numeric literal 2)", () => {
+    const [call] = findTcfapiCalls('window.__tcfapi("postRejectAll", tcfVersion, (ok) => {});');
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+  });
+
+  test("rejects a missing callback argument", () => {
+    const [call] = findTcfapiCalls('window.__tcfapi("postRejectAll", 2);');
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /3 arguments/);
+  });
+
+  test("rejects a non-function literal in the callback position", () => {
+    const [call] = findTcfapiCalls('window.__tcfapi("postRejectAll", 2, "not-a-function");');
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /callback/);
+  });
+
+  test("rejects a bare variable in the callback position", () => {
+    const [call] = findTcfapiCalls("window.__tcfapi(\"postRejectAll\", 2, myCallbackRef);");
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, false);
+  });
+
+  test("accepts a valid call with a 4th optional parameter argument", () => {
+    const [call] = findTcfapiCalls('window.__tcfapi("postRejectAll", 2, (ok) => {}, undefined);');
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, true);
+  });
+
+  test("accepts a valid call using a classic function expression callback", () => {
+    const [call] = findTcfapiCalls("window.__tcfapi(\"postRejectAll\", 2, function (ok) { return ok; });");
+    const result = validateTcfapiCall(call);
+    assert.equal(result.valid, true);
+  });
+});
+
+// ── Argument splitter itself: nested structures must not break parsing ────
+
+describe("tcf-contract — top-level argument splitter handles nested parens/braces/strings", () => {
+  test("does not mis-split on a comma inside the callback body", () => {
+    const src = 'window.__tcfapi("postRejectAll", 2, (a, b) => { doThing(a, b); });';
+    const [call] = findTcfapiCalls(src);
+    assert.equal(call.args.length, 3, "nested commas inside the callback must not create extra top-level args");
+  });
+
+  test("does not mis-split on a string literal containing a comma or paren", () => {
+    const src = 'window.__tcfapi("postRejectAll", 2, (ok) => { console.log("a, (b)"); });';
+    const [call] = findTcfapiCalls(src);
+    assert.equal(call.args.length, 3);
+    assert.equal(validateTcfapiCall(call).valid, true);
+  });
+});

--- a/tests/unit/tcf-contract.test.mjs
+++ b/tests/unit/tcf-contract.test.mjs
@@ -85,6 +85,36 @@ function splitTopLevelArgs(source, startIndex) {
       continue;
     }
 
+    // Comment awareness (only when NOT inside a string). A `//` line comment
+    // or `/* ... */` block comment must not be tokenized: its contents can
+    // legitimately contain apostrophes (a contraction like `don't`), an
+    // unbalanced quote, or an unbalanced paren that would otherwise flip the
+    // splitter into phantom-string mode and mis-parse or throw. Copy the
+    // comment text through verbatim without touching string/paren/brace state.
+    if (ch === "/" && source[i + 1] === "/") {
+      current += ch;
+      i++;
+      while (i < source.length && source[i] !== "\n") {
+        current += source[i];
+        i++;
+      }
+      i--; // let the for-loop's i++ land back on the newline (or past end)
+      continue;
+    }
+    if (ch === "/" && source[i + 1] === "*") {
+      current += "/*";
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) {
+        current += source[i];
+        i++;
+      }
+      if (i < source.length) {
+        current += "*/";
+        i++; // land on the closing '/'; the for-loop's i++ moves past it
+      }
+      continue;
+    }
+
     if (ch === '"' || ch === "'" || ch === "`") {
       inString = ch;
       current += ch;
@@ -156,6 +186,10 @@ function findTcfapiCalls(source) {
 // ── TCF v2.2 command-signature validator ─────────────────────────────────
 
 const REJECT_COMMAND_LITERAL = /^(["'])postRejectAll\1$/;
+// Known limitation (deliberately left fail-closed): the `[^()=]*` parameter
+// class does not admit a default-param arrow like `(ok = foo()) =>`. Such a
+// callback would fail this check rather than pass — safe by design. Widening
+// it risks a false-pass, so it is intentionally NOT broadened.
 const ARROW_CALLBACK = /^(async\s*)?\(?[^()=]*\)?\s*=>/;
 const FUNCTION_CALLBACK = /^(async\s+)?function\b/;
 
@@ -333,6 +367,24 @@ describe("tcf-contract — top-level argument splitter handles nested parens/bra
     const src = 'window.__tcfapi("postRejectAll", 2, (ok) => { console.log("a, (b)"); });';
     const [call] = findTcfapiCalls(src);
     assert.equal(call.args.length, 3);
+    assert.equal(validateTcfapiCall(call).valid, true);
+  });
+
+  test("does not mis-parse a line comment (inside the callback body) containing an apostrophe/contraction", () => {
+    // The `don't` apostrophe inside a `//` comment WITHIN the callback body
+    // must NOT flip the splitter into phantom-string mode (which would swallow
+    // the closing `)` and throw "Unterminated __tcfapi(...) call"). Mirrors the
+    // natural-language comment carried at src/content/cookie-noise-mainworld.js:403.
+    const src = 'window.__tcfapi("postRejectAll", 2, (success) => {\n  // we don\'t gate on this\n  return success;\n});';
+    const [call] = findTcfapiCalls(src);
+    assert.equal(call.args.length, 3, "a line comment's apostrophe must not create phantom string state");
+    assert.equal(validateTcfapiCall(call).valid, true);
+  });
+
+  test("does not mis-parse a block comment containing an apostrophe/contraction", () => {
+    const src = 'window.__tcfapi("postRejectAll", 2, (success) => { /* we don\'t gate on this */ });';
+    const [call] = findTcfapiCalls(src);
+    assert.equal(call.args.length, 3, "a block comment's apostrophe must not create phantom string state");
     assert.equal(validateTcfapiCall(call).valid, true);
   });
 });

--- a/tests/unit/workflow-hardening.test.mjs
+++ b/tests/unit/workflow-hardening.test.mjs
@@ -42,6 +42,7 @@ describe("G1 — SHA pinning across all hardened workflows", () => {
     "publish-rules.yml",
     "auto-ingest-rules.yml",
     "validate-rules.yml",
+    "cmp-canary.yml",
   ];
 
   for (const file of FILES) {

--- a/tests/unit/workflows-hardened.test.mjs
+++ b/tests/unit/workflows-hardened.test.mjs
@@ -19,7 +19,8 @@ const workflowsDir = join(__dirname, "../../.github/workflows");
 // npm test, duplicating PR CI with no additional signal. A meaningful
 // canary will be re-added when a stable fixture set is available.
 // validate-rules.yml and publish-rules.yml added in Phase 6 (T6.2, T6.3).
-const WORKFLOW_FILES = ["ci.yml", "release.yml", "validate-rules.yml", "publish-rules.yml", "auto-ingest-rules.yml"];
+// cmp-canary.yml added with the nightly CMP drift alarm (#1129).
+const WORKFLOW_FILES = ["ci.yml", "release.yml", "validate-rules.yml", "publish-rules.yml", "auto-ingest-rules.yml", "cmp-canary.yml"];
 
 function readWorkflow(name) {
   return readFileSync(join(workflowsDir, name), "utf8");

--- a/tools/canary-report.mjs
+++ b/tools/canary-report.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * MUGA — CMP canary drift report + auto-issue (#1129).
+ *
+ * Pure decision logic (decideDrift, formatIssueBody) is exported and
+ * unit-tested directly in tests/unit/canary-report.test.mjs (no I/O, no
+ * Date.now() inside — the caller injects a timestamp, mirroring the
+ * tools/moat-expansion/cli.mjs "CLI owns Date, pure modules don't" pattern).
+ *
+ * The CLI part (reads test-results/canary-results.json, computes drift,
+ * files/updates a GitHub issue per drifting CMP via `gh`) only runs when
+ * this file is executed directly — importing it (as the unit test does)
+ * never triggers network/gh calls.
+ *
+ * Usage:
+ *   node tools/canary-report.mjs [timestamp]
+ *   GH_TOKEN=... node tools/canary-report.mjs 2026-07-16T03:00:00Z
+ *
+ * Non-blocking by design: this script's exit code is never wired into a
+ * blocking CI gate (see .github/workflows/cmp-canary.yml) — it only files
+ * or updates tracking issues for maintainers to triage.
+ *
+ * Public API (named exports only — no default):
+ *   decideDrift(results, opts?) → Record<string, {inDrift: boolean, failCount: number, inconclusiveCount: number, passCount: number, sites: Array<{url, status, detail}>}>
+ *   formatIssueBody(cmp, driftDetail, timestamp) → string
+ */
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Pure decision logic ───────────────────────────────────────────────────
+
+/**
+ * Decides, per CMP, whether the canary results show drift.
+ *
+ * A CMP is in drift when the number of "fail" results for that CMP is
+ * `>= threshold` (default 2). "inconclusive" results never count toward
+ * drift — a site whose banner never appeared this run (already-consented,
+ * geo-variant, or a transient miss) says nothing about whether MUGA's
+ * reject adapter still works. A CMP with only "pass"/"inconclusive"
+ * results is healthy.
+ *
+ * Pure: no I/O, no Date.now() — the caller supplies `results` and
+ * `threshold`. Never throws on well-formed input; malformed entries are
+ * skipped defensively (fail-closed: unknown shape never counts as "fail").
+ *
+ * @param {Array<{cmp: string, url: string, status: "pass"|"fail"|"inconclusive", detail?: string}>} results
+ * @param {{threshold?: number}} [opts]
+ * @returns {Record<string, {inDrift: boolean, failCount: number, inconclusiveCount: number, passCount: number, sites: Array<{url: string, status: string, detail: string}>}>}
+ */
+export function decideDrift(results, { threshold = 2 } = {}) {
+  /** @type {Record<string, {inDrift: boolean, failCount: number, inconclusiveCount: number, passCount: number, sites: Array<{url: string, status: string, detail: string}>}>} */
+  const byCmp = {};
+
+  const list = Array.isArray(results) ? results : [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") continue;
+    const cmp = typeof entry.cmp === "string" ? entry.cmp : null;
+    const status = entry.status;
+    if (!cmp || (status !== "pass" && status !== "fail" && status !== "inconclusive")) continue;
+
+    if (!byCmp[cmp]) {
+      byCmp[cmp] = { inDrift: false, failCount: 0, inconclusiveCount: 0, passCount: 0, sites: [] };
+    }
+    const bucket = byCmp[cmp];
+    bucket.sites.push({
+      url: typeof entry.url === "string" ? entry.url : "",
+      status,
+      detail: typeof entry.detail === "string" ? entry.detail : "",
+    });
+    if (status === "fail") bucket.failCount += 1;
+    else if (status === "inconclusive") bucket.inconclusiveCount += 1;
+    else bucket.passCount += 1;
+  }
+
+  for (const cmp of Object.keys(byCmp)) {
+    byCmp[cmp].inDrift = byCmp[cmp].failCount >= threshold;
+  }
+
+  return byCmp;
+}
+
+/**
+ * Renders the Markdown body for a drift-tracking GitHub issue.
+ *
+ * Pure: takes the timestamp as a parameter — never calls Date.now()/new
+ * Date() internally, so output is deterministic and testable.
+ *
+ * @param {string} cmp
+ * @param {{inDrift: boolean, failCount: number, inconclusiveCount: number, passCount: number, sites: Array<{url: string, status: string, detail: string}>}} driftDetail
+ * @param {string} timestamp ISO-ish string, caller-supplied.
+ * @returns {string}
+ */
+export function formatIssueBody(cmp, driftDetail, timestamp) {
+  const lines = [];
+  lines.push(`**Detected:** ${timestamp}`);
+  lines.push("");
+  lines.push(
+    `\`${cmp}\` failed the reject check on ${driftDetail.failCount} of its canary site(s) this run ` +
+      `(${driftDetail.passCount} pass, ${driftDetail.inconclusiveCount} inconclusive).`,
+  );
+  lines.push("");
+  lines.push("| Site | Status | Detail |");
+  lines.push("| --- | --- | --- |");
+  for (const site of driftDetail.sites) {
+    lines.push(`| ${site.url} | ${site.status} | ${site.detail} |`);
+  }
+  lines.push("");
+  lines.push(
+    "This is a NON-BLOCKING nightly drift alarm (tests/canary/cmp-canary.spec.mjs) — it does not gate any PR " +
+      "or release. It fires when >=2 candidate sites for this CMP show the banner staying visible after MUGA's " +
+      "reject call, which usually means the CMP vendor changed its DOM anchor or reject API and " +
+      "src/lib/cmp-adapters.js needs an update.",
+  );
+  lines.push("");
+  lines.push(
+    "_Opened/updated automatically by tools/canary-report.mjs. Do not rename the title — de-duping matches on it._",
+  );
+  return lines.join("\n");
+}
+
+// ── CLI I/O boundary ───────────────────────────────────────────────────────
+
+const DEFAULT_RESULTS_PATH = join(__dirname, "..", "test-results", "canary-results.json");
+
+function issueTitle(cmp) {
+  return `CMP canary: ${cmp} drift?`;
+}
+
+/**
+ * Reads canary-results.json, computes drift, and files/updates a GitHub
+ * issue per drifting CMP via the `gh` CLI. I/O boundary only — all decision
+ * logic lives in the pure functions above.
+ *
+ * @param {{resultsPath?: string, timestamp?: string, threshold?: number, execImpl?: typeof execFileSync}} [opts]
+ */
+export function runCanaryReportCli({
+  resultsPath = DEFAULT_RESULTS_PATH,
+  timestamp = new Date().toISOString(),
+  threshold = 2,
+  execImpl = execFileSync,
+} = {}) {
+  let raw;
+  try {
+    raw = readFileSync(resultsPath, "utf8");
+  } catch (err) {
+    console.error(`[canary-report] cannot read ${resultsPath}: ${err.message}`);
+    console.error("[canary-report] no canary results — nothing to report (non-blocking, exiting cleanly).");
+    return;
+  }
+
+  let results;
+  try {
+    results = JSON.parse(raw);
+  } catch (err) {
+    console.error(`[canary-report] cannot parse ${resultsPath} as JSON: ${err.message}`);
+    return;
+  }
+
+  const byCmp = decideDrift(results, { threshold });
+  const driftingCmps = Object.keys(byCmp).filter((cmp) => byCmp[cmp].inDrift);
+
+  if (driftingCmps.length === 0) {
+    console.log("[canary-report] no CMP crossed the drift threshold this run.");
+    return;
+  }
+
+  for (const cmp of driftingCmps) {
+    const title = issueTitle(cmp);
+    const body = formatIssueBody(cmp, byCmp[cmp], timestamp);
+
+    let existingNumber = null;
+    try {
+      const searchOut = execImpl(
+        "gh",
+        ["issue", "list", "--state", "open", "--search", `"${title}" in:title`, "--json", "number,title"],
+        { encoding: "utf8" },
+      );
+      const found = JSON.parse(searchOut).find((i) => i.title === title);
+      existingNumber = found ? found.number : null;
+    } catch (err) {
+      console.error(`[canary-report] gh issue list failed for "${title}": ${err.message}`);
+      continue;
+    }
+
+    try {
+      if (existingNumber) {
+        execImpl("gh", ["issue", "comment", String(existingNumber), "--body", body], { encoding: "utf8" });
+        console.log(`[canary-report] updated existing issue #${existingNumber} for ${cmp}`);
+      } else {
+        execImpl("gh", ["issue", "create", "--title", title, "--body", body, "--label", "enhancement"], {
+          encoding: "utf8",
+        });
+        console.log(`[canary-report] created new issue for ${cmp}`);
+      }
+    } catch (err) {
+      console.error(`[canary-report] gh issue create/comment failed for "${title}": ${err.message}`);
+    }
+  }
+}
+
+// Only run the CLI when this file is executed directly — importing it (as
+// tests/unit/canary-report.test.mjs does) must never trigger gh/network
+// calls. Mirrors tools/moat-expansion/cli.mjs's entry guard (endsWith check,
+// not a strict path-equality compare, so it works the same whether invoked
+// as `node tools/canary-report.mjs` or via a relative/absolute npm script
+// path on any platform).
+const isMain = process.argv[1] && process.argv[1].endsWith("canary-report.mjs");
+if (isMain) {
+  const timestampArg = process.argv[2];
+  runCanaryReportCli(timestampArg ? { timestamp: timestampArg } : {});
+}


### PR DESCRIPTION
Closes #1129

## Summary

Reduces the cookie-consent module's dependence on **manual** pre-ship smoke tests by adding two automated safety nets. The 6 CMP adapters are covered by stub-based e2e fixtures — a stub encodes our *assumed* vendor API shape, so it regression-guards our dispatcher but cannot detect when a real vendor API drifts. This adds continuous + standards-based validation to close part of that gap.

Targets **`develop`** (integration branch), not main. Test/CI infrastructure only — **no runtime code touched** (`cleaner-bundle.js` diff clean).

## A — Nightly real-site canary (non-blocking drift alarm)

- `.github/workflows/cmp-canary.yml` — `schedule` (nightly) + `workflow_dispatch` only (**never** `pull_request`/`push`, so it never gates a merge or hits third-party sites on PRs). Headed Chromium via `xvfb`, extension loaded with the feature ON. Canary step is `continue-on-error` so a flaky site never fails the run. Minimal `permissions:` (`contents: read`, `issues: write`).
- `tests/canary/cmp-sites.json` — 12 **candidate** sites (2 per CMP) with the banner selector to watch, each citing how the CMP was determined. Two are flagged lower-confidence. The list is self-validating: the first nightly runs calibrate it; sites the canary can't reliably drive get pruned.
- `tests/canary/cmp-canary.spec.mjs` + `playwright.canary.config.mjs` — isolated `testDir`, reuses the e2e extension-loading fixture. Per site: if the banner never appears → `inconclusive` (already-consented/geo, NOT a failure); if it appears then disappears → `pass`; still visible → `fail`.
- `tools/canary-report.mjs` — pure `decideDrift(results, {threshold})` (a CMP drifts only when `fail count >= threshold`, default 2; `inconclusive` never counts) + a `gh`-backed CLI that, on confirmed drift, creates OR updates an issue titled `CMP canary: <cmp> drift?` (dedup by **exact** title match against open issues — comments on the existing one, never duplicates). CLI is guarded so importing the module never shells out.

## B1 — TCF spec-contract test (deterministic, blocking)

- `tests/unit/tcf-contract.test.mjs` — parses every `__tcfapi(` call site in both content scripts (comment-aware arg splitter) and asserts conformance to the **published IAB TCF v2.2** signature: command is exactly `"postRejectAll"`, version is exactly `2`, callback is a function. 10 synthetic negative cases prove the validator has teeth. Upgrades the TCF path (Sourcepoint; TCF-mode Didomi/Usercentrics) from third-party-corroborated to standards-conformant, and doubles as a second never-accept guard.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/cmp-canary.yml` | nightly canary workflow (SHA-pinned, minimal perms) |
| `tests/canary/cmp-canary.spec.mjs`, `cmp-sites.json` | canary runner + candidate site manifest |
| `playwright.canary.config.mjs`, `package.json` | isolated canary config + `test:canary` script |
| `tools/canary-report.mjs` | pure drift logic + `gh` drift-issue CLI |
| `tests/unit/canary-report.test.mjs` | `decideDrift`/`formatIssueBody` unit tests |
| `tests/unit/tcf-contract.test.mjs` | TCF v2.2 spec-contract test + negatives |
| `tests/unit/workflows-hardened.test.mjs`, `workflow-hardening.test.mjs` | cover `cmp-canary.yml` in the SHA-pin/permissions hardening net |

## Test + review

- [x] `npm test` — 6715 pass / 0 fail / 1 pre-existing skip (net +41 from baseline)
- [x] `npm run lint`, `npm run lint:js`, `npm run check:i18n` — clean
- [x] `build:content` drift gate — clean (no runtime code touched; additions only)
- [x] Isolation verified via `--list`: canary specs appear ONLY under the canary config; `test:e2e` excludes `tests/canary/**`
- [x] Adversarial review (independent verify — every gate RUN) — **MERGE-READY**. The top concern (auto-issue spam) confirmed guarded (exact-title dedup, one CMP per iteration, `--state open`). Two findings fixed before this PR: **(F2, MEDIUM)** the new workflow was escaping the hardening regression net — now covered in `workflows-hardened.test.mjs` + `workflow-hardening.test.mjs`; **(F3, LOW)** the TCF arg-splitter was not comment-aware (a contraction in a `__tcfapi` callback comment could false-fail the blocking gate) — now comment-aware with regression tests that genuinely fail pre-fix.

## Honest limits (by design)

- The canary is a **non-blocking drift alarm**, not a merge gate; the stub-based e2e remains the gate. It validates the real API continuously but is flaky by nature and cannot cover geo-variant banners or bot-blocked sites.
- The site list is a candidate; first runs calibrate it.
- Firefox automation is **out of scope** — tracked in #1128 (Playwright can't load extensions in Firefox; needs a `web-ext` harness). The Firefox reject path stays covered by `@sync` byte-identity + the pre-ship smoke gate.
- One LOW review note (F4: the arrow-callback regex rejects a default-param callback) is intentionally left as-is — fail-closed, not hit by the real call sites, and widening it risks a false-pass. Documented in-code.
