### PR TITLE
test(e2e-firefox): Firefox smoke suite for all 6 CMP adapters + CI gate (#1128)

### DIFF
--- a/.github/workflows/firefox-smoke.yml
+++ b/.github/workflows/firefox-smoke.yml
@@ -1,0 +1,46 @@
+name: Firefox Smoke
+
+# Real headless-Firefox smoke coverage for the Cookie Consent Minimizer's
+# Firefox-only wrappedJSObject reject path (#1128). Deterministic: every
+# fixture is a local HTTP page served by tests/e2e-firefox/helpers/local-server.mjs,
+# not a live site, so this CAN be a real merge gate.
+on:
+  pull_request:
+    branches: [develop, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  firefox-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Firefox
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795  # v1.7.2
+        with:
+          firefox-version: latest
+
+      # No separate geckodriver install step: selenium-webdriver's bundled
+      # Selenium Manager auto-provisions a matching geckodriver on first
+      # launch, exactly as it did locally (proven on Windows without any
+      # explicit geckodriver setup — see tests/e2e-firefox/fixtures.mjs). If
+      # Selenium Manager ever fails to resolve geckodriver on this runner,
+      # add a browser-actions/setup-geckodriver step here (SHA-pinned) as a
+      # fallback before this step.
+
+      - name: Run Firefox smoke tests (#1128)
+        run: npm run test:firefox-smoke

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "muga",
-  "version": "2.3.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muga",
-      "version": "2.3.0",
+      "version": "2.6.0",
       "devDependencies": {
         "@playwright/test": "^1.52.0",
         "@types/node": "^25.9.2",
         "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
         "playwright": "^1.58.2",
+        "selenium-webdriver": "^4.46.0",
         "typescript": "^6.0.3",
         "web-ext": "^8.0.0"
       },
@@ -57,6 +58,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.5.0.tgz",
+      "integrity": "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@devicefarmer/adbkit": {
       "version": "3.3.8",
@@ -4441,6 +4449,42 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/selenium-webdriver": {
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.46.0.tgz",
+      "integrity": "sha512-UlTkgnx9y+bf3QxFsrgUyMqC2oy1Yf+qcOs7xIC/XfsUPv/ow7Sicx6SJ7AeOn2/Z+xF1M8SLqyn983wipI82w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.5.0",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.7",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/selenium-webdriver/node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -5131,6 +5175,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:dnr": "node scripts/generate-dnr-rules.mjs",
     "add-rule": "node tools/add-rule.mjs",
     "test:e2e": "npx playwright test",
+    "test:firefox-smoke": "node --test tests/e2e-firefox/*.smoke.mjs",
     "test:canary": "playwright test --config playwright.canary.config.mjs",
     "typecheck": "tsc -p jsconfig.json",
     "lint:js": "eslint .",
@@ -58,6 +59,7 @@
     "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
     "playwright": "^1.58.2",
+    "selenium-webdriver": "^4.46.0",
     "typescript": "^6.0.3",
     "web-ext": "^8.0.0"
   },

--- a/tests/e2e-firefox/cookiebot.smoke.mjs
+++ b/tests/e2e-firefox/cookiebot.smoke.mjs
@@ -1,0 +1,119 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — Cookiebot reject path (#1128).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookiebot.spec.mjs's fixture
+ * page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.Cookiebot.submitCustomConsent(false, false, false)`
+ * path (src/content/cookie-noise.js) actually fires in Gecko.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as tests/e2e/cookie-consent-minimizer-cookiebot.spec.mjs's
+// stubCookiebotPage: mandatory signal (Cookiebot global + submitCustomConsent
+// fn) plus corroborating secondary signals (Cybot dialog DOM, consent object
+// global, hasResponse boolean).
+const COOKIEBOT_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="CybotCookiebotDialog">
+    <button id="CybotCookiebotDialogBodyLevelButtonAccept">Allow all</button>
+    <button id="CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll">Allow all</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.Cookiebot = {
+      consent: { necessary: true, preferences: false, statistics: false, marketing: false },
+      hasResponse: false,
+      submitCustomConsent(preferences, statistics, marketing) {
+        window.__consentState =
+          preferences === false && statistics === false && marketing === false
+            ? "necessary-only"
+            : "unexpected-consent";
+        document.getElementById("CybotCookiebotDialog").remove();
+      },
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: Cookiebot submitCustomConsent(false, false, false) fires via wrappedJSObject when the feature is enabled", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(COOKIEBOT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('CybotCookiebotDialog') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: Cookiebot submitCustomConsent does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(COOKIEBOT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    // WebDriver's executeScript serializes a JS `undefined` return value as
+    // `null` over the wire — assert against `null`, not `undefined`.
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('CybotCookiebotDialog') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e-firefox/cookieyes.smoke.mjs
+++ b/tests/e2e-firefox/cookieyes.smoke.mjs
@@ -1,0 +1,131 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — CookieYes reject path (#1128).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookieyes.spec.mjs's fixture
+ * page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.performBannerAction("reject")` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ *
+ * CookieYes deviates from OneTrust/Cookiebot/Didomi: it exposes BARE page
+ * globals (`getCkyConsent`, `performBannerAction`), not methods on a
+ * vendor-namespaced object — the dispatcher requires BOTH bare globals
+ * (dual-mandatory) plus at least one DOM secondary signal
+ * (`.cky-consent-container`) before it will act (src/lib/cmp-adapters.js).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as tests/e2e/cookie-consent-minimizer-cookieyes.spec.mjs's
+// stubCookieYesPage: both mandatory bare globals (getCkyConsent,
+// performBannerAction) present alongside the .cky-consent-container DOM
+// anchor.
+const COOKIEYES_FIXTURE_HTML = `<!doctype html><html><body>
+  <div class="cky-consent-container">
+    <div class="cky-consent-bar">
+      <button id="cky-btn-accept">Accept All</button>
+      <button id="cky-btn-reject">Reject All</button>
+    </div>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.getCkyConsent = function () {
+      return {
+        activeLaw: "gdpr",
+        categories: { necessary: true, functional: false, analytics: false, performance: false, advertisement: false },
+        isUserActionCompleted: false,
+        consentID: "test-consent-id",
+        languageCode: "en",
+      };
+    };
+    window.performBannerAction = function (action) {
+      if (action !== "reject") {
+        window.__consentState = "unexpected-consent";
+        return;
+      }
+      window.__consentState = "necessary-only";
+      document.querySelector(".cky-consent-container").remove();
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test('Firefox smoke: CookieYes performBannerAction("reject") fires via wrappedJSObject when the feature is enabled', async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(COOKIEYES_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const bannerGone = await driver.executeScript(
+      "return document.querySelector('.cky-consent-container') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: CookieYes performBannerAction does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(COOKIEYES_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.querySelector('.cky-consent-container') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e-firefox/didomi.smoke.mjs
+++ b/tests/e2e-firefox/didomi.smoke.mjs
@@ -1,0 +1,114 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — Didomi reject path (#1128).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-didomi.spec.mjs's fixture page
+ * and assertions, but drives REAL headless Firefox via Selenium + geckodriver
+ * (see ./fixtures.mjs) instead of Playwright's chromium fixture, to prove the
+ * Firefox-only `window.wrappedJSObject.Didomi.setUserDisagreeToAll()` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as tests/e2e/cookie-consent-minimizer-didomi.spec.mjs's
+// stubDidomiPage: mandatory signal (Didomi global + setUserDisagreeToAll fn)
+// plus corroborating secondary signals (#didomi-host DOM anchor,
+// getCurrentUserStatus function).
+const DIDOMI_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="didomi-host">
+    <button id="didomi-notice-agree-button">Agree</button>
+    <button id="didomi-notice-disagree-button">Disagree</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.Didomi = {
+      getCurrentUserStatus() {
+        return { purposes: {}, vendors: {} };
+      },
+      setUserDisagreeToAll() {
+        window.__consentState = "necessary-only";
+        document.getElementById("didomi-host").remove();
+      },
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: Didomi setUserDisagreeToAll() fires via wrappedJSObject when the feature is enabled", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(DIDOMI_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('didomi-host') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: Didomi setUserDisagreeToAll() does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(DIDOMI_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('didomi-host') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e-firefox/fixtures.mjs
+++ b/tests/e2e-firefox/fixtures.mjs
@@ -1,0 +1,168 @@
+/**
+ * Selenium/geckodriver fixtures for MUGA Firefox extension E2E smoke tests
+ * (#1128, slice 1).
+ *
+ * Chosen design (engram sdd/firefox-webext-smoke/explore): Selenium
+ * WebDriver + geckodriver, headless Firefox, driver.installAddon(dir, true).
+ * Rejected: web-ext run, playwright-webextext.
+ *
+ * Firefox internal add-on UUID gotcha:
+ * -------------------------------------
+ * The `browser_specific_settings.gecko.id` in the manifest ("muga@..." here)
+ * is the extension's STABLE ID, but it is NOT the host segment used in
+ * moz-extension://<host>/... URLs. Firefox maps each installed extension ID
+ * to a randomly-generated internal UUID (stored in the
+ * `extensions.webextensions.uuids` pref) and uses THAT UUID as the
+ * moz-extension:// host. A fresh temporary install normally gets a fresh
+ * random UUID, which would make the extension origin non-deterministic
+ * across runs.
+ *
+ * Firefox honors a PRESET mapping in that same pref: if we set
+ * `extensions.webextensions.uuids` to `{"<gecko-id>": "<our-chosen-uuid>"}`
+ * as a profile preference BEFORE the browser starts, Firefox uses our UUID
+ * instead of generating a random one. That is what makes the extension
+ * origin deterministic here — not the gecko id itself.
+ */
+
+import { Builder } from "selenium-webdriver";
+import firefox from "selenium-webdriver/firefox.js";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const SRC_DIR = path.join(REPO_ROOT, "src");
+const MANIFEST_V2_PATH = path.join(SRC_DIR, "manifest.v2.json");
+
+// Fixed internal UUID we preset via extensions.webextensions.uuids so
+// moz-extension://<this>/... is deterministic across runs. Not meaningful
+// beyond being a valid UUID string.
+export const FIXED_EXTENSION_UUID = "3a9f7a10-3f4c-4c8e-9b1a-8f5a3c9d2e11";
+
+/**
+ * Reads the Firefox (MV2) manifest and returns its declared gecko id.
+ */
+export function readGeckoId() {
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_V2_PATH, "utf8"));
+  const geckoId = manifest?.browser_specific_settings?.gecko?.id;
+  if (!geckoId) {
+    throw new Error(`manifest.v2.json is missing browser_specific_settings.gecko.id at ${MANIFEST_V2_PATH}`);
+  }
+  return geckoId;
+}
+
+/**
+ * Builds an ISOLATED temp copy of src/ with manifest.json overwritten by
+ * manifest.v2.json's content, for loading into Firefox. This avoids the
+ * collision/dirty-tree risk of scripts/with-firefox-manifest.sh, which
+ * swaps the TRACKED src/manifest.json in place.
+ *
+ * @returns {Promise<string>} path to the temp extension directory
+ */
+export async function buildFirefoxExtensionDir() {
+  const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "muga-ff-ext-"));
+  const extDir = path.join(tmpRoot, "src");
+  await fsp.cp(SRC_DIR, extDir, { recursive: true });
+
+  const manifestV2Raw = await fsp.readFile(MANIFEST_V2_PATH, "utf8");
+  await fsp.writeFile(path.join(extDir, "manifest.json"), manifestV2Raw, "utf8");
+
+  return extDir;
+}
+
+async function removeDirSafe(dir) {
+  if (!dir) return;
+  await fsp.rm(path.dirname(dir), { recursive: true, force: true });
+}
+
+/**
+ * Launches headless Firefox with the MUGA extension loaded (as a temporary
+ * add-on) and the internal UUID pinned to FIXED_EXTENSION_UUID.
+ *
+ * @returns {Promise<{driver: import('selenium-webdriver').WebDriver, extDir: string, geckoId: string, extensionOrigin: string}>}
+ */
+export async function launchFirefoxWithExtension() {
+  const geckoId = readGeckoId();
+  const extDir = await buildFirefoxExtensionDir();
+
+  const options = new firefox.Options();
+  options.addArguments("-headless");
+  options.setPreference("extensions.webextensions.uuids", JSON.stringify({ [geckoId]: FIXED_EXTENSION_UUID }));
+  // Allow the temporary install to run without additional prompts.
+  options.setPreference("xpinstall.signatures.required", false);
+
+  const firefoxBinary = process.env.MUGA_FIREFOX_BINARY;
+  if (firefoxBinary) {
+    options.setBinary(firefoxBinary);
+  }
+
+  const driver = await new Builder().forBrowser("firefox").setFirefoxOptions(options).build();
+
+  await driver.installAddon(extDir, /* temporary */ true);
+
+  const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+  return { driver, extDir, geckoId, extensionOrigin };
+}
+
+/**
+ * Completes onboarding by setting the same storage flags the Chromium
+ * fixture sets (tests/e2e/fixtures.mjs's completeOnboarding), via
+ * chrome.storage (the WebExtension polyfill exposes `chrome.*` in Firefox
+ * too, see src/lib/browser-polyfill.min.js).
+ *
+ * @param {import('selenium-webdriver').WebDriver} driver
+ * @param {string} extensionOrigin - e.g. "moz-extension://<uuid>"
+ * @param {{enableFeature?: boolean}} [opts]
+ */
+export async function completeOnboarding(driver, extensionOrigin, { enableFeature = true } = {}) {
+  await driver.get(`${extensionOrigin}/popup/popup.html`);
+
+  await driver.executeAsyncScript(
+    (enableFeatureArg, callback) => {
+      chrome.storage.sync.set(
+        {
+          enabled: true,
+          cookieConsentMinimizerEnabled: enableFeatureArg,
+          injectOwnAffiliate: false,
+          notifyForeignAffiliate: false,
+          language: "en",
+        },
+        () => {
+          chrome.storage.local.set(
+            {
+              mugaConsent: {
+                onboardingDone: true,
+                consentVersion: "1.2",
+                consentDate: Date.now(),
+              },
+            },
+            () => {
+              chrome.storage.sync.set({ onboardingDone: true }, () => callback());
+            }
+          );
+        }
+      );
+    },
+    enableFeature
+  );
+
+  // Mirrors tests/e2e/helpers/dnr-propagation.mjs's waitForDnrPropagation:
+  // no observable signal exists for prefs-cache/DNR propagation after a
+  // storage.set call, so a short fixed settle window is used (#824 debt).
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+/**
+ * Tears down the driver and removes the temp extension directory.
+ */
+export async function teardown(driver, extDir) {
+  try {
+    if (driver) await driver.quit();
+  } finally {
+    await removeDirSafe(extDir);
+  }
+}

--- a/tests/e2e-firefox/helpers/local-server.mjs
+++ b/tests/e2e-firefox/helpers/local-server.mjs
@@ -1,0 +1,31 @@
+/**
+ * Tiny local HTTP server for Firefox e2e fixtures (#1128 slice 1).
+ *
+ * MUGA's content scripts run on http/https pages, not data:/file: URLs, so
+ * Selenium (which lacks Playwright's page.route() request interception)
+ * needs a real page served over http to exercise the extension against.
+ */
+
+import http from "node:http";
+
+/**
+ * Starts a local HTTP server on 127.0.0.1 that serves `html` for every
+ * request path.
+ *
+ * @param {string} html
+ * @returns {Promise<{url: string, close: () => Promise<void>}>}
+ */
+export async function serveFixturePage(html) {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(html);
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    url: `http://127.0.0.1:${port}/index.html`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}

--- a/tests/e2e-firefox/onetrust.smoke.mjs
+++ b/tests/e2e-firefox/onetrust.smoke.mjs
@@ -1,0 +1,124 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — OneTrust reject path (#1128
+ * slice 1, de-risking proof for a Firefox WebExtension e2e harness).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer.spec.mjs's OneTrust fixture
+ * page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.OneTrust.RejectAll()` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ *
+ * Scope: slice 1 proves the harness works end-to-end for ONE adapter
+ * (OneTrust). Extending to the other 5 adapters (Cookiebot, Didomi,
+ * CookieYes, Sourcepoint, Usercentrics) is follow-up work, not this slice.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as tests/e2e/cookie-consent-minimizer.spec.mjs's
+// stubOneTrustPage: mandatory signal (OneTrust global + RejectAll fn) plus
+// two corroborating secondary signals (banner DOM + OnetrustActiveGroups).
+const ONETRUST_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="onetrust-banner-sdk">
+    <button id="onetrust-reject-all-handler">Reject All</button>
+    <button id="onetrust-accept-btn-handler">Allow All</button>
+  </div>
+  <div id="onetrust-consent-sdk"></div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.OnetrustActiveGroups = "C0001";
+    window.OneTrust = {
+      RejectAll() {
+        window.__consentState = "necessary-only";
+        document.getElementById("onetrust-banner-sdk").remove();
+        document.getElementById("onetrust-consent-sdk").remove();
+      },
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: OneTrust RejectAll fires via wrappedJSObject when the feature is enabled", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(ONETRUST_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Poll for the dispatcher's outcome — mirrors the Chromium spec's
+    // waitForFunction(() => window.__consentState === "necessary-only").
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('onetrust-banner-sdk') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: OneTrust RejectAll does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(ONETRUST_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    // WebDriver's executeScript serializes a JS `undefined` return value as
+    // `null` over the wire (a documented Selenium/WebDriver protocol quirk,
+    // not a MUGA bug) — assert against `null`, not `undefined`.
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('onetrust-banner-sdk') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e-firefox/sourcepoint.smoke.mjs
+++ b/tests/e2e-firefox/sourcepoint.smoke.mjs
@@ -1,0 +1,131 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — Sourcepoint reject path (#1128).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs's fixture
+ * page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.__tcfapi("postRejectAll", 2, cb)` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ *
+ * Sourcepoint rides the generic IAB TCF surface (`__tcfapi`) that every
+ * TCF-compliant CMP exposes (including Didomi, already shipped) — the
+ * dispatcher requires BOTH `__tcfapi` AND the Sourcepoint-specific
+ * `div[id^="sp_message_container"]` DOM anchor (dual-mandatory) before it
+ * will act (src/lib/cmp-adapters.js).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as tests/e2e/cookie-consent-minimizer-sourcepoint.spec.mjs's
+// stubSourcepointPage: both mandatory signals (__tcfapi fn,
+// sp_message_container DOM anchor) present, plus a corroborating iframe.
+// Records every __tcfapi command invoked so the test can assert
+// "postRejectAll" specifically fired (not some other TCF command).
+const SOURCEPOINT_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="sp_message_container_1234">
+    <iframe src="https://some-account.privacy-mgmt.com/consent/some-message" title="consent"></iframe>
+    <button id="sp-btn-accept">Accept All</button>
+    <button id="sp-btn-reject">Reject All</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__tcfapiCalls = [];
+    window.__tcfapi = function (command, version, callback) {
+      window.__tcfapiCalls.push(command);
+      if (command !== "postRejectAll") {
+        if (typeof callback === "function") callback(false, false);
+        return;
+      }
+      window.__consentState = "necessary-only";
+      document.getElementById("sp_message_container_1234").remove();
+      if (typeof callback === "function") {
+        setTimeout(() => callback(true, true), 0);
+      }
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test('Firefox smoke: Sourcepoint __tcfapi("postRejectAll", ...) fires via wrappedJSObject when the feature is enabled', async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(SOURCEPOINT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    // postRejectAll was actually invoked (not some other TCF command).
+    const tcfCalls = await driver.executeScript("return window.__tcfapiCalls");
+    assert.ok(Array.isArray(tcfCalls) && tcfCalls.includes("postRejectAll"), `expected __tcfapiCalls to include "postRejectAll", got ${JSON.stringify(tcfCalls)}`);
+
+    const bannerGone = await driver.executeScript(
+      "return document.querySelector('div[id^=\"sp_message_container\"]') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: Sourcepoint __tcfapi postRejectAll does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(SOURCEPOINT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.querySelector('div[id^=\"sp_message_container\"]') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e-firefox/usercentrics.smoke.mjs
+++ b/tests/e2e-firefox/usercentrics.smoke.mjs
@@ -1,0 +1,178 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — Usercentrics reject path (#1128).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-usercentrics.spec.mjs's fixture
+ * page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.UC_UI.denyAllConsents()` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ *
+ * THE ASYNC WRINKLE: unlike the other 5 adapters, `denyAllConsents()`
+ * returns a Promise. The fixture's stub models this explicitly (a Promise
+ * resolved on a macrotask delay), so this spec exercises the fire-and-forget
+ * async path — src/content/cookie-noise.js calls
+ * `window.wrappedJSObject.UC_UI.denyAllConsents().catch(() => {})` and marks
+ * the reject as done SYNCHRONOUSLY, without awaiting the promise. This test
+ * confirms the reject still fires (polling for the async outcome) AND that
+ * the page never surfaces an unhandled error / rejection despite the
+ * Promise-returning call — Selenium has no `page.on("pageerror")`
+ * equivalent, so a `window.onerror` / `unhandledrejection` listener is
+ * installed via `executeScript` right after navigation (before the
+ * dispatcher's async gate-open/act sequence has had time to run) and polled
+ * at assertion time.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as tests/e2e/cookie-consent-minimizer-usercentrics.spec.mjs's
+// stubUsercentricsPage: both mandatory signals (UC_UI global,
+// denyAllConsents function) present, plus the #usercentrics-root DOM host as
+// the corroborating secondary signal. denyAllConsents returns a real
+// Promise (resolved on a macrotask delay) so this fixture exercises the
+// fire-and-forget async path, not a synchronous stub.
+const USERCENTRICS_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="usercentrics-root">
+    <button id="uc-btn-accept">Accept All</button>
+    <button id="uc-btn-deny">Deny All</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__ucCalls = [];
+    window.UC_UI = {
+      isInitialized: function () { return true; },
+      denyAllConsents: function () {
+        window.__ucCalls.push("denyAllConsents");
+        return new Promise(function (resolve) {
+          setTimeout(function () {
+            window.__consentState = "necessary-only";
+            document.getElementById("usercentrics-root").remove();
+            resolve(true);
+          }, 0);
+        });
+      },
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+/**
+ * Installs a window-level error/unhandledrejection collector. Called right
+ * after navigation, before the dispatcher's async gate-open/act sequence has
+ * had time to run (chrome.runtime.sendMessage + the isolated-world gate read
+ * both take at least one macrotask), so it is in place before
+ * denyAllConsents()'s promise settles.
+ */
+async function installPageErrorCollector(driver) {
+  await driver.executeScript(`
+    window.__mugaPageErrors = [];
+    window.addEventListener("error", function (e) {
+      window.__mugaPageErrors.push(String((e && e.message) || e));
+    });
+    window.addEventListener("unhandledrejection", function (e) {
+      window.__mugaPageErrors.push("unhandledrejection: " + String((e && e.reason) || e));
+    });
+  `);
+}
+
+test("Firefox smoke: Usercentrics UC_UI.denyAllConsents() fires via wrappedJSObject when the feature is enabled, no unhandled error despite the Promise-returning call", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(USERCENTRICS_FIXTURE_HTML);
+    await driver.get(server.url);
+    await installPageErrorCollector(driver);
+
+    // denyAllConsents() resolves the page's consent state asynchronously
+    // (macrotask) — poll for the outcome rather than asserting immediately,
+    // since the dispatcher's call site never awaits it either.
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    // denyAllConsents was actually invoked (not some other UC_UI method).
+    const ucCalls = await driver.executeScript("return window.__ucCalls");
+    assert.deepEqual(ucCalls, ["denyAllConsents"]);
+
+    // Banner host dismissed.
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('usercentrics-root') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+
+    // The promise returned by denyAllConsents() was never awaited by the
+    // dispatcher itself (fire-and-forget) and its rejection path (if any) is
+    // swallowed via .catch(() => {}) — no unhandled error / rejection
+    // surfaces on the page.
+    const pageErrors = await driver.executeScript("return window.__mugaPageErrors");
+    assert.deepEqual(pageErrors, []);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: Usercentrics UC_UI.denyAllConsents() does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(USERCENTRICS_FIXTURE_HTML);
+    await driver.get(server.url);
+    await installPageErrorCollector(driver);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('usercentrics-root') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+
+    const ucCalls = await driver.executeScript("return window.__ucCalls");
+    assert.deepEqual(ucCalls, []);
+
+    const pageErrors = await driver.executeScript("return window.__mugaPageErrors");
+    assert.deepEqual(pageErrors, []);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/unit/workflow-hardening.test.mjs
+++ b/tests/unit/workflow-hardening.test.mjs
@@ -43,6 +43,9 @@ describe("G1 — SHA pinning across all hardened workflows", () => {
     "auto-ingest-rules.yml",
     "validate-rules.yml",
     "cmp-canary.yml",
+    // firefox-smoke.yml added with the Firefox WebExtension smoke harness CI
+    // gate (#1128) — a new workflow must never escape this hardening net.
+    "firefox-smoke.yml",
   ];
 
   for (const file of FILES) {

--- a/tests/unit/workflows-hardened.test.mjs
+++ b/tests/unit/workflows-hardened.test.mjs
@@ -20,7 +20,9 @@ const workflowsDir = join(__dirname, "../../.github/workflows");
 // canary will be re-added when a stable fixture set is available.
 // validate-rules.yml and publish-rules.yml added in Phase 6 (T6.2, T6.3).
 // cmp-canary.yml added with the nightly CMP drift alarm (#1129).
-const WORKFLOW_FILES = ["ci.yml", "release.yml", "validate-rules.yml", "publish-rules.yml", "auto-ingest-rules.yml", "cmp-canary.yml"];
+// firefox-smoke.yml added with the Firefox WebExtension smoke harness CI
+// gate (#1128) — a new workflow must never escape this hardening net.
+const WORKFLOW_FILES = ["ci.yml", "release.yml", "validate-rules.yml", "publish-rules.yml", "auto-ingest-rules.yml", "cmp-canary.yml", "firefox-smoke.yml"];
 
 function readWorkflow(name) {
   return readFileSync(join(workflowsDir, name), "utf8");


### PR DESCRIPTION
Closes #1128

## Summary

Automated **Firefox** smoke coverage for all 6 cookie-consent adapters, closing the one real gap the Chromium e2e couldn't reach: the `window.wrappedJSObject.<CMP>.<method>()` reject paths in `src/content/cookie-noise.js`, which were structurally-tested only. Uses **Selenium WebDriver + geckodriver** (headless Firefox), the harness proven in slice 1.

Targets **`develop`**. Test/CI infrastructure only — **no runtime code touched** (`cleaner-bundle.js` diff clean). Adds `selenium-webdriver` as a devDep.

## Why Selenium (not Playwright)

Playwright core still cannot load a WebExtension in Firefox (Chromium-only, confirmed via open upstream issues). Selenium's `driver.installAddon` is a first-party, long-stable WebDriver command, and Firefox headless runs content scripts natively (no xvfb). Full rationale in the #1128 exploration.

## What it does

- `tests/e2e-firefox/` — a Selenium harness (`fixtures.mjs`: temp `src/` copy with the MV2 manifest, deterministic `moz-extension://` origin via a preset `extensions.webextensions.uuids` pref, `completeOnboarding` via `chrome.storage`) + a local `http.createServer` fixture + **6 smoke specs** (one per adapter), each porting its existing Chromium fixture and asserting the real `wrappedJSObject` reject fires in Gecko, plus a feature-OFF negative case.
- Per-adapter reject verified in real Firefox: OneTrust `RejectAll()`, Cookiebot `submitCustomConsent(false,false,false)`, Didomi `setUserDisagreeToAll()`, CookieYes `performBannerAction("reject")`, Sourcepoint `__tcfapi("postRejectAll",2,cb)`, Usercentrics `UC_UI.denyAllConsents()` (the async/Promise one — the spec also asserts no unhandled error via an injected `error`/`unhandledrejection` collector).
- `.github/workflows/firefox-smoke.yml` — runs the suite on `pull_request` ([develop, main]) + `workflow_dispatch`. **This is a deterministic gate** (local fixtures, not live sites), so unlike the nightly canary it can block a merge. ubuntu-latest + Node 20 + `browser-actions/setup-firefox` (Selenium Manager auto-provisions geckodriver). All actions SHA-pinned; `permissions: {contents: read}`.
- `firefox-smoke.yml` added to both workflow-hardening test lists (`workflows-hardened.test.mjs`, `workflow-hardening.test.mjs`) so it can't escape the SHA-pin/permissions regression net.

## Test + review

- [x] `npm run test:firefox-smoke` — **12/12 pass** (6 adapters x on/off) in real headless Firefox 152, reproducible, with and without an explicit binary override
- [x] `npm test` — 6741 pass / 0 fail / 1 pre-existing skip (hardening tests now cover `firefox-smoke.yml`; `tests/e2e-firefox/**` excluded from the unit glob)
- [x] `npm run lint:js` — clean
- [x] `build:content` drift gate — clean (no runtime code touched)
- [ ] **The ubuntu CI run on THIS PR is the verification** of `setup-firefox` PATH injection + Selenium Manager geckodriver provisioning on a fresh Linux runner — this is the one thing not verifiable locally (local proof is Windows-only). Watch the `firefox-smoke` check on this PR.

## Notes

- This introduces a second E2E toolchain (Selenium) alongside Playwright — a deliberate cost accepted to get real-Gecko coverage of the Firefox-specific `wrappedJSObject` wrapper (the only behavioral delta vs Chrome; the dispatcher logic itself is `@sync` byte-identical).
- It also means `develop` PRs now get Firefox-smoke CI, which they previously did not have.
