### PR TITLE
feat(consent): add consentmanager.net Tier 1 adapter

### DIFF
--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -2,9 +2,9 @@
 
 ## Why this exists
 
-The 9 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
+The 10 Tier 1 cookie-consent adapters in `src/lib/cmp-adapters.js` (OneTrust,
 Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information,
-CookieScript, tarteaucitron) are unit-green:
+CookieScript, tarteaucitron, consentmanager.net) are unit-green:
 every detection truth table, every reject call shape, and every
 never-auto-accept structural guard is covered by `npm test`. Unit-green is
 not the same thing as real-env-green. Every adapter's merge PR shipped with
@@ -78,7 +78,7 @@ sites (`src/content/cookie-noise-mainworld.js` for Chrome MAIN world,
 `tests/canary/cmp-sites.json` - do not test against a different site
 without first adding it there.
 
-General Chrome steps (same shape for all 9 adapters unless noted):
+General Chrome steps (same shape for all 10 adapters unless noted):
 
 1. `npm run build:content` then load the unpacked extension from `src/`
    in `chrome://extensions` (Developer mode > Load unpacked).
@@ -93,7 +93,7 @@ General Chrome steps (same shape for all 9 adapters unless noted):
    inspector (where available) to confirm the resulting consent state is
    reject / necessary-only, not accept.
 
-General Firefox steps (same shape for all 9 adapters unless noted):
+General Firefox steps (same shape for all 10 adapters unless noted):
 manual only, automation is tracked separately in #1128.
 
 1. `bash scripts/with-firefox-manifest.sh npm run build:content` then load
@@ -383,9 +383,55 @@ following before marking this adapter PASS:
 - **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
 - **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
 
+### 10. consentmanager.net
+
+- **Reject call:** `window.__cmp("setConsent", 0, callback, true)` (Chrome
+  MAIN world); `window.wrappedJSObject.__cmp("setConsent", 0, callback, true)`
+  (Firefox). Fire-and-forget: the callback fires in practice but is
+  optional-log-only and never gates control flow — `_acted`/`stopObserver()`
+  fire synchronously right after the call returns. The literal `0`
+  consent-value argument denies all (reject-all); `1` would grant broad
+  consent, so this call site never passes a variable there — confirmed
+  behaviorally on 3 live customer deployments (see the specific-risk note
+  below).
+- **Detection signals:** TRIPLE-mandatory (all three required together, since
+  `window.__cmp` is the legacy IAB TCF v1.1 generic surface every v1.1-era
+  CMP can expose and can never be a sole anchor): `hasCmpMngrGlobal`
+  (`typeof window.cmpmngr === "object"`, the vendor-specific global),
+  `hasCmpFn` (`typeof window.__cmp === "function"`, the reject surface), and
+  `hasCmpBoxDom` (`#cmpbox`, the vendor-specific DOM anchor); corroborating
+  (>=1 required): `hasCmpWelcomeBtnYesDom` (`#cmpwelcomebtnyes`),
+  `hasCmpWelcomeBtnNoDom` (`#cmpwelcomebtnno`), `hasCmpBoxBtnDom`
+  (`#cmpbox .cmpboxbtn`).
+- **Candidate live site(s):** `https://www.hoerzu.de` (banner selector
+  `#cmpbox`) — PLACEHOLDER, needs independent curation/confirmation before
+  relying on this entry for release gating. This is one of the real customer
+  deployments (alongside adac.de, blic.rs, hrt.hr) where a live headless-
+  Chromium behavioral probe confirmed `window.cmpmngr`/`window.__cmp`
+  present, `#cmpbox` visible, and `__cmp("setConsent", 0, callback, true)`
+  dismissing the banner with parity to the native reject button (engram
+  `sdd/cookie-consent-coverage/tier1-live-probe`) — but that probe was a
+  one-off verification run, not the same repeatable canary-site curation
+  process used for the other 9 adapters' entries.
+- **Specific risk to verify:** Firefox `wrappedJSObject` reject path is
+  structurally tested only — confirm `__cmp("setConsent", 0, callback, true)`
+  actually clears the banner on a live site in Firefox, not just via the
+  Chrome probe evidence above. Also confirm the dual-anchor discrimination
+  holds: this vendor's `__cmp` is the shared/generic legacy TCF v1.1 surface,
+  so verify on a real consentmanager.net page that the adapter fires (not a
+  misfire from some other bare-`__cmp`-exposing v1.1 CMP), and that a
+  non-consentmanager.net page exposing only a bare `__cmp` never triggers
+  this adapter. consentmanager.net's banner is geo-gated per-deployment
+  (confirmed during the live probe — 2 of 5 real customer sites did not
+  render from a non-EU vantage), so a single failed manual check from a
+  non-EU location is not evidence of drift; retry from an EU vantage or a
+  different candidate site before treating a no-show as a FAIL.
+- **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
+- **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
+
 ## Sign-off table
 
-All 18 cells (9 adapters x Chrome/Firefox) must be green before the
+All 20 cells (10 adapters x Chrome/Firefox) must be green before the
 `develop -> main` release PR opens.
 
 | Adapter | Chrome | Firefox |
@@ -399,5 +445,6 @@ All 18 cells (9 adapters x Chrome/Firefox) must be green before the
 | Cookie Information | ____ | ____ |
 | CookieScript | ____ | ____ |
 | tarteaucitron | ____ | ____ |
+| consentmanager.net | ____ | ____ |
 
 Reviewer: ______________________  Date: ______________________

--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -218,6 +218,32 @@
   function canRejectTarteaucitron(signals) {
     return detectTarteaucitron(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // consentmanager.net: __cmp is the legacy IAB TCF v1.1 generic surface
+  // every v1.1-era CMP can expose, so it can never be the sole mandatory
+  // anchor — see the dual-anchor discrimination rationale above
+  // detectSourcepoint. hasCmpMngrGlobal AND hasCmpFn AND hasCmpBoxDom are all
+  // mandatory together (see the TRIPLE-mandatory rationale in the docblock
+  // preceding this sync block).
+  function detectConsentmanager(signals) {
+    if (
+      !signals ||
+      signals.hasCmpMngrGlobal !== true ||
+      signals.hasCmpFn !== true ||
+      signals.hasCmpBoxDom !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCmpWelcomeBtnYesDom === true ? 1 : 0) +
+      (signals.hasCmpWelcomeBtnNoDom === true ? 1 : 0) +
+      (signals.hasCmpBoxBtnDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectConsentmanager(signals) {
+    return detectConsentmanager(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   /**
@@ -445,6 +471,30 @@
     } catch {
       // document not ready / detached — leave all false.
     }
+    // consentmanager.net: window.cmpmngr is the vendor-specific global,
+    // window.__cmp is the legacy IAB TCF v1.1 generic reject surface — do
+    // NOT key detection off __cmp alone, see the dual-anchor discrimination
+    // rationale above detectConsentmanager.
+    let hasCmpMngrGlobal = false;
+    let hasCmpFn = false;
+    try {
+      hasCmpMngrGlobal = typeof window.cmpmngr === "object" && window.cmpmngr !== null;
+      hasCmpFn = typeof window.__cmp === "function";
+    } catch {
+      // Leave both false — fail-closed.
+    }
+    let hasCmpBoxDom = false;
+    let hasCmpWelcomeBtnYesDom = false;
+    let hasCmpWelcomeBtnNoDom = false;
+    let hasCmpBoxBtnDom = false;
+    try {
+      hasCmpBoxDom = !!document.getElementById("cmpbox");
+      hasCmpWelcomeBtnYesDom = !!document.getElementById("cmpwelcomebtnyes");
+      hasCmpWelcomeBtnNoDom = !!document.getElementById("cmpwelcomebtnno");
+      hasCmpBoxBtnDom = !!document.querySelector("#cmpbox .cmpboxbtn");
+    } catch {
+      // document not ready / detached — leave all false.
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -493,6 +543,12 @@
       hasTarteaucitronAlertBigDom,
       hasTarteaucitronBackDom,
       hasTarteaucitronModalOpenDom,
+      hasCmpMngrGlobal,
+      hasCmpFn,
+      hasCmpBoxDom,
+      hasCmpWelcomeBtnYesDom,
+      hasCmpWelcomeBtnNoDom,
+      hasCmpBoxBtnDom,
     };
   }
 
@@ -634,6 +690,23 @@
       _acted = true;
       try {
         window.tarteaucitron.userInterface.respondAll(false);
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // Tier 1: consentmanager.net API adapter. setConsent's second argument
+    // is the literal `0` (reject-all) — `1` would grant broad consent, so
+    // this call site must never pass a variable there. Same fire-and-forget
+    // family as the Sourcepoint adapter above: the callback fires in
+    // practice but is optional-log-only and never gates control flow —
+    // _acted and stopObserver() fire synchronously right after the call
+    // returns.
+    if (canRejectConsentmanager(signals)) {
+      _acted = true;
+      try {
+        window.__cmp("setConsent", 0, () => {}, true);
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -215,6 +215,32 @@
   function canRejectTarteaucitron(signals) {
     return detectTarteaucitron(signals) >= CONFIDENCE_THRESHOLD;
   }
+
+  // consentmanager.net: __cmp is the legacy IAB TCF v1.1 generic surface
+  // every v1.1-era CMP can expose, so it can never be the sole mandatory
+  // anchor — see the dual-anchor discrimination rationale above
+  // detectSourcepoint. hasCmpMngrGlobal AND hasCmpFn AND hasCmpBoxDom are all
+  // mandatory together (see the TRIPLE-mandatory rationale in the docblock
+  // preceding this sync block).
+  function detectConsentmanager(signals) {
+    if (
+      !signals ||
+      signals.hasCmpMngrGlobal !== true ||
+      signals.hasCmpFn !== true ||
+      signals.hasCmpBoxDom !== true
+    ) {
+      return 0;
+    }
+    const secondary =
+      (signals.hasCmpWelcomeBtnYesDom === true ? 1 : 0) +
+      (signals.hasCmpWelcomeBtnNoDom === true ? 1 : 0) +
+      (signals.hasCmpBoxBtnDom === true ? 1 : 0);
+    return secondary >= 1 ? 1 : 0.4;
+  }
+
+  function canRejectConsentmanager(signals) {
+    return detectConsentmanager(signals) >= CONFIDENCE_THRESHOLD;
+  }
   // @sync:cmp-adapters:end
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
@@ -495,6 +521,33 @@
     } catch {
       // ignore
     }
+    // consentmanager.net: window.cmpmngr is the vendor-specific global,
+    // window.__cmp is the legacy IAB TCF v1.1 generic reject surface,
+    // reached via wrappedJSObject — same Xray-safety pattern as the other
+    // Firefox signal reads above. Do NOT key detection off __cmp alone —
+    // see the dual-anchor discrimination rationale above detectConsentmanager.
+    let hasCmpMngrGlobal = false;
+    let hasCmpFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const cm = wrapped && wrapped.cmpmngr;
+      hasCmpMngrGlobal = typeof cm === "object" && cm !== null;
+      hasCmpFn = wrapped && typeof wrapped.__cmp === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
+    }
+    let hasCmpBoxDom = false;
+    let hasCmpWelcomeBtnYesDom = false;
+    let hasCmpWelcomeBtnNoDom = false;
+    let hasCmpBoxBtnDom = false;
+    try {
+      hasCmpBoxDom = !!document.getElementById("cmpbox");
+      hasCmpWelcomeBtnYesDom = !!document.getElementById("cmpwelcomebtnyes");
+      hasCmpWelcomeBtnNoDom = !!document.getElementById("cmpwelcomebtnno");
+      hasCmpBoxBtnDom = !!document.querySelector("#cmpbox .cmpboxbtn");
+    } catch {
+      // ignore
+    }
     return {
       hasOneTrustGlobal,
       hasRejectAllFn,
@@ -543,6 +596,12 @@
       hasTarteaucitronAlertBigDom,
       hasTarteaucitronBackDom,
       hasTarteaucitronModalOpenDom,
+      hasCmpMngrGlobal,
+      hasCmpFn,
+      hasCmpBoxDom,
+      hasCmpWelcomeBtnYesDom,
+      hasCmpWelcomeBtnNoDom,
+      hasCmpBoxBtnDom,
     };
   }
 
@@ -660,6 +719,20 @@
       _fxActed = true;
       try {
         window.wrappedJSObject.tarteaucitron.userInterface.respondAll(false);
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // Tier 1: consentmanager.net API adapter. Same literal-`0`,
+    // fire-and-forget shape as the Chrome MAIN-world caller — see
+    // cookie-noise-mainworld.js. setConsent's callback is optional-log-only
+    // and never gates control flow.
+    if (canRejectConsentmanager(signals)) {
+      _fxActed = true;
+      try {
+        window.wrappedJSObject.__cmp("setConsent", 0, () => {}, true);
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -137,6 +137,22 @@
  *   present in the DOM. Secondary/corroborating signal.
  * @property {boolean} [hasTarteaucitronModalOpenDom] - `.tarteaucitron-modal-open`
  *   present on `document.body`. Secondary/corroborating signal.
+ * @property {boolean} [hasCmpMngrGlobal] - `typeof window.cmpmngr === "object"`.
+ *   Mandatory signal: the consentmanager.net-specific vendor global.
+ * @property {boolean} [hasCmpFn] - `typeof window.__cmp === "function"`.
+ *   Mandatory signal: `__cmp` is the legacy IAB TCF v1.1 generic surface
+ *   (shared risk with other v1.1-era CMPs), so it can never be a sole
+ *   anchor — see the dual-anchor discrimination rationale above
+ *   detectConsentmanager below.
+ * @property {boolean} [hasCmpBoxDom] - `#cmpbox` present in the DOM.
+ *   Mandatory signal: the consentmanager.net-specific DOM anchor that
+ *   discriminates this CMP from every other bare-`__cmp`-exposing vendor.
+ * @property {boolean} [hasCmpWelcomeBtnYesDom] - `#cmpwelcomebtnyes`
+ *   present in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCmpWelcomeBtnNoDom] - `#cmpwelcomebtnno` present
+ *   in the DOM. Secondary/corroborating signal.
+ * @property {boolean} [hasCmpBoxBtnDom] - `#cmpbox .cmpboxbtn` present in
+ *   the DOM. Secondary/corroborating signal.
  */
 
 /**
@@ -246,6 +262,25 @@ export const ACTIONS = Object.freeze({
  * corroborating DOM secondary (`#tarteaucitronRoot`, `#tarteaucitronAlertBig`,
  * `#tarteaucitronBack`, `.tarteaucitron-modal-open`) — same fail-closed
  * CONFIDENCE_THRESHOLD as every other adapter here.
+ *
+ * The consentmanager.net adapter DEVIATES from every prior adapter's
+ * discrimination shape on purpose (dual-anchor discrimination, extended to
+ * a mandatory TRIPLE): its reject call rides `window.__cmp`, the legacy IAB
+ * TCF v1.1 generic global name — shared risk with other v1.1-era CMPs, so
+ * it can never be a sole anchor, mirroring the TCF-generic-signal
+ * discrimination rationale on detectSourcepoint above. Unlike Sourcepoint's
+ * dual-mandatory (generic fn + vendor DOM), this adapter requires a THIRD
+ * mandatory signal on top of that pair: `hasCmpMngrGlobal`
+ * (`typeof window.cmpmngr === "object"`, the vendor-specific global) AND
+ * `hasCmpFn` (`typeof window.__cmp === "function"`, the legacy generic
+ * reject surface) AND `hasCmpBoxDom` (`#cmpbox`, the vendor-specific DOM
+ * anchor) are all mandatory together — a bare `__cmp` function is common to
+ * every TCF v1.1 CMP and must never claim this adapter on its own, and
+ * `window.cmpmngr` alone (without the DOM anchor or the reject surface) is
+ * not enough either. The usual >=1 corroborating DOM secondary
+ * (`#cmpwelcomebtnyes`, `#cmpwelcomebtnno`, `#cmpbox .cmpboxbtn`) still
+ * gates the same fail-closed CONFIDENCE_THRESHOLD as every other adapter
+ * here.
  */
 // @sync:cmp-adapters:start
 const CONFIDENCE_THRESHOLD = 1;
@@ -424,6 +459,32 @@ function detectTarteaucitron(signals) {
 
 function canRejectTarteaucitron(signals) {
   return detectTarteaucitron(signals) >= CONFIDENCE_THRESHOLD;
+}
+
+// consentmanager.net: __cmp is the legacy IAB TCF v1.1 generic surface
+// every v1.1-era CMP can expose, so it can never be the sole mandatory
+// anchor — see the dual-anchor discrimination rationale above
+// detectSourcepoint. hasCmpMngrGlobal AND hasCmpFn AND hasCmpBoxDom are all
+// mandatory together (see the TRIPLE-mandatory rationale in the docblock
+// preceding this sync block).
+function detectConsentmanager(signals) {
+  if (
+    !signals ||
+    signals.hasCmpMngrGlobal !== true ||
+    signals.hasCmpFn !== true ||
+    signals.hasCmpBoxDom !== true
+  ) {
+    return 0;
+  }
+  const secondary =
+    (signals.hasCmpWelcomeBtnYesDom === true ? 1 : 0) +
+    (signals.hasCmpWelcomeBtnNoDom === true ? 1 : 0) +
+    (signals.hasCmpBoxBtnDom === true ? 1 : 0);
+  return secondary >= 1 ? 1 : 0.4;
+}
+
+function canRejectConsentmanager(signals) {
+  return detectConsentmanager(signals) >= CONFIDENCE_THRESHOLD;
 }
 // @sync:cmp-adapters:end
 
@@ -660,6 +721,40 @@ export const tarteaucitronAdapter = Object.freeze({
   reject,
 });
 
+/**
+ * consentmanager.net Tier 1 adapter. The reject call
+ * (`window.__cmp("setConsent", 0, callback, true)`) is invoked by the
+ * caller-supplied callback via the shared `reject()` helper above — this
+ * adapter definition never touches `window` itself. The literal `0`
+ * consent-value argument denies all (reject-all); `1` would grant broad
+ * consent, so this call site must never pass a variable there — see the
+ * literal-arg guard in tests/unit/cookie-noise-sync.test.mjs.
+ *
+ * Async call shape, fire-and-forget, same family as the Sourcepoint
+ * adapter's `__tcfapi("postRejectAll", 2, callback)`: the callback fires in
+ * practice but is optional-log-only and never gates control flow —
+ * `_acted`/`stopObserver()` fire synchronously right after the call
+ * returns, never awaited on the callback settling.
+ *
+ * Detection deviates from every prior adapter's discrimination shape on
+ * purpose (dual-anchor discrimination extended to a mandatory TRIPLE) — see
+ * detectConsentmanager's rationale above.
+ *
+ * Registered LAST in TIER1 (after tarteaucitronAdapter): `window.__cmp` is
+ * a shared/generic legacy TCF v1.1 surface (like Sourcepoint's
+ * `__tcfapi`), so ordering relative to the vendor-namespaced-global
+ * adapters is not safety-critical — appended at the end to keep the
+ * registry's history append-only.
+ * @type {Readonly<{id: "consentmanager", tier: 1, detect: typeof detectConsentmanager, canReject: typeof canRejectConsentmanager, reject: typeof reject}>}
+ */
+export const consentmanagerAdapter = Object.freeze({
+  id: "consentmanager",
+  tier: 1,
+  detect: detectConsentmanager,
+  canReject: canRejectConsentmanager,
+  reject,
+});
+
 /** Tier 1 registry: API adapters that call a page-authored global directly. */
 export const TIER1 = Object.freeze([
   oneTrustAdapter,
@@ -671,6 +766,7 @@ export const TIER1 = Object.freeze([
   cookieInformationAdapter,
   cookieScriptAdapter,
   tarteaucitronAdapter,
+  consentmanagerAdapter,
 ]);
 
 /**
@@ -752,6 +848,14 @@ export function decideAction(signals) {
   // sub-cases collapse to `hasRespondAllFn !== true` here, same shape as
   // the CookieScript hard wall above.
   if (s.hasTarteaucitronGlobal === true && s.hasRespondAllFn !== true) {
+    return { action: null, reason: "no-reject-path", adapterId: null };
+  }
+  // consentmanager.net hard wall: the MIRROR IMAGE of the Sourcepoint check
+  // above, keyed off the vendor-specific DOM anchor (hasCmpBoxDom), NOT
+  // bare hasCmpFn alone — a bare __cmp function is true on every TCF v1.1
+  // CMP and must fall through to "uncertain" below, never claim
+  // consentmanager.net.
+  if (s.hasCmpBoxDom === true && (s.hasCmpMngrGlobal !== true || s.hasCmpFn !== true)) {
     return { action: null, reason: "no-reject-path", adapterId: null };
   }
   return { action: null, reason: "uncertain", adapterId: null };

--- a/tests/canary/cmp-sites.json
+++ b/tests/canary/cmp-sites.json
@@ -88,5 +88,11 @@
     "url": "https://tarteaucitron.io",
     "bannerSelector": "#tarteaucitronRoot, #tarteaucitronAlertBig",
     "note": "PLACEHOLDER — UNVERIFIED, needs curation. tarteaucitron.js's own project/marketing site, following the same dogfooding-inference pattern used for the Cookiebot/Cookie Information/CookieScript entries above. Not independently confirmed via script inspection. Replace with a representative, independently-confirmed tarteaucitron customer deployment (strong France/gov-sector presence per the CMP triage in engram) before relying on this entry for release gating — curation is tracked as a follow-up, separate from adapter correctness."
+  },
+  {
+    "cmp": "consentmanager",
+    "url": "https://www.hoerzu.de",
+    "bannerSelector": "#cmpbox",
+    "note": "PLACEHOLDER — flagged as needing independent curation like the other placeholder entries above, but with STRONGER evidence than a dogfooding inference: a live headless-Chromium behavioral probe (2026-07, engram sdd/cookie-consent-coverage/tier1-live-probe) confirmed window.cmpmngr/window.__cmp present, #cmpbox visible, and __cmp('setConsent', 0, callback, true) dismissing the banner with parity to the native reject button on this real customer deployment (one of adac.de/hoerzu.de/blic.rs/hrt.hr tested in that probe). Geo-gated per-deployment — the same probe found 2 of 5 real customer sites did not render the banner from a non-EU vantage, so a single inconclusive canary run here is expected noise, not drift."
   }
 ]

--- a/tests/e2e-firefox/consentmanager.smoke.mjs
+++ b/tests/e2e-firefox/consentmanager.smoke.mjs
@@ -1,0 +1,119 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — consentmanager.net reject path.
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-consentmanager.spec.mjs's
+ * fixture page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.__cmp("setConsent", 0, callback, true)` path
+ * (src/content/cookie-noise.js) actually fires in Gecko.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as
+// tests/e2e/cookie-consent-minimizer-consentmanager.spec.mjs's
+// stubConsentmanagerPage: all three mandatory signals (cmpmngr global,
+// __cmp fn, #cmpbox DOM) plus the #cmpwelcomebtnyes/#cmpwelcomebtnno DOM
+// anchors as the corroborating secondary signal.
+const CONSENTMANAGER_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="cmpbox">
+    <button id="cmpwelcomebtnyes">Accept all</button>
+    <button id="cmpwelcomebtnno">Reject all</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__cmpCalls = [];
+    window.cmpmngr = {};
+    window.__cmp = function (command, consentValue, callback, isAsync) {
+      window.__cmpCalls.push([command, consentValue]);
+      if (command === "setConsent") {
+        window.__consentState = consentValue === 0 ? "necessary-only" : "accepted";
+        document.getElementById("cmpbox").remove();
+        if (typeof callback === "function") callback(true);
+      }
+    };
+  </script>
+</body></html>`;
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: consentmanager.net __cmp('setConsent', 0, callback, true) fires via wrappedJSObject when the feature is enabled", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    server = await serveFixturePage(CONSENTMANAGER_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'necessary-only'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "necessary-only");
+
+    const cmpCalls = await driver.executeScript("return window.__cmpCalls");
+    assert.deepEqual(cmpCalls, [["setConsent", 0]]);
+
+    const bannerGone = await driver.executeScript("return document.getElementById('cmpbox') === null");
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: consentmanager.net __cmp('setConsent', 0, callback, true) does NOT fire when the feature is disabled (default OFF)", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: false });
+
+    server = await serveFixturePage(CONSENTMANAGER_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    // Negative assertion — no positive signal to poll on, so use a fixed
+    // settle window (mirrors the Chromium spec's disabled-state test).
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript("return document.getElementById('cmpbox') !== null");
+    assert.equal(bannerStillThere, true);
+
+    const cmpCalls = await driver.executeScript("return window.__cmpCalls");
+    assert.deepEqual(cmpCalls, []);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e/cookie-consent-minimizer-consentmanager.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-consentmanager.spec.mjs
@@ -1,0 +1,328 @@
+/**
+ * E2E: Cookie Consent Minimizer — consentmanager.net Tier 1 adapter
+ *
+ * Verifies the consentmanager.net reject path against a real Chromium with
+ * the extension loaded. The fixture page mimics a consentmanager.net
+ * banner: a `window.cmpmngr` object plus a `window.__cmp` function and the
+ * `#cmpbox` DOM anchor — the triple-mandatory (cmpmngr global + __cmp fn +
+ * #cmpbox DOM) plus corroboration signal combination the dispatcher
+ * requires before acting (src/lib/cmp-adapters.js).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-tarteaucitron.spec.mjs's
+ * structure exactly (same onboarding helper shape, same feature pref) — the
+ * one structural difference is the reject call
+ * (`__cmp("setConsent", 0, callback, true)`) takes a literal command name
+ * PLUS a literal consent-value argument, so the fixture records the exact
+ * arguments it received.
+ *
+ * HONEST LIMIT: this is a REGRESSION oracle only — a snapshot of one
+ * fixture's behavior at write time. It proves the Chrome MAIN-world nonce
+ * handshake (content/cookie-noise-mainworld.js) and the
+ * never-auto-reject-the-other-way outcome on the fixture used here. It does
+ * NOT validate the Firefox `window.wrappedJSObject` reject path
+ * (content/cookie-noise.js) — Playwright's `chromium` fixture only exercises
+ * Chrome — see tests/e2e-firefox/consentmanager.smoke.mjs for that. It does
+ * confirm real-vendor-script compatibility against a live probe (engram
+ * sdd/cookie-consent-coverage/tier1-live-probe), but this fixture itself is
+ * a synthetic reproduction, not a live site. Re-capture this fixture
+ * manually whenever the consentmanager.net markup/API shape this test
+ * hardcodes changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-consentmanager.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode: enableFeature ? "reject-only" : "off" },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  // Prefs broadcast has no observable signal after storage.set resolves.
+  // Centralised in waitForDnrPropagation so the debt is greppable (#824).
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a consentmanager.net banner offering a reject-all via
+ * `window.__cmp("setConsent", 0, callback, true)`. All three mandatory
+ * signals (cmpmngr global, __cmp fn, #cmpbox DOM) are present alongside the
+ * `#cmpwelcomebtnyes`/`#cmpwelcomebtnno` DOM anchors — the confidence gate
+ * in cmp-adapters.js requires the mandatory triple plus at least one
+ * corroborating DOM secondary.
+ */
+async function stubConsentmanagerPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="cmpbox">
+          <button id="cmpwelcomebtnyes">Accept all</button>
+          <button id="cmpwelcomebtnno">Reject all</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__cmpCalls = [];
+          window.cmpmngr = {};
+          window.__cmp = function (command, consentValue, callback, isAsync) {
+            window.__cmpCalls.push([command, consentValue]);
+            if (command === "setConsent") {
+              window.__consentState = consentValue === 0 ? "necessary-only" : "accepted";
+              document.getElementById("cmpbox").remove();
+              if (typeof callback === "function") callback(true);
+            }
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — consentmanager.net", () => {
+  test("rejects a consentmanager.net banner with __cmp('setConsent', 0, callback, true) when the feature is enabled", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubConsentmanagerPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Wait for the Chrome MAIN-world caller's once-guard flag — set only
+    // after the nonce handshake completes and the gate opens.
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The dispatcher acts on gate-open (initial sweep) or on the
+    // MutationObserver's first pass — poll for the outcome.
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    // __cmp was actually invoked with the literal setConsent command and
+    // the literal 0 consent value — not accept (1), not omitted, not some
+    // other command.
+    const cmpCalls = await page.evaluate(() => window.__cmpCalls);
+    expect(cmpCalls).toEqual([["setConsent", 0]]);
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(() => document.getElementById("cmpbox") === null);
+    expect(bannerGone).toBe(true);
+
+    // Page remains functional — the unrelated marker is untouched.
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF)", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubConsentmanagerPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this test suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(() => document.getElementById("cmpbox") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    const cmpCalls = await page.evaluate(() => window.__cmpCalls);
+    expect(cmpCalls).toEqual([]);
+
+    await page.close();
+  });
+
+  test("never misfires on a Didomi-only page (no cmpmngr/__cmp/#cmpbox present)", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    const DIDOMI_HOST = "muga-test-cookie-consent-consentmanager-didomi-guard.invalid";
+    await page.route(`**://${DIDOMI_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <div id="didomi-host"></div>
+          <p id="page-content">Real page content</p>
+          <script>
+            // A Didomi-shaped page: exposes window.Didomi.setUserDisagreeToAll
+            // but NO window.cmpmngr / window.__cmp / #cmpbox at all. The
+            // consentmanager.net adapter must never act here.
+            window.__didomiCalls = [];
+            window.Didomi = {
+              getCurrentUserStatus: function () { return {}; },
+              setUserDisagreeToAll: function () {
+                window.__didomiCalls.push("setUserDisagreeToAll");
+              },
+            };
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${DIDOMI_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // The Didomi adapter IS expected to fire here (it is a real Didomi
+    // page) — what this test guards is that the consentmanager.net adapter
+    // never ALSO claims it / never references __cmp on a page that has
+    // none.
+    await page.waitForFunction(
+      () => Array.isArray(window.__didomiCalls) && window.__didomiCalls.includes("setUserDisagreeToAll"),
+      { timeout: 10000 }
+    );
+
+    const cmpFnPresent = await page.evaluate(() => typeof window.__cmp !== "undefined");
+    expect(cmpFnPresent).toBe(false);
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("never misfires on a bare-__cmp-only page (legacy TCF v1.1 CMP shape, no cmpmngr/#cmpbox)", async ({
+    context,
+    extensionId,
+  }) => {
+    // Regression guard for the exact discrimination hazard the
+    // triple-mandatory gate exists to prevent: __cmp is the legacy IAB TCF
+    // v1.1 generic surface shared by many CMPs. A page that exposes a bare
+    // __cmp function but NOT the consentmanager.net-specific cmpmngr global
+    // or #cmpbox DOM must never trigger this adapter.
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const BARE_CMP_HOST = "muga-test-cookie-consent-consentmanager-bare-cmp-guard.invalid";
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.route(`**://${BARE_CMP_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <p id="page-content">Real page content</p>
+          <script>
+            // A generic TCF v1.1 CMP shape: bare __cmp function, but NO
+            // window.cmpmngr and NO #cmpbox — this is exactly the
+            // discrimination gap the triple-mandatory gate closes.
+            window.__cmpCalls = [];
+            window.__cmp = function (command, consentValue, callback) {
+              window.__cmpCalls.push([command, consentValue]);
+              if (typeof callback === "function") callback(true);
+            };
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${BARE_CMP_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed) has no
+    // positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const cmpCalls = await page.evaluate(() => window.__cmpCalls);
+    expect(cmpCalls).toEqual([]);
+
+    const cmpMngrPresent = await page.evaluate(() => typeof window.cmpmngr !== "undefined");
+    expect(cmpMngrPresent).toBe(false);
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("does not throw or reject when __cmp is present but cmpmngr/#cmpbox are absent (null-safety)", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const NO_ANCHOR_HOST = "muga-test-cookie-consent-consentmanager-no-anchor.invalid";
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.route(`**://${NO_ANCHOR_HOST}/**`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: `<!doctype html><html><body>
+          <p id="page-content">Real page content</p>
+          <script>
+            // __cmp present, but no cmpmngr global and no #cmpbox DOM —
+            // the mandatory triple must fail closed without throwing.
+            window.__cmp = function () {};
+          </script>
+        </body></html>`,
+      })
+    );
+    await page.goto(`https://${NO_ANCHOR_HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+
+    // Asserting an ABSENCE of behavior (the gate must stay closed and no
+    // TypeError must surface) has no positive DOM/window signal to wait on.
+    // REASON: a fixed settle window is the standard pattern for a negative
+    // assertion in this suite — there is nothing to waitForFunction on.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const cmpMngrShape = await page.evaluate(() => ({
+      hasCmp: typeof window.__cmp === "function",
+      hasCmpMngr: typeof window.cmpmngr !== "undefined",
+      hasCmpBox: document.getElementById("cmpbox") !== null,
+    }));
+    expect(cmpMngrShape).toEqual({ hasCmp: true, hasCmpMngr: false, hasCmpBox: false });
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -32,6 +32,7 @@ import {
   cookieInformationAdapter,
   cookieScriptAdapter,
   tarteaucitronAdapter,
+  consentmanagerAdapter,
   decideAction,
   computeCookieGate,
 } from "../../src/lib/cmp-adapters.js";
@@ -41,8 +42,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Registry shape ──────────────────────────────────────────────────────────
 
 describe("cmp-adapters — registry shape", () => {
-  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information, CookieScript and tarteaucitron adapters, in order", () => {
-    assert.equal(TIER1.length, 9);
+  test("TIER1 contains exactly the OneTrust, Cookiebot, Didomi, CookieYes, Sourcepoint, Usercentrics, Cookie Information, CookieScript, tarteaucitron and consentmanager.net adapters, in order", () => {
+    assert.equal(TIER1.length, 10);
     assert.strictEqual(TIER1[0], oneTrustAdapter);
     assert.strictEqual(TIER1[1], cookiebotAdapter);
     assert.strictEqual(TIER1[2], didomiAdapter);
@@ -52,6 +53,7 @@ describe("cmp-adapters — registry shape", () => {
     assert.strictEqual(TIER1[6], cookieInformationAdapter);
     assert.strictEqual(TIER1[7], cookieScriptAdapter);
     assert.strictEqual(TIER1[8], tarteaucitronAdapter);
+    assert.strictEqual(TIER1[9], consentmanagerAdapter);
   });
 
   test("TIER2 ships empty in this slice", () => {
@@ -134,6 +136,14 @@ describe("cmp-adapters — registry shape", () => {
     assert.equal(typeof tarteaucitronAdapter.detect, "function");
     assert.equal(typeof tarteaucitronAdapter.canReject, "function");
     assert.equal(typeof tarteaucitronAdapter.reject, "function");
+  });
+
+  test("consentmanagerAdapter exposes id, tier, detect, canReject, reject", () => {
+    assert.equal(consentmanagerAdapter.id, "consentmanager");
+    assert.equal(consentmanagerAdapter.tier, 1);
+    assert.equal(typeof consentmanagerAdapter.detect, "function");
+    assert.equal(typeof consentmanagerAdapter.canReject, "function");
+    assert.equal(typeof consentmanagerAdapter.reject, "function");
   });
 
   test("ACTIONS is a closed set containing only the reject-family action", () => {
@@ -587,6 +597,90 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "uncertain");
+  });
+
+  test("consentmanager.net: cmpmngr global + __cmp fn + #cmpbox DOM + corroborating DOM -> reject", () => {
+    const r = decideAction({
+      hasCmpMngrGlobal: true,
+      hasCmpFn: true,
+      hasCmpBoxDom: true,
+      hasCmpWelcomeBtnYesDom: true,
+      hasCmpWelcomeBtnNoDom: false,
+      hasCmpBoxBtnDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "consentmanager");
+  });
+
+  test("consentmanager.net: #cmpbox DOM present but cmpmngr global missing (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasCmpMngrGlobal: false,
+      hasCmpFn: true,
+      hasCmpBoxDom: true,
+      hasCmpWelcomeBtnYesDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("consentmanager.net: #cmpbox DOM present but __cmp fn missing (hard wall) -> NOOP, no-reject-path", () => {
+    const r = decideAction({
+      hasCmpMngrGlobal: true,
+      hasCmpFn: false,
+      hasCmpBoxDom: true,
+      hasCmpWelcomeBtnYesDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "no-reject-path");
+  });
+
+  test("consentmanager.net: cmpmngr + __cmp present but #cmpbox DOM missing -> NOOP, uncertain (generic TCF v1.1 CMP, not consentmanager.net)", () => {
+    const r = decideAction({
+      hasCmpMngrGlobal: true,
+      hasCmpFn: true,
+      hasCmpBoxDom: false,
+      hasCmpWelcomeBtnYesDom: true,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("consentmanager.net: all three mandatory signals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
+    const r = decideAction({
+      hasCmpMngrGlobal: true,
+      hasCmpFn: true,
+      hasCmpBoxDom: true,
+      hasCmpWelcomeBtnYesDom: false,
+      hasCmpWelcomeBtnNoDom: false,
+      hasCmpBoxBtnDom: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("bare __cmp function present alone (no cmpmngr, no #cmpbox) -> NOOP, uncertain — never misfires as consentmanager.net", () => {
+    const r = decideAction({
+      hasCmpFn: true,
+      hasCmpMngrGlobal: false,
+      hasCmpBoxDom: false,
+    });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+
+  test("Sourcepoint-shaped signals (__tcfapi + sp_message_container, NO cmpmngr/#cmpbox) resolve to Sourcepoint, never misfire as consentmanager.net", () => {
+    const r = decideAction({
+      hasTcfApiFn: true,
+      hasSpMessageContainerDom: true,
+      hasSpPrivacyMgmtIframeDom: true,
+      hasCmpMngrGlobal: false,
+      hasCmpFn: false,
+      hasCmpBoxDom: false,
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "sourcepoint");
   });
 });
 
@@ -1198,6 +1292,78 @@ describe("tarteaucitronAdapter.detect — triple-mandatory confidence gate", () 
   });
 });
 
+describe("consentmanagerAdapter.detect — triple-mandatory confidence gate", () => {
+  const FULL_CMP_SIGNALS = Object.freeze({
+    hasCmpMngrGlobal: true,
+    hasCmpFn: true,
+    hasCmpBoxDom: true,
+    hasCmpWelcomeBtnYesDom: true,
+    hasCmpWelcomeBtnNoDom: true,
+    hasCmpBoxBtnDom: true,
+  });
+
+  test("mandatory triple + >=1 secondary -> confidence at ceiling, canReject true", () => {
+    const c = consentmanagerAdapter.detect(FULL_CMP_SIGNALS);
+    assert.ok(c >= 1);
+    assert.equal(consentmanagerAdapter.canReject(FULL_CMP_SIGNALS), true);
+  });
+
+  test("mandatory triple + exactly one secondary (#cmpwelcomebtnyes only) -> canReject true", () => {
+    const s = {
+      hasCmpMngrGlobal: true,
+      hasCmpFn: true,
+      hasCmpBoxDom: true,
+      hasCmpWelcomeBtnYesDom: true,
+      hasCmpWelcomeBtnNoDom: false,
+      hasCmpBoxBtnDom: false,
+    };
+    assert.equal(consentmanagerAdapter.canReject(s), true);
+  });
+
+  test("mandatory triple present, zero secondary signals -> uncertain, canReject false", () => {
+    const s = {
+      hasCmpMngrGlobal: true,
+      hasCmpFn: true,
+      hasCmpBoxDom: true,
+      hasCmpWelcomeBtnYesDom: false,
+      hasCmpWelcomeBtnNoDom: false,
+      hasCmpBoxBtnDom: false,
+    };
+    assert.equal(consentmanagerAdapter.canReject(s), false);
+    assert.ok(consentmanagerAdapter.detect(s) < 1);
+  });
+
+  test("DOM-only (mandatory global/fn missing) -> confidence 0, canReject false", () => {
+    const s = {
+      hasCmpMngrGlobal: false,
+      hasCmpFn: false,
+      hasCmpBoxDom: true,
+      hasCmpWelcomeBtnYesDom: true,
+      hasCmpWelcomeBtnNoDom: true,
+      hasCmpBoxBtnDom: true,
+    };
+    assert.equal(consentmanagerAdapter.detect(s), 0);
+    assert.equal(consentmanagerAdapter.canReject(s), false);
+  });
+
+  test("cmpmngr global + __cmp fn present but #cmpbox DOM absent -> confidence 0, canReject false", () => {
+    const s = {
+      hasCmpMngrGlobal: true,
+      hasCmpFn: true,
+      hasCmpBoxDom: false,
+      hasCmpWelcomeBtnYesDom: true,
+    };
+    assert.equal(consentmanagerAdapter.detect(s), 0);
+    assert.equal(consentmanagerAdapter.canReject(s), false);
+  });
+
+  test("malformed/missing signals object never throws", () => {
+    assert.doesNotThrow(() => consentmanagerAdapter.detect(null));
+    assert.doesNotThrow(() => consentmanagerAdapter.detect(undefined));
+    assert.equal(consentmanagerAdapter.detect(null), 0);
+  });
+});
+
 // ── reject() — pure, callback-injected global call ──────────────────────────
 
 describe("oneTrustAdapter.reject — pure callback invocation", () => {
@@ -1389,6 +1555,25 @@ describe("tarteaucitronAdapter.reject — pure callback invocation", () => {
 
   test("non-function argument -> status noop, no call", () => {
     const r = tarteaucitronAdapter.reject(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+describe("consentmanagerAdapter.reject — pure callback invocation", () => {
+  test("calls the injected function and reports rejected", () => {
+    let called = false;
+    const r = consentmanagerAdapter.reject(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "rejected");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = consentmanagerAdapter.reject(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = consentmanagerAdapter.reject(undefined);
     assert.equal(r.status, "noop");
   });
 });
@@ -1587,5 +1772,18 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
     assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must still include usercentricsAdapter");
     assert.ok(TIER1.includes(cookieInformationAdapter), "TIER1 must still include cookieInformationAdapter");
     assert.ok(TIER1.includes(cookieScriptAdapter), "TIER1 must still include cookieScriptAdapter");
+  });
+
+  test("consentmanagerAdapter is registered in TIER1 alongside the other nine adapters", () => {
+    assert.ok(TIER1.includes(consentmanagerAdapter), "TIER1 must include consentmanagerAdapter");
+    assert.ok(TIER1.includes(oneTrustAdapter), "TIER1 must still include oneTrustAdapter");
+    assert.ok(TIER1.includes(cookiebotAdapter), "TIER1 must still include cookiebotAdapter");
+    assert.ok(TIER1.includes(didomiAdapter), "TIER1 must still include didomiAdapter");
+    assert.ok(TIER1.includes(cookieYesAdapter), "TIER1 must still include cookieYesAdapter");
+    assert.ok(TIER1.includes(sourcepointAdapter), "TIER1 must still include sourcepointAdapter");
+    assert.ok(TIER1.includes(usercentricsAdapter), "TIER1 must still include usercentricsAdapter");
+    assert.ok(TIER1.includes(cookieInformationAdapter), "TIER1 must still include cookieInformationAdapter");
+    assert.ok(TIER1.includes(cookieScriptAdapter), "TIER1 must still include cookieScriptAdapter");
+    assert.ok(TIER1.includes(tarteaucitronAdapter), "TIER1 must still include tarteaucitronAdapter");
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -148,6 +148,12 @@ describe("cookie-noise-sync — sync block is byte-identical (modulo indentation
     assert.ok(/function detectTarteaucitron/.test(joined));
     assert.ok(/function canRejectTarteaucitron/.test(joined));
   });
+
+  test("sync block also defines detectConsentmanager and canRejectConsentmanager", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/function detectConsentmanager/.test(joined));
+    assert.ok(/function canRejectConsentmanager/.test(joined));
+  });
 });
 
 // ── @sync:cookie-gate block (disabled-state gate) ───────────────────────────
@@ -507,6 +513,46 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       assert.ok(calls.length > 0, `${label} must call respondAll`);
       for (const args of calls) {
         assert.equal(args, "false", `${label} respondAll must be called with the literal false, and only false`);
+      }
+    }
+  });
+
+  // consentmanager.net (__cmp): a DUAL literal-arg guard — unlike every
+  // prior single-literal-arg adapter above, setConsent's command name
+  // ("setConsent") AND its consent-value argument (`0`) must BOTH be
+  // pinned. `setConsent(...)`'s documented shape is
+  // (command, consentValue, callback, isAsync) where consentValue: `0` =
+  // reject-all, `1` = accept-all (grants broad consent) — verified via a
+  // live behavioral probe (engram sdd/cookie-consent-coverage/tier1-live-probe).
+  // A future edit to `__cmp("setConsent", 1, ...)` (accept) or any other
+  // __cmp command must fail here.
+
+  test("only __cmp (or wrappedJSObject equivalent) is invoked as the consentmanager.net reject call", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/__cmp\s*\(([^)]*)/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call __cmp`);
+    }
+  });
+
+  test("every __cmp call's first argument is exactly the literal 'setConsent' — never another command, never a variable", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/__cmp\s*\(([^,]*),/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call __cmp`);
+      for (const firstArg of calls) {
+        assert.equal(firstArg, "\"setConsent\"", `${label} __cmp's first argument must be the literal "setConsent"`);
+      }
+    }
+  });
+
+  test("every __cmp setConsent call's second argument (the consent value) is exactly the literal 0 — never 1 (accept), never a variable", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/__cmp\s*\(\s*"setConsent"\s*,\s*([^,]+),/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call __cmp("setConsent", ...)`);
+      for (const secondArg of calls) {
+        assert.equal(secondArg, "0", `${label} __cmp("setConsent", ...)'s second argument must be the literal 0, and only 0`);
       }
     }
   });

--- a/tests/unit/release-smoke-report.test.mjs
+++ b/tests/unit/release-smoke-report.test.mjs
@@ -231,6 +231,6 @@ describe("release-smoke-report — importing the module never triggers CLI/files
     assert.equal(typeof mod.formatReleaseTable, "function");
     assert.equal(typeof mod.runReleaseSmokeReportCli, "function");
     assert.ok(Array.isArray(mod.RELEASE_CMPS));
-    assert.equal(mod.RELEASE_CMPS.length, 9);
+    assert.equal(mod.RELEASE_CMPS.length, 10);
   });
 });

--- a/tools/release-smoke-report.mjs
+++ b/tools/release-smoke-report.mjs
@@ -5,9 +5,10 @@
  * Reduces the existing CMP canary results (tests/canary/cmp-sites.json +
  * tools/canary-report.mjs's `test-results/canary-results.json` schema,
  * `{cmp, url, status: "pass"|"fail"|"inconclusive", detail}`) into a
- * per-adapter RELEASE verdict for the 9 Tier 1 cookie-consent adapters
+ * per-adapter RELEASE verdict for the 10 Tier 1 cookie-consent adapters
  * (src/lib/cmp-adapters.js TIER1: onetrust, cookiebot, didomi, cookieyes,
- * sourcepoint, usercentrics, cookieinformation, cookiescript, tarteaucitron).
+ * sourcepoint, usercentrics, cookieinformation, cookiescript, tarteaucitron,
+ * consentmanager).
  *
  * This does NOT run the canary itself — see tools/canary-report.mjs for
  * that (drift-alarm reporting) and .github/workflows/cmp-canary.yml (the
@@ -28,7 +29,7 @@
  * decision logic vs. CLI I/O boundary).
  *
  * Public API (named exports only — no default):
- *   RELEASE_CMPS → the 8 Tier 1 CMP ids, in cmp-adapters.js TIER1 order.
+ *   RELEASE_CMPS → the 10 Tier 1 CMP ids, in cmp-adapters.js TIER1 order.
  *   summarizeRelease(results) → Record<string, {verdict, passCount, failCount, inconclusiveCount, sites}>
  *   formatReleaseTable(summary) → string
  *
@@ -46,7 +47,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ── Pure decision logic ───────────────────────────────────────────────────
 
 /**
- * The 9 Tier 1 cookie-consent CMP ids, in the same order as
+ * The 10 Tier 1 cookie-consent CMP ids, in the same order as
  * src/lib/cmp-adapters.js's TIER1 registry.
  * @type {ReadonlyArray<string>}
  */
@@ -60,6 +61,7 @@ export const RELEASE_CMPS = Object.freeze([
   "cookieinformation",
   "cookiescript",
   "tarteaucitron",
+  "consentmanager",
 ]);
 
 function emptyBucket() {


### PR DESCRIPTION
Closes #1145. Relates to #1027.

## Summary
10th Tier 1 API adapter — **consentmanager.net**. Live-probe-verified: `window.__cmp("setConsent", 0, cb, true)` dismisses the banner on 3 real deployments (probe id 1319).
- Reject: `window.__cmp("setConsent", 0, () => {}, true)` — fire-and-forget.
- Detect: TRIPLE-mandatory (`window.cmpmngr` + `window.__cmp` fn + `#cmpbox`) + >=1 secondary. Never keys off bare `__cmp` (legacy TCF v1.1 generic surface — collision risk).
- Enrolls in release-smoke (RELEASE_CMPS 9->10; 10 adapters / 20 cells).

## Safety — LITERAL-ARG (0=reject, 1=accept)
Dual literal-arg guard pins BOTH `"setConsent"` and `0` at both call sites. Adversarial review empirically mutation-tested it: FAILS on `setConsent",1`, on a variable, on arg-removed, on call-removed. `ACTIONS` stays {REJECT_ALL}; `/allowall|accept/i` scan passes.

## Test plan
- `npm test` 6876 pass / 0 fail / 1 pre-existing skip.
- **Chromium e2e 5/5 EXECUTED & GREEN** (reject fires `[["setConsent",0]]`, feature-OFF, 3 misfire guards incl. bare-`__cmp`).
- **Firefox smoke 2/2 EXECUTED & GREEN** (wrappedJSObject reject fires).
- Adversarial review: NO safety-critical defects; guard teeth confirmed, discrimination sound, never-accept holds.

## Notes
- Canary entry PLACEHOLDER (hoerzu.de, probe-backed) — needs EU-geo curation.
- Minor (non-blocking): e2e fixture models dismissal as DOM-removal vs the real visibility-hide; the load-bearing assertion (`__cmp` call args) is real.