### PR TITLE
feat(consent): add Cookie Information Tier 1 adapter

### DIFF
--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -2,8 +2,9 @@
 
 ## Why this exists
 
-The 6 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
-Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics) are unit-green:
+The 7 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
+Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information)
+are unit-green:
 every detection truth table, every reject call shape, and every
 never-auto-accept structural guard is covered by `npm test`. Unit-green is
 not the same thing as real-env-green. Every adapter's merge PR shipped with
@@ -284,9 +285,39 @@ following before marking this adapter PASS:
       across third-party sources per PR #1127 - note the finding either
       way, do not silently assume).
 
+### 7. Cookie Information
+
+- **Reject call:** `window.CookieInformation.declineAllCategories()` (Chrome
+  MAIN world); `window.wrappedJSObject.CookieInformation.declineAllCategories()`
+  (Firefox). Synchronous, zero-argument, void return — same call shape as
+  `Didomi.setUserDisagreeToAll()`; there is no consent-granting parameter on
+  this call at all.
+- **Detection signals:** mandatory `hasCookieInformationGlobal`
+  (`typeof window.CookieInformation === "object"`) + `hasDeclineAllCategoriesFn`
+  (`typeof window.CookieInformation.declineAllCategories === "function"`);
+  corroborating (>=1 required): `hasCoiOverlayDom` (`#coiOverlay`),
+  `hasCoiConsentBannerDom` (`#coiConsentBanner`), `hasCoiSummeryDom`
+  (`#coiSummery`), `hasCoiBannerWrapperDom` (`#coi-banner-wrapper`),
+  `hasCoiConsentSummaryDom` (`.coi-consent-summary`).
+- **Candidate live site(s):** `https://cookieinformation.com` (PLACEHOLDER —
+  UNVERIFIED, needs curation; vendor's own site, banner selector
+  `#coiOverlay, #coiConsentBanner, #coiSummery, #coi-banner-wrapper,
+  .coi-consent-summary`). Replace with an independently-confirmed customer
+  deployment before treating this as a release gate.
+- **Specific risk to verify:** Firefox `wrappedJSObject` reject path and
+  live-Cookie-Information compatibility are structurally tested only (the
+  Chromium e2e fixture is a regression oracle, not a real-vendor test) —
+  confirm `declineAllCategories()` actually clears the banner on a live
+  site, not just in the fixture. Also confirm the discrimination note
+  holds: this vendor can additionally expose the generic `__tcfapi` surface
+  (opt-in per site) without this adapter or the Sourcepoint adapter
+  misfiring on each other.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
 ## Sign-off table
 
-All 12 cells (6 adapters x Chrome/Firefox) must be green before the
+All 14 cells (7 adapters x Chrome/Firefox) must be green before the
 `develop -> main` release PR opens.
 
 | Adapter | Chrome | Firefox |
@@ -297,5 +328,6 @@ All 12 cells (6 adapters x Chrome/Firefox) must be green before the
 | CookieYes | ____ | ____ |
 | Sourcepoint | ____ | ____ |
 | Usercentrics | ____ | ____ |
+| Cookie Information | ____ | ____ |
 
 Reviewer: ______________________  Date: ______________________

--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -78,7 +78,7 @@ sites (`src/content/cookie-noise-mainworld.js` for Chrome MAIN world,
 `tests/canary/cmp-sites.json` - do not test against a different site
 without first adding it there.
 
-General Chrome steps (same shape for all 6 adapters unless noted):
+General Chrome steps (same shape for all 7 adapters unless noted):
 
 1. `npm run build:content` then load the unpacked extension from `src/`
    in `chrome://extensions` (Developer mode > Load unpacked).
@@ -93,7 +93,7 @@ General Chrome steps (same shape for all 6 adapters unless noted):
    inspector (where available) to confirm the resulting consent state is
    reject / necessary-only, not accept.
 
-General Firefox steps (same shape for all 6 adapters unless noted):
+General Firefox steps (same shape for all 7 adapters unless noted):
 manual only, automation is tracked separately in #1128.
 
 1. `bash scripts/with-firefox-manifest.sh npm run build:content` then load

--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -144,6 +144,33 @@
   function canRejectUsercentrics(signals) {
     return detectUsercentrics(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // Cookie Information: window.CookieInformation is a vendor-namespaced
+  // global (like OneTrust/Didomi/UC_UI), so this mirrors detectDidomi's shape
+  // (mandatory global + mandatory reject-fn signal, plus >=1 corroborating
+  // secondary signal). Do NOT key off __tcfapi — see the discrimination
+  // rationale above detectCookieInformation in the docblock preceding this
+  // sync block.
+  function detectCookieInformation(signals) {
+    if (
+      !signals ||
+      signals.hasCookieInformationGlobal !== true ||
+      signals.hasDeclineAllCategoriesFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCoiOverlayDom === true ? 1 : 0) +
+      (signals.hasCoiConsentBannerDom === true ? 1 : 0) +
+      (signals.hasCoiSummeryDom === true ? 1 : 0) +
+      (signals.hasCoiBannerWrapperDom === true ? 1 : 0) +
+      (signals.hasCoiConsentSummaryDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookieInformation(signals) {
+    return detectCookieInformation(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -290,6 +317,34 @@
     } catch {
       // ignore
     }
+    // Cookie Information: window.CookieInformation is a vendor-namespaced
+    // global. Do NOT key off the generic __tcfapi surface (hasTcfApiFn,
+    // already collected above) — this vendor's TCF surface is opt-in per
+    // site and is Sourcepoint's dual-mandatory anchor, not this adapter's.
+    let hasCookieInformationGlobal = false;
+    let hasDeclineAllCategoriesFn = false;
+    try {
+      hasCookieInformationGlobal =
+        typeof window.CookieInformation === "object" && window.CookieInformation !== null;
+      hasDeclineAllCategoriesFn =
+        hasCookieInformationGlobal && typeof window.CookieInformation.declineAllCategories === "function";
+    } catch {
+      // Leave both false — fail-closed.
+    }
+    let hasCoiOverlayDom = false;
+    let hasCoiConsentBannerDom = false;
+    let hasCoiSummeryDom = false;
+    let hasCoiBannerWrapperDom = false;
+    let hasCoiConsentSummaryDom = false;
+    try {
+      hasCoiOverlayDom = !!document.getElementById("coiOverlay");
+      hasCoiConsentBannerDom = !!document.getElementById("coiConsentBanner");
+      hasCoiSummeryDom = !!document.getElementById("coiSummery");
+      hasCoiBannerWrapperDom = !!document.getElementById("coi-banner-wrapper");
+      hasCoiConsentSummaryDom = !!document.querySelector(".coi-consent-summary");
+    } catch {
+      // document not ready / detached — leave all false.
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -319,6 +374,13 @@
       hasDenyAllConsentsFn,
       hasUsercentricsRootDom,
       hasIsInitializedFn,
+      hasCookieInformationGlobal,
+      hasDeclineAllCategoriesFn,
+      hasCoiOverlayDom,
+      hasCoiConsentBannerDom,
+      hasCoiSummeryDom,
+      hasCoiBannerWrapperDom,
+      hasCoiConsentSummaryDom,
     };
   }
 
@@ -417,6 +479,20 @@
       _acted = true;
       try {
         window.UC_UI.denyAllConsents().catch(() => {});
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: Cookie Information API adapter. Same zero-argument,
+    // synchronous reject-call shape as OneTrust.RejectAll() /
+    // Didomi.setUserDisagreeToAll() — declineAllCategories() takes no
+    // consent-granting parameter at all.
+    if (canRejectCookieInformation(signals)) {
+      _acted = true;
+      try {
+        window.CookieInformation.declineAllCategories();
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -141,6 +141,33 @@
   function canRejectUsercentrics(signals) {
     return detectUsercentrics(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // Cookie Information: window.CookieInformation is a vendor-namespaced
+  // global (like OneTrust/Didomi/UC_UI), so this mirrors detectDidomi's shape
+  // (mandatory global + mandatory reject-fn signal, plus >=1 corroborating
+  // secondary signal). Do NOT key off __tcfapi — see the discrimination
+  // rationale above detectCookieInformation in the docblock preceding this
+  // sync block.
+  function detectCookieInformation(signals) {
+    if (
+      !signals ||
+      signals.hasCookieInformationGlobal !== true ||
+      signals.hasDeclineAllCategoriesFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCoiOverlayDom === true ? 1 : 0) +
+      (signals.hasCoiConsentBannerDom === true ? 1 : 0) +
+      (signals.hasCoiSummeryDom === true ? 1 : 0) +
+      (signals.hasCoiBannerWrapperDom === true ? 1 : 0) +
+      (signals.hasCoiConsentSummaryDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookieInformation(signals) {
+    return detectCookieInformation(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -337,6 +364,36 @@
     } catch {
       // ignore
     }
+    // Cookie Information: window.CookieInformation is a vendor-namespaced
+    // global, reached via wrappedJSObject — same Xray-safety pattern as the
+    // other Firefox signal reads above. Do NOT key off the generic __tcfapi
+    // surface (hasTcfApiFn, already collected above) — this vendor's TCF
+    // surface is opt-in per site and is Sourcepoint's dual-mandatory
+    // anchor, not this adapter's.
+    let hasCookieInformationGlobal = false;
+    let hasDeclineAllCategoriesFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const ci = wrapped && wrapped.CookieInformation;
+      hasCookieInformationGlobal = typeof ci === "object" && ci !== null;
+      hasDeclineAllCategoriesFn = hasCookieInformationGlobal && typeof ci.declineAllCategories === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasCoiOverlayDom = false;
+    let hasCoiConsentBannerDom = false;
+    let hasCoiSummeryDom = false;
+    let hasCoiBannerWrapperDom = false;
+    let hasCoiConsentSummaryDom = false;
+    try {
+      hasCoiOverlayDom = !!document.getElementById("coiOverlay");
+      hasCoiConsentBannerDom = !!document.getElementById("coiConsentBanner");
+      hasCoiSummeryDom = !!document.getElementById("coiSummery");
+      hasCoiBannerWrapperDom = !!document.getElementById("coi-banner-wrapper");
+      hasCoiConsentSummaryDom = !!document.querySelector(".coi-consent-summary");
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -366,6 +423,13 @@
       hasDenyAllConsentsFn,
       hasUsercentricsRootDom,
       hasIsInitializedFn,
+      hasCookieInformationGlobal,
+      hasDeclineAllCategoriesFn,
+      hasCoiOverlayDom,
+      hasCoiConsentBannerDom,
+      hasCoiSummeryDom,
+      hasCoiBannerWrapperDom,
+      hasCoiConsentSummaryDom,
     };
   }
 
@@ -444,6 +508,19 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.UC_UI.denyAllConsents().catch(() => {});
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: Cookie Information API adapter. Same zero-argument,
+    // synchronous reject-call shape as OneTrust.RejectAll() /
+    // Didomi.setUserDisagreeToAll() — see cookie-noise-mainworld.js.
+    if (canRejectCookieInformation(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.CookieInformation.declineAllCategories();
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -100,6 +100,19 @@
  *   queryable). Secondary/corroborating signal.
  * @property {boolean} [hasIsInitializedFn] - `typeof window.UC_UI.isInitialized === "function"`.
  *   Secondary/corroborating signal.
+ * @property {boolean} [hasCookieInformationGlobal] - `typeof window.CookieInformation === "object"`.
+ * @property {boolean} [hasDeclineAllCategoriesFn] - `typeof window.CookieInformation.declineAllCategories === "function"`.
+ *   Mandatory signal: without this, no reject action can be confirmed.
+ * @property {boolean} [hasCoiOverlayDom] - `#coiOverlay` present in the DOM.
+ *   Secondary/corroborating signal.
+ * @property {boolean} [hasCoiConsentBannerDom] - `#coiConsentBanner` present
+ *   in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCoiSummeryDom] - `#coiSummery` present in the DOM.
+ *   Secondary/corroborating signal.
+ * @property {boolean} [hasCoiBannerWrapperDom] - `#coi-banner-wrapper`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCoiConsentSummaryDom] - `.coi-consent-summary`
+ *   present in the DOM. Secondary/corroborating signal.
  */
 
 /**
@@ -173,6 +186,18 @@ export const ACTIONS = Object.freeze({
  * (a separate, rarer Usercentrics integration mode) and would either
  * collide with Sourcepoint/Didomi discrimination or fail to discriminate
  * at all.
+ *
+ * The Cookie Information adapter reuses the OneTrust/Didomi/Usercentrics
+ * shape again: `window.CookieInformation` is a vendor-namespaced global, so
+ * detectCookieInformation requires the mandatory `hasCookieInformationGlobal`
+ * + `hasDeclineAllCategoriesFn` pair plus >=1 corroborating DOM secondary
+ * (`#coiOverlay`, `#coiConsentBanner`, `#coiSummery`, `#coi-banner-wrapper`,
+ * `.coi-consent-summary`) — same fail-closed confidence gate, same
+ * threshold. Do NOT key detection off `window.__tcfapi`: Cookie Information
+ * can ALSO expose the generic IAB TCF surface (opt-in per site via
+ * `data-tcf-v2-enabled`), which is Sourcepoint's dual-mandatory anchor
+ * above, not this adapter's. Detection here is keyed ONLY off the
+ * `window.CookieInformation` vendor global + `declineAllCategories`.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -277,6 +302,33 @@ function detectUsercentrics(signals) {
 
 function canRejectUsercentrics(signals) {
   return detectUsercentrics(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+// Cookie Information: window.CookieInformation is a vendor-namespaced
+// global (like OneTrust/Didomi/UC_UI), so this mirrors detectDidomi's shape
+// (mandatory global + mandatory reject-fn signal, plus >=1 corroborating
+// secondary signal). Do NOT key off __tcfapi — see the discrimination
+// rationale above detectCookieInformation in the docblock preceding this
+// sync block.
+function detectCookieInformation(signals) {
+  if (
+    !signals ||
+    signals.hasCookieInformationGlobal !== true ||
+    signals.hasDeclineAllCategoriesFn !== true
+  ) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasCoiOverlayDom === true ? 1 : 0) +
+    (signals.hasCoiConsentBannerDom === true ? 1 : 0) +
+    (signals.hasCoiSummeryDom === true ? 1 : 0) +
+    (signals.hasCoiBannerWrapperDom === true ? 1 : 0) +
+    (signals.hasCoiConsentSummaryDom === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectCookieInformation(signals) {
+  return detectCookieInformation(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -432,6 +484,32 @@ export const usercentricsAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * Cookie Information Tier 1 adapter. The reject call
+ * (`window.CookieInformation.declineAllCategories()`) is invoked by the
+ * caller-supplied callback via the shared `reject()` helper above — this
+ * adapter definition never touches `window` itself. Same call shape as
+ * `oneTrustAdapter.RejectAll()` / `didomiAdapter.setUserDisagreeToAll()`:
+ * synchronous, zero arguments, void return — the library's own default
+ * decline button listens for click and calls this exact method (a core SDK
+ * global method, not gated behind custom-template opt-in). Independent of
+ * IAB TCF (`window.__tcfapi`, which for this vendor is additionally opt-in
+ * per site) — see detectCookieInformation's discrimination rationale above.
+ *
+ * Registered LAST in TIER1 (after usercentricsAdapter): `window.CookieInformation`
+ * is a direct, unambiguous vendor-namespaced global (like Didomi's/UC_UI's),
+ * so ordering relative to the other adapters is not safety-critical either
+ * way — appended at the end to keep the registry's history append-only.
+ * @type {Readonly<{id: "cookieinformation", tier: 1, detect: typeof detectCookieInformation, canReject: typeof canRejectCookieInformation, reject: typeof reject}>}
+ */
+export const cookieInformationAdapter = Object.freeze({
+  id: "cookieinformation",
+  tier: 1,
+  detect: detectCookieInformation,
+  canReject: canRejectCookieInformation,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
 export const TIER1 = Object.freeze([
   oneTrustAdapter,
@@ -440,6 +518,7 @@ export const TIER1 = Object.freeze([
   cookieYesAdapter,
   sourcepointAdapter,
   usercentricsAdapter,
+  cookieInformationAdapter,
 ]);
 
 /**
@@ -500,6 +579,12 @@ export function decideAction(signals) {
   // Usercentrics (#1121) hard wall: same shape as the OneTrust/Didomi
   // checks above (mandatory global present, mandatory reject fn absent).
   if (s.hasUcUiGlobal === true && s.hasDenyAllConsentsFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  // Cookie Information hard wall: same shape as the OneTrust/Didomi/
+  // Usercentrics checks above (mandatory global present, mandatory reject
+  // fn absent).
+  if (s.hasCookieInformationGlobal === true && s.hasDeclineAllCategoriesFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/canary/cmp-sites.json
+++ b/tests/canary/cmp-sites.json
@@ -70,5 +70,11 @@
     "url": "https://www.conrad.de",
     "bannerSelector": "#usercentrics-root",
     "note": "Conrad Electronic is named as a Usercentrics case study customer (https://usercentrics.com/case-studies/, \"Conrad Electronic — Privacy compliance at scale\")."
+  },
+  {
+    "cmp": "cookieinformation",
+    "url": "https://cookieinformation.com",
+    "bannerSelector": "#coiOverlay, #coiConsentBanner, #coiSummery, #coi-banner-wrapper, .coi-consent-summary",
+    "note": "PLACEHOLDER — UNVERIFIED, needs curation. Cookie Information's own marketing site, following the same dogfooding-inference pattern used for the Cookiebot entry above (CMP vendors commonly run their own product on their own site). Not independently confirmed via script inspection. Replace with a representative, independently-confirmed Cookie Information customer deployment before relying on this entry for release gating — curation is tracked as a follow-up, separate from adapter correctness."
   }
 ]

--- a/tests/e2e-firefox/cookieinformation.smoke.mjs
+++ b/tests/e2e-firefox/cookieinformation.smoke.mjs
@@ -1,0 +1,121 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — Cookie Information reject path.
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookieinformation.spec.mjs's
+ * fixture page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.CookieInformation.declineAllCategories()` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as
+// tests/e2e/cookie-consent-minimizer-cookieinformation.spec.mjs's
+// stubCookieInformationPage: mandatory signal (CookieInformation global +
+// declineAllCategories fn) plus the #coiOverlay DOM anchor as the
+// corroborating secondary signal.
+const COOKIEINFORMATION_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="coiOverlay">
+    <button id="coi-accept-button">Accept all</button>
+    <button id="declineButton">Decline</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__ciCalls = [];
+    window.CookieInformation = {
+      declineAllCategories() {
+        window.__ciCalls.push("declineAllCategories");
+        window.__consentState = "necessary-only";
+        document.getElementById("coiOverlay").remove();
+      },
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: Cookie Information declineAllCategories() fires via wrappedJSObject when the feature is enabled", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(COOKIEINFORMATION_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const ciCalls = await driver.executeScript("return window.__ciCalls");
+    assert.deepEqual(ciCalls, ["declineAllCategories"]);
+
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('coiOverlay') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: Cookie Information declineAllCategories() does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(COOKIEINFORMATION_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('coiOverlay') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+
+    const ciCalls = await driver.executeScript("return window.__ciCalls");
+    assert.deepEqual(ciCalls, []);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e/cookie-consent-minimizer-cookieinformation.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-cookieinformation.spec.mjs
@@ -1,0 +1,214 @@
+/**
+ * E2E: Cookie Consent Minimizer — Cookie Information Tier 1 adapter
+ *
+ * Verifies the Cookie Information reject path against a real Chromium with
+ * the extension loaded. The fixture page mimics a Cookie Information
+ * banner: a `window.CookieInformation` object with a
+ * `declineAllCategories()` method plus the `#coiOverlay` DOM anchor — the
+ * mandatory-plus-corroboration signal combination the dispatcher requires
+ * before acting (src/lib/cmp-adapters.js).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-didomi.spec.mjs's structure
+ * exactly (same onboarding helper shape, same feature pref, same
+ * zero-argument synchronous reject-call shape).
+ *
+ * HONEST LIMIT: this is a REGRESSION oracle only — a snapshot of one
+ * fixture's behavior at write time. It proves the Chrome MAIN-world nonce
+ * handshake (content/cookie-noise-mainworld.js) and the
+ * never-auto-reject-the-other-way outcome on the fixture used here. It does
+ * NOT validate the Firefox `window.wrappedJSObject` reject path
+ * (content/cookie-noise.js) — Playwright's `chromium` fixture only exercises
+ * Chrome — and it does NOT prove real-vendor-script compatibility against a
+ * live Cookie Information CMP build. A real-browser smoke test against at
+ * least one live Cookie Information deployment is required before
+ * considering this adapter done — flagged for sdd-verify. Re-capture this
+ * fixture manually whenever the Cookie Information markup/API shape this
+ * test hardcodes changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-cookieinformation.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode: enableFeature ? "reject-only" : "off" },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a Cookie Information banner offering a reject-all via
+ * `declineAllCategories()`. The mandatory `declineAllCategories` function is
+ * present alongside the `#coiOverlay` DOM anchor — the confidence gate in
+ * cmp-adapters.js requires the mandatory signal plus at least one
+ * corroborating DOM secondary.
+ */
+async function stubCookieInformationPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="coiOverlay">
+          <button id="coi-accept-button">Accept all</button>
+          <button id="declineButton">Decline</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__ciCalls = [];
+          window.CookieInformation = {
+            declineAllCategories() {
+              window.__ciCalls.push("declineAllCategories");
+              window.__consentState = "necessary-only";
+              document.getElementById("coiOverlay").remove();
+            },
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — Cookie Information", () => {
+  test("rejects a Cookie Information banner with declineAllCategories() when the feature is enabled", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubCookieInformationPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // declineAllCategories was actually invoked (not some other method).
+    const ciCalls = await page.evaluate(() => window.__ciCalls);
+    expect(ciCalls).toEqual(["declineAllCategories"]);
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(() => document.getElementById("coiOverlay") === null);
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubCookieInformationPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(() => document.getElementById("coiOverlay") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    const ciCalls = await page.evaluate(() => window.__ciCalls);
+    expect(ciCalls).toEqual([]);
+
+    await page.close();
+  });
+
+  test("never misfires on a Didomi-only page (no CookieInformation global present)", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    const DIDOMI_HOST = "muga-test-cookie-consent-cookieinformation-didomi-guard.invalid";
+    await page.route(`**://${DIDOMI_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <div id="didomi-host"></div>
+          <p id="page-content">Real page content</p>
+          <script>
+            // A Didomi-shaped page: exposes window.Didomi.setUserDisagreeToAll
+            // but NO window.CookieInformation global at all. The Cookie
+            // Information adapter must never act here.
+            window.__didomiCalls = [];
+            window.Didomi = {
+              getCurrentUserStatus: function () { return {}; },
+              setUserDisagreeToAll: function () {
+                window.__didomiCalls.push("setUserDisagreeToAll");
+              },
+            };
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${DIDOMI_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The Didomi adapter IS expected to fire here (it is a real Didomi
+    // page) — what this test guards is that the Cookie Information adapter
+    // never ALSO claims it / never references CookieInformation on a page
+    // that has none.
+    await page.waitForFunction(
+      () => Array.isArray(window.__didomiCalls) && window.__didomiCalls.includes("setUserDisagreeToAll"),
+      { timeout: 10000 }
+    );
+
+    const ciGlobalPresent = await page.evaluate(() => typeof window.CookieInformation !== "undefined");
+    expect(ciGlobalPresent).toBe(false);
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -29,6 +29,7 @@ import {
   cookieYesAdapter,
   sourcepointAdapter,
   usercentricsAdapter,
+  cookieInformationAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -38,14 +39,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint and Usercentrics adapters, in order", () => {
-    assert.equal(TIER1.length, 6);
+  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics and Cookie Information adapters, in order", () => {
+    assert.equal(TIER1.length, 7);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
     assert.strictEqual(TIER1[2], didomiAdapter);
     assert.strictEqual(TIER1[3], cookieYesAdapter);
     assert.strictEqual(TIER1[4], sourcepointAdapter);
     assert.strictEqual(TIER1[5], usercentricsAdapter);
+    assert.strictEqual(TIER1[6], cookieInformationAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -104,6 +106,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof usercentricsAdapter.detect, "function");
     assert.equal(typeof usercentricsAdapter.canReject, "function");
     assert.equal(typeof usercentricsAdapter.reject, "function");
+  });
+
+  test("cookieInformationAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(cookieInformationAdapter.id, "cookieinformation");
+    assert.equal(cookieInformationAdapter.tier, 1);
+    assert.equal(typeof cookieInformationAdapter.detect, "function");
+    assert.equal(typeof cookieInformationAdapter.canReject, "function");
+    assert.equal(typeof cookieInformationAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -407,6 +417,58 @@ describe("decideAction — truth table", () => {
     assert.equal(r.action, ACTIONS.REJECT_ALL);
     assert.equal(r.reason, "reject");
     assert.equal(r.adapterId, "sourcepoint");
+  });
+
+  test("Cookie Information: CookieInformation global + declineAllCategories fn + corroborating DOM -> reject", () => {
+    const r = decideAction({
+      hasCookieInformationGlobal: true,
+      hasDeclineAllCategoriesFn: true,
+      hasCoiOverlayDom: true,
+      hasCoiConsentBannerDom: false,
+      hasCoiSummeryDom: false,
+      hasCoiBannerWrapperDom: false,
+      hasCoiConsentSummaryDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "cookieinformation");
+  });
+
+  test("Cookie Information: global present but declineAllCategories absent (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasCookieInformationGlobal: true,
+      hasDeclineAllCategoriesFn: false,
+      hasCoiOverlayDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("Cookie Information: mandatory signals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasCookieInformationGlobal: true,
+      hasDeclineAllCategoriesFn: true,
+      hasCoiOverlayDom: false,
+      hasCoiConsentBannerDom: false,
+      hasCoiSummeryDom: false,
+      hasCoiBannerWrapperDom: false,
+      hasCoiConsentSummaryDom: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("Cookie Information: __tcfapi ALSO present (opt-in TCF mode) still resolves to cookieinformation, never misfires as Sourcepoint/uncertain", () => {
+    const r = decideAction({
+      hasCookieInformationGlobal: true,
+      hasDeclineAllCategoriesFn: true,
+      hasCoiOverlayDom: true,
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "cookieinformation");
   });
 });
 
@@ -797,6 +859,82 @@ describe("usercentricsAdapter.detect — dual-mandatory confidence gate", () => 
   });
 });
 
+describe("cookieInformationAdapter.detect — confidence gate", () => {
+  const FULL_COI_SIGNALS = Object.freeze({
+    hasCookieInformationGlobal: true,
+    hasDeclineAllCategoriesFn: true,
+    hasCoiOverlayDom: true,
+    hasCoiConsentBannerDom: true,
+    hasCoiSummeryDom: true,
+    hasCoiBannerWrapperDom: true,
+    hasCoiConsentSummaryDom: true,
+  });
+
+  test("mandatory + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = cookieInformationAdapter.detect(FULL_COI_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(cookieInformationAdapter.canReject(FULL_COI_SIGNALS), true);
+  });
+
+  test("mandatory + exactly one secondary (#coiOverlay only) -> canReject true", () => {
+    const s = {
+      hasCookieInformationGlobal: true,
+      hasDeclineAllCategoriesFn: true,
+      hasCoiOverlayDom: true,
+      hasCoiConsentBannerDom: false,
+      hasCoiSummeryDom: false,
+      hasCoiBannerWrapperDom: false,
+      hasCoiConsentSummaryDom: false,
+    };
+    assert.equal(cookieInformationAdapter.canReject(s), true);
+  });
+
+  test("mandatory + exactly one secondary (.coi-consent-summary only) -> canReject true", () => {
+    const s = {
+      hasCookieInformationGlobal: true,
+      hasDeclineAllCategoriesFn: true,
+      hasCoiOverlayDom: false,
+      hasCoiConsentBannerDom: false,
+      hasCoiSummeryDom: false,
+      hasCoiBannerWrapperDom: false,
+      hasCoiConsentSummaryDom: true,
+    };
+    assert.equal(cookieInformationAdapter.canReject(s), true);
+  });
+
+  test("global-only (mandatory present, zero secondary signals) -> uncertain, canReject false", () => {
+    const s = {
+      hasCookieInformationGlobal: true,
+      hasDeclineAllCategoriesFn: true,
+      hasCoiOverlayDom: false,
+      hasCoiConsentBannerDom: false,
+      hasCoiSummeryDom: false,
+      hasCoiBannerWrapperDom: false,
+      hasCoiConsentSummaryDom: false,
+    };
+    assert.equal(cookieInformationAdapter.canReject(s), false);
+    assert.ok(cookieInformationAdapter.detect(s) < 1);
+  });
+
+  test("DOM-only (mandatory declineAllCategories fn missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasCookieInformationGlobal: false,
+      hasDeclineAllCategoriesFn: false,
+      hasCoiOverlayDom: true,
+      hasCoiConsentBannerDom: true,
+      hasCoiSummeryDom: true,
+    };
+    assert.equal(cookieInformationAdapter.detect(s), 0);
+    assert.equal(cookieInformationAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => cookieInformationAdapter.detect(null));
+    assert.doesNotThrow(() => cookieInformationAdapter.detect(undefined));
+    assert.equal(cookieInformationAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -932,6 +1070,25 @@ describe("usercentricsAdapter.reject — pure callback invocation", () => {
     // already swallowed it) and must not throw here.
     settleReject(new Error("denyAllConsents rejected"));
     await promise.catch(() => {});
+  });
+});
+
+describe("cookieInformationAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = cookieInformationAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = cookieInformationAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = cookieInformationAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
   });
 });
 
@@ -1096,5 +1253,15 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
     assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
     assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
     assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
+  });
+
+  test("cookieInformationAdapter is registered in TIER1 alongside the other six adapters", () => {
+    assert.ok(TIER1.includes(cookieInformationAdapter), "TIER1 must include cookieInformationAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
+    assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
+    assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
+    assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must still include usercentricsAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -130,6 +130,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectUsercentrics/.test(joined));
     assert.ok(/function canRejectUsercentrics/.test(joined));
   });
+
+  test("sync block also defines detectCookieInformation and canRejectCookieInformation", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectCookieInformation/.test(joined));
+    assert.ok(/function canRejectCookieInformation/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -417,6 +423,28 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
         /denyAllConsents\(\)\s*\.catch\s*\(/.test(src),
         `${label} must chain .catch(...) directly onto the denyAllConsents() call`,
       );
+    }
+  });
+
+  test("only CookieInformation.declineAllCategories (or wrappedJSObject equivalent) is invoked — no other CookieInformation method call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/CookieInformation\.(\w+)\s*\(/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call CookieInformation.declineAllCategories`);
+      for (const fn of calls) {
+        assert.equal(fn, "declineAllCategories", `${label} calls CookieInformation.${fn}() — only declineAllCategories is permitted`);
+      }
+    }
+  });
+
+  test("every declineAllCategories call passes zero arguments", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/declineAllCategories\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call declineAllCategories`);
+      for (const args of calls) {
+        assert.equal(args, "", `${label} declineAllCategories must be called with zero arguments`);
+      }
     }
   });
 });

--- a/tests/unit/release-smoke-report.test.mjs
+++ b/tests/unit/release-smoke-report.test.mjs
@@ -231,6 +231,6 @@ describe("release-smoke-report — importing the module never triggers CLI/files
     assert.equal(typeof mod.formatReleaseTable, "function");
     assert.equal(typeof mod.runReleaseSmokeReportCli, "function");
     assert.ok(Array.isArray(mod.RELEASE_CMPS));
-    assert.equal(mod.RELEASE_CMPS.length, 6);
+    assert.equal(mod.RELEASE_CMPS.length, 7);
   });
 });

--- a/tools/release-smoke-report.mjs
+++ b/tools/release-smoke-report.mjs
@@ -5,9 +5,9 @@
  * Reduces the existing CMP canary results (tests/canary/cmp-sites.json +
  * tools/canary-report.mjs's `test-results/canary-results.json` schema,
  * `{cmp, url, status: "pass"|"fail"|"inconclusive", detail}`) into a
- * per-adapter RELEASE verdict for the 6 Tier 1 cookie-consent adapters
+ * per-adapter RELEASE verdict for the 7 Tier 1 cookie-consent adapters
  * (src/lib/cmp-adapters.js TIER1: onetrust, cookiebot, didomi, cookieyes,
- * sourcepoint, usercentrics).
+ * sourcepoint, usercentrics, cookieinformation).
  *
  * This does NOT run the canary itself — see tools/canary-report.mjs for
  * that (drift-alarm reporting) and .github/workflows/cmp-canary.yml (the
@@ -28,7 +28,7 @@
  * decision logic vs. CLI I/O boundary).
  *
  * Public API (named exports only — no default):
- *   RELEASE_CMPS → the 6 Tier 1 CMP ids, in cmp-adapters.js TIER1 order.
+ *   RELEASE_CMPS → the 7 Tier 1 CMP ids, in cmp-adapters.js TIER1 order.
  *   summarizeRelease(results) → Record<string, {verdict, passCount, failCount, inconclusiveCount, sites}>
  *   formatReleaseTable(summary) → string
  *
@@ -46,7 +46,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Pure decision logic ───────────────────────────────────────────────────
 
 /**
- * The 6 Tier 1 cookie-consent CMP ids, in the same order as
+ * The 7 Tier 1 cookie-consent CMP ids, in the same order as
  * src/lib/cmp-adapters.js's TIER1 registry.
  * @type {ReadonlyArray<string>}
  */
@@ -57,6 +57,7 @@ export const RELEASE_CMPS = Object.freeze([
   "cookieyes",
   "sourcepoint",
   "usercentrics",
+  "cookieinformation",
 ]);
 
 function emptyBucket() {
@@ -71,8 +72,8 @@ function emptyBucket() {
  * (canary run never covered it, or the results file is empty/missing)
  * still shows up as UNVERIFIED rather than silently disappearing. Any
  * other `cmp` value present in `results` is also tracked defensively
- * (forward-compatible with a 7th adapter before this file's RELEASE_CMPS
- * list is updated), just not required to be READY for `formatReleaseTable`
+ * (forward-compatible with a not-yet-registered adapter before this file's
+ * RELEASE_CMPS list is updated), just not required to be READY for `formatReleaseTable`
  * to render cleanly.
  *
  * Pure: no I/O, no Date.now(). Never throws on well-formed input;


### PR DESCRIPTION
Relates to #1140, #1027. First of a 2-PR chain (#1140).

## Summary
New Tier 1 API adapter for **Cookie Information**, mirroring the 6 existing adapters. Reject-only, no accept, no DOM clicking.
- Reject: `window.CookieInformation.declineAllCategories()` (zero-arg, synchronous).
- Detect: mandatory `window.CookieInformation` vendor global + `declineAllCategories` fn + >=1 DOM secondary (`#coiOverlay`/`#coiConsentBanner`/`#coiSummery`/`#coi-banner-wrapper`/`.coi-consent-summary`), threshold 1, fail-closed.
- Discrimination: keys ONLY off the vendor global, NEVER `__tcfapi` (Cookie Information can expose opt-in IAB TCF, which is Sourcepoint's anchor). Test proves a CI page with `__tcfapi` still resolves to cookieinformation.
- Enrolls in the automated release-smoke gate (RELEASE_CMPS 6->7; 7 adapters / 14 cells).

## Test plan
- `npm test` 6809 pass / 0 fail / 1 pre-existing skip; new detect/canReject/decideAction (reject + hard-wall + uncertain) unit tests, e2e stub (incl. feature-OFF negative + cross-CMP misfire guard), Firefox smoke.
- `npm run lint` / `lint:js` / `check:i18n` clean; bundle-drift clean.
- Never-accept spine byte-unchanged (ACTIONS still {REJECT_ALL}; literal-arg guard pins `declineAllCategories()` to zero args).

## Notes
- Adversarial review passed (null-safety, @sync byte-identity, discrimination, spine all confirmed).
- Manual-smoke open item: confirm `declineAllCategories()` is sync/void on a real vendor page (no `.catch()` guard, by design).
- Canary entry uses the vendor site as a PLACEHOLDER (needs EU-geo curation).