### PR TITLE
docs(cmp): bank canary calibration findings — annotate artifact sites + document geo limit

### DIFF
--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -45,6 +45,18 @@ To run it as part of a release:
    only prints a warning - it never fails the run, because real sites are
    flaky, geo-variant, or already-consented on a given run.
 
+**Geo limitation:** consent banners render based on the visitor's inferred
+geography, so the automated canary's vantage point matters. From a non-EU
+vantage - including the US-based GitHub Actions runners this workflow runs
+on - most EU-gated CMP banners never appear at all, and those runs land as
+`inconclusive` rather than pass or fail (see the GEO LIMITATION note in
+`tests/canary/cmp-canary.spec.mjs`, #1135). A first real-site calibration
+run confirmed this: 9 of 12 candidate sites came back inconclusive from US
+CI. This means the automated Chrome portion is a coarse, US-CI-biased
+signal, not a release gate on its own - the manual Chrome + Firefox
+checklist below, run from a correct (EU) geo vantage, remains the real
+release gate.
+
 **What this covers, and what it does not:** the automated Chrome portion
 confirms the Chrome MAIN-world detection signals fire and the reject call
 executes without the banner staying visible, on real vendor pages, in

--- a/tests/canary/cmp-canary.spec.mjs
+++ b/tests/canary/cmp-canary.spec.mjs
@@ -24,6 +24,24 @@
  *     drift and opening a tracking issue — a single flaky site never
  *     triggers an alert.
  *
+ * ── GEO LIMITATION (2026-07 calibration finding, #1135) ────────────────────
+ *
+ * Consent banners render based on the visitor's inferred geography. From a
+ * non-EU vantage point — including US-based GitHub Actions runners — most
+ * EU-gated CMP banners never appear at all, and that run is recorded as
+ * "inconclusive" per the self-validation rule above, not "fail". A first
+ * real-site calibration run (12 candidate sites) produced 1 pass / 2 fail /
+ * 9 inconclusive from this repo's US CI vantage; both "fail" results were
+ * independently confirmed (via a Playwright probe) to be a flaky vendor
+ * site and a documented fail-closed gap, not adapter drift — see the `note`
+ * fields on the cookiebot.com and heraldscotland.com entries in
+ * cmp-sites.json. Because of this geo skew, this canary is a COARSE drift
+ * alarm only — it is NOT a substitute for the manual release smoke checklist
+ * (docs/qa/cookie-consent-release-smoke.md), which a human runs from a
+ * correct (EU) geo vantage. Treat a single flaky/low-confidence "fail" as
+ * noise; a real drift signal is >=2 "fail" results on representative sites,
+ * matching the same >=2 threshold tools/canary-report.mjs already enforces.
+ *
  * This file is NOT picked up by the normal `npm run test:e2e` run —
  * playwright.config.mjs's testDir is "tests/e2e", not "tests/canary". It
  * runs only via `npm run test:canary` (playwright.canary.config.mjs) or the

--- a/tests/canary/cmp-sites.json
+++ b/tests/canary/cmp-sites.json
@@ -21,7 +21,7 @@
     "cmp": "cookiebot",
     "url": "https://www.cookiebot.com",
     "bannerSelector": "#CybotCookiebotDialog",
-    "note": "LOWER CONFIDENCE: Cookiebot's own marketing site — inferred from the industry-standard practice of CMP vendors running their own product on their own site (\"dogfooding\"), not from an independent citation. A direct WebFetch script-tag check was inconclusive because HTML-to-markdown conversion strips <script> tags before analysis; only one confidently-sourced Cookiebot site (clece.es above) was found via search. The canary's self-validation (inconclusive vs fail) covers this if wrong."
+    "note": "LOWER CONFIDENCE: Cookiebot's own marketing site — inferred from the industry-standard practice of CMP vendors running their own product on their own site (\"dogfooding\"), not from an independent citation. A Playwright probe (2026-07 calibration) confirmed the adapter's top-frame preconditions ARE present on this site (window.Cookiebot.submitCustomConsent function, window.Cookiebot.consent object, window.Cookiebot.hasResponse boolean) — the calibration run's 'fail' here was vendor-site flakiness (the probe observed the dialog as dialogVisible:false on a fresh load), not adapter drift. Replacement with a representative Cookiebot customer deployment is tracked in #1135."
   },
   {
     "cmp": "didomi",
@@ -57,7 +57,7 @@
     "cmp": "sourcepoint",
     "url": "https://www.heraldscotland.com",
     "bannerSelector": "div[id^=\"sp_message_container\"]",
-    "note": "LOWER CONFIDENCE: heraldscotland.com is a masthead of Newsquest, and Sourcepoint's own case-studies page (https://sourcepoint.com/case-studies/) names Newsquest as running Sourcepoint's \"Consent or Pay\" across 200+ Newsquest sites — the specific masthead itself is not individually named in the case study."
+    "note": "LOWER CONFIDENCE: heraldscotland.com is a masthead of Newsquest, and Sourcepoint's own case-studies page (https://sourcepoint.com/case-studies/) names Newsquest as running Sourcepoint's \"Consent or Pay\" across 200+ Newsquest sites — the specific masthead itself is not individually named in the case study. A Playwright probe (2026-07 calibration) confirmed the calibration run's 'fail' here is the documented self-hosted/proxied Sourcepoint fail-closed case: the consent message renders in an iframe on the publisher's own domain (a02342.heraldscotland.com) with no sp-prod.net/privacy-mgmt.com secondary signals, so confidence lands at 0.4, below the adapter's threshold of 1 — a deliberate NOOP, not drift. Replacement with a representative Sourcepoint deployment is tracked in #1135."
   },
   {
     "cmp": "usercentrics",


### PR DESCRIPTION
Refs #1135 (partial — site replacement not included, needs a geo-appropriate vantage).

## Summary

Documentation + annotation only, banking the verified findings from the CMP canary's first real-site calibration. **No runtime code, no test logic** (`cleaner-bundle.js` clean; only `note` text + docstrings changed). Targets `develop`.

The calibration (1 pass / 2 fail / 9 inconclusive over 12 sites) confirmed the pipeline works, OneTrust rejects on a live site, and **no adapter is broken** — both fails were investigated with a Playwright probe and explained.

## Changes

| File | Change |
|------|--------|
| `tests/canary/cmp-sites.json` | `note` on cookiebot.com (adapter preconditions confirmed present top-frame; 'fail' = vendor-site flakiness) + heraldscotland.com ('fail' = documented self-hosted Sourcepoint fail-closed, confidence 0.4 < threshold). No `cmp`/`url`/`bannerSelector` touched. |
| `tests/canary/cmp-canary.spec.mjs` | GEO LIMITATION paragraph in the docstring: banners render by visitor geo, US CI runs are mostly inconclusive, canary is a coarse alarm not a gate. |
| `docs/qa/cookie-consent-release-smoke.md` | Geo limitation note: the manual checklist (correct geo) remains the real release gate. |

## Test

- [x] `npm test` 6741 pass / 0 fail / 1 skip
- [x] lint, lint:js, check:i18n clean
- [x] `build:content` drift gate clean (no runtime code)
- [x] Self-reviewed the diff (doc-only, proportionate to the change)

Site replacement (representative Cookiebot/Sourcepoint deployments) stays open in #1135 — it needs an EU-geo vantage to validate.