### PR TITLE
feat(consent): add tarteaucitron.js Tier 1 adapter

### DIFF
--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -2,9 +2,9 @@
 
 ## Why this exists
 
-The 8 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
+The 9 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
 Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information,
-CookieScript) are unit-green:
+CookieScript, tarteaucitron) are unit-green:
 every detection truth table, every reject call shape, and every
 never-auto-accept structural guard is covered by `npm test`. Unit-green is
 not the same thing as real-env-green. Every adapter's merge PR shipped with
@@ -78,7 +78,7 @@ sites (`src/content/cookie-noise-mainworld.js` for Chrome MAIN world,
 `tests/canary/cmp-sites.json` - do not test against a different site
 without first adding it there.
 
-General Chrome steps (same shape for all 8 adapters unless noted):
+General Chrome steps (same shape for all 9 adapters unless noted):
 
 1. `npm run build:content` then load the unpacked extension from `src/`
    in `chrome://extensions` (Developer mode > Load unpacked).
@@ -93,7 +93,7 @@ General Chrome steps (same shape for all 8 adapters unless noted):
    inspector (where available) to confirm the resulting consent state is
    reject / necessary-only, not accept.
 
-General Firefox steps (same shape for all 8 adapters unless noted):
+General Firefox steps (same shape for all 9 adapters unless noted):
 manual only, automation is tracked separately in #1128.
 
 1. `bash scripts/with-firefox-manifest.sh npm run build:content` then load
@@ -346,9 +346,46 @@ following before marking this adapter PASS:
 - **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
 - **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
 
+### 9. tarteaucitron
+
+- **Reject call:** `window.tarteaucitron.userInterface.respondAll(false)`
+  (Chrome MAIN world); `window.wrappedJSObject.tarteaucitron.userInterface.respondAll(false)`
+  (Firefox). Synchronous (a plain `for` loop over `tarteaucitron.job`, no
+  Promise/callback) — the literal `false` status argument denies every
+  registered service; this is the exact function/argument the vendor's own
+  "tout refuser" (reject all) UI button calls.
+- **Detection signals:** TRIPLE-mandatory (all three required together,
+  since the reject call lives on `.userInterface`, not directly on the
+  vendor global): `hasTarteaucitronGlobal` (`typeof window.tarteaucitron === "object"`),
+  `hasTarteaucitronUserInterface` (`typeof window.tarteaucitron.userInterface === "object"`),
+  and `hasRespondAllFn`
+  (`typeof window.tarteaucitron.userInterface.respondAll === "function"`);
+  corroborating (>=1 required): `hasTarteaucitronRootDom`
+  (`#tarteaucitronRoot`), `hasTarteaucitronAlertBigDom`
+  (`#tarteaucitronAlertBig`), `hasTarteaucitronBackDom`
+  (`#tarteaucitronBack`), `hasTarteaucitronModalOpenDom`
+  (`.tarteaucitron-modal-open` on `document.body`).
+- **Candidate live site(s):** `https://tarteaucitron.io` (PLACEHOLDER —
+  UNVERIFIED, needs curation; the project's own site, banner selector
+  `#tarteaucitronRoot, #tarteaucitronAlertBig`). Replace with an
+  independently-confirmed customer deployment (strong France/gov-sector
+  presence) before treating this as a release gate.
+- **Specific risk to verify:** Firefox `wrappedJSObject` reject path and
+  live-tarteaucitron compatibility are structurally tested only (the
+  Chromium e2e fixture is a regression oracle, not a real-vendor test) —
+  confirm `userInterface.respondAll(false)` actually clears the banner on a
+  live site, not just in the fixture. Also confirm `.userInterface` is
+  reliably populated by the time the dispatcher's MutationObserver fires,
+  and that the literal `false` argument (not `true`, not omitted) is the
+  one that actually denies consent on a live deployment — `respondAll`'s
+  second and third arguments (`type`, `allowSafeAnalytics`) are never
+  passed by this adapter.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
 ## Sign-off table
 
-All 16 cells (8 adapters x Chrome/Firefox) must be green before the
+All 18 cells (9 adapters x Chrome/Firefox) must be green before the
 `develop -> main` release PR opens.
 
 | Adapter | Chrome | Firefox |
@@ -361,5 +398,6 @@ All 16 cells (8 adapters x Chrome/Firefox) must be green before the
 | Usercentrics | ____ | ____ |
 | Cookie Information | ____ | ____ |
 | CookieScript | ____ | ____ |
+| tarteaucitron | ____ | ____ |
 
 Reviewer: ______________________  Date: ______________________

--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -193,6 +193,31 @@
   function canRejectCookieScript(signals) {
     return detectCookieScript(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // tarteaucitron: the reject call lives on window.tarteaucitron.userInterface,
+  // not directly on the vendor global — see the TRIPLE-mandatory-gate
+  // rationale above detectTarteaucitron in the docblock preceding this sync
+  // block.
+  function detectTarteaucitron(signals) {
+    if (
+      !signals ||
+      signals.hasTarteaucitronGlobal !== true ||
+      signals.hasTarteaucitronUserInterface !== true ||
+      signals.hasRespondAllFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasTarteaucitronRootDom === true ? 1 : 0) +
+      (signals.hasTarteaucitronAlertBigDom === true ? 1 : 0) +
+      (signals.hasTarteaucitronBackDom === true ? 1 : 0) +
+      (signals.hasTarteaucitronModalOpenDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectTarteaucitron(signals) {
+    return detectTarteaucitron(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -391,6 +416,35 @@
     } catch {
       // document not ready / detached — leave both false.
     }
+    // tarteaucitron: the reject call lives on window.tarteaucitron.userInterface,
+    // not directly on the vendor global — hasTarteaucitronUserInterface must
+    // be confirmed an object BEFORE probing .respondAll, otherwise reading a
+    // property off `undefined` would throw inside this try block (still
+    // caught, but the intent is explicit here). Null-safe staged checks, not
+    // a naive chained typeof.
+    let hasTarteaucitronGlobal = false;
+    let hasTarteaucitronUserInterface = false;
+    let hasRespondAllFn = false;
+    try {
+      hasTarteaucitronGlobal = typeof window.tarteaucitron === "object" && window.tarteaucitron !== null;
+      const ui = hasTarteaucitronGlobal && window.tarteaucitron.userInterface;
+      hasTarteaucitronUserInterface = typeof ui === "object" && ui !== null;
+      hasRespondAllFn = hasTarteaucitronUserInterface && typeof ui.respondAll === "function";
+    } catch {
+      // Leave all false — fail-closed.
+    }
+    let hasTarteaucitronRootDom = false;
+    let hasTarteaucitronAlertBigDom = false;
+    let hasTarteaucitronBackDom = false;
+    let hasTarteaucitronModalOpenDom = false;
+    try {
+      hasTarteaucitronRootDom = !!document.getElementById("tarteaucitronRoot");
+      hasTarteaucitronAlertBigDom = !!document.getElementById("tarteaucitronAlertBig");
+      hasTarteaucitronBackDom = !!document.getElementById("tarteaucitronBack");
+      hasTarteaucitronModalOpenDom = !!(document.body && document.body.classList.contains("tarteaucitron-modal-open"));
+    } catch {
+      // document not ready / detached — leave all false.
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -432,6 +486,13 @@
       hasRejectAllActionFn,
       hasCookiescriptInjectedDom,
       hasCookiescriptDescriptionDom,
+      hasTarteaucitronGlobal,
+      hasTarteaucitronUserInterface,
+      hasRespondAllFn,
+      hasTarteaucitronRootDom,
+      hasTarteaucitronAlertBigDom,
+      hasTarteaucitronBackDom,
+      hasTarteaucitronModalOpenDom,
     };
   }
 
@@ -557,6 +618,22 @@
       _acted = true;
       try {
         window.CookieScript.instance.rejectAllAction();
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: tarteaucitron API adapter. Same zero-argument-shape family as
+    // the adapters above, except respondAll takes one literal argument:
+    // `false` denies every registered service (the vendor's own "tout
+    // refuser" button calls this exact function with the exact same
+    // literal). Synchronous — a plain for-loop over tarteaucitron.job, no
+    // Promise/callback.
+    if (canRejectTarteaucitron(signals)) {
+      _acted = true;
+      try {
+        window.tarteaucitron.userInterface.respondAll(false);
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -190,6 +190,31 @@
   function canRejectCookieScript(signals) {
     return detectCookieScript(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // tarteaucitron: the reject call lives on window.tarteaucitron.userInterface,
+  // not directly on the vendor global — see the TRIPLE-mandatory-gate
+  // rationale above detectTarteaucitron in the docblock preceding this sync
+  // block.
+  function detectTarteaucitron(signals) {
+    if (
+      !signals ||
+      signals.hasTarteaucitronGlobal !== true ||
+      signals.hasTarteaucitronUserInterface !== true ||
+      signals.hasRespondAllFn !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasTarteaucitronRootDom === true ? 1 : 0) +
+      (signals.hasTarteaucitronAlertBigDom === true ? 1 : 0) +
+      (signals.hasTarteaucitronBackDom === true ? 1 : 0) +
+      (signals.hasTarteaucitronModalOpenDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectTarteaucitron(signals) {
+    return detectTarteaucitron(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -440,6 +465,36 @@
     } catch {
       // ignore
     }
+    // tarteaucitron: the reject call lives on window.tarteaucitron.userInterface,
+    // not directly on the vendor global, reached via wrappedJSObject — same
+    // Xray-safety pattern as the other Firefox signal reads above. Null-safe
+    // staged checks, not a naive chained typeof — hasTarteaucitronUserInterface
+    // must be confirmed an object BEFORE probing .respondAll.
+    let hasTarteaucitronGlobal = false;
+    let hasTarteaucitronUserInterface = false;
+    let hasRespondAllFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const tac = wrapped && wrapped.tarteaucitron;
+      hasTarteaucitronGlobal = typeof tac === "object" && tac !== null;
+      const ui = hasTarteaucitronGlobal && tac.userInterface;
+      hasTarteaucitronUserInterface = typeof ui === "object" && ui !== null;
+      hasRespondAllFn = hasTarteaucitronUserInterface && typeof ui.respondAll === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasTarteaucitronRootDom = false;
+    let hasTarteaucitronAlertBigDom = false;
+    let hasTarteaucitronBackDom = false;
+    let hasTarteaucitronModalOpenDom = false;
+    try {
+      hasTarteaucitronRootDom = !!document.getElementById("tarteaucitronRoot");
+      hasTarteaucitronAlertBigDom = !!document.getElementById("tarteaucitronAlertBig");
+      hasTarteaucitronBackDom = !!document.getElementById("tarteaucitronBack");
+      hasTarteaucitronModalOpenDom = !!(document.body && document.body.classList.contains("tarteaucitron-modal-open"));
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -481,6 +536,13 @@
       hasRejectAllActionFn,
       hasCookiescriptInjectedDom,
       hasCookiescriptDescriptionDom,
+      hasTarteaucitronGlobal,
+      hasTarteaucitronUserInterface,
+      hasRespondAllFn,
+      hasTarteaucitronRootDom,
+      hasTarteaucitronAlertBigDom,
+      hasTarteaucitronBackDom,
+      hasTarteaucitronModalOpenDom,
     };
   }
 
@@ -584,6 +646,20 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.CookieScript.instance.rejectAllAction();
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: tarteaucitron API adapter. Same zero-argument-shape family as
+    // the adapters above, except respondAll takes one literal argument:
+    // `false` denies every registered service — see
+    // cookie-noise-mainworld.js for the full rationale.
+    if (canRejectTarteaucitron(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.tarteaucitron.userInterface.respondAll(false);
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -123,6 +123,20 @@
  *   present in the DOM. Secondary/corroborating signal.
  * @property {boolean} [hasCookiescriptDescriptionDom] - `#cookiescript_description`
  *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasTarteaucitronGlobal] - `typeof window.tarteaucitron === "object"`.
+ * @property {boolean} [hasTarteaucitronUserInterface] - `typeof window.tarteaucitron.userInterface === "object"`.
+ *   Mandatory signal: the reject call lives on `.userInterface`, so this
+ *   must be present before probing for the reject function itself.
+ * @property {boolean} [hasRespondAllFn] - `typeof window.tarteaucitron.userInterface.respondAll === "function"`.
+ *   Mandatory signal: without this, no reject action can be confirmed.
+ * @property {boolean} [hasTarteaucitronRootDom] - `#tarteaucitronRoot`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasTarteaucitronAlertBigDom] - `#tarteaucitronAlertBig`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasTarteaucitronBackDom] - `#tarteaucitronBack`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasTarteaucitronModalOpenDom] - `.tarteaucitron-modal-open`
+ *   present on `document.body`. Secondary/corroborating signal.
  */
 
 /**
@@ -220,6 +234,17 @@ export const ACTIONS = Object.freeze({
  * would either throw or silently read `undefined`. The usual >=1
  * corroborating DOM secondary (`#cookiescript_injected`,
  * `#cookiescript_description`) still gates the same fail-closed
+ * CONFIDENCE_THRESHOLD as every other adapter here.
+ *
+ * The tarteaucitron adapter reuses the CookieScript TRIPLE-mandatory-gate
+ * shape on purpose: its reject call (`tarteaucitron.userInterface.respondAll(false)`)
+ * lives on a `.userInterface` property, not directly on the vendor global
+ * itself — the same "present-but-not-yet-populated-with-the-nested-object"
+ * hazard the CookieScript rationale above describes. detectTarteaucitron
+ * therefore requires `hasTarteaucitronGlobal` AND `hasTarteaucitronUserInterface`
+ * AND `hasRespondAllFn` together, before probing for the usual >=1
+ * corroborating DOM secondary (`#tarteaucitronRoot`, `#tarteaucitronAlertBig`,
+ * `#tarteaucitronBack`, `.tarteaucitron-modal-open`) — same fail-closed
  * CONFIDENCE_THRESHOLD as every other adapter here.
  */
 // @sync:cmp-adapters:start
@@ -374,6 +399,31 @@ function detectCookieScript(signals) {
 
 function canRejectCookieScript(signals) {
   return detectCookieScript(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+// tarteaucitron: the reject call lives on window.tarteaucitron.userInterface,
+// not directly on the vendor global — see the TRIPLE-mandatory-gate
+// rationale above detectTarteaucitron in the docblock preceding this sync
+// block.
+function detectTarteaucitron(signals) {
+  if (
+    !signals ||
+    signals.hasTarteaucitronGlobal !== true ||
+    signals.hasTarteaucitronUserInterface !== true ||
+    signals.hasRespondAllFn !== true
+  ) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasTarteaucitronRootDom === true ? 1 : 0) +
+    (signals.hasTarteaucitronAlertBigDom === true ? 1 : 0) +
+    (signals.hasTarteaucitronBackDom === true ? 1 : 0) +
+    (signals.hasTarteaucitronModalOpenDom === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectTarteaucitron(signals) {
+  return detectTarteaucitron(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -581,6 +631,35 @@ export const cookieScriptAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * tarteaucitron Tier 1 adapter. The reject call
+ * (`window.tarteaucitron.userInterface.respondAll(false)`) is invoked by
+ * the caller-supplied callback via the shared `reject()` helper above —
+ * this adapter definition never touches `window` itself. Synchronous
+ * (a plain `for` loop over `tarteaucitron.job`, no Promise/callback) — the
+ * `false` status argument denies every registered service, mirroring the
+ * vendor's own "tout refuser" (reject all) UI button, which calls this
+ * exact function with the exact same literal argument.
+ *
+ * Detection deviates from the vendor-namespaced-global shape on purpose
+ * (same TRIPLE-mandatory-gate rationale as CookieScript): the reject call
+ * lives on `.userInterface`, not directly on `window.tarteaucitron` — see
+ * detectTarteaucitron's rationale above.
+ *
+ * Registered LAST in TIER1 (after cookieScriptAdapter): `window.tarteaucitron`
+ * is a direct, unambiguous vendor-namespaced global (like CookieScript's),
+ * so ordering relative to the other adapters is not safety-critical —
+ * appended at the end to keep the registry's history append-only.
+ * @type {Readonly<{id: "tarteaucitron", tier: 1, detect: typeof detectTarteaucitron, canReject: typeof canRejectTarteaucitron, reject: typeof reject}>}
+ */
+export const tarteaucitronAdapter = Object.freeze({
+  id: "tarteaucitron",
+  tier: 1,
+  detect: detectTarteaucitron,
+  canReject: canRejectTarteaucitron,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
 export const TIER1 = Object.freeze([
   oneTrustAdapter,
@@ -591,6 +670,7 @@ export const TIER1 = Object.freeze([
   usercentricsAdapter,
   cookieInformationAdapter,
   cookieScriptAdapter,
+  tarteaucitronAdapter,
 ]);
 
 /**
@@ -664,6 +744,14 @@ export function decideAction(signals) {
   // `.instance` exists but `.rejectAllAction` is not a function. Both
   // sub-cases collapse to `hasRejectAllActionFn !== true` here.
   if (s.hasCookieScriptGlobal === true && s.hasRejectAllActionFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  // tarteaucitron hard wall: mandatory global present but the reject
+  // function is not reachable — either `.userInterface` itself is absent,
+  // or `.userInterface` exists but `.respondAll` is not a function. Both
+  // sub-cases collapse to `hasRespondAllFn !== true` here, same shape as
+  // the CookieScript hard wall above.
+  if (s.hasTarteaucitronGlobal === true && s.hasRespondAllFn !== true) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/canary/cmp-sites.json
+++ b/tests/canary/cmp-sites.json
@@ -82,5 +82,11 @@
     "url": "https://cookie-script.com",
     "bannerSelector": "#cookiescript_injected, #cookiescript_description",
     "note": "PLACEHOLDER — UNVERIFIED, needs curation. CookieScript's own marketing site, following the same dogfooding-inference pattern used for the Cookiebot entry above. Not independently confirmed via script inspection. Replace with a representative, independently-confirmed CookieScript customer deployment before relying on this entry for release gating — curation is tracked as a follow-up, separate from adapter correctness."
+  },
+  {
+    "cmp": "tarteaucitron",
+    "url": "https://tarteaucitron.io",
+    "bannerSelector": "#tarteaucitronRoot, #tarteaucitronAlertBig",
+    "note": "PLACEHOLDER — UNVERIFIED, needs curation. tarteaucitron.js's own project/marketing site, following the same dogfooding-inference pattern used for the Cookiebot/Cookie Information/CookieScript entries above. Not independently confirmed via script inspection. Replace with a representative, independently-confirmed tarteaucitron customer deployment (strong France/gov-sector presence per the CMP triage in engram) before relying on this entry for release gating — curation is tracked as a follow-up, separate from adapter correctness."
   }
 ]

--- a/tests/e2e-firefox/tarteaucitron.smoke.mjs
+++ b/tests/e2e-firefox/tarteaucitron.smoke.mjs
@@ -1,0 +1,125 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — tarteaucitron reject path.
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-tarteaucitron.spec.mjs's
+ * fixture page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.tarteaucitron.userInterface.respondAll(false)`
+ * path (src/content/cookie-noise.js) actually fires in Gecko.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as
+// tests/e2e/cookie-consent-minimizer-tarteaucitron.spec.mjs's
+// stubTarteaucitronPage: all three mandatory signals (global, userInterface,
+// respondAll fn) plus the #tarteaucitronRoot DOM anchor as the
+// corroborating secondary signal.
+const TARTEAUCITRON_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="tarteaucitronRoot">
+    <div id="tarteaucitronAlertBig">
+      <button id="tarteaucitronAllAllowed">Tout accepter</button>
+      <button id="tarteaucitronAllDenied">Tout refuser</button>
+    </div>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__tacCalls = [];
+    window.tarteaucitron = {
+      userInterface: {
+        respondAll: function (status) {
+          window.__tacCalls.push(["respondAll", status]);
+          window.__consentState = status === false ? "necessary-only" : "accepted";
+          document.getElementById("tarteaucitronRoot").remove();
+        },
+      },
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: tarteaucitron userInterface.respondAll(false) fires via wrappedJSObject when the feature is enabled", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(TARTEAUCITRON_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const tacCalls = await driver.executeScript("return window.__tacCalls");
+    assert.deepEqual(tacCalls, [["respondAll", false]]);
+
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('tarteaucitronRoot') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: tarteaucitron userInterface.respondAll(false) does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(TARTEAUCITRON_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('tarteaucitronRoot') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+
+    const tacCalls = await driver.executeScript("return window.__tacCalls");
+    assert.deepEqual(tacCalls, []);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e/cookie-consent-minimizer-tarteaucitron.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-tarteaucitron.spec.mjs
@@ -1,0 +1,303 @@
+/**
+ * E2E: Cookie Consent Minimizer — tarteaucitron Tier 1 adapter
+ *
+ * Verifies the tarteaucitron reject path against a real Chromium with the
+ * extension loaded. The fixture page mimics a tarteaucitron banner: a
+ * `window.tarteaucitron.userInterface` object with a `respondAll()` method
+ * plus the `#tarteaucitronRoot` DOM anchor — the triple-mandatory
+ * (global + userInterface + fn) plus corroboration signal combination the
+ * dispatcher requires before acting (src/lib/cmp-adapters.js).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs's
+ * structure exactly (same onboarding helper shape, same feature pref, same
+ * triple-mandatory-gate adapter shape) — the one structural difference is
+ * the reject call takes a literal argument (`respondAll(false)`) instead of
+ * zero arguments, so the fixture records the exact argument it received.
+ *
+ * HONEST LIMIT: this is a REGRESSION oracle only — a snapshot of one
+ * fixture's behavior at write time. It proves the Chrome MAIN-world nonce
+ * handshake (content/cookie-noise-mainworld.js) and the
+ * never-auto-reject-the-other-way outcome on the fixture used here. It does
+ * NOT validate the Firefox `window.wrappedJSObject` reject path
+ * (content/cookie-noise.js) — Playwright's `chromium` fixture only exercises
+ * Chrome — and it does NOT prove real-vendor-script compatibility against a
+ * live tarteaucitron CMP build. A real-browser smoke test against at least
+ * one live tarteaucitron deployment is required before considering this
+ * adapter done — flagged for sdd-verify. Re-capture this fixture manually
+ * whenever the tarteaucitron markup/API shape this test hardcodes changes
+ * upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-tarteaucitron.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode: enableFeature ? "reject-only" : "off" },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a tarteaucitron banner offering a reject-all via
+ * `tarteaucitron.userInterface.respondAll(false)`. All three mandatory
+ * signals (global, userInterface, respondAll fn) are present alongside the
+ * `#tarteaucitronRoot` DOM anchor — the confidence gate in cmp-adapters.js
+ * requires the mandatory triple plus at least one corroborating DOM
+ * secondary.
+ */
+async function stubTarteaucitronPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="tarteaucitronRoot">
+          <div id="tarteaucitronAlertBig">
+            <button id="tarteaucitronAllAllowed">Tout accepter</button>
+            <button id="tarteaucitronAllDenied">Tout refuser</button>
+          </div>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__tacCalls = [];
+          window.tarteaucitron = {
+            userInterface: {
+              respondAll: function (status) {
+                window.__tacCalls.push(["respondAll", status]);
+                window.__consentState = status === false ? "necessary-only" : "accepted";
+                document.getElementById("tarteaucitronRoot").remove();
+              },
+            },
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — tarteaucitron", () => {
+  test("rejects a tarteaucitron banner with userInterface.respondAll(false) when the feature is enabled", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubTarteaucitronPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // respondAll was actually invoked with the literal false — not true,
+    // not omitted, not some other method.
+    const tacCalls = await page.evaluate(() => window.__tacCalls);
+    expect(tacCalls).toEqual([["respondAll", false]]);
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(
+      () => document.getElementById("tarteaucitronRoot") === null
+    );
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubTarteaucitronPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(
+      () => document.getElementById("tarteaucitronRoot") !== null
+    );
+    expect(bannerStillThere).toBe(true);
+
+    const tacCalls = await page.evaluate(() => window.__tacCalls);
+    expect(tacCalls).toEqual([]);
+
+    await page.close();
+  });
+
+  test("never misfires on a Didomi-only page (no tarteaucitron global present)", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    const DIDOMI_HOST = "muga-test-cookie-consent-tarteaucitron-didomi-guard.invalid";
+    await page.route(`**://${DIDOMI_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <div id="didomi-host"></div>
+          <p id="page-content">Real page content</p>
+          <script>
+            // A Didomi-shaped page: exposes window.Didomi.setUserDisagreeToAll
+            // but NO window.tarteaucitron global at all. The tarteaucitron
+            // adapter must never act here.
+            window.__didomiCalls = [];
+            window.Didomi = {
+              getCurrentUserStatus: function () { return {}; },
+              setUserDisagreeToAll: function () {
+                window.__didomiCalls.push("setUserDisagreeToAll");
+              },
+            };
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${DIDOMI_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The Didomi adapter IS expected to fire here (it is a real Didomi
+    // page) — what this test guards is that the tarteaucitron adapter never
+    // ALSO claims it / never references tarteaucitron on a page that has
+    // none.
+    await page.waitForFunction(
+      () => Array.isArray(window.__didomiCalls) && window.__didomiCalls.includes("setUserDisagreeToAll"),
+      { timeout: 10000 }
+    );
+
+    const tacGlobalPresent = await page.evaluate(() => typeof window.tarteaucitron !== "undefined");
+    expect(tacGlobalPresent).toBe(false);
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("does not throw or reject when tarteaucitron is present but has no .userInterface (null-safety)", async ({
+    context,
+    extensionId,
+  }) => {
+    // Regression guard for the exact TypeError hazard the triple-mandatory
+    // gate exists to prevent: window.tarteaucitron is a truthy object but
+    // has NO `.userInterface` (the vendor script attaches the global before
+    // the UI module is constructed). Reading
+    // `window.tarteaucitron.userInterface.respondAll` naively would throw
+    // "Cannot read properties of undefined". The signal collector
+    // short-circuits on the missing userInterface, so detection must fail
+    // closed and the adapter must NOOP — with zero page errors captured.
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const NO_UI_HOST = "muga-test-cookie-consent-tarteaucitron-no-userinterface.invalid";
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.route(`**://${NO_UI_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <div id="tarteaucitronRoot">
+            <div id="tarteaucitronAlertBig">
+              <button id="tarteaucitronAllAllowed">Tout accepter</button>
+              <button id="tarteaucitronAllDenied">Tout refuser</button>
+            </div>
+          </div>
+          <p id="page-content">Real page content</p>
+          <script>
+            // Truthy tarteaucitron global WITHOUT a .userInterface — the
+            // exact present-but-not-yet-populated shape the triple gate
+            // guards.
+            window.tarteaucitron = {};
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${NO_UI_HOST}/index.html`);
+
+    // Wait for the MAIN-world caller's once-guard flag — proves the signal
+    // collection path (including the tarteaucitron `.userInterface`-undefined
+    // branch) actually ran under real page-error capture.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed and no
+    // TypeError must surface) has no positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    // The adapter must NOT have acted: no consent state was mutated.
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    // Banner is untouched — the feature-safe NOOP left the page alone.
+    const bannerStillThere = await page.evaluate(
+      () => document.getElementById("tarteaucitronRoot") !== null
+    );
+    expect(bannerStillThere).toBe(true);
+
+    // The global is still the userInterface-less object we planted (no
+    // crash mid-collection that would have aborted the script).
+    const tacShape = await page.evaluate(() => ({
+      isObject: typeof window.tarteaucitron === "object" && window.tarteaucitron !== null,
+      hasUserInterface: typeof window.tarteaucitron?.userInterface !== "undefined",
+    }));
+    expect(tacShape).toEqual({ isObject: true, hasUserInterface: false });
+
+    // The whole point: reading `.userInterface.respondAll` never threw.
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -31,6 +31,7 @@ import {
   usercentricsAdapter,
   cookieInformationAdapter,
   cookieScriptAdapter,
+  tarteaucitronAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -40,8 +41,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information and CookieScript adapters, in order", () => {
-    assert.equal(TIER1.length, 8);
+  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information, CookieScript and tarteaucitron adapters, in order", () => {
+    assert.equal(TIER1.length, 9);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
     assert.strictEqual(TIER1[2], didomiAdapter);
@@ -50,6 +51,7 @@ describe("cmp-adapters — registry shape", () => {
     assert.strictEqual(TIER1[5], usercentricsAdapter);
     assert.strictEqual(TIER1[6], cookieInformationAdapter);
     assert.strictEqual(TIER1[7], cookieScriptAdapter);
+    assert.strictEqual(TIER1[8], tarteaucitronAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -124,6 +126,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof cookieScriptAdapter.detect, "function");
     assert.equal(typeof cookieScriptAdapter.canReject, "function");
     assert.equal(typeof cookieScriptAdapter.reject, "function");
+  });
+
+  test("tarteaucitronAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(tarteaucitronAdapter.id, "tarteaucitron");
+    assert.equal(tarteaucitronAdapter.tier, 1);
+    assert.equal(typeof tarteaucitronAdapter.detect, "function");
+    assert.equal(typeof tarteaucitronAdapter.canReject, "function");
+    assert.equal(typeof tarteaucitronAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -523,6 +533,57 @@ describe("decideAction — truth table", () => {
       hasRejectAllActionFn: true,
       hasCookiescriptInjectedDom: false,
       hasCookiescriptDescriptionDom: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("tarteaucitron: global + userInterface + respondAll fn + corroborating DOM -> reject", () => {
+    const r = decideAction({
+      hasTarteaucitronGlobal: true,
+      hasTarteaucitronUserInterface: true,
+      hasRespondAllFn: true,
+      hasTarteaucitronRootDom: true,
+      hasTarteaucitronAlertBigDom: false,
+      hasTarteaucitronBackDom: false,
+      hasTarteaucitronModalOpenDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "tarteaucitron");
+  });
+
+  test("tarteaucitron: global present but userInterface/respondAll absent (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasTarteaucitronGlobal: true,
+      hasTarteaucitronUserInterface: false,
+      hasRespondAllFn: false,
+      hasTarteaucitronRootDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("tarteaucitron: global + userInterface present but respondAll fn absent (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasTarteaucitronGlobal: true,
+      hasTarteaucitronUserInterface: true,
+      hasRespondAllFn: false,
+      hasTarteaucitronRootDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("tarteaucitron: mandatory signals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasTarteaucitronGlobal: true,
+      hasTarteaucitronUserInterface: true,
+      hasRespondAllFn: true,
+      hasTarteaucitronRootDom: false,
+      hasTarteaucitronAlertBigDom: false,
+      hasTarteaucitronBackDom: false,
+      hasTarteaucitronModalOpenDom: false,
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "uncertain");
@@ -1061,6 +1122,82 @@ describe("cookieScriptAdapter.detect — dual-mandatory-plus-instance confidence
   });
 });
 
+describe("tarteaucitronAdapter.detect — triple-mandatory confidence gate", () => {
+  const FULL_TAC_SIGNALS = Object.freeze({
+    hasTarteaucitronGlobal: true,
+    hasTarteaucitronUserInterface: true,
+    hasRespondAllFn: true,
+    hasTarteaucitronRootDom: true,
+    hasTarteaucitronAlertBigDom: true,
+    hasTarteaucitronBackDom: true,
+    hasTarteaucitronModalOpenDom: true,
+  });
+
+  test("mandatory triple + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = tarteaucitronAdapter.detect(FULL_TAC_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(tarteaucitronAdapter.canReject(FULL_TAC_SIGNALS), true);
+  });
+
+  test("mandatory triple + exactly one secondary (#tarteaucitronRoot only) -> canReject true", () => {
+    const s = {
+      hasTarteaucitronGlobal: true,
+      hasTarteaucitronUserInterface: true,
+      hasRespondAllFn: true,
+      hasTarteaucitronRootDom: true,
+      hasTarteaucitronAlertBigDom: false,
+      hasTarteaucitronBackDom: false,
+      hasTarteaucitronModalOpenDom: false,
+    };
+    assert.equal(tarteaucitronAdapter.canReject(s), true);
+  });
+
+  test("global-only (mandatory triple present, zero secondary signals) -> uncertain, canReject false", () => {
+    const s = {
+      hasTarteaucitronGlobal: true,
+      hasTarteaucitronUserInterface: true,
+      hasRespondAllFn: true,
+      hasTarteaucitronRootDom: false,
+      hasTarteaucitronAlertBigDom: false,
+      hasTarteaucitronBackDom: false,
+      hasTarteaucitronModalOpenDom: false,
+    };
+    assert.equal(tarteaucitronAdapter.canReject(s), false);
+    assert.ok(tarteaucitronAdapter.detect(s) < 1);
+  });
+
+  test("DOM-only (mandatory respondAll fn missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasTarteaucitronGlobal: false,
+      hasTarteaucitronUserInterface: false,
+      hasRespondAllFn: false,
+      hasTarteaucitronRootDom: true,
+      hasTarteaucitronAlertBigDom: true,
+      hasTarteaucitronBackDom: true,
+      hasTarteaucitronModalOpenDom: true,
+    };
+    assert.equal(tarteaucitronAdapter.detect(s), 0);
+    assert.equal(tarteaucitronAdapter.canReject(s), false);
+  });
+
+  test("global present but userInterface absent (respondAll unreachable) -> confidence 0, canReject false", () => {
+    const s = {
+      hasTarteaucitronGlobal: true,
+      hasTarteaucitronUserInterface: false,
+      hasRespondAllFn: false,
+      hasTarteaucitronRootDom: true,
+    };
+    assert.equal(tarteaucitronAdapter.detect(s), 0);
+    assert.equal(tarteaucitronAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => tarteaucitronAdapter.detect(null));
+    assert.doesNotThrow(() => tarteaucitronAdapter.detect(undefined));
+    assert.equal(tarteaucitronAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -1233,6 +1370,25 @@ describe("cookieScriptAdapter.reject — pure callback invocation", () => {
 
   test("non-function argument -> status noop, no call", () => {
     const r = cookieScriptAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+describe("tarteaucitronAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = tarteaucitronAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = tarteaucitronAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = tarteaucitronAdapter.reject(undefined);
     assert.equal(r.status, "noop");
   });
 });
@@ -1419,5 +1575,17 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
     assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
     assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must still include usercentricsAdapter");
     assert.ok(TIER1.includes(cookieInformationAdapter), "TIER1 must still include cookieInformationAdapter");
+  });
+
+  test("tarteaucitronAdapter is registered in TIER1 alongside the other eight adapters", () => {
+    assert.ok(TIER1.includes(tarteaucitronAdapter), "TIER1 must include tarteaucitronAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
+    assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
+    assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
+    assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must still include usercentricsAdapter");
+    assert.ok(TIER1.includes(cookieInformationAdapter), "TIER1 must still include cookieInformationAdapter");
+    assert.ok(TIER1.includes(cookieScriptAdapter), "TIER1 must still include cookieScriptAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -142,6 +142,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectCookieScript/.test(joined));
     assert.ok(/function canRejectCookieScript/.test(joined));
   });
+
+  test("sync block also defines detectTarteaucitron and canRejectTarteaucitron", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectTarteaucitron/.test(joined));
+    assert.ok(/function canRejectTarteaucitron/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -472,6 +478,35 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       assert.ok(calls.length > 0, `${label} must call rejectAllAction`);
       for (const args of calls) {
         assert.equal(args, "", `${label} rejectAllAction must be called with zero arguments`);
+      }
+    }
+  });
+
+  test("only tarteaucitron.userInterface.respondAll (or wrappedJSObject equivalent) is invoked — no other tarteaucitron method call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/tarteaucitron\.userInterface\.(\w+)\s*\(/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call tarteaucitron.userInterface.respondAll`);
+      for (const fn of calls) {
+        assert.equal(fn, "respondAll", `${label} calls tarteaucitron.userInterface.${fn}() — only respondAll is permitted`);
+      }
+    }
+  });
+
+  // LITERAL-ARG GUARD (unlike the zero-argument adapters above): respondAll's
+  // first argument is a boolean where false = deny and true = accept-all —
+  // this call site must be pinned to the literal `false`, mirroring the
+  // Cookiebot submitCustomConsent(false, false, false) literal-args guard
+  // above. A future edit to `respondAll(true)` or `respondAll()` (default
+  // parameter semantics aside, the call site itself must never read that
+  // way) must fail here.
+  test("every respondAll call passes the literal false — never true, never a variable, never zero arguments", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/respondAll\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call respondAll`);
+      for (const args of calls) {
+        assert.equal(args, "false", `${label} respondAll must be called with the literal false, and only false`);
       }
     }
   });

--- a/tests/unit/release-smoke-report.test.mjs
+++ b/tests/unit/release-smoke-report.test.mjs
@@ -231,6 +231,6 @@ describe("release-smoke-report — importing the module never triggers CLI/files
     assert.equal(typeof mod.formatReleaseTable, "function");
     assert.equal(typeof mod.runReleaseSmokeReportCli, "function");
     assert.ok(Array.isArray(mod.RELEASE_CMPS));
-    assert.equal(mod.RELEASE_CMPS.length, 8);
+    assert.equal(mod.RELEASE_CMPS.length, 9);
   });
 });

--- a/tools/release-smoke-report.mjs
+++ b/tools/release-smoke-report.mjs
@@ -5,9 +5,9 @@
  * Reduces the existing CMP canary results (tests/canary/cmp-sites.json +
  * tools/canary-report.mjs's `test-results/canary-results.json` schema,
  * `{cmp, url, status: "pass"|"fail"|"inconclusive", detail}`) into a
- * per-adapter RELEASE verdict for the 8 Tier 1 cookie-consent adapters
+ * per-adapter RELEASE verdict for the 9 Tier 1 cookie-consent adapters
  * (src/lib/cmp-adapters.js TIER1: onetrust, cookiebot, didomi, cookieyes,
- * sourcepoint, usercentrics, cookieinformation, cookiescript).
+ * sourcepoint, usercentrics, cookieinformation, cookiescript, tarteaucitron).
  *
  * This does NOT run the canary itself — see tools/canary-report.mjs for
  * that (drift-alarm reporting) and .github/workflows/cmp-canary.yml (the
@@ -46,7 +46,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Pure decision logic ───────────────────────────────────────────────────
 
 /**
- * The 8 Tier 1 cookie-consent CMP ids, in the same order as
+ * The 9 Tier 1 cookie-consent CMP ids, in the same order as
  * src/lib/cmp-adapters.js's TIER1 registry.
  * @type {ReadonlyArray<string>}
  */
@@ -59,6 +59,7 @@ export const RELEASE_CMPS = Object.freeze([
   "usercentrics",
   "cookieinformation",
   "cookiescript",
+  "tarteaucitron",
 ]);
 
 function emptyBucket() {


### PR DESCRIPTION
Closes #1143. Relates to #1027.

## Summary
9th Tier 1 API adapter — **tarteaucitron.js** (dominant in France / French gov). Reject-only, no accept, no DOM clicking. Source-verified against github.com/AmauriC/tarteaucitron.js.
- Reject: `window.tarteaucitron.userInterface.respondAll(false)` (synchronous).
- Detect: triple-mandatory (`window.tarteaucitron` + `.userInterface` + `.respondAll` fn) with null-safe staged `&&` collection + >=1 DOM secondary (`#tarteaucitronRoot`/`#tarteaucitronAlertBig`/`#tarteaucitronBack`/`.tarteaucitron-modal-open`), threshold 1, fail-closed.
- Enrolls in release-smoke (RELEASE_CMPS 8->9; 9 adapters / 18 cells).

## Safety — LITERAL-ARG adapter (novel vs the last 3 zero-arg ones)
`respondAll(false)`=deny; `respondAll(true)`=accept-all (byte-verified in source). The `false` literal is pinned by a structural guard (mirrors Cookiebot's `(false,false,false)`) that FAILS on `respondAll(true)`/`respondAll()`/`respondAll(var)`; a method-name guard forbids any other tarteaucitron method. `ACTIONS` stays {REJECT_ALL}; `/allowall|accept/i` scan passes.

## Test plan
- `npm test` 6851 pass / 0 fail / 1 pre-existing skip.
- **Chromium e2e 4/4 EXECUTED & GREEN** (reject fires, feature-OFF, cross-CMP misfire, null-safety).
- **Firefox smoke 2/2 EXECUTED & GREEN** (wrappedJSObject reject fires + feature-OFF).
- `lint`/`lint:js`/`check:i18n` clean; bundle-drift clean (cookie-noise*.js not bundled).
- Adversarial review passed: literal-`false` guard has real teeth, null-safety staged both worlds, @sync byte-identity, discrimination, never-accept spine all confirmed.

## Notes
- Canary entry is a PLACEHOLDER (tarteaucitron.io) — needs EU-geo curation (separate).
- Manual-smoke open item: confirm respondAll(false) on a real production tarteaucitron site (source-verified sync/deny, but not live-probed).