### PR TITLE
feat(consent): add CookieScript Tier 1 adapter

### DIFF
--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -78,7 +78,7 @@ sites (`src/content/cookie-noise-mainworld.js` for Chrome MAIN world,
 `tests/canary/cmp-sites.json` - do not test against a different site
 without first adding it there.
 
-General Chrome steps (same shape for all 7 adapters unless noted):
+General Chrome steps (same shape for all 8 adapters unless noted):
 
 1. `npm run build:content` then load the unpacked extension from `src/`
    in `chrome://extensions` (Developer mode > Load unpacked).
@@ -93,7 +93,7 @@ General Chrome steps (same shape for all 7 adapters unless noted):
    inspector (where available) to confirm the resulting consent state is
    reject / necessary-only, not accept.
 
-General Firefox steps (same shape for all 7 adapters unless noted):
+General Firefox steps (same shape for all 8 adapters unless noted):
 manual only, automation is tracked separately in #1128.
 
 1. `bash scripts/with-firefox-manifest.sh npm run build:content` then load

--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -2,9 +2,9 @@
 
 ## Why this exists
 
-The 7 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
-Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information)
-are unit-green:
+The 8 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
+Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information,
+CookieScript) are unit-green:
 every detection truth table, every reject call shape, and every
 never-auto-accept structural guard is covered by `npm test`. Unit-green is
 not the same thing as real-env-green. Every adapter's merge PR shipped with
@@ -315,9 +315,40 @@ following before marking this adapter PASS:
 - **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
 - **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
 
+### 8. CookieScript
+
+- **Reject call:** `window.CookieScript.instance.rejectAllAction()` (Chrome
+  MAIN world); `window.wrappedJSObject.CookieScript.instance.rejectAllAction()`
+  (Firefox). Synchronous, zero-argument, void return — "rejects all cookies
+  except strictly necessary" per the vendor's own documentation.
+- **Detection signals:** TRIPLE-mandatory (all three required together,
+  since the reject call lives on `.instance`, not directly on the vendor
+  global): `hasCookieScriptGlobal` (`typeof window.CookieScript === "object"`),
+  `hasCookieScriptInstance` (`typeof window.CookieScript.instance === "object"`),
+  and `hasRejectAllActionFn`
+  (`typeof window.CookieScript.instance.rejectAllAction === "function"`);
+  corroborating (>=1 required): `hasCookiescriptInjectedDom`
+  (`#cookiescript_injected`), `hasCookiescriptDescriptionDom`
+  (`#cookiescript_description`).
+- **Candidate live site(s):** `https://cookie-script.com` (PLACEHOLDER —
+  UNVERIFIED, needs curation; vendor's own site, banner selector
+  `#cookiescript_injected, #cookiescript_description`). Replace with an
+  independently-confirmed customer deployment before treating this as a
+  release gate.
+- **Specific risk to verify:** Firefox `wrappedJSObject` reject path and
+  live-CookieScript compatibility are structurally tested only (the
+  Chromium e2e fixture is a regression oracle, not a real-vendor test) —
+  confirm `instance.rejectAllAction()` actually clears the banner on a live
+  site, not just in the fixture. Also confirm `.instance` is reliably
+  populated by the time the dispatcher's MutationObserver fires (the vendor
+  SDK may attach `.instance` asynchronously after the global itself
+  appears) — a real-site smoke is the only way to observe this timing.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
 ## Sign-off table
 
-All 14 cells (7 adapters x Chrome/Firefox) must be green before the
+All 16 cells (8 adapters x Chrome/Firefox) must be green before the
 `develop -> main` release PR opens.
 
 | Adapter | Chrome | Firefox |
@@ -329,5 +360,6 @@ All 14 cells (7 adapters x Chrome/Firefox) must be green before the
 | Sourcepoint | ____ | ____ |
 | Usercentrics | ____ | ____ |
 | Cookie Information | ____ | ____ |
+| CookieScript | ____ | ____ |
 
 Reviewer: ______________________  Date: ______________________

--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -171,6 +171,28 @@
   function canRejectCookieInformation(signals) {
     return detectCookieInformation(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // CookieScript: the reject call lives on window.CookieScript.instance, not
+  // directly on the vendor global — see the TRIPLE-mandatory-gate rationale
+  // above detectCookieScript in the docblock preceding this sync block.
+  function detectCookieScript(signals) {
+    if (
+      !signals ||
+      signals.hasCookieScriptGlobal !== true ||
+      signals.hasCookieScriptInstance !== true ||
+      signals.hasRejectAllActionFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCookiescriptInjectedDom === true ? 1 : 0) +
+      (signals.hasCookiescriptDescriptionDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookieScript(signals) {
+    return detectCookieScript(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -345,6 +367,30 @@
     } catch {
       // document not ready / detached — leave all false.
     }
+    // CookieScript: the reject call lives on window.CookieScript.instance,
+    // not directly on the vendor global — hasCookieScriptInstance must be
+    // confirmed an object BEFORE probing .rejectAllAction, otherwise reading
+    // a property off `undefined` would throw inside this try block (still
+    // caught, but the intent is explicit here).
+    let hasCookieScriptGlobal = false;
+    let hasCookieScriptInstance = false;
+    let hasRejectAllActionFn = false;
+    try {
+      hasCookieScriptGlobal = typeof window.CookieScript === "object" && window.CookieScript !== null;
+      const instance = hasCookieScriptGlobal && window.CookieScript.instance;
+      hasCookieScriptInstance = typeof instance === "object" && instance !== null;
+      hasRejectAllActionFn = hasCookieScriptInstance && typeof instance.rejectAllAction === "function";
+    } catch {
+      // Leave all false — fail-closed.
+    }
+    let hasCookiescriptInjectedDom = false;
+    let hasCookiescriptDescriptionDom = false;
+    try {
+      hasCookiescriptInjectedDom = !!document.getElementById("cookiescript_injected");
+      hasCookiescriptDescriptionDom = !!document.getElementById("cookiescript_description");
+    } catch {
+      // document not ready / detached — leave both false.
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -381,6 +427,11 @@
       hasCoiSummeryDom,
       hasCoiBannerWrapperDom,
       hasCoiConsentSummaryDom,
+      hasCookieScriptGlobal,
+      hasCookieScriptInstance,
+      hasRejectAllActionFn,
+      hasCookiescriptInjectedDom,
+      hasCookiescriptDescriptionDom,
     };
   }
 
@@ -493,6 +544,19 @@
       _acted = true;
       try {
         window.CookieInformation.declineAllCategories();
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: CookieScript API adapter. Same zero-argument, synchronous
+    // reject-call shape as the adapters above — rejectAllAction() "rejects
+    // all cookies except strictly necessary" per the vendor's own docs.
+    if (canRejectCookieScript(signals)) {
+      _acted = true;
+      try {
+        window.CookieScript.instance.rejectAllAction();
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -168,6 +168,28 @@
   function canRejectCookieInformation(signals) {
     return detectCookieInformation(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // CookieScript: the reject call lives on window.CookieScript.instance, not
+  // directly on the vendor global — see the TRIPLE-mandatory-gate rationale
+  // above detectCookieScript in the docblock preceding this sync block.
+  function detectCookieScript(signals) {
+    if (
+      !signals ||
+      signals.hasCookieScriptGlobal !== true ||
+      signals.hasCookieScriptInstance !== true ||
+      signals.hasRejectAllActionFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCookiescriptInjectedDom === true ? 1 : 0) +
+      (signals.hasCookiescriptDescriptionDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectCookieScript(signals) {
+    return detectCookieScript(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -394,6 +416,30 @@
     } catch {
       // ignore
     }
+    // CookieScript: the reject call lives on window.CookieScript.instance,
+    // not directly on the vendor global, reached via wrappedJSObject — same
+    // Xray-safety pattern as the other Firefox signal reads above.
+    let hasCookieScriptGlobal = false;
+    let hasCookieScriptInstance = false;
+    let hasRejectAllActionFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const cs = wrapped && wrapped.CookieScript;
+      hasCookieScriptGlobal = typeof cs === "object" && cs !== null;
+      const instance = hasCookieScriptGlobal && cs.instance;
+      hasCookieScriptInstance = typeof instance === "object" && instance !== null;
+      hasRejectAllActionFn = hasCookieScriptInstance && typeof instance.rejectAllAction === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasCookiescriptInjectedDom = false;
+    let hasCookiescriptDescriptionDom = false;
+    try {
+      hasCookiescriptInjectedDom = !!document.getElementById("cookiescript_injected");
+      hasCookiescriptDescriptionDom = !!document.getElementById("cookiescript_description");
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -430,6 +476,11 @@
       hasCoiSummeryDom,
       hasCoiBannerWrapperDom,
       hasCoiConsentSummaryDom,
+      hasCookieScriptGlobal,
+      hasCookieScriptInstance,
+      hasRejectAllActionFn,
+      hasCookiescriptInjectedDom,
+      hasCookiescriptDescriptionDom,
     };
   }
 
@@ -521,6 +572,18 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.CookieInformation.declineAllCategories();
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: CookieScript API adapter. Same zero-argument, synchronous
+    // reject-call shape as the adapters above — see cookie-noise-mainworld.js.
+    if (canRejectCookieScript(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.CookieScript.instance.rejectAllAction();
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -113,6 +113,16 @@
  *   present in the DOM. Secondary/corroborating signal.
  * @property {boolean} [hasCoiConsentSummaryDom] - `.coi-consent-summary`
  *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCookieScriptGlobal] - `typeof window.CookieScript === "object"`.
+ * @property {boolean} [hasCookieScriptInstance] - `typeof window.CookieScript.instance === "object"`.
+ *   Mandatory signal: the reject call lives on `.instance`, so this must be
+ *   present before probing for the reject function itself.
+ * @property {boolean} [hasRejectAllActionFn] - `typeof window.CookieScript.instance.rejectAllAction === "function"`.
+ *   Mandatory signal: without this, no reject action can be confirmed.
+ * @property {boolean} [hasCookiescriptInjectedDom] - `#cookiescript_injected`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCookiescriptDescriptionDom] - `#cookiescript_description`
+ *   present in the DOM. Secondary/corroborating signal.
  */
 
 /**
@@ -198,6 +208,19 @@ export const ACTIONS = Object.freeze({
  * `data-tcf-v2-enabled`), which is Sourcepoint's dual-mandatory anchor
  * above, not this adapter's. Detection here is keyed ONLY off the
  * `window.CookieInformation` vendor global + `declineAllCategories`.
+ *
+ * The CookieScript adapter DEVIATES from the vendor-namespaced-global shape
+ * on purpose: its reject call (`CookieScript.instance.rejectAllAction()`)
+ * lives on a `.instance` property, not directly on the vendor global
+ * itself. detectCookieScript therefore strengthens the mandatory bar to a
+ * TRIPLE gate — `hasCookieScriptGlobal` AND `hasCookieScriptInstance` AND
+ * `hasRejectAllActionFn` — because `.instance` can be present-but-not-yet
+ * populated (or absent) even when the vendor global itself already exists,
+ * and probing `.rejectAllAction` before confirming `.instance` is an object
+ * would either throw or silently read `undefined`. The usual >=1
+ * corroborating DOM secondary (`#cookiescript_injected`,
+ * `#cookiescript_description`) still gates the same fail-closed
+ * CONFIDENCE_THRESHOLD as every other adapter here.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -329,6 +352,28 @@ function detectCookieInformation(signals) {
 
 function canRejectCookieInformation(signals) {
   return detectCookieInformation(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+// CookieScript: the reject call lives on window.CookieScript.instance, not
+// directly on the vendor global — see the TRIPLE-mandatory-gate rationale
+// above detectCookieScript in the docblock preceding this sync block.
+function detectCookieScript(signals) {
+  if (
+    !signals ||
+    signals.hasCookieScriptGlobal !== true ||
+    signals.hasCookieScriptInstance !== true ||
+    signals.hasRejectAllActionFn !== true
+  ) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasCookiescriptInjectedDom === true ? 1 : 0) +
+    (signals.hasCookiescriptDescriptionDom === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectCookieScript(signals) {
+  return detectCookieScript(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -510,6 +555,32 @@ export const cookieInformationAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * CookieScript Tier 1 adapter. The reject call
+ * (`window.CookieScript.instance.rejectAllAction()`) is invoked by the
+ * caller-supplied callback via the shared `reject()` helper above — this
+ * adapter definition never touches `window` itself. Synchronous,
+ * zero-argument, void return — "rejects all cookies except strictly
+ * necessary" per the vendor's own documentation, the same call shape as
+ * `oneTrustAdapter.RejectAll()` / `didomiAdapter.setUserDisagreeToAll()` /
+ * `cookieInformationAdapter.declineAllCategories()`.
+ *
+ * Registered LAST in TIER1 (after cookieInformationAdapter): the
+ * `.instance` indirection makes this adapter's mandatory gate the
+ * strictest of the eight (see detectCookieScript's TRIPLE-mandatory-gate
+ * rationale above), so ordering relative to the others is not
+ * safety-critical — appended at the end to keep the registry's history
+ * append-only.
+ * @type {Readonly<{id: "cookiescript", tier: 1, detect: typeof detectCookieScript, canReject: typeof canRejectCookieScript, reject: typeof reject}>}
+ */
+export const cookieScriptAdapter = Object.freeze({
+  id: "cookiescript",
+  tier: 1,
+  detect: detectCookieScript,
+  canReject: canRejectCookieScript,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
 export const TIER1 = Object.freeze([
   oneTrustAdapter,
@@ -519,6 +590,7 @@ export const TIER1 = Object.freeze([
   sourcepointAdapter,
   usercentricsAdapter,
   cookieInformationAdapter,
+  cookieScriptAdapter,
 ]);
 
 /**
@@ -585,6 +657,13 @@ export function decideAction(signals) {
   // Usercentrics checks above (mandatory global present, mandatory reject
   // fn absent).
   if (s.hasCookieInformationGlobal === true && s.hasDeclineAllCategoriesFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  // CookieScript hard wall: mandatory global present but the reject
+  // function is not reachable — either `.instance` itself is absent, or
+  // `.instance` exists but `.rejectAllAction` is not a function. Both
+  // sub-cases collapse to `hasRejectAllActionFn !== true` here.
+  if (s.hasCookieScriptGlobal === true && s.hasRejectAllActionFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/canary/cmp-sites.json
+++ b/tests/canary/cmp-sites.json
@@ -76,5 +76,11 @@
     "url": "https://cookieinformation.com",
     "bannerSelector": "#coiOverlay, #coiConsentBanner, #coiSummery, #coi-banner-wrapper, .coi-consent-summary",
     "note": "PLACEHOLDER — UNVERIFIED, needs curation. Cookie Information's own marketing site, following the same dogfooding-inference pattern used for the Cookiebot entry above (CMP vendors commonly run their own product on their own site). Not independently confirmed via script inspection. Replace with a representative, independently-confirmed Cookie Information customer deployment before relying on this entry for release gating — curation is tracked as a follow-up, separate from adapter correctness."
+  },
+  {
+    "cmp": "cookiescript",
+    "url": "https://cookie-script.com",
+    "bannerSelector": "#cookiescript_injected, #cookiescript_description",
+    "note": "PLACEHOLDER — UNVERIFIED, needs curation. CookieScript's own marketing site, following the same dogfooding-inference pattern used for the Cookiebot entry above. Not independently confirmed via script inspection. Replace with a representative, independently-confirmed CookieScript customer deployment before relying on this entry for release gating — curation is tracked as a follow-up, separate from adapter correctness."
   }
 ]

--- a/tests/e2e-firefox/cookiescript.smoke.mjs
+++ b/tests/e2e-firefox/cookiescript.smoke.mjs
@@ -1,0 +1,123 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — CookieScript reject path.
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs's
+ * fixture page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.CookieScript.instance.rejectAllAction()` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as
+// tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs's
+// stubCookieScriptPage: all three mandatory signals (global, instance,
+// rejectAllAction fn) plus the #cookiescript_injected DOM anchor as the
+// corroborating secondary signal.
+const COOKIESCRIPT_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="cookiescript_injected">
+    <button id="cookiescript_accept">Accept</button>
+    <button id="cookiescript_reject">Reject all</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__csCalls = [];
+    window.CookieScript = {
+      instance: {
+        rejectAllAction: function () {
+          window.__csCalls.push("rejectAllAction");
+          window.__consentState = "necessary-only";
+          document.getElementById("cookiescript_injected").remove();
+        },
+      },
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: CookieScript instance.rejectAllAction() fires via wrappedJSObject when the feature is enabled", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(COOKIESCRIPT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const csCalls = await driver.executeScript("return window.__csCalls");
+    assert.deepEqual(csCalls, ["rejectAllAction"]);
+
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('cookiescript_injected') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: CookieScript instance.rejectAllAction() does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(COOKIESCRIPT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('cookiescript_injected') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+
+    const csCalls = await driver.executeScript("return window.__csCalls");
+    assert.deepEqual(csCalls, []);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs
@@ -1,0 +1,221 @@
+/**
+ * E2E: Cookie Consent Minimizer — CookieScript Tier 1 adapter
+ *
+ * Verifies the CookieScript reject path against a real Chromium with the
+ * extension loaded. The fixture page mimics a CookieScript banner: a
+ * `window.CookieScript.instance` object with a `rejectAllAction()` method
+ * plus the `#cookiescript_injected` DOM anchor — the triple-mandatory
+ * (global + instance + fn) plus corroboration signal combination the
+ * dispatcher requires before acting (src/lib/cmp-adapters.js).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookieinformation.spec.mjs's
+ * structure exactly (same onboarding helper shape, same feature pref, same
+ * zero-argument synchronous reject-call shape).
+ *
+ * HONEST LIMIT: this is a REGRESSION oracle only — a snapshot of one
+ * fixture's behavior at write time. It proves the Chrome MAIN-world nonce
+ * handshake (content/cookie-noise-mainworld.js) and the
+ * never-auto-reject-the-other-way outcome on the fixture used here. It does
+ * NOT validate the Firefox `window.wrappedJSObject` reject path
+ * (content/cookie-noise.js) — Playwright's `chromium` fixture only exercises
+ * Chrome — and it does NOT prove real-vendor-script compatibility against a
+ * live CookieScript CMP build. A real-browser smoke test against at least
+ * one live CookieScript deployment is required before considering this
+ * adapter done — flagged for sdd-verify. Re-capture this fixture manually
+ * whenever the CookieScript markup/API shape this test hardcodes changes
+ * upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-cookiescript.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode: enableFeature ? "reject-only" : "off" },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a CookieScript banner offering a reject-all via
+ * `CookieScript.instance.rejectAllAction()`. All three mandatory signals
+ * (global, instance, rejectAllAction fn) are present alongside the
+ * `#cookiescript_injected` DOM anchor — the confidence gate in
+ * cmp-adapters.js requires the mandatory triple plus at least one
+ * corroborating DOM secondary.
+ */
+async function stubCookieScriptPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="cookiescript_injected">
+          <button id="cookiescript_accept">Accept</button>
+          <button id="cookiescript_reject">Reject all</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__csCalls = [];
+          window.CookieScript = {
+            instance: {
+              rejectAllAction: function () {
+                window.__csCalls.push("rejectAllAction");
+                window.__consentState = "necessary-only";
+                document.getElementById("cookiescript_injected").remove();
+              },
+            },
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — CookieScript", () => {
+  test("rejects a CookieScript banner with instance.rejectAllAction() when the feature is enabled", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubCookieScriptPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // rejectAllAction was actually invoked (not some other method).
+    const csCalls = await page.evaluate(() => window.__csCalls);
+    expect(csCalls).toEqual(["rejectAllAction"]);
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(
+      () => document.getElementById("cookiescript_injected") === null
+    );
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubCookieScriptPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(
+      () => document.getElementById("cookiescript_injected") !== null
+    );
+    expect(bannerStillThere).toBe(true);
+
+    const csCalls = await page.evaluate(() => window.__csCalls);
+    expect(csCalls).toEqual([]);
+
+    await page.close();
+  });
+
+  test("never misfires on a Didomi-only page (no CookieScript global present)", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    const DIDOMI_HOST = "muga-test-cookie-consent-cookiescript-didomi-guard.invalid";
+    await page.route(`**://${DIDOMI_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <div id="didomi-host"></div>
+          <p id="page-content">Real page content</p>
+          <script>
+            // A Didomi-shaped page: exposes window.Didomi.setUserDisagreeToAll
+            // but NO window.CookieScript global at all. The CookieScript
+            // adapter must never act here.
+            window.__didomiCalls = [];
+            window.Didomi = {
+              getCurrentUserStatus: function () { return {}; },
+              setUserDisagreeToAll: function () {
+                window.__didomiCalls.push("setUserDisagreeToAll");
+              },
+            };
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${DIDOMI_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The Didomi adapter IS expected to fire here (it is a real Didomi
+    // page) — what this test guards is that the CookieScript adapter never
+    // ALSO claims it / never references CookieScript on a page that has
+    // none.
+    await page.waitForFunction(
+      () => Array.isArray(window.__didomiCalls) && window.__didomiCalls.includes("setUserDisagreeToAll"),
+      { timeout: 10000 }
+    );
+
+    const csGlobalPresent = await page.evaluate(() => typeof window.CookieScript !== "undefined");
+    expect(csGlobalPresent).toBe(false);
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+});

--- a/tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs
@@ -218,4 +218,77 @@ test.describe("Cookie Consent Minimizer — CookieScript", () => {
 
     await page.close();
   });
+
+  test("does not throw or reject when CookieScript is present but has no .instance (null-safety)", async ({
+    context,
+    extensionId,
+  }) => {
+    // Regression guard for the exact TypeError hazard the triple-mandatory
+    // gate exists to prevent: window.CookieScript is a truthy object but has
+    // NO `.instance` (the vendor SDK attaches the global before the instance
+    // is constructed). Reading `window.CookieScript.instance.rejectAllAction`
+    // naively would throw "Cannot read properties of undefined". The signal
+    // collector short-circuits on the missing instance, so detection must
+    // fail closed and the adapter must NOOP — with zero page errors captured.
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const NO_INSTANCE_HOST = "muga-test-cookie-consent-cookiescript-no-instance.invalid";
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.route(`**://${NO_INSTANCE_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <div id="cookiescript_injected">
+            <button id="cookiescript_accept">Accept</button>
+            <button id="cookiescript_reject">Reject all</button>
+          </div>
+          <p id="page-content">Real page content</p>
+          <script>
+            // Truthy CookieScript global WITHOUT an .instance — the exact
+            // present-but-not-yet-populated shape the triple gate guards.
+            window.CookieScript = {};
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${NO_INSTANCE_HOST}/index.html`);
+
+    // Wait for the MAIN-world caller's once-guard flag — proves the signal
+    // collection path (including the CookieScript `.instance`-undefined
+    // branch) actually ran under real page-error capture.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed and no
+    // TypeError must surface) has no positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    // The adapter must NOT have acted: no consent state was mutated.
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    // Banner is untouched — the feature-safe NOOP left the page alone.
+    const bannerStillThere = await page.evaluate(
+      () => document.getElementById("cookiescript_injected") !== null
+    );
+    expect(bannerStillThere).toBe(true);
+
+    // The global is still the instance-less object we planted (no crash
+    // mid-collection that would have aborted the script).
+    const csShape = await page.evaluate(() => ({
+      isObject: typeof window.CookieScript === "object" && window.CookieScript !== null,
+      hasInstance: typeof window.CookieScript?.instance !== "undefined",
+    }));
+    expect(csShape).toEqual({ isObject: true, hasInstance: false });
+
+    // The whole point: reading `.instance.rejectAllAction` never threw.
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
 });

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -30,6 +30,7 @@ import {
   sourcepointAdapter,
   usercentricsAdapter,
   cookieInformationAdapter,
+  cookieScriptAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -39,8 +40,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics and Cookie Information adapters, in order", () => {
-    assert.equal(TIER1.length, 7);
+  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information and CookieScript adapters, in order", () => {
+    assert.equal(TIER1.length, 8);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
     assert.strictEqual(TIER1[2], didomiAdapter);
@@ -48,6 +49,7 @@ describe("cmp-adapters — registry shape", () => {
     assert.strictEqual(TIER1[4], sourcepointAdapter);
     assert.strictEqual(TIER1[5], usercentricsAdapter);
     assert.strictEqual(TIER1[6], cookieInformationAdapter);
+    assert.strictEqual(TIER1[7], cookieScriptAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -114,6 +116,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof cookieInformationAdapter.detect, "function");
     assert.equal(typeof cookieInformationAdapter.canReject, "function");
     assert.equal(typeof cookieInformationAdapter.reject, "function");
+  });
+
+  test("cookieScriptAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(cookieScriptAdapter.id, "cookiescript");
+    assert.equal(cookieScriptAdapter.tier, 1);
+    assert.equal(typeof cookieScriptAdapter.detect, "function");
+    assert.equal(typeof cookieScriptAdapter.canReject, "function");
+    assert.equal(typeof cookieScriptAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -469,6 +479,53 @@ describe("decideAction — truth table", () => {
     assert.equal(r.action, ACTIONS.REJECT_ALL);
     assert.equal(r.reason, "reject");
     assert.equal(r.adapterId, "cookieinformation");
+  });
+
+  test("CookieScript: global + instance + rejectAllAction fn + corroborating DOM -> reject", () => {
+    const r = decideAction({
+      hasCookieScriptGlobal: true,
+      hasCookieScriptInstance: true,
+      hasRejectAllActionFn: true,
+      hasCookiescriptInjectedDom: true,
+      hasCookiescriptDescriptionDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "cookiescript");
+  });
+
+  test("CookieScript: global present but instance/rejectAllAction absent (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasCookieScriptGlobal: true,
+      hasCookieScriptInstance: false,
+      hasRejectAllActionFn: false,
+      hasCookiescriptInjectedDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("CookieScript: global + instance present but rejectAllAction fn absent (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasCookieScriptGlobal: true,
+      hasCookieScriptInstance: true,
+      hasRejectAllActionFn: false,
+      hasCookiescriptInjectedDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("CookieScript: mandatory signals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasCookieScriptGlobal: true,
+      hasCookieScriptInstance: true,
+      hasRejectAllActionFn: true,
+      hasCookiescriptInjectedDom: false,
+      hasCookiescriptDescriptionDom: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
   });
 });
 
@@ -935,6 +992,75 @@ describe("cookieInformationAdapter.detect — confidence gate", () => {
   });
 });
 
+describe("cookieScriptAdapter.detect — dual-mandatory-plus-instance confidence gate", () => {
+  const FULL_CS_SIGNALS = Object.freeze({
+    hasCookieScriptGlobal: true,
+    hasCookieScriptInstance: true,
+    hasRejectAllActionFn: true,
+    hasCookiescriptInjectedDom: true,
+    hasCookiescriptDescriptionDom: true,
+  });
+
+  test("mandatory + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = cookieScriptAdapter.detect(FULL_CS_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(cookieScriptAdapter.canReject(FULL_CS_SIGNALS), true);
+  });
+
+  test("mandatory + exactly one secondary (#cookiescript_injected only) -> canReject true", () => {
+    const s = {
+      hasCookieScriptGlobal: true,
+      hasCookieScriptInstance: true,
+      hasRejectAllActionFn: true,
+      hasCookiescriptInjectedDom: true,
+      hasCookiescriptDescriptionDom: false,
+    };
+    assert.equal(cookieScriptAdapter.canReject(s), true);
+  });
+
+  test("global-only (mandatory present, zero secondary signals) -> uncertain, canReject false", () => {
+    const s = {
+      hasCookieScriptGlobal: true,
+      hasCookieScriptInstance: true,
+      hasRejectAllActionFn: true,
+      hasCookiescriptInjectedDom: false,
+      hasCookiescriptDescriptionDom: false,
+    };
+    assert.equal(cookieScriptAdapter.canReject(s), false);
+    assert.ok(cookieScriptAdapter.detect(s) < 1);
+  });
+
+  test("DOM-only (mandatory instance/rejectAllAction missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasCookieScriptGlobal: false,
+      hasCookieScriptInstance: false,
+      hasRejectAllActionFn: false,
+      hasCookiescriptInjectedDom: true,
+      hasCookiescriptDescriptionDom: true,
+    };
+    assert.equal(cookieScriptAdapter.detect(s), 0);
+    assert.equal(cookieScriptAdapter.canReject(s), false);
+  });
+
+  test("global present but instance absent (rejectAllAction unreachable) -> confidence 0, canReject false", () => {
+    const s = {
+      hasCookieScriptGlobal: true,
+      hasCookieScriptInstance: false,
+      hasRejectAllActionFn: false,
+      hasCookiescriptInjectedDom: true,
+      hasCookiescriptDescriptionDom: true,
+    };
+    assert.equal(cookieScriptAdapter.detect(s), 0);
+    assert.equal(cookieScriptAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => cookieScriptAdapter.detect(null));
+    assert.doesNotThrow(() => cookieScriptAdapter.detect(undefined));
+    assert.equal(cookieScriptAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -1088,6 +1214,25 @@ describe("cookieInformationAdapter.reject — pure callback invocation", () => {
 
   test("non-function argument -> status noop, no call", () => {
     const r = cookieInformationAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+describe("cookieScriptAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = cookieScriptAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = cookieScriptAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = cookieScriptAdapter.reject(undefined);
     assert.equal(r.status, "noop");
   });
 });
@@ -1263,5 +1408,16 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
     assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
     assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
     assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must still include usercentricsAdapter");
+  });
+
+  test("cookieScriptAdapter is registered in TIER1 alongside the other seven adapters", () => {
+    assert.ok(TIER1.includes(cookieScriptAdapter), "TIER1 must include cookieScriptAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
+    assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
+    assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
+    assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must still include usercentricsAdapter");
+    assert.ok(TIER1.includes(cookieInformationAdapter), "TIER1 must still include cookieInformationAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -136,6 +136,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectCookieInformation/.test(joined));
     assert.ok(/function canRejectCookieInformation/.test(joined));
   });
+
+  test("sync block also defines detectCookieScript and canRejectCookieScript", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectCookieScript/.test(joined));
+    assert.ok(/function canRejectCookieScript/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -444,6 +450,28 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       assert.ok(calls.length > 0, `${label} must call declineAllCategories`);
       for (const args of calls) {
         assert.equal(args, "", `${label} declineAllCategories must be called with zero arguments`);
+      }
+    }
+  });
+
+  test("only CookieScript.instance.rejectAllAction (or wrappedJSObject equivalent) is invoked — no other CookieScript method call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/CookieScript\.instance\.(\w+)\s*\(/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call CookieScript.instance.rejectAllAction`);
+      for (const fn of calls) {
+        assert.equal(fn, "rejectAllAction", `${label} calls CookieScript.instance.${fn}() — only rejectAllAction is permitted`);
+      }
+    }
+  });
+
+  test("every rejectAllAction call passes zero arguments", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/rejectAllAction\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call rejectAllAction`);
+      for (const args of calls) {
+        assert.equal(args, "", `${label} rejectAllAction must be called with zero arguments`);
       }
     }
   });

--- a/tests/unit/release-smoke-report.test.mjs
+++ b/tests/unit/release-smoke-report.test.mjs
@@ -231,6 +231,6 @@ describe("release-smoke-report — importing the module never triggers CLI/files
     assert.equal(typeof mod.formatReleaseTable, "function");
     assert.equal(typeof mod.runReleaseSmokeReportCli, "function");
     assert.ok(Array.isArray(mod.RELEASE_CMPS));
-    assert.equal(mod.RELEASE_CMPS.length, 7);
+    assert.equal(mod.RELEASE_CMPS.length, 8);
   });
 });

--- a/tools/release-smoke-report.mjs
+++ b/tools/release-smoke-report.mjs
@@ -5,9 +5,9 @@
  * Reduces the existing CMP canary results (tests/canary/cmp-sites.json +
  * tools/canary-report.mjs's `test-results/canary-results.json` schema,
  * `{cmp, url, status: "pass"|"fail"|"inconclusive", detail}`) into a
- * per-adapter RELEASE verdict for the 7 Tier 1 cookie-consent adapters
+ * per-adapter RELEASE verdict for the 8 Tier 1 cookie-consent adapters
  * (src/lib/cmp-adapters.js TIER1: onetrust, cookiebot, didomi, cookieyes,
- * sourcepoint, usercentrics, cookieinformation).
+ * sourcepoint, usercentrics, cookieinformation, cookiescript).
  *
  * This does NOT run the canary itself — see tools/canary-report.mjs for
  * that (drift-alarm reporting) and .github/workflows/cmp-canary.yml (the
@@ -28,7 +28,7 @@
  * decision logic vs. CLI I/O boundary).
  *
  * Public API (named exports only — no default):
- *   RELEASE_CMPS → the 7 Tier 1 CMP ids, in cmp-adapters.js TIER1 order.
+ *   RELEASE_CMPS → the 8 Tier 1 CMP ids, in cmp-adapters.js TIER1 order.
  *   summarizeRelease(results) → Record<string, {verdict, passCount, failCount, inconclusiveCount, sites}>
  *   formatReleaseTable(summary) → string
  *
@@ -46,7 +46,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Pure decision logic ───────────────────────────────────────────────────
 
 /**
- * The 7 Tier 1 cookie-consent CMP ids, in the same order as
+ * The 8 Tier 1 cookie-consent CMP ids, in the same order as
  * src/lib/cmp-adapters.js's TIER1 registry.
  * @type {ReadonlyArray<string>}
  */
@@ -58,6 +58,7 @@ export const RELEASE_CMPS = Object.freeze([
   "sourcepoint",
   "usercentrics",
   "cookieinformation",
+  "cookiescript",
 ]);
 
 function emptyBucket() {


### PR DESCRIPTION
Relates to #1140, #1027. Second of the 2-PR chain (#1140), **stacked on** the Cookie Information PR (base = `feat/cmp-cookieinformation`; will retarget to `develop` after PR1 merges).

## Summary
New Tier 1 API adapter for **CookieScript**. Reject-only, no accept, no DOM clicking.
- Reject: `window.CookieScript.instance.rejectAllAction()` (zero-arg, synchronous).
- Detect: TRIPLE-mandatory gate (`window.CookieScript` object + `.instance` object + `.instance.rejectAllAction` fn) since the reject method lives on `.instance`; + >=1 DOM secondary (`#cookiescript_injected`/`#cookiescript_description`), threshold 1, fail-closed.
- Signal collection is null-safe: staged `&&` guards, so `window.CookieScript = {}` (no `.instance`) never throws. An e2e proves this end-to-end under pageerror capture.
- Enrolls in the release-smoke gate (RELEASE_CMPS 7->8; 8 adapters / 16 cells).

## Test plan
- `npm test` 6830 pass / 0 fail / 1 pre-existing skip; unit tests (detect + canReject + BOTH hard-wall sub-cases + uncertain), e2e stub (feature-OFF negative, cross-CMP misfire, and the `.instance`-undefined null-safety case, 4/4), Firefox smoke.
- `npm run lint` / `lint:js` / `check:i18n` clean; bundle-drift clean.
- Never-accept spine byte-unchanged (literal-arg guard pins `rejectAllAction()` to zero args).

## Notes
- Manual-smoke open item: confirm `rejectAllAction()` is sync/void on a real vendor page (F2).
- Canary entry is a PLACEHOLDER (needs EU-geo curation).