### PR TITLE
test(cmp): cookie-consent release smoke battery (checklist + Chrome report)

### DIFF
--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -1,0 +1,289 @@
+# Cookie-consent release smoke battery
+
+## Why this exists
+
+The 6 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
+Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics) are unit-green:
+every detection truth table, every reject call shape, and every
+never-auto-accept structural guard is covered by `npm test`. Unit-green is
+not the same thing as real-env-green. Every adapter's merge PR shipped with
+an explicit, unchecked "Pre-ship gate" item asking for a real-browser smoke
+test against a live vendor page before the adapter goes into a store
+release, and none of those checkboxes have been closed yet.
+
+This document turns those scattered PR checkboxes into one runnable gate:
+a per-adapter human QA checklist (Chrome + Firefox) plus an automated
+Chrome-only report (`npm run smoke:release`) that reuses the existing
+nightly CMP canary's results.
+
+**When to run:** before every `develop -> main` release PR that ships a
+build containing the cookie-consent minimizer. All rows in every adapter
+section below, and every cell in the final sign-off table, must be PASS
+before the release PR opens. A single unresolved FAIL blocks the release
+for that build.
+
+## Automated Chrome portion
+
+The nightly CMP canary (`.github/workflows/cmp-canary.yml`,
+`tests/canary/cmp-canary.spec.mjs`) already loads the real built extension
+against the real-site candidates in `tests/canary/cmp-sites.json` and
+records `{cmp, url, status: pass|fail|inconclusive, detail}` results to
+`test-results/canary-results.json`. This release-smoke report
+(`tools/release-smoke-report.mjs`) does not run a second copy of that
+suite - it reduces the same results file into a release-readiness verdict
+per adapter.
+
+To run it as part of a release:
+
+1. Trigger the canary workflow on demand: `gh workflow run cmp-canary.yml`
+   (or use the Actions tab's "Run workflow" button on `cmp-canary.yml`).
+2. Wait for the run to finish, then download its results artifact
+   (`cmp-canary-results`): `gh run download <run-id> -n cmp-canary-results -D test-results/`.
+3. Run `npm run smoke:release`. It prints a per-adapter table with verdict
+   `READY` / `BLOCKED` / `UNVERIFIED`, and exits non-zero if any adapter is
+   `BLOCKED` (so this can be wired into a release-gate script). `UNVERIFIED`
+   only prints a warning - it never fails the run, because real sites are
+   flaky, geo-variant, or already-consented on a given run.
+
+**What this covers, and what it does not:** the automated Chrome portion
+confirms the Chrome MAIN-world detection signals fire and the reject call
+executes without the banner staying visible, on real vendor pages, in
+Chrome. It does **not** cover: the Firefox `wrappedJSObject` path (Chrome
+and Firefox use different content-script worlds - see
+`src/content/cookie-noise-mainworld.js` vs `src/content/cookie-noise.js`),
+visual confirmation that no cookie was actually set after reject, or any
+geography-gated banner variant the canary's candidate site didn't happen
+to show that run. Those require the manual Chrome + Firefox steps below.
+
+## Per-adapter checklist
+
+Each section lists the exact reject call and detection signals as
+extracted from `src/lib/cmp-adapters.js` and the content-script call
+sites (`src/content/cookie-noise-mainworld.js` for Chrome MAIN world,
+`src/content/cookie-noise.js` for the isolated world / Firefox
+`wrappedJSObject` path). Candidate live sites are reused verbatim from
+`tests/canary/cmp-sites.json` - do not test against a different site
+without first adding it there.
+
+General Chrome steps (same shape for all 6 adapters unless noted):
+
+1. `npm run build:content` then load the unpacked extension from `src/`
+   in `chrome://extensions` (Developer mode > Load unpacked).
+2. Open the extension's Settings and enable the cookie-consent minimizer
+   toggle (default OFF - must be turned on for this smoke).
+3. Visit the candidate site in a fresh profile / incognito window (no
+   prior consent cookie) so the banner actually renders.
+4. Confirm the banner disappears (or the page reports a rejected/necessary
+   -only state) within a few seconds, with no "Accept all" click ever
+   fired by the extension.
+5. Open DevTools > Application > Cookies and/or the vendor's own consent
+   inspector (where available) to confirm the resulting consent state is
+   reject / necessary-only, not accept.
+
+General Firefox steps (same shape for all 6 adapters unless noted):
+manual only, automation is tracked separately in #1128.
+
+1. `bash scripts/with-firefox-manifest.sh npm run build:content` then load
+   the extension via `about:debugging#/runtime/this-firefox` > Load
+   Temporary Add-on (or `npm run dev:firefox`).
+2. Repeat Chrome steps 2-5 above in Firefox. The reject call itself is
+   reached through `window.wrappedJSObject.<Vendor>...` in Firefox
+   (`src/content/cookie-noise.js`) instead of the Chrome MAIN-world direct
+   call (`src/content/cookie-noise-mainworld.js`) - this is the one path
+   that has never been exercised against a live vendor script, only
+   structurally tested, so treat any Firefox FAIL here as high-signal.
+
+### 1. OneTrust
+
+- **Reject call:** `window.OneTrust.RejectAll()` (Chrome MAIN world);
+  `window.wrappedJSObject.OneTrust.RejectAll()` (Firefox). Synchronous,
+  zero-argument, void return.
+- **Detection signals:** mandatory `hasOneTrustGlobal`
+  (`typeof window.OneTrust === "object"`) + `hasRejectAllFn`
+  (`typeof window.OneTrust.RejectAll === "function"`); corroborating (>=1
+  required): `hasBannerDom` (`#onetrust-banner-sdk` or
+  `#onetrust-consent-sdk`), `hasActiveGroupsGlobal`
+  (`typeof window.OnetrustActiveGroups === "string"`),
+  `hasRejectHandlerDom` (`#onetrust-reject-all-handler`).
+- **Candidate live site(s):** `https://www.aircanada.com`,
+  `https://www.bertelsmann.com` (banner selector `#onetrust-banner-sdk`).
+- **Specific risk to verify (PR #1117):** the Firefox
+  `wrappedJSObject.OneTrust.RejectAll()` path and the bounded
+  MutationObserver give-up are structurally tested only - this is the
+  first adapter, so it also validates the give-up timeout doesn't fire
+  early on a real page's load timing.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
+### 2. Cookiebot
+
+- **Reject call:** `window.Cookiebot.submitCustomConsent(false, false, false)`
+  (Chrome MAIN world); `window.wrappedJSObject.Cookiebot.submitCustomConsent(false, false, false)`
+  (Firefox). Synchronous. The three literal `false` positional args are
+  preferences / statistics / marketing; necessary cookies are
+  implicit/always-on in Cookiebot's model and are not one of the three
+  booleans.
+- **Detection signals:** mandatory `hasCookiebotGlobal`
+  (`typeof window.Cookiebot === "object"`) + `hasSubmitCustomConsentFn`
+  (`typeof window.Cookiebot.submitCustomConsent === "function"`);
+  corroborating (>=1 required): `hasCybotDialogDom`
+  (`#CybotCookiebotDialog`), `hasConsentObjectGlobal`
+  (`typeof window.Cookiebot.consent === "object"`),
+  `hasResponseBooleanGlobal` (`typeof window.Cookiebot.hasResponse === "boolean"`).
+- **Candidate live site(s):** `https://www.clece.es`,
+  `https://www.cookiebot.com` (lower confidence - vendor's own site;
+  banner selector `#CybotCookiebotDialog`).
+- **Specific risk to verify (PR #1122):** Firefox `wrappedJSObject` reject
+  path and live-Cookiebot compatibility are structurally tested only
+  (the Chromium e2e fixture is a regression oracle, not a real-vendor
+  test) - confirm the literal `(false, false, false)` call actually
+  clears the banner on a live site, not just in the fixture.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
+### 3. Didomi
+
+- **Reject call:** `window.Didomi.setUserDisagreeToAll()` (Chrome MAIN
+  world); `window.wrappedJSObject.Didomi.setUserDisagreeToAll()`
+  (Firefox). Synchronous, zero-argument, void return - no consent-granting
+  parameter exists on this call at all.
+- **Detection signals:** mandatory `hasDidomiGlobal`
+  (`typeof window.Didomi === "object"`) + `hasSetUserDisagreeToAllFn`
+  (`typeof window.Didomi.setUserDisagreeToAll === "function"`);
+  corroborating (>=1 required): `hasDidomiHostDom` (`#didomi-host`),
+  `hasGetCurrentUserStatusFn` (`typeof window.Didomi.getCurrentUserStatus === "function"`,
+  typeof-checked only, never invoked).
+- **Candidate live site(s):** `https://www.orange.fr`,
+  `https://www.europcar.com` (banner selector `#didomi-host`).
+- **Specific risk to verify (PR #1124):** Firefox `wrappedJSObject` path
+  and live-Didomi compatibility are structurally tested only; this
+  adapter also fixed a Firefox-dispatcher symmetry bug (missing `return`)
+  in the same PR - confirm the reject call actually fires exactly once
+  per page load in Firefox, not zero or twice.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
+### 4. CookieYes
+
+- **Reject call:** `window.performBannerAction("reject")` (Chrome MAIN
+  world); `window.wrappedJSObject.performBannerAction("reject")`
+  (Firefox). Synchronous; the argument is always the literal string
+  `"reject"`.
+- **Detection signals:** DUAL-MANDATORY bare globals (both required
+  together, since neither is a vendor-namespaced anchor):
+  `hasGetCkyConsentFn` (`typeof window.getCkyConsent === "function"`) and
+  `hasPerformBannerActionFn` (`typeof window.performBannerAction === "function"`);
+  corroborating (>=1 required): `hasCkyConsentContainerDom`
+  (`.cky-consent-container`), `hasCkyOverlayDom` (`.cky-overlay`),
+  `hasCkyConsentBarDom` (`.cky-consent-bar`).
+- **Candidate live site(s):** `https://ahrefs.com`,
+  `https://www.dominos.gr` (banner selector
+  `.cky-consent-container, .cky-consent-bar`).
+- **Specific risk to verify (PR #1125):** Firefox `wrappedJSObject` path
+  AND `performBannerAction`'s load-timing (undocumented upstream - is
+  the function defined before the banner mounts, and does calling it too
+  early no-op safely?) are structurally tested only.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
+### 5. Sourcepoint
+
+- **Reject call:** `window.__tcfapi("postRejectAll", 2, callback)` (Chrome
+  MAIN world); `window.wrappedJSObject.__tcfapi("postRejectAll", 2, callback)`
+  (Firefox). Fire-and-forget: the callback is async/log-only and never
+  gates control flow - `_acted`/`stopObserver()` fire synchronously right
+  after the call returns.
+- **Detection signals:** DUAL-MANDATORY: `hasTcfApiFn`
+  (`typeof window.__tcfapi === "function"` - generic to every TCF CMP,
+  including Didomi, so never a sole anchor) AND `hasSpMessageContainerDom`
+  (`div[id^="sp_message_container"]` - the Sourcepoint-specific anchor);
+  corroborating (>=1 required): `hasSpPrivacyMgmtIframeDom`
+  (`iframe[src*="privacy-mgmt.com"]`), `hasSpProdIframeDom`
+  (`iframe[src*="sp-prod.net"]`), `hasSpProdScriptDom`
+  (`script[src*="sp-prod.net"]`).
+- **Candidate live site(s):** `https://9gag.com`,
+  `https://www.heraldscotland.com` (lower confidence - masthead-level
+  citation only; banner selector `div[id^="sp_message_container"]`).
+- **Specific risk to verify (PR #1126):** TCF-vs-Didomi discrimination -
+  confirm on a real Sourcepoint page that `postRejectAll` fires (not a
+  Didomi-shaped misfire), and separately confirm on a real Didomi-only
+  page (if convenient) that Sourcepoint does NOT fire. Also verify the
+  Firefox `wrappedJSObject.__tcfapi` path, which is structurally tested
+  only. Known accepted gap (not part of this smoke): a self-hosted/proxied
+  Sourcepoint loader lacking the `privacy-mgmt.com`/`sp-prod.net`
+  secondary signals yields confidence 0.4 and is deliberately missed
+  (fail-closed, never misfires) - do not treat that as a FAIL here.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
+### 6. Usercentrics
+
+- **Reject call:** `window.UC_UI.denyAllConsents()` (Chrome MAIN world);
+  `window.wrappedJSObject.UC_UI.denyAllConsents()` (Firefox). Returns a
+  **Promise** (the only adapter of the 6 that does) - the call site
+  chains `.catch(() => {})` to swallow a floating rejection and never
+  awaits it; `_acted`/`stopObserver()` fire synchronously right after the
+  call, not after the promise settles.
+- **Detection signals:** mandatory `hasUcUiGlobal`
+  (`typeof window.UC_UI === "object"`) + `hasDenyAllConsentsFn`
+  (`typeof window.UC_UI.denyAllConsents === "function"`); corroborating
+  (>=1 required): `hasUsercentricsRootDom` (`#usercentrics-root`, the
+  Shadow DOM host element - the shadow root itself is never queried),
+  `hasIsInitializedFn` (`typeof window.UC_UI.isInitialized === "function"`,
+  typeof-checked only, never invoked as a runtime gate).
+- **Candidate live site(s):** `https://www.dish.com`,
+  `https://www.conrad.de` (banner selector `#usercentrics-root`).
+- **Specific risk to verify (PR #1127) - see the dedicated callout below.**
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
+#### Usercentrics callout: third-party-corroborated API, reinforced gate
+
+Usercentrics' own canonical API docs were unreachable during adapter
+research - the `denyAllConsents()` / `isInitialized()` shape was
+corroborated only via third-party integration docs, not Usercentrics'
+first-party reference. This smoke test therefore validates the API shape
+itself, not just real-env compatibility, and this gate carries more
+weight than the other five. On a real drop-in Usercentrics site
+(`https://www.dish.com` or `https://www.conrad.de`), confirm ALL of the
+following before marking this adapter PASS:
+
+- [ ] `window.UC_UI.denyAllConsents` exists and is a function.
+- [ ] Calling it actually denies consent (check the resulting consent
+      state via DevTools / the vendor's own consent inspector, not just
+      "the banner went away").
+- [ ] It returns a Promise (log `window.UC_UI.denyAllConsents()` in the
+      console and confirm `instanceof Promise`). If it returns `undefined`
+      instead, confirm the adapter still fails safe (no page break, no
+      thrown error surfaced to the user) - the `.catch()` chain would
+      throw a `TypeError` on `undefined.catch`, but that throw is caught
+      by the enclosing `try/catch` in `cookie-noise-mainworld.js` /
+      `cookie-noise.js`.
+- [ ] Calling `denyAllConsents()` again on an already-consented page (i.e.
+      the user already went through the banner once) is inert - no error,
+      no unexpected UI state, no duplicate network call storm.
+- [ ] `window.UC_UI.isInitialized` exists as a function (the adapter only
+      `typeof`-checks it as a corroborating signal, never invokes it as a
+      gate - confirm that remains a safe assumption on a live site: does
+      calling `isInitialized()` manually in the console return a stable
+      boolean before/after the reject call?).
+- [ ] If the site uses TCF-2.2-addon mode, confirm whether `window.UC_UI`
+      is still exposed or swapped for a different surface (ambiguous
+      across third-party sources per PR #1127 - note the finding either
+      way, do not silently assume).
+
+## Sign-off table
+
+All 12 cells (6 adapters x Chrome/Firefox) must be green before the
+`develop -> main` release PR opens.
+
+| Adapter | Chrome | Firefox |
+| --- | --- | --- |
+| OneTrust | ____ | ____ |
+| Cookiebot | ____ | ____ |
+| Didomi | ____ | ____ |
+| CookieYes | ____ | ____ |
+| Sourcepoint | ____ | ____ |
+| Usercentrics | ____ | ____ |
+
+Reviewer: ______________________  Date: ______________________

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "typecheck": "tsc -p jsconfig.json",
     "lint:js": "eslint .",
     "moat:report": "node tools/moat-expansion/cli.mjs",
-    "fpfn": "node tools/fpfn-harness/run.mjs"
+    "fpfn": "node tools/fpfn-harness/run.mjs",
+    "smoke:release": "node tools/release-smoke-report.mjs"
   },
   "engines": {
     "node": ">=20.11"

--- a/tests/unit/release-smoke-report.test.mjs
+++ b/tests/unit/release-smoke-report.test.mjs
@@ -1,0 +1,236 @@
+/**
+ * MUGA — tools/release-smoke-report.mjs pure-logic unit tests
+ * (release-smoke-battery).
+ *
+ * Covers summarizeRelease's READY/BLOCKED/UNVERIFIED boundaries, per-CMP
+ * independence, the absent-CMP => UNVERIFIED default, and mixed inputs;
+ * plus formatReleaseTable's deterministic rendering. Importing
+ * tools/release-smoke-report.mjs must never read the filesystem or call
+ * process.exit — see the entry-guard smoke test at the bottom, which is
+ * what makes this file safe to run in the normal `npm test` gate.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { summarizeRelease, formatReleaseTable, RELEASE_CMPS } from "../../tools/release-smoke-report.mjs";
+
+// ── summarizeRelease — READY boundary ─────────────────────────────────────
+
+describe("release-smoke-report — summarizeRelease READY boundary", () => {
+  test("1 pass, 0 fail is READY", () => {
+    const summary = summarizeRelease([{ cmp: "onetrust", url: "https://a.example", status: "pass" }]);
+    assert.equal(summary.onetrust.verdict, "READY");
+    assert.equal(summary.onetrust.passCount, 1);
+    assert.equal(summary.onetrust.failCount, 0);
+  });
+
+  test("multiple passes, 0 fail is still READY", () => {
+    const summary = summarizeRelease([
+      { cmp: "cookiebot", url: "https://a.example", status: "pass" },
+      { cmp: "cookiebot", url: "https://b.example", status: "pass" },
+    ]);
+    assert.equal(summary.cookiebot.verdict, "READY");
+    assert.equal(summary.cookiebot.passCount, 2);
+  });
+
+  test("pass + inconclusive (0 fail) is READY — inconclusive does not downgrade a confirmed pass", () => {
+    const summary = summarizeRelease([
+      { cmp: "didomi", url: "https://a.example", status: "pass" },
+      { cmp: "didomi", url: "https://b.example", status: "inconclusive" },
+    ]);
+    assert.equal(summary.didomi.verdict, "READY");
+  });
+});
+
+// ── summarizeRelease — BLOCKED boundary ───────────────────────────────────
+
+describe("release-smoke-report — summarizeRelease BLOCKED boundary", () => {
+  test("1 fail (0 pass) is BLOCKED", () => {
+    const summary = summarizeRelease([{ cmp: "cookieyes", url: "https://a.example", status: "fail" }]);
+    assert.equal(summary.cookieyes.verdict, "BLOCKED");
+    assert.equal(summary.cookieyes.failCount, 1);
+  });
+
+  test("any fail is BLOCKED even alongside passes — fail always wins", () => {
+    const summary = summarizeRelease([
+      { cmp: "sourcepoint", url: "https://a.example", status: "pass" },
+      { cmp: "sourcepoint", url: "https://b.example", status: "fail" },
+    ]);
+    assert.equal(summary.sourcepoint.verdict, "BLOCKED");
+    assert.equal(summary.sourcepoint.passCount, 1);
+    assert.equal(summary.sourcepoint.failCount, 1);
+  });
+
+  test("fail + inconclusive (0 pass) is BLOCKED", () => {
+    const summary = summarizeRelease([
+      { cmp: "usercentrics", url: "https://a.example", status: "fail" },
+      { cmp: "usercentrics", url: "https://b.example", status: "inconclusive" },
+    ]);
+    assert.equal(summary.usercentrics.verdict, "BLOCKED");
+  });
+});
+
+// ── summarizeRelease — UNVERIFIED boundary ────────────────────────────────
+
+describe("release-smoke-report — summarizeRelease UNVERIFIED boundary", () => {
+  test("only inconclusive results is UNVERIFIED", () => {
+    const summary = summarizeRelease([
+      { cmp: "onetrust", url: "https://a.example", status: "inconclusive" },
+      { cmp: "onetrust", url: "https://b.example", status: "inconclusive" },
+    ]);
+    assert.equal(summary.onetrust.verdict, "UNVERIFIED");
+    assert.equal(summary.onetrust.passCount, 0);
+    assert.equal(summary.onetrust.failCount, 0);
+    assert.equal(summary.onetrust.inconclusiveCount, 2);
+  });
+
+  test("absent CMP (no results at all) is UNVERIFIED", () => {
+    const summary = summarizeRelease([{ cmp: "onetrust", url: "https://a.example", status: "pass" }]);
+    // cookiebot never appears in the results array at all.
+    assert.equal(summary.cookiebot.verdict, "UNVERIFIED");
+    assert.equal(summary.cookiebot.passCount, 0);
+    assert.equal(summary.cookiebot.failCount, 0);
+    assert.equal(summary.cookiebot.inconclusiveCount, 0);
+    assert.deepEqual(summary.cookiebot.sites, []);
+  });
+
+  test("empty results array: all 6 CMPs are UNVERIFIED", () => {
+    const summary = summarizeRelease([]);
+    for (const cmp of RELEASE_CMPS) {
+      assert.equal(summary[cmp].verdict, "UNVERIFIED");
+    }
+  });
+
+  test("non-array input is treated as no results — all 6 CMPs UNVERIFIED, no throw", () => {
+    for (const bad of [null, undefined, "garbage", 42]) {
+      const summary = summarizeRelease(bad);
+      for (const cmp of RELEASE_CMPS) {
+        assert.equal(summary[cmp].verdict, "UNVERIFIED");
+      }
+    }
+  });
+});
+
+// ── summarizeRelease — per-CMP independence + malformed input ─────────────
+
+describe("release-smoke-report — per-CMP independence and malformed entries", () => {
+  test("one CMP BLOCKED does not affect another CMP's READY verdict", () => {
+    const summary = summarizeRelease([
+      { cmp: "onetrust", url: "https://a.example", status: "fail" },
+      { cmp: "didomi", url: "https://b.example", status: "pass" },
+    ]);
+    assert.equal(summary.onetrust.verdict, "BLOCKED");
+    assert.equal(summary.didomi.verdict, "READY");
+  });
+
+  test("all 6 CMPs mixed: one of each verdict plus one fully absent", () => {
+    const summary = summarizeRelease([
+      { cmp: "onetrust", url: "https://a.example", status: "pass" },
+      { cmp: "cookiebot", url: "https://b.example", status: "fail" },
+      { cmp: "didomi", url: "https://c.example", status: "inconclusive" },
+      { cmp: "cookieyes", url: "https://d.example", status: "pass" },
+      { cmp: "cookieyes", url: "https://e.example", status: "fail" },
+    ]);
+    assert.equal(summary.onetrust.verdict, "READY");
+    assert.equal(summary.cookiebot.verdict, "BLOCKED");
+    assert.equal(summary.didomi.verdict, "UNVERIFIED");
+    assert.equal(summary.cookieyes.verdict, "BLOCKED");
+    assert.equal(summary.sourcepoint.verdict, "UNVERIFIED");
+    assert.equal(summary.usercentrics.verdict, "UNVERIFIED");
+  });
+
+  test("malformed entries (missing cmp, bad status, null, non-object) are skipped, never counted", () => {
+    const summary = summarizeRelease([
+      { url: "https://a.example", status: "fail" }, // missing cmp
+      { cmp: "onetrust", url: "https://b.example", status: "not-a-real-status" },
+      null,
+      "not-an-object",
+      42,
+      { cmp: "onetrust", url: "https://c.example", status: "pass" },
+    ]);
+    assert.equal(summary.onetrust.verdict, "READY");
+    assert.equal(summary.onetrust.passCount, 1);
+    assert.equal(summary.onetrust.failCount, 0);
+  });
+
+  test("an unknown CMP id not in RELEASE_CMPS is still tracked defensively", () => {
+    const summary = summarizeRelease([{ cmp: "future-cmp", url: "https://a.example", status: "pass" }]);
+    assert.equal(summary["future-cmp"].verdict, "READY");
+    // The 6 known CMPs are still all present and UNVERIFIED.
+    for (const cmp of RELEASE_CMPS) {
+      assert.equal(summary[cmp].verdict, "UNVERIFIED");
+    }
+  });
+
+  test("each CMP's sites array preserves url/status/detail for every entry", () => {
+    const summary = summarizeRelease([
+      { cmp: "onetrust", url: "https://a.example", status: "fail", detail: "banner still visible" },
+    ]);
+    assert.deepEqual(summary.onetrust.sites, [
+      { url: "https://a.example", status: "fail", detail: "banner still visible" },
+    ]);
+  });
+});
+
+// ── formatReleaseTable ─────────────────────────────────────────────────────
+
+describe("release-smoke-report — formatReleaseTable", () => {
+  test("renders a header row and one row per RELEASE_CMPS entry, in canonical order", () => {
+    const summary = summarizeRelease([]);
+    const table = formatReleaseTable(summary);
+    const lines = table.split("\n");
+    assert.match(lines[0], /CMP/);
+    assert.match(lines[0], /Verdict/);
+    // Body rows appear in RELEASE_CMPS order (header + separator take the first 2 lines).
+    RELEASE_CMPS.forEach((cmp, i) => {
+      assert.match(lines[2 + i], new RegExp(`^${cmp}\\s`));
+    });
+  });
+
+  test("includes each CMP's verdict and counts", () => {
+    const summary = summarizeRelease([
+      { cmp: "onetrust", url: "https://a.example", status: "pass" },
+      { cmp: "cookiebot", url: "https://b.example", status: "fail" },
+    ]);
+    const table = formatReleaseTable(summary);
+    assert.match(table, /onetrust\s+\|\s+READY/);
+    assert.match(table, /cookiebot\s+\|\s+BLOCKED/);
+  });
+
+  test("appends unknown extra CMP keys after the 6 canonical rows, sorted", () => {
+    const summary = summarizeRelease([{ cmp: "zzz-future", url: "https://a.example", status: "pass" }]);
+    const table = formatReleaseTable(summary);
+    const lines = table.split("\n").filter((l) => l.trim().length > 0);
+    // Last content row should be the extra CMP, not one of the 6 canonical ones.
+    assert.match(lines[lines.length - 1], /zzz-future/);
+  });
+
+  test("is deterministic given the same input", () => {
+    const summary = summarizeRelease([{ cmp: "didomi", url: "https://a.example", status: "pass" }]);
+    assert.equal(formatReleaseTable(summary), formatReleaseTable(summary));
+  });
+
+  test("handles a null/undefined summary without throwing", () => {
+    assert.doesNotThrow(() => formatReleaseTable(null));
+    assert.doesNotThrow(() => formatReleaseTable(undefined));
+  });
+});
+
+// ── Import safety: the CLI must never run on import ───────────────────────
+
+describe("release-smoke-report — importing the module never triggers CLI/filesystem/exit calls", () => {
+  test("module loads and exports the pure functions without side effects", async () => {
+    // If importing this module ever executed runReleaseSmokeReportCli() at
+    // top-level, this test process would attempt to read
+    // test-results/canary-results.json and call process.exit — either
+    // hiding a real regression or killing the test runner outright. The
+    // import at the top of this file already proves this is safe; this
+    // test just asserts the shape of what got exported.
+    const mod = await import("../../tools/release-smoke-report.mjs");
+    assert.equal(typeof mod.summarizeRelease, "function");
+    assert.equal(typeof mod.formatReleaseTable, "function");
+    assert.equal(typeof mod.runReleaseSmokeReportCli, "function");
+    assert.ok(Array.isArray(mod.RELEASE_CMPS));
+    assert.equal(mod.RELEASE_CMPS.length, 6);
+  });
+});

--- a/tools/release-smoke-report.mjs
+++ b/tools/release-smoke-report.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * MUGA — cookie-consent release-smoke report (release-smoke-battery).
+ *
+ * Reduces the existing CMP canary results (tests/canary/cmp-sites.json +
+ * tools/canary-report.mjs's `test-results/canary-results.json` schema,
+ * `{cmp, url, status: "pass"|"fail"|"inconclusive", detail}`) into a
+ * per-adapter RELEASE verdict for the 6 Tier 1 cookie-consent adapters
+ * (src/lib/cmp-adapters.js TIER1: onetrust, cookiebot, didomi, cookieyes,
+ * sourcepoint, usercentrics).
+ *
+ * This does NOT run the canary itself — see tools/canary-report.mjs for
+ * that (drift-alarm reporting) and .github/workflows/cmp-canary.yml (the
+ * nightly job that produces the results file this script consumes). This
+ * script answers a narrower, release-gating question: for each adapter, is
+ * there real-site evidence good enough to ship?
+ *
+ * Verdicts (per CMP):
+ *   READY      — at least 1 "pass" and 0 "fail" real-site results.
+ *   BLOCKED    — at least 1 "fail" real-site result (any pass count).
+ *   UNVERIFIED — only "inconclusive" results, or no results at all (no
+ *                positive real-site confirmation either way). Treated as a
+ *                WARNING by the CLI, not a hard release blocker — real
+ *                sites are flaky/geo-variant/already-consented.
+ *
+ * Pure: no I/O, no Date.now() inside summarizeRelease/formatReleaseTable —
+ * mirrors tools/canary-report.mjs's decideDrift/formatIssueBody split (pure
+ * decision logic vs. CLI I/O boundary).
+ *
+ * Public API (named exports only — no default):
+ *   RELEASE_CMPS → the 6 Tier 1 CMP ids, in cmp-adapters.js TIER1 order.
+ *   summarizeRelease(results) → Record<string, {verdict, passCount, failCount, inconclusiveCount, sites}>
+ *   formatReleaseTable(summary) → string
+ *
+ * Usage:
+ *   node tools/release-smoke-report.mjs
+ *   npm run smoke:release
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Pure decision logic ───────────────────────────────────────────────────
+
+/**
+ * The 6 Tier 1 cookie-consent CMP ids, in the same order as
+ * src/lib/cmp-adapters.js's TIER1 registry.
+ * @type {ReadonlyArray<string>}
+ */
+export const RELEASE_CMPS = Object.freeze([
+  "onetrust",
+  "cookiebot",
+  "didomi",
+  "cookieyes",
+  "sourcepoint",
+  "usercentrics",
+]);
+
+function emptyBucket() {
+  return { verdict: "UNVERIFIED", passCount: 0, failCount: 0, inconclusiveCount: 0, sites: [] };
+}
+
+/**
+ * Reduces canary results into a per-adapter release verdict.
+ *
+ * Every CMP in RELEASE_CMPS is always present in the output — even with
+ * zero matching results — so an adapter with no real-site evidence at all
+ * (canary run never covered it, or the results file is empty/missing)
+ * still shows up as UNVERIFIED rather than silently disappearing. Any
+ * other `cmp` value present in `results` is also tracked defensively
+ * (forward-compatible with a 7th adapter before this file's RELEASE_CMPS
+ * list is updated), just not required to be READY for `formatReleaseTable`
+ * to render cleanly.
+ *
+ * Pure: no I/O, no Date.now(). Never throws on well-formed input;
+ * malformed entries are skipped defensively (fail-closed: unknown shape
+ * never counts as pass/fail either way).
+ *
+ * @param {Array<{cmp: string, url: string, status: "pass"|"fail"|"inconclusive", detail?: string}>} results
+ * @returns {Record<string, {verdict: "READY"|"BLOCKED"|"UNVERIFIED", passCount: number, failCount: number, inconclusiveCount: number, sites: Array<{url: string, status: string, detail: string}>}>}
+ */
+export function summarizeRelease(results) {
+  /** @type {Record<string, ReturnType<typeof emptyBucket>>} */
+  const byCmp = {};
+  for (const cmp of RELEASE_CMPS) {
+    byCmp[cmp] = emptyBucket();
+  }
+
+  const list = Array.isArray(results) ? results : [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") continue;
+    const cmp = typeof entry.cmp === "string" ? entry.cmp : null;
+    const status = entry.status;
+    if (!cmp || (status !== "pass" && status !== "fail" && status !== "inconclusive")) continue;
+
+    if (!byCmp[cmp]) byCmp[cmp] = emptyBucket();
+    const bucket = byCmp[cmp];
+    bucket.sites.push({
+      url: typeof entry.url === "string" ? entry.url : "",
+      status,
+      detail: typeof entry.detail === "string" ? entry.detail : "",
+    });
+    if (status === "pass") bucket.passCount += 1;
+    else if (status === "fail") bucket.failCount += 1;
+    else bucket.inconclusiveCount += 1;
+  }
+
+  for (const cmp of Object.keys(byCmp)) {
+    const bucket = byCmp[cmp];
+    if (bucket.failCount >= 1) bucket.verdict = "BLOCKED";
+    else if (bucket.passCount >= 1) bucket.verdict = "READY";
+    else bucket.verdict = "UNVERIFIED";
+  }
+
+  return byCmp;
+}
+
+/**
+ * Renders a readable per-adapter release table.
+ *
+ * Pure: takes the summary as a parameter, no I/O. RELEASE_CMPS entries are
+ * always rendered in the canonical order first (even if `summary` was
+ * built by hand and only has a subset); any extra CMP keys present in
+ * `summary` beyond RELEASE_CMPS are appended after, sorted, so the output
+ * never silently drops an adapter.
+ *
+ * @param {Record<string, {verdict: string, passCount: number, failCount: number, inconclusiveCount: number}>} summary
+ * @returns {string}
+ */
+export function formatReleaseTable(summary) {
+  const s = summary && typeof summary === "object" ? summary : {};
+  const known = RELEASE_CMPS.filter((cmp) => cmp in s);
+  const extra = Object.keys(s)
+    .filter((cmp) => !RELEASE_CMPS.includes(cmp))
+    .sort();
+  const order = [...known, ...extra];
+
+  const header = ["CMP", "Verdict", "Pass", "Fail", "Inconclusive"];
+  const rows = order.map((cmp) => {
+    const bucket = s[cmp] || emptyBucket();
+    return [cmp, bucket.verdict, String(bucket.passCount), String(bucket.failCount), String(bucket.inconclusiveCount)];
+  });
+
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+  const formatRow = (cells) => cells.map((cell, i) => cell.padEnd(widths[i])).join(" | ");
+
+  const lines = [formatRow(header), widths.map((w) => "-".repeat(w)).join("-|-"), ...rows.map(formatRow)];
+  return lines.join("\n");
+}
+
+// ── CLI I/O boundary ───────────────────────────────────────────────────────
+
+const DEFAULT_RESULTS_PATH = join(__dirname, "..", "test-results", "canary-results.json");
+
+/**
+ * Reads canary-results.json, computes the release summary, and prints the
+ * table. Exits non-zero when any adapter is BLOCKED (a real-site reject
+ * failure), so this can be wired as a hard release-gate check. UNVERIFIED
+ * adapters print a warning but never fail the run — real sites are flaky,
+ * geo-variant, or already-consented, so a missing positive confirmation is
+ * not proof of a broken adapter.
+ *
+ * @param {{resultsPath?: string, exitImpl?: (code: number) => void}} [opts]
+ */
+export function runReleaseSmokeReportCli({ resultsPath = DEFAULT_RESULTS_PATH, exitImpl = process.exit } = {}) {
+  let raw;
+  try {
+    raw = readFileSync(resultsPath, "utf8");
+  } catch (err) {
+    console.error(`[release-smoke-report] cannot read ${resultsPath}: ${err.message}`);
+    console.error("[release-smoke-report] no canary results — trigger the cmp-canary workflow first (see docs/qa/cookie-consent-release-smoke.md).");
+    console.log(formatReleaseTable(summarizeRelease([])));
+    exitImpl(0);
+    return;
+  }
+
+  let results;
+  try {
+    results = JSON.parse(raw);
+  } catch (err) {
+    console.error(`[release-smoke-report] cannot parse ${resultsPath} as JSON: ${err.message}`);
+    exitImpl(1);
+    return;
+  }
+
+  const summary = summarizeRelease(results);
+  console.log(formatReleaseTable(summary));
+
+  const blocked = RELEASE_CMPS.filter((cmp) => summary[cmp] && summary[cmp].verdict === "BLOCKED");
+  const unverified = RELEASE_CMPS.filter((cmp) => summary[cmp] && summary[cmp].verdict === "UNVERIFIED");
+
+  if (unverified.length > 0) {
+    console.warn(`[release-smoke-report] WARNING: unverified adapter(s), no positive real-site confirmation: ${unverified.join(", ")}`);
+  }
+
+  if (blocked.length > 0) {
+    console.error(`[release-smoke-report] BLOCKED: real-site reject failure for: ${blocked.join(", ")}`);
+    exitImpl(1);
+    return;
+  }
+
+  console.log("[release-smoke-report] no adapter is BLOCKED.");
+  exitImpl(0);
+}
+
+// Only run the CLI when this file is executed directly — importing it (as
+// tests/unit/release-smoke-report.test.mjs does) must never read the
+// filesystem or call process.exit. Mirrors tools/canary-report.mjs's entry
+// guard (endsWith check, not a strict path-equality compare, so it works
+// the same whether invoked as `node tools/release-smoke-report.mjs` or via
+// a relative/absolute npm script path on any platform).
+const isMain = process.argv[1] && process.argv[1].endsWith("release-smoke-report.mjs");
+if (isMain) {
+  runReleaseSmokeReportCli();
+}


### PR DESCRIPTION
Closes #1131

## Summary

A **release smoke battery** for the cookie-consent module: it consolidates the 6 adapters' scattered, unchecked "Pre-ship gate" items into one runnable `develop -> main` release gate. Two parts — a human QA checklist and an automated Chrome-only readiness report that reuses the existing nightly canary's results.

Targets **`develop`**, not main. Docs + a pure-function tool + unit tests only — **no runtime code, no workflow change** (`cleaner-bundle.js` diff clean).

## What it adds

- **`docs/qa/cookie-consent-release-smoke.md`** — per-adapter checklist (6 sections, Chrome + Firefox), each with the exact reject call, detection signals, candidate live site, and the specific risk flagged in that adapter's PR. Includes a reinforced **Usercentrics callout** (its API was third-party-corroborated only — the smoke must confirm `denyAllConsents` exists, denies, returns a Promise, is inert on re-invocation, and `isInitialized()` semantics) and a 6x2 sign-off table required all-green before a release PR opens.
- **`tools/release-smoke-report.mjs`** — pure `summarizeRelease(results)` reducing the canary results (`{cmp, url, status: pass|fail|inconclusive}`) to a per-adapter verdict: `READY` (>=1 pass, 0 fail), `BLOCKED` (>=1 fail), `UNVERIFIED` (only inconclusive / absent — a warning, never a hard fail, since real sites are flaky/geo-variant). Guarded CLI (`npm run smoke:release`) exits non-zero on any BLOCKED adapter, so it can wire into a release-gate script. Import never runs the CLI (mirrors `canary-report.mjs`'s entry guard).
- **`tests/unit/release-smoke-report.test.mjs`** — 21 unit tests (verdict boundaries, per-CMP independence, absent CMP => UNVERIFIED, malformed-skip, table rendering).

## How a release runs it

1. `gh workflow run cmp-canary.yml` (on-demand) -> wait -> `gh run download <id> -n cmp-canary-results -D test-results/`.
2. `npm run smoke:release` -> per-adapter READY/BLOCKED/UNVERIFIED table; non-zero exit if any adapter is BLOCKED.
3. Complete the manual Chrome + Firefox rows in the checklist (the automated portion covers only the Chrome detection+reject signal, not visual/geo/Firefox).

## Changes

| File | Change |
|------|--------|
| `docs/qa/cookie-consent-release-smoke.md` | per-adapter QA checklist + sign-off table |
| `tools/release-smoke-report.mjs` | pure `summarizeRelease`/`formatReleaseTable` + guarded CLI |
| `tests/unit/release-smoke-report.test.mjs` | 21 unit tests |
| `package.json` | `smoke:release` script |

## Test + review

- [x] `npm test` — 6737 pass / 0 fail / 1 pre-existing skip (+21)
- [x] `npm run lint`, `lint:js`, `check:i18n` — clean
- [x] `build:content` drift gate — clean (no runtime code touched)
- [x] `node --check` + import-smoke — CLI never runs on import
- [x] Self-verified: reject calls + detection signals in the checklist cross-checked against `cmp-adapters.js` and the content-script call sites; `summarizeRelease` verdict logic read and confirmed

## Notes

- Firefox automation is out of scope — feasibility explored (verdict: feasible via Selenium+geckodriver headless, but adds a second E2E toolchain), tracked in #1128. The checklist's Firefox column is manual for now.
- The candidate sites come verbatim from `tests/canary/cmp-sites.json`; two are flagged lower-confidence there.
