### PR TITLE
feat(consent): accept-when-necessary mode + Didomi pilot (Slice 2a)

### DIFF
--- a/docs/DESIGN-cookie-consent-accept.md
+++ b/docs/DESIGN-cookie-consent-accept.md
@@ -1,0 +1,206 @@
+# Design: Cookie Consent Minimizer — ACCEPT-WHEN-NECESSARY slice (Slice 2)
+
+> DESIGN + per-vendor VERIFICATION only. NO code in this slice.
+> Supersedes the Slice 2 section of `sdd/cookie-consent-modes/design` (engram id 1305).
+> Implements policy `architecture/cookie-consent-accept-policy` (engram id 1285).
+> Corrected framing (2026-07-17): there is **no permanent never-accept guarantee**. Reject-only
+> is **mode-scoped**, not absolute. `accept-when-necessary` is an agreed opt-in mode, deferred until
+> now only because the accept path was never built. The `/allowall|accept/i` lexical guard on
+> `cmp-adapters.js` is a **file-scoped** artifact (accept lives in a separate file), NOT an eternal
+> behavioral invariant.
+
+This is the highest-stakes change in the project: the first time MUGA takes a consent-granting action
+on the user's behalf. Lead with the SAFETY MODEL (Part B), then vendor reality (Part A).
+
+---
+
+## PART B — SAFETY MODEL (the gate; read first)
+
+Accept is STRUCTURALLY unreachable except when the user has explicitly and specifically asked for it.
+Five independent layers, each one sufficient on its own to prevent an unwanted accept:
+
+### L1 — File-scoped lexical purity (unchanged, absolute)
+`src/lib/cmp-adapters.js` (the reject brain) and the reject regions of the two content scripts stay
+FOREVER free of `/allowall|accept/i`. This is NOT relaxed. ALL accept logic physically lives in a NEW
+file `src/lib/cmp-accept-adapters.js` and a NEW `@sync:cmp-accept` content-script region. The reject
+brain literally cannot spell an accept action.
+
+Resolves the id 1305 Part-1 contradiction (one row extended `ACTIONS` inside `cmp-adapters.js`, another
+kept that file absolute) in favor of the absolute guarantee, per id 1311's recommendation:
+`decideAction` stays fully accept-agnostic; `ACTIONS.ACCEPT_MINIMUM` and every mode-name comparison
+exist ONLY in `cmp-accept-adapters.js`.
+
+### L2 — Double-gate as a DATA invariant
+Accept dispatch is unreachable unless BOTH hold:
+- `cookieConsentMode === "accept-when-necessary"`, AND
+- `cookieConsentAcceptConsented === true`.
+
+Both prefs already exist (Slice 1). The gate is a pure function `computeAcceptGate(prefs, deps)` in the
+accept module, returning `true` only when both are set AND `enabled` AND `onboardingDone` AND the site
+is not exempt. Unit-tested with EACH of the two invariants absent → gate closed. The separate boolean
+flag (not a 4th enum value) makes guarantee L2 robust against a corrupted/imported mode string.
+
+### L3 — Reject-first ladder (accept only on a true hard wall)
+`decideAction` (unchanged reject ladder) runs first in EVERY active mode. Accept is considered ONLY when
+`decideAction` returns `reason: "no-reject-path"` (a genuine hard wall for a specific vendor). If reject
+succeeds, or the page is `uncertain`, accept never runs. In `reject-only` mode the accept region's entry
+guard (`computeAcceptGate`) returns false, so accept is dead-on-arrival regardless.
+
+### L4 — Minimum enforcement + broad-accept DENYLIST
+When accept fires it MUST pick the least-permissive control the vendor exposes:
+- If a granular necessary-only construction exists (Didomi) → use it, NEVER accept-all.
+- Only on a pure accept-all-only wall (no lesser control) does minimum == accept-all, and that is a
+  DOCUMENTED last resort behind explicit per-decision safety (deferred past the pilot).
+
+A structural test pins every accept call to its minimum literal and enforces a DENYLIST of broad-accept
+methods anywhere in the accept module: `AllowAll`, `acceptAllConsents`, `acceptAllServices`,
+`acceptAllAction`, `postAcceptAll`, `submitCustomConsent(true`, `respondAll(true)`,
+`__cmp("setConsent", 1`, `performBannerAction("accept_all"`.
+
+### L5 — Fail-toward-NOOP everywhere
+Every failure mode resolves to no-accept: missing signal, corrupted pref, thrown page global, unknown
+vendor, absent accept fn on a shared-function wall → all return NOOP. There is no code path where an
+error or ambiguity produces an accept. Never hides the banner (no `opacity`/`display:none`); a
+never-hide scan stays in force.
+
+### Gate wiring reconciliation (open decision — see Part D)
+`computeCookieGate` (reject gate, in `cmp-adapters.js`) currently opens only for `"reject-only"`. To let
+the reject ladder run first in accept mode too, it must open for any active mode WITHOUT spelling
+`"accept-when-necessary"` (L1). Adopt id 1311 recommendation #1: the `@sync:cookie-gate` fenced block
+receives a pre-validated boolean `modeActive` (mode clamped to the closed enum in `settings-schema.js`,
+which is lexically unrestricted), instead of comparing the mode string inside the fence. Fail-closed on
+corruption moves to the clamp boundary. The accept double-gate stays entirely in the accept module.
+
+### Residual risk (stated honestly)
+The one irreducible risk is a **live-behavior** risk, not a structural one: that a vendor's minimum-accept
+call does not actually dismiss the wall, or grants more than expected, on a real site. This is why NO
+accept vendor ships without a live real-Chromium/real-Firefox probe (we have been burned by docs:
+CookieYes `accept_necessary` did not exist; Iubenda `storeConsent` did not dismiss). Structural guards
+prove "cannot accept when not asked"; the live probe proves "accepts the minimum and works."
+
+---
+
+## PART A — per-vendor minimum-accept VERIFICATION (all 10 adapters)
+
+Key structural axis (from id 1311): does the vendor route reject AND accept through the SAME page global,
+or through INDEPENDENTLY-NAMED functions?
+- SHARED function → on a hard wall (reject fn absent) the accept fn is EQUALLY absent → accept dispatch
+  is **dead code** under the current signal model. Building it fires never.
+- INDEPENDENT functions → a hard wall for reject does NOT preclude an accept fn existing → these are the
+  ONLY vendors where accept dispatch could ever actually fire.
+
+| # | Vendor | Reject call | Accept path | Shared vs independent | Bucket |
+|---|--------|-------------|-------------|-----------------------|--------|
+| 1 | OneTrust | `RejectAll()` | `AllowAll()` (broad); `UpdateConsent("Cat","C000n:1")` granular but per-tenant IDs | INDEPENDENT | ACCEPT-ALL-LAST-RESORT-ONLY |
+| 2 | Cookiebot | `submitCustomConsent(false,false,false)` | same fn `(…,true)` = accept | SHARED | DEAD-CODE-NO-HARDWALL |
+| 3 | Didomi | `setUserDisagreeToAll()` | `setCurrentUserStatus({purposes,vendors})` granular, sync→bool; `getRequiredPurposeIds()` generic getter | INDEPENDENT | **MINIMUM-ACCEPT-AVAILABLE** |
+| 4 | CookieYes | `performBannerAction("reject")` | same fn `("accept_all"/"accept_partial")`; `accept_necessary` DOES NOT EXIST | SHARED | DEAD-CODE-NO-HARDWALL |
+| 5 | Sourcepoint | `__tcfapi("postRejectAll",2,cb)` | `__tcfapi("postCustomConsent",…)`; empty-array semantics UNDOCUMENTED | SHARED (`__tcfapi`) | DEAD-CODE-NO-HARDWALL |
+| 6 | Usercentrics | `UC_UI.denyAllConsents()` | `UC_UI.acceptAllServices`/`updateServices` — legacy `UC_UI` vs new headless SDK CONFUSED in docs | INDEPENDENT (if legacy) | UNVERIFIED-NEEDS-PROBE |
+| 7 | Cookie Information | `declineAllCategories()` | `submitConsent(...)` with fixed category names (`cookie_cat_necessary` etc., NOT per-tenant) | INDEPENDENT | UNVERIFIED-NEEDS-PROBE (granular plausible) |
+| 8 | CookieScript | `instance.rejectAllAction()` | `instance.acceptAllAction()` (broad); no documented granular one-call | INDEPENDENT | ACCEPT-ALL-LAST-RESORT-ONLY |
+| 9 | tarteaucitron | `userInterface.respondAll(false)` | same fn `(true)` = accept-all | SHARED (boolean arg) | DEAD-CODE-NO-HARDWALL |
+| 10 | consentmanager | `__cmp("setConsent",0,cb,true)` | same fn `("setConsent",1,…)` = accept-all | SHARED (`__cmp`) | DEAD-CODE-NO-HARDWALL |
+
+### Bucket summary
+- **MINIMUM-ACCEPT-AVAILABLE (1):** Didomi. The only verified vendor with BOTH a real hard-wall scenario
+  AND a generalizable granular necessary-only construction. Recommended pilot.
+- **ACCEPT-ALL-LAST-RESORT-ONLY (2):** OneTrust (`AllowAll`), CookieScript (`acceptAllAction`).
+  Independent accept fns, so accept COULD fire on a wall, but only broad accept-all is exposed — permitted
+  only where NO lesser control exists, behind explicit per-decision safety. Defer past pilot.
+- **DEAD-CODE-NO-HARDWALL (5):** Cookiebot, CookieYes, Sourcepoint, tarteaucitron, consentmanager. Reject
+  and accept share one function, so accept dispatch can never fire on a hard wall. Do NOT build.
+- **UNVERIFIED-NEEDS-PROBE (2):** Usercentrics (legacy `UC_UI` vs headless SDK product-confusion trap —
+  disambiguate which product the site runs before building), Cookie Information (fixed-category granular
+  minimum is plausible from docs but `submitConsent` signature + does-it-dismiss unverified).
+
+### Flags for the product owner (do NOT green-light on docs)
+- Didomi: pin the exact vendors-enumeration getter name (parallel to `getRequiredPurposeIds()`); live-probe
+  that `setCurrentUserStatus` with all-non-essential-disabled actually dismisses a real hard-wall.
+- Every non-Didomi vendor requires a live probe before it ships; two (Usercentrics, Cookie Information)
+  need a probe even to be bucketed confidently.
+
+---
+
+## PART C — consent UX + prefs
+
+- **Mode selector:** Slice 1 hid the 3rd option. Add `accept-when-necessary` to the Settings > Advanced
+  radio/select (`COOKIE_CONSENT_MODE_OPTIONS` already contains it). Selecting it opens an explicit
+  informed-consent step; it does NOT set `cookieConsentAcceptConsented` by itself.
+- **Explicit consent gesture:** a dedicated in-UI confirmation (checkbox + explanatory copy) that, only on
+  a real click, sets `cookieConsentAcceptConsented = true`. Copy states plainly: "On sites that block
+  content until you answer a cookie banner and offer no reject option, MUGA will submit the MINIMUM choice
+  — granting only strictly necessary cookies — so you can proceed. MUGA never grants tracking cookies."
+  English default, no em-dashes, peninsular Spanish for `es`, 7 locales (en/es/fr/de/it/ja/pt) + onboarding
+  + options.html.
+- **Consent version:** bump `REQUIRED_CONSENT_VERSION` → `"1.3"` (currently staged/inactive) and add a
+  `CONSENT_CLAUSES_BY_VERSION["1.3"]` clause disclosing the minimum-accept capability. This is a genuinely
+  new capability class, so existing users get a SOFT re-onboard (delta review). The per-user gesture is a
+  second, belt-and-suspenders gate on top of the version bump.
+- **Import safety (unchanged):** `clampImportedCookieConsentMode` still collapses `accept-when-necessary`
+  to `reject-only` and `cookieConsentAcceptConsented` stays `exportOnlyBoolean` — an imported blob can
+  NEVER pre-seed the accept gate without a real in-app gesture. Keep this.
+
+---
+
+## PART D — decideAction, dispatch, slicing
+
+### decideAction (pure, stays accept-agnostic)
+One small accept-FREE enhancement: thread the real `adapterId` through the `no-reject-path` branches
+(today they return `adapterId: null`) so the accept layer knows WHICH vendor hit the wall. No accept text
+enters `cmp-adapters.js`.
+
+### Accept decision + dispatch (new, accept module only)
+`cmp-accept-adapters.js`:
+- `ACTIONS_ACCEPT = Object.freeze({ ACCEPT_MINIMUM: "accept-minimum" })`
+- `decideMinimumAccept(decision, mode, consented)` — pure. Returns `ACCEPT_MINIMUM` only when
+  `mode === "accept-when-necessary"` AND `consented === true` AND `decision.reason === "no-reject-path"`
+  AND `decision.adapterId` is in the accept-capable set; else NOOP.
+- `computeAcceptGate(prefs, deps)` — the double-gate + enabled/onboarded/exemption.
+- `didomiAcceptAdapter` — builds the minimum payload from `getRequiredPurposeIds()` (no hardcoded IDs, no
+  accept-all).
+
+New signals collected in both content scripts (accept-related, so their DISPATCH lives in the
+`@sync:cmp-accept` region): `hasSetCurrentUserStatusFn`, `hasGetRequiredPurposeIdsFn` (+ vendors getter).
+
+### Dispatch threading (@sync)
+- Chrome: after the isolated-world reject flow yields `no-reject-path`, the `@sync:cmp-accept` region runs
+  the accept dispatcher in the MAIN world (via the existing nonce-gated event), gated by `computeAcceptGate`.
+- Firefox: the isolated-world `fxRunDispatcher` gets a mirror `@sync:cmp-accept` tail that, after the reject
+  ladder returns `no-reject-path`, runs the accept call via `wrappedJSObject`, gated by `computeAcceptGate`.
+- The content-script whole-file `/allowall|accept/i` scan RELAXES to POSITIONAL: accept tokens allowed ONLY
+  inside `@sync:cmp-accept`; reject regions stay absolutely accept-free. `cmp-adapters.js` stays absolute.
+
+### Testing strategy
+| Layer | What | How |
+|-------|------|-----|
+| Unit | double-gate with each invariant absent → NOOP | pure `computeAcceptGate` matrix |
+| Unit | reject-only mode + hard wall → NOOP (accept impossible) | `decideMinimumAccept` matrix |
+| Unit | minimum enforcement: never accept-all when lesser exists | Didomi payload builder + DENYLIST scan |
+| Adversarial | "make it accept in reject-only mode" / "accept more than minimum" must be impossible | structural + pure |
+| Structural | `cmp-adapters.js` stays `/allowall|accept/i`-free; positional relax on content scripts | source scan |
+| E2E / probe | Didomi minimum-accept dismisses a real hard-wall, grants zero non-essential | real-Chromium + real-Firefox |
+
+### Slicing (recommended)
+- **Slice 2a (RECOMMENDED FIRST — Didomi-only pilot):** gate refactor (`modeActive` boolean),
+  `decideAction` adapterId threading, `cmp-accept-adapters.js` (ACTIONS_ACCEPT + `decideMinimumAccept` +
+  `computeAcceptGate` + `didomiAcceptAdapter`), new signals, `@sync:cmp-accept` region in both content
+  scripts (Didomi only), positional lexical relax, consent UX + gesture + `REQUIRED_CONSENT_VERSION` 1.3,
+  full adversarial/structural test suite, Didomi live probe. Smallest safe first accept.
+- **Slice 2b (later):** all-or-nothing last-resort vendors (OneTrust `AllowAll`, CookieScript
+  `acceptAllAction`) behind explicit per-decision confirmation, each after a live probe.
+- **Defer indefinitely:** the 5 dead-code vendors (never build accept dispatch); the 2 unverified vendors
+  until a probe reclassifies them.
+
+---
+
+## Open decisions for the product owner
+1. Consent disclosure: global soft re-onboard via 1.3 bump + per-user gesture (RECOMMENDED) vs gesture-only.
+2. Gate wiring: `modeActive` boolean into the fenced block (RECOMMENDED, per id 1311) vs a second dedicated
+   accept-only gate that also runs reject first.
+3. First slice: Didomi-only pilot (RECOMMENDED) vs Didomi + last-resort vendors together.
+4. Last-resort accept-all (OneTrust/CookieScript): ship in 2b behind per-decision confirmation vs never.
+5. Didomi minimum semantics: confirm "all non-essential disabled" is the right minimum vs a narrower
+   required-only payload — resolve at the live probe.
+
+**Ready to build Slice 2a once decisions 1–3 and 5 are confirmed and the Didomi live probe passes.**

--- a/docs/qa/cookie-consent-release-smoke.md
+++ b/docs/qa/cookie-consent-release-smoke.md
@@ -176,6 +176,60 @@ manual only, automation is tracked separately in #1128.
 - **Chrome:** PASS / FAIL / N/A ____  Notes: ______________________
 - **Firefox:** PASS / FAIL / N/A ____  Notes: ______________________
 
+#### Didomi accept-when-necessary pilot (minimum-grant) — BLOCKING EU-geo item
+
+cookie-consent-accept Slice 2a adds a second, opt-in Didomi capability on
+top of the reject adapter above: when the user selects "Accept minimum
+when necessary" in Settings AND completes the dedicated informed-consent
+gesture, MUGA can submit a minimum-consent payload
+(`window.Didomi.setCurrentUserStatus({purposes, vendors})`, built from the
+vendor's OWN `getRequiredPurposeIds()`/`getRequiredVendorIds()`/
+`getPurposes()`/`getVendors()`) on a genuine Didomi hard wall — a page
+where `setUserDisagreeToAll` is absent, so the reject adapter above cannot
+act at all.
+
+**This item is a HARD PRE-ENABLE GATE, not an optional nice-to-have.** The
+synthetic e2e/Firefox fixtures (`tests/e2e/cookie-consent-minimizer-didomi-accept.spec.mjs`,
+`tests/e2e-firefox/didomi-accept.smoke.mjs`) only prove the MECHANICS: MUGA
+calls `setCurrentUserStatus` with the minimum payload, only in the
+consented accept-when-necessary state, and never in reject-only mode or
+without the gesture. They run against a stub page and CANNOT verify that a
+real Didomi SDK actually honors the call — i.e. that it dismisses a real
+hard wall AND grants zero non-essential purposes/vendors. A prior probe
+(engram `sdd/cookie-consent-accept/didomi-probe`) confirmed the API shape
+(getter names, sync boolean return) on 3 real production Didomi sites but
+was geo-blocked from observing an actual hard-wall/consent-wall session
+from a non-EU vantage — `getCurrentUserStatus()` showed every purpose/
+vendor already `enabled: true` before any call, meaning there was no live
+consent transaction to mutate.
+
+- [ ] **BLOCKING:** run a real behavioral smoke from a genuine EU/France
+  vantage point (VPN/proxy or an EU-hosted CI runner) against a live
+  Didomi hard-wall page (a site where `setUserDisagreeToAll` is absent —
+  `abeille-assurances.fr` migrated away from Didomi during the probe, so
+  needs a fresh candidate; do not reuse `orange.fr`/`europcar.com` as-is
+  unless re-confirmed as a genuine hard wall from that vantage).
+- [ ] Confirm the minimum-payload call actually DISMISSES the wall (the
+  page's own banner/host element goes away or the page unblocks), not
+  just that the call returns without throwing.
+- [ ] Confirm `getCurrentUserStatus()` (or the vendor's own consent
+  inspector) shows ONLY the required purposes/vendors as enabled
+  afterward — zero non-essential/tracking purposes or vendors granted.
+- [ ] Confirm the checkbox gesture in Settings actually gates this: with
+  the mode selected but the gesture NOT confirmed, the hard wall must
+  stay untouched (same manual check as the automated adversarial suite,
+  repeated against the real vendor as a sanity cross-check).
+- [ ] Repeat once in Firefox (the `wrappedJSObject.Didomi.setCurrentUserStatus`
+  path is a separate code path from the Chrome MAIN-world call and has
+  never been exercised against a live vendor script).
+
+**Until every box above is checked, "Accept minimum when necessary" must
+NOT be enabled/released to real users** — ship it dormant (the mode
+selectable in Settings is fine; the underlying capability working
+correctly on real Didomi infrastructure is not yet proven). Track this
+alongside the Didomi reject row in the sign-off table below as its own
+line.
+
 ### 4. CookieYes
 
 - **Reject call:** `window.performBannerAction("reject")` (Chrome MAIN
@@ -431,14 +485,18 @@ following before marking this adapter PASS:
 
 ## Sign-off table
 
-All 20 cells (10 adapters x Chrome/Firefox) must be green before the
-`develop -> main` release PR opens.
+All 20 reject-adapter cells (10 adapters x Chrome/Firefox), PLUS the
+Didomi accept-when-necessary row below, must be green before the
+`develop -> main` release PR opens. The accept row is a HARD PRE-ENABLE
+GATE (see the "Didomi accept-when-necessary pilot" subsection above) — a
+release may ship with the mode dormant (unchecked) but must NOT enable it
+for real users while that row is unchecked.
 
 | Adapter | Chrome | Firefox |
 | --- | --- | --- |
 | OneTrust | ____ | ____ |
 | Cookiebot | ____ | ____ |
-| Didomi | ____ | ____ |
+| Didomi (reject) | ____ | ____ |
 | CookieYes | ____ | ____ |
 | Sourcepoint | ____ | ____ |
 | Usercentrics | ____ | ____ |
@@ -446,5 +504,6 @@ All 20 cells (10 adapters x Chrome/Firefox) must be green before the
 | CookieScript | ____ | ____ |
 | tarteaucitron | ____ | ____ |
 | consentmanager.net | ____ | ____ |
+| **Didomi accept-when-necessary (minimum-grant) - EU-geo vantage required** | ____ | ____ |
 
 Reviewer: ______________________  Date: ______________________

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -9,6 +9,7 @@ import { getAffiliateDomains, resolveOurTag } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, migrateLegacyProxyPref, migratePerSiteDisableToAllowlist, migrateCookieConsentMode, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules, getRemoteParams } from "../lib/storage.js";
 import { migrateConsentToLocal } from "../lib/sync-migration.js";
 import { evaluate as evaluateConsent } from "../lib/consent-policy.js";
+import { isCookieConsentModeActive } from "../lib/settings-schema.js";
 import { isValidListEntry } from "../lib/validation.js";
 import { DNR_CUSTOM_PARAMS_RULE_ID, DNR_REMOTE_PARAMS_RULE_ID, DNR_ALLOWLIST_RULE_ID_BASE, DNR_ALLOWLIST_MAX_RULES } from "../lib/dnr-ids.js";
 import { partitionRulesets } from "../lib/dnr-ruleset-state.js";
@@ -1314,7 +1315,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (message.type === "getPrefs") {
     getPrefsWithCache()
-      .then(prefs => sendResponse({ ...prefs, _affiliateDomains }))
+      .then(prefs => sendResponse({
+        ...prefs,
+        _affiliateDomains,
+        // Cookie Consent Minimizer gate wiring (cookie-consent-accept Slice
+        // 2a): content scripts cannot import settings-schema.js (no ES
+        // imports — AGENTS.md), and src/lib/cmp-adapters.js's
+        // computeCookieGate is lexically restricted, so this pre-validated
+        // boolean is computed here (the one place both concerns are
+        // importable) and handed down verbatim. See the @sync:cookie-gate
+        // comment in cmp-adapters.js / content/cookie-noise.js.
+        modeActive: isCookieConsentModeActive(prefs.cookieConsentMode),
+      }))
       .catch(() => { try { sendResponse(null); } catch { /* channel closed */ } });
     return true;
   }

--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -341,9 +341,12 @@
   // REQUIRED lists are parsed STRICTLY (extractRequiredIds); if EITHER is
   // unresolvable the whole accept is abandoned (returns null → the caller must
   // NOT call setCurrentUserStatus, leaving the banner as the safe outcome).
-  // Returns a validly-constructed minimum payload otherwise. Pure; never
-  // throws (the getter calls themselves stay in the world-specific dispatch
-  // region, wrapped there).
+  // A DEGENERATE full registry (both getPurposes() and getVendors() collapse
+  // to empty) also NOOPs — there is no valid minimum to construct, so the
+  // call must never fire with an all-empty payload. Returns a validly-
+  // constructed minimum payload otherwise. Pure; never throws (the getter
+  // calls themselves stay in the world-specific dispatch region, wrapped
+  // there).
   function resolveDidomiMinimumStatus(raw) {
     const r = raw && typeof raw === "object" ? raw : {};
     const requiredPurposeIds = extractRequiredIds(r.requiredPurposeIds);
@@ -351,6 +354,7 @@
     if (requiredPurposeIds === null || requiredVendorIds === null) return null;
     const allPurposeIds = extractDidomiIds(r.allPurposeIds);
     const allVendorIds = extractDidomiIds(r.allVendorIds);
+    if (allPurposeIds.length === 0 && allVendorIds.length === 0) return null;
     return buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
   }
   // @sync:cmp-accept:end

--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -246,6 +246,78 @@
   }
   // @sync:cmp-adapters:end
 
+  // Cookie Consent Minimizer — Didomi minimum-grant pilot (see the design
+  // docs for the full mode name; this file's own structural guard forbids
+  // spelling it outside the fenced region directly below). The two pure
+  // functions in that fenced block are a hand-maintained COPY of the
+  // sibling lib module's own same-named block (content scripts cannot use
+  // ES module imports — AGENTS.md). Kept in sync by
+  // tests/unit/cookie-noise-sync.test.mjs. World-agnostic and pure — never
+  // touches `window` itself; the dispatch region further below supplies
+  // the real page-global reads.
+  // @sync:cmp-accept:start
+  function canAttemptDidomiMinimumAccept(signals) {
+    const s = signals && typeof signals === "object" ? signals : {};
+    if (s.hasDidomiGlobal !== true) return false;
+    if (s.hasSetUserDisagreeToAllFn === true) return false;
+    if (s.hasSetCurrentUserStatusFn !== true) return false;
+    if (s.hasGetRequiredPurposeIdsFn !== true) return false;
+    if (s.hasGetRequiredVendorIdsFn !== true) return false;
+    if (s.hasGetPurposesFn !== true) return false;
+    if (s.hasGetVendorsFn !== true) return false;
+    return true;
+  }
+
+  function buildMinimumPayload(input) {
+    const i = input && typeof input === "object" ? input : {};
+    const allPurposeIds = Array.isArray(i.allPurposeIds) ? i.allPurposeIds : [];
+    const allVendorIds = Array.isArray(i.allVendorIds) ? i.allVendorIds : [];
+    const requiredPurposeIds = Array.isArray(i.requiredPurposeIds) ? i.requiredPurposeIds : [];
+    const requiredVendorIds = Array.isArray(i.requiredVendorIds) ? i.requiredVendorIds : [];
+
+    const enabledPurposes = allPurposeIds.filter((id) => requiredPurposeIds.includes(id));
+    const enabledVendors = allVendorIds.filter((id) => requiredVendorIds.includes(id));
+    const enabledPurposeSet = new Set(enabledPurposes);
+    const enabledVendorSet = new Set(enabledVendors);
+
+    return {
+      purposes: {
+        enabled: enabledPurposes,
+        disabled: allPurposeIds.filter((id) => !enabledPurposeSet.has(id)),
+      },
+      vendors: {
+        enabled: enabledVendors,
+        disabled: allVendorIds.filter((id) => !enabledVendorSet.has(id)),
+      },
+    };
+  }
+  // @sync:cmp-accept:end
+
+  // Normalizes Didomi's getPurposes()/getVendors() return shape (array of
+  // ids, array of {id} objects, or an id-keyed object map — the exact
+  // shape was not fully confirmed by a live probe against real Didomi
+  // sites, see the project's design docs) into a plain array of id
+  // strings. Never throws; unrecognized shapes resolve to an empty array
+  // (fail-closed).
+  function extractDidomiIds(value) {
+    try {
+      if (Array.isArray(value)) {
+        const ids = [];
+        for (const item of value) {
+          if (typeof item === "string") ids.push(item);
+          else if (item && typeof item.id === "string") ids.push(item.id);
+        }
+        return ids;
+      }
+      if (value && typeof value === "object") {
+        return Object.keys(value);
+      }
+    } catch {
+      // Fall through to the fail-closed empty array below.
+    }
+    return [];
+  }
+
   /**
    * Collects world-specific signals from the page's real globals/DOM.
    * Wrapped defensively: a hostile or broken page-authored getter on
@@ -321,6 +393,27 @@
         hasDidomiGlobal && typeof window.Didomi.getCurrentUserStatus === "function";
     } catch {
       // ignore
+    }
+    // Didomi minimum-grant pilot signals: setCurrentUserStatus is the
+    // granular grant-call surface; getRequiredPurposeIds/
+    // getRequiredVendorIds report the vendor's OWN minimum-required ids;
+    // getPurposes/getVendors report the vendor's OWN full registry (used
+    // to build the "disable everything else" half of the minimum
+    // payload). All five are typeof-checked only here — never invoked as
+    // part of signal collection.
+    let hasSetCurrentUserStatusFn = false;
+    let hasGetRequiredPurposeIdsFn = false;
+    let hasGetRequiredVendorIdsFn = false;
+    let hasGetPurposesFn = false;
+    let hasGetVendorsFn = false;
+    try {
+      hasSetCurrentUserStatusFn = hasDidomiGlobal && typeof window.Didomi.setCurrentUserStatus === "function";
+      hasGetRequiredPurposeIdsFn = hasDidomiGlobal && typeof window.Didomi.getRequiredPurposeIds === "function";
+      hasGetRequiredVendorIdsFn = hasDidomiGlobal && typeof window.Didomi.getRequiredVendorIds === "function";
+      hasGetPurposesFn = hasDidomiGlobal && typeof window.Didomi.getPurposes === "function";
+      hasGetVendorsFn = hasDidomiGlobal && typeof window.Didomi.getVendors === "function";
+    } catch {
+      // Leave all false — fail-closed.
     }
     // CookieYes (#1120): unlike the three adapters above, the reject call
     // is a BARE global (`window.performBannerAction`), not a method on a
@@ -510,6 +603,11 @@
       hasSetUserDisagreeToAllFn,
       hasDidomiHostDom,
       hasGetCurrentUserStatusFn,
+      hasSetCurrentUserStatusFn,
+      hasGetRequiredPurposeIdsFn,
+      hasGetRequiredVendorIdsFn,
+      hasGetPurposesFn,
+      hasGetVendorsFn,
       hasGetCkyConsentFn,
       hasPerformBannerActionFn,
       hasCkyConsentContainerDom,
@@ -713,6 +811,32 @@
       stopObserver();
       return;
     }
+    // Cookie Consent Minimizer — Didomi minimum-grant pilot, own fenced
+    // region below (this file's structural guard forbids spelling the
+    // mode name outside it). Reached ONLY after every Tier 1 reject
+    // adapter above returned false for this page — i.e. a genuine hard
+    // wall, mirroring cmp-adapters.js's decideAction "no-reject-path"
+    // reason exactly. Double-gated by a boolean computed in the isolated
+    // world from the user's real prefs (this world never reads prefs) and
+    // relayed here over the same nonce-gated event channel as the reject
+    // gate, AND the region's own signal check.
+    // @sync:cmp-accept-dispatch:start
+    if (_didomiMinimumGateOpen && canAttemptDidomiMinimumAccept(signals)) {
+      _acted = true;
+      try {
+        const requiredPurposeIds = extractDidomiIds(window.Didomi.getRequiredPurposeIds());
+        const requiredVendorIds = extractDidomiIds(window.Didomi.getRequiredVendorIds());
+        const allPurposeIds = extractDidomiIds(window.Didomi.getPurposes());
+        const allVendorIds = extractDidomiIds(window.Didomi.getVendors());
+        const payload = buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
+        window.Didomi.setCurrentUserStatus(payload);
+      } catch {
+        // A throwing page global must never break the page's own script.
+      }
+      stopObserver();
+      return;
+    }
+    // @sync:cmp-accept-dispatch:end
     // Tier 2: declarative click-rule adapters. Empty in this slice.
   }
 
@@ -731,6 +855,10 @@
   document.addEventListener("muga:cookie-gate:nonce", _onNonce);
 
   let _gateOpen = false;
+  // Relayed from the isolated world (content/cookie-noise.js), which is
+  // the only world with prefs access — this world never reads prefs
+  // itself. See computeDidomiMinimumGate() there.
+  let _didomiMinimumGateOpen = false;
   let _warnedOrder = false;
   document.addEventListener("muga:cookie-gate", (e) => {
     // Reject events that do not carry the handshake nonce. A missing or
@@ -748,6 +876,7 @@
       return;
     }
     _gateOpen = !!e.detail.enabled;
+    _didomiMinimumGateOpen = !!e.detail.didomiMinimumGateOpen;
     if (_gateOpen) {
       runDispatcher(); // initial sweep — the banner may already exist
       startObserver();

--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -268,6 +268,50 @@
     return true;
   }
 
+  // Broad, permissive normalizer for the vendor's FULL registry getters
+  // (getPurposes()/getVendors()): an array of id strings, an array of {id}
+  // objects, or an id-keyed object map all normalize to a plain array of id
+  // strings. This breadth is SAFE here because the "all" lists are only ever
+  // intersected against the strictly-parsed required set below — a broad read
+  // of the registry can never, by itself, widen consent. Never throws;
+  // unrecognized shapes resolve to an empty array (fail-closed).
+  function extractDidomiIds(value) {
+    try {
+      if (Array.isArray(value)) {
+        const ids = [];
+        for (const item of value) {
+          if (typeof item === "string") ids.push(item);
+          else if (item && typeof item.id === "string") ids.push(item.id);
+        }
+        return ids;
+      }
+      if (value && typeof value === "object") {
+        return Object.keys(value);
+      }
+    } catch {
+      // Fall through to the fail-closed empty array below.
+    }
+    return [];
+  }
+
+  // STRICT, fail-closed parser for the REQUIRED getters
+  // (getRequiredPurposeIds()/getRequiredVendorIds()). Didomi's real getters
+  // return a plain array of id strings (engram sdd/cookie-consent-accept
+  // probe, id 1324); this accepts ONLY that exact shape. Anything else — a
+  // flag-map object, an array of registry objects, an array with a non-string
+  // or empty-string member, null, a non-array — is UNRESOLVABLE and returns
+  // null so the caller abandons the entire accept rather than guessing a
+  // payload that could widen consent. Never throws.
+  function extractRequiredIds(value) {
+    if (!Array.isArray(value)) return null;
+    const ids = [];
+    for (const item of value) {
+      if (typeof item !== "string" || item.length === 0) return null;
+      ids.push(item);
+    }
+    return ids;
+  }
+
   function buildMinimumPayload(input) {
     const i = input && typeof input === "object" ? input : {};
     const allPurposeIds = Array.isArray(i.allPurposeIds) ? i.allPurposeIds : [];
@@ -291,32 +335,25 @@
       },
     };
   }
-  // @sync:cmp-accept:end
 
-  // Normalizes Didomi's getPurposes()/getVendors() return shape (array of
-  // ids, array of {id} objects, or an id-keyed object map — the exact
-  // shape was not fully confirmed by a live probe against real Didomi
-  // sites, see the project's design docs) into a plain array of id
-  // strings. Never throws; unrecognized shapes resolve to an empty array
-  // (fail-closed).
-  function extractDidomiIds(value) {
-    try {
-      if (Array.isArray(value)) {
-        const ids = [];
-        for (const item of value) {
-          if (typeof item === "string") ids.push(item);
-          else if (item && typeof item.id === "string") ids.push(item.id);
-        }
-        return ids;
-      }
-      if (value && typeof value === "object") {
-        return Object.keys(value);
-      }
-    } catch {
-      // Fall through to the fail-closed empty array below.
-    }
-    return [];
+  // Runtime seam the content-script dispatch regions call with the RAW return
+  // values of Didomi's four getters. Owns the fail-closed contract: the
+  // REQUIRED lists are parsed STRICTLY (extractRequiredIds); if EITHER is
+  // unresolvable the whole accept is abandoned (returns null → the caller must
+  // NOT call setCurrentUserStatus, leaving the banner as the safe outcome).
+  // Returns a validly-constructed minimum payload otherwise. Pure; never
+  // throws (the getter calls themselves stay in the world-specific dispatch
+  // region, wrapped there).
+  function resolveDidomiMinimumStatus(raw) {
+    const r = raw && typeof raw === "object" ? raw : {};
+    const requiredPurposeIds = extractRequiredIds(r.requiredPurposeIds);
+    const requiredVendorIds = extractRequiredIds(r.requiredVendorIds);
+    if (requiredPurposeIds === null || requiredVendorIds === null) return null;
+    const allPurposeIds = extractDidomiIds(r.allPurposeIds);
+    const allVendorIds = extractDidomiIds(r.allVendorIds);
+    return buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
   }
+  // @sync:cmp-accept:end
 
   /**
    * Collects world-specific signals from the page's real globals/DOM.
@@ -824,12 +861,13 @@
     if (_didomiMinimumGateOpen && canAttemptDidomiMinimumAccept(signals)) {
       _acted = true;
       try {
-        const requiredPurposeIds = extractDidomiIds(window.Didomi.getRequiredPurposeIds());
-        const requiredVendorIds = extractDidomiIds(window.Didomi.getRequiredVendorIds());
-        const allPurposeIds = extractDidomiIds(window.Didomi.getPurposes());
-        const allVendorIds = extractDidomiIds(window.Didomi.getVendors());
-        const payload = buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
-        window.Didomi.setCurrentUserStatus(payload);
+        const payload = resolveDidomiMinimumStatus({
+          requiredPurposeIds: window.Didomi.getRequiredPurposeIds(),
+          requiredVendorIds: window.Didomi.getRequiredVendorIds(),
+          allPurposeIds: window.Didomi.getPurposes(),
+          allVendorIds: window.Didomi.getVendors(),
+        });
+        if (payload) window.Didomi.setCurrentUserStatus(payload);
       } catch {
         // A throwing page global must never break the page's own script.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -808,13 +808,16 @@
   // (modulo indentation) to the library copy by
   // tests/unit/cookie-noise-sync.test.mjs. The pure helper takes injected
   // deps so it stays unit-testable in src/lib/; the thin call site below
-  // supplies this world's real location + cleaner exemption predicate.
+  // supplies this world's real location + cleaner exemption predicate. The
+  // `modeActive` deps field is a boolean already pre-validated upstream
+  // (background/service-worker.js, via settings-schema.js's closed-enum
+  // check) — this gate never reads or compares the raw mode string itself.
   // @sync:cookie-gate:start
   function computeCookieGate(prefs, deps) {
     if (!prefs) return false;
     if (prefs.enabled === false) return false;
     if (prefs.onboardingDone !== true) return false;
-    if (prefs.cookieConsentMode !== "reject-only") return false;
+    if (!deps || deps.modeActive !== true) return false;
     const isSiteFullyExempt = deps && deps.isSiteFullyExempt;
     if (typeof isSiteFullyExempt === "function") {
       try {
@@ -830,9 +833,12 @@
   function computeGate(prefs) {
     // isSiteFullyExempt is a standalone function on __mugaCleaner (no `this`
     // dependency — see src/lib/cleaner.js), so passing the reference detached
-    // is safe.
+    // is safe. modeActive is precomputed by the service worker's getPrefs
+    // response (see the @sync:cookie-gate comment above) — read verbatim,
+    // never recomputed here.
     const cleaner = window.__mugaCleaner;
     return computeCookieGate(prefs, {
+      modeActive: !!(prefs && prefs.modeActive === true),
       hostname: location.hostname,
       isSiteFullyExempt:
         cleaner && typeof cleaner.isSiteFullyExempt === "function" ? cleaner.isSiteFullyExempt : null,

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -265,6 +265,50 @@
     return true;
   }
 
+  // Broad, permissive normalizer for the vendor's FULL registry getters
+  // (getPurposes()/getVendors()): an array of id strings, an array of {id}
+  // objects, or an id-keyed object map all normalize to a plain array of id
+  // strings. This breadth is SAFE here because the "all" lists are only ever
+  // intersected against the strictly-parsed required set below — a broad read
+  // of the registry can never, by itself, widen consent. Never throws;
+  // unrecognized shapes resolve to an empty array (fail-closed).
+  function extractDidomiIds(value) {
+    try {
+      if (Array.isArray(value)) {
+        const ids = [];
+        for (const item of value) {
+          if (typeof item === "string") ids.push(item);
+          else if (item && typeof item.id === "string") ids.push(item.id);
+        }
+        return ids;
+      }
+      if (value && typeof value === "object") {
+        return Object.keys(value);
+      }
+    } catch {
+      // Fall through to the fail-closed empty array below.
+    }
+    return [];
+  }
+
+  // STRICT, fail-closed parser for the REQUIRED getters
+  // (getRequiredPurposeIds()/getRequiredVendorIds()). Didomi's real getters
+  // return a plain array of id strings (engram sdd/cookie-consent-accept
+  // probe, id 1324); this accepts ONLY that exact shape. Anything else — a
+  // flag-map object, an array of registry objects, an array with a non-string
+  // or empty-string member, null, a non-array — is UNRESOLVABLE and returns
+  // null so the caller abandons the entire accept rather than guessing a
+  // payload that could widen consent. Never throws.
+  function extractRequiredIds(value) {
+    if (!Array.isArray(value)) return null;
+    const ids = [];
+    for (const item of value) {
+      if (typeof item !== "string" || item.length === 0) return null;
+      ids.push(item);
+    }
+    return ids;
+  }
+
   function buildMinimumPayload(input) {
     const i = input && typeof input === "object" ? input : {};
     const allPurposeIds = Array.isArray(i.allPurposeIds) ? i.allPurposeIds : [];
@@ -287,6 +331,24 @@
         disabled: allVendorIds.filter((id) => !enabledVendorSet.has(id)),
       },
     };
+  }
+
+  // Runtime seam the content-script dispatch regions call with the RAW return
+  // values of Didomi's four getters. Owns the fail-closed contract: the
+  // REQUIRED lists are parsed STRICTLY (extractRequiredIds); if EITHER is
+  // unresolvable the whole accept is abandoned (returns null → the caller must
+  // NOT call setCurrentUserStatus, leaving the banner as the safe outcome).
+  // Returns a validly-constructed minimum payload otherwise. Pure; never
+  // throws (the getter calls themselves stay in the world-specific dispatch
+  // region, wrapped there).
+  function resolveDidomiMinimumStatus(raw) {
+    const r = raw && typeof raw === "object" ? raw : {};
+    const requiredPurposeIds = extractRequiredIds(r.requiredPurposeIds);
+    const requiredVendorIds = extractRequiredIds(r.requiredVendorIds);
+    if (requiredPurposeIds === null || requiredVendorIds === null) return null;
+    const allPurposeIds = extractDidomiIds(r.allPurposeIds);
+    const allVendorIds = extractDidomiIds(r.allVendorIds);
+    return buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
   }
   // @sync:cmp-accept:end
 
@@ -313,31 +375,6 @@
     return true;
   }
   // @sync:cmp-accept-gate:end
-
-  // Normalizes Didomi's getPurposes()/getVendors() return shape (array of
-  // ids, array of {id} objects, or an id-keyed object map — the exact
-  // shape was not fully confirmed by a live probe against real Didomi
-  // sites, see the project's design docs) into a plain array of id
-  // strings. Never throws; unrecognized shapes resolve to an empty array
-  // (fail-closed).
-  function extractDidomiIds(value) {
-    try {
-      if (Array.isArray(value)) {
-        const ids = [];
-        for (const item of value) {
-          if (typeof item === "string") ids.push(item);
-          else if (item && typeof item.id === "string") ids.push(item.id);
-        }
-        return ids;
-      }
-      if (value && typeof value === "object") {
-        return Object.keys(value);
-      }
-    } catch {
-      // Fall through to the fail-closed empty array below.
-    }
-    return [];
-  }
 
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
   // Mirrors the #811 pattern from history-defuser.js on its own channel.
@@ -874,12 +911,13 @@
     if (_fxDidomiMinimumGateOpen && canAttemptDidomiMinimumAccept(signals)) {
       _fxActed = true;
       try {
-        const requiredPurposeIds = extractDidomiIds(window.wrappedJSObject.Didomi.getRequiredPurposeIds());
-        const requiredVendorIds = extractDidomiIds(window.wrappedJSObject.Didomi.getRequiredVendorIds());
-        const allPurposeIds = extractDidomiIds(window.wrappedJSObject.Didomi.getPurposes());
-        const allVendorIds = extractDidomiIds(window.wrappedJSObject.Didomi.getVendors());
-        const payload = buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
-        window.wrappedJSObject.Didomi.setCurrentUserStatus(payload);
+        const payload = resolveDidomiMinimumStatus({
+          requiredPurposeIds: window.wrappedJSObject.Didomi.getRequiredPurposeIds(),
+          requiredVendorIds: window.wrappedJSObject.Didomi.getRequiredVendorIds(),
+          allPurposeIds: window.wrappedJSObject.Didomi.getPurposes(),
+          allVendorIds: window.wrappedJSObject.Didomi.getVendors(),
+        });
+        if (payload) window.wrappedJSObject.Didomi.setCurrentUserStatus(payload);
       } catch {
         // A throwing page global must never break the page.
       }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -243,6 +243,102 @@
   }
   // @sync:cmp-adapters:end
 
+  // Cookie Consent Minimizer — Didomi minimum-grant pilot (see the design
+  // docs for the full mode name; this file's own structural guard forbids
+  // spelling it outside the fenced regions below). The two pure functions
+  // in the fenced block directly below are a hand-maintained COPY of the
+  // sibling lib module's own same-named block (content scripts cannot use
+  // ES module imports — AGENTS.md). Kept in sync by
+  // tests/unit/cookie-noise-sync.test.mjs. World-agnostic and pure — never
+  // touches `window` itself; the dispatch regions further below supply
+  // the real page-global reads.
+  // @sync:cmp-accept:start
+  function canAttemptDidomiMinimumAccept(signals) {
+    const s = signals && typeof signals === "object" ? signals : {};
+    if (s.hasDidomiGlobal !== true) return false;
+    if (s.hasSetUserDisagreeToAllFn === true) return false;
+    if (s.hasSetCurrentUserStatusFn !== true) return false;
+    if (s.hasGetRequiredPurposeIdsFn !== true) return false;
+    if (s.hasGetRequiredVendorIdsFn !== true) return false;
+    if (s.hasGetPurposesFn !== true) return false;
+    if (s.hasGetVendorsFn !== true) return false;
+    return true;
+  }
+
+  function buildMinimumPayload(input) {
+    const i = input && typeof input === "object" ? input : {};
+    const allPurposeIds = Array.isArray(i.allPurposeIds) ? i.allPurposeIds : [];
+    const allVendorIds = Array.isArray(i.allVendorIds) ? i.allVendorIds : [];
+    const requiredPurposeIds = Array.isArray(i.requiredPurposeIds) ? i.requiredPurposeIds : [];
+    const requiredVendorIds = Array.isArray(i.requiredVendorIds) ? i.requiredVendorIds : [];
+
+    const enabledPurposes = allPurposeIds.filter((id) => requiredPurposeIds.includes(id));
+    const enabledVendors = allVendorIds.filter((id) => requiredVendorIds.includes(id));
+    const enabledPurposeSet = new Set(enabledPurposes);
+    const enabledVendorSet = new Set(enabledVendors);
+
+    return {
+      purposes: {
+        enabled: enabledPurposes,
+        disabled: allPurposeIds.filter((id) => !enabledPurposeSet.has(id)),
+      },
+      vendors: {
+        enabled: enabledVendors,
+        disabled: allVendorIds.filter((id) => !enabledVendorSet.has(id)),
+      },
+    };
+  }
+  // @sync:cmp-accept:end
+
+  // Pure double-gate for the minimum-grant path (mirrors
+  // computeCookieGate's @sync:cookie-gate shape). Hand-maintained COPY of
+  // the sibling lib module's own same-named block. Kept in sync by
+  // tests/unit/cookie-noise-sync.test.mjs. The main-world caller does NOT
+  // carry this block — it never reads prefs.
+  // @sync:cmp-accept-gate:start
+  function computeAcceptGate(prefs, deps) {
+    if (!prefs) return false;
+    if (prefs.enabled === false) return false;
+    if (prefs.onboardingDone !== true) return false;
+    if (prefs.cookieConsentMode !== "accept-when-necessary") return false;
+    if (prefs.cookieConsentAcceptConsented !== true) return false;
+    const isSiteFullyExempt = deps && deps.isSiteFullyExempt;
+    if (typeof isSiteFullyExempt === "function") {
+      try {
+        if (isSiteFullyExempt(deps.hostname, prefs)) return false;
+      } catch {
+        // Fail-safe: treat as not exempt on any unexpected throw.
+      }
+    }
+    return true;
+  }
+  // @sync:cmp-accept-gate:end
+
+  // Normalizes Didomi's getPurposes()/getVendors() return shape (array of
+  // ids, array of {id} objects, or an id-keyed object map — the exact
+  // shape was not fully confirmed by a live probe against real Didomi
+  // sites, see the project's design docs) into a plain array of id
+  // strings. Never throws; unrecognized shapes resolve to an empty array
+  // (fail-closed).
+  function extractDidomiIds(value) {
+    try {
+      if (Array.isArray(value)) {
+        const ids = [];
+        for (const item of value) {
+          if (typeof item === "string") ids.push(item);
+          else if (item && typeof item.id === "string") ids.push(item.id);
+        }
+        return ids;
+      }
+      if (value && typeof value === "object") {
+        return Object.keys(value);
+      }
+    } catch {
+      // Fall through to the fail-closed empty array below.
+    }
+    return [];
+  }
+
   // ── Nonce handshake (separate channel: muga:cookie-gate) ────────────────
   // Mirrors the #811 pattern from history-defuser.js on its own channel.
   // The nonce lives only in this closure — no global property stores it.
@@ -261,10 +357,10 @@
   }
   dispatchNonceOnce();
 
-  function dispatchGate(enabled) {
+  function dispatchGate(enabled, didomiMinimumGateOpen) {
     try {
       document.dispatchEvent(new CustomEvent("muga:cookie-gate", {
-        detail: { enabled: !!enabled, nonce: _nonce },
+        detail: { enabled: !!enabled, didomiMinimumGateOpen: !!didomiMinimumGateOpen, nonce: _nonce },
       }));
     } catch {
       // document detached or CustomEvent unavailable — silent. Harmless
@@ -280,6 +376,10 @@
   // needed here — we only READ `wrappedJSObject.OneTrust` and CALL its
   // `RejectAll` method, we don't install anything onto the page.
   let _fxGateOpen = false;
+  // Firefox-local mirror of the minimum-grant double-gate — computed
+  // directly from prefs in this same world (Firefox has no MAIN-world
+  // relay to receive), via computeDidomiMinimumGate() further below.
+  let _fxDidomiMinimumGateOpen = false;
   let _fxActed = false;
   let _fxObserver = null;
 
@@ -360,6 +460,25 @@
       hasGetCurrentUserStatusFn = hasDidomiGlobal && typeof di.getCurrentUserStatus === "function";
     } catch {
       // ignore
+    }
+    // Didomi minimum-grant pilot signals (Firefox wrappedJSObject path) —
+    // same five signals as the Chrome MAIN-world caller, see
+    // cookie-noise-mainworld.js for the full rationale.
+    let hasSetCurrentUserStatusFn = false;
+    let hasGetRequiredPurposeIdsFn = false;
+    let hasGetRequiredVendorIdsFn = false;
+    let hasGetPurposesFn = false;
+    let hasGetVendorsFn = false;
+    try {
+      const wrapped = window.wrappedJSObject;
+      const di = wrapped && wrapped.Didomi;
+      hasSetCurrentUserStatusFn = hasDidomiGlobal && typeof di.setCurrentUserStatus === "function";
+      hasGetRequiredPurposeIdsFn = hasDidomiGlobal && typeof di.getRequiredPurposeIds === "function";
+      hasGetRequiredVendorIdsFn = hasDidomiGlobal && typeof di.getRequiredVendorIds === "function";
+      hasGetPurposesFn = hasDidomiGlobal && typeof di.getPurposes === "function";
+      hasGetVendorsFn = hasDidomiGlobal && typeof di.getVendors === "function";
+    } catch {
+      // Xray wrapper / permission failure — fail closed.
     }
     // CookieYes (#1120): unlike the three adapters above, the reject call
     // is a BARE global (`wrappedJSObject.performBannerAction`), not a
@@ -563,6 +682,11 @@
       hasSetUserDisagreeToAllFn,
       hasDidomiHostDom,
       hasGetCurrentUserStatusFn,
+      hasSetCurrentUserStatusFn,
+      hasGetRequiredPurposeIdsFn,
+      hasGetRequiredVendorIdsFn,
+      hasGetPurposesFn,
+      hasGetVendorsFn,
       hasGetCkyConsentFn,
       hasPerformBannerActionFn,
       hasCkyConsentContainerDom,
@@ -739,6 +863,30 @@
       fxStopObserver();
       return;
     }
+    // Cookie Consent Minimizer — Didomi minimum-grant pilot, own fenced
+    // region below (this file's structural guard forbids spelling the
+    // mode name outside it). Same shape as the Chrome MAIN-world caller's
+    // dispatch — see cookie-noise-mainworld.js — reached ONLY after every
+    // Tier 1 reject adapter above returned false for this page (a genuine
+    // hard wall), double-gated by a boolean computed directly from prefs
+    // in this world, AND the region's own signal check.
+    // @sync:cmp-accept-dispatch:start
+    if (_fxDidomiMinimumGateOpen && canAttemptDidomiMinimumAccept(signals)) {
+      _fxActed = true;
+      try {
+        const requiredPurposeIds = extractDidomiIds(window.wrappedJSObject.Didomi.getRequiredPurposeIds());
+        const requiredVendorIds = extractDidomiIds(window.wrappedJSObject.Didomi.getRequiredVendorIds());
+        const allPurposeIds = extractDidomiIds(window.wrappedJSObject.Didomi.getPurposes());
+        const allVendorIds = extractDidomiIds(window.wrappedJSObject.Didomi.getVendors());
+        const payload = buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
+        window.wrappedJSObject.Didomi.setCurrentUserStatus(payload);
+      } catch {
+        // A throwing page global must never break the page.
+      }
+      fxStopObserver();
+      return;
+    }
+    // @sync:cmp-accept-dispatch:end
   }
 
   // Bounded give-up window (#1027) — Firefox mirror of the MAIN-world
@@ -845,16 +993,37 @@
     });
   }
 
+  // Computes the minimum-grant double-gate from the real prefs in this
+  // world — this world is the only one with prefs access; the Chrome
+  // MAIN-world caller receives the already-computed boolean via the
+  // nonce-gated event (see dispatchGate above), and Firefox reads this
+  // function's result directly (no cross-world relay needed, same world).
+  // This thin wrapper is itself fenced (this file's structural guard
+  // forbids spelling the wrapped function's name outside a fenced
+  // region — see the fenced block directly below).
+  // @sync:cmp-accept-gate-call:start
+  function computeDidomiMinimumGate(prefs) {
+    const cleaner = window.__mugaCleaner;
+    return computeAcceptGate(prefs, {
+      hostname: location.hostname,
+      isSiteFullyExempt:
+        cleaner && typeof cleaner.isSiteFullyExempt === "function" ? cleaner.isSiteFullyExempt : null,
+    });
+  }
+  // @sync:cmp-accept-gate-call:end
+
   function readPrefsAndGate() {
     try {
       chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
         void chrome.runtime.lastError;
         const open = computeGate(prefs);
+        const minimumGateOpen = computeDidomiMinimumGate(prefs);
         // Always dispatch — harmless no-op on Firefox, where no MAIN-world
         // listener is ever loaded (no world:"MAIN" content script there).
-        dispatchGate(open);
+        dispatchGate(open, minimumGateOpen);
         if (_isFirefox) {
           _fxGateOpen = open;
+          _fxDidomiMinimumGateOpen = minimumGateOpen;
           if (open) {
             fxRunDispatcher(); // initial sweep — the banner may already exist
             fxStartObserver();

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -338,9 +338,12 @@
   // REQUIRED lists are parsed STRICTLY (extractRequiredIds); if EITHER is
   // unresolvable the whole accept is abandoned (returns null → the caller must
   // NOT call setCurrentUserStatus, leaving the banner as the safe outcome).
-  // Returns a validly-constructed minimum payload otherwise. Pure; never
-  // throws (the getter calls themselves stay in the world-specific dispatch
-  // region, wrapped there).
+  // A DEGENERATE full registry (both getPurposes() and getVendors() collapse
+  // to empty) also NOOPs — there is no valid minimum to construct, so the
+  // call must never fire with an all-empty payload. Returns a validly-
+  // constructed minimum payload otherwise. Pure; never throws (the getter
+  // calls themselves stay in the world-specific dispatch region, wrapped
+  // there).
   function resolveDidomiMinimumStatus(raw) {
     const r = raw && typeof raw === "object" ? raw : {};
     const requiredPurposeIds = extractRequiredIds(r.requiredPurposeIds);
@@ -348,6 +351,7 @@
     if (requiredPurposeIds === null || requiredVendorIds === null) return null;
     const allPurposeIds = extractDidomiIds(r.allPurposeIds);
     const allVendorIds = extractDidomiIds(r.allVendorIds);
+    if (allPurposeIds.length === 0 && allVendorIds.length === 0) return null;
     return buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
   }
   // @sync:cmp-accept:end

--- a/src/lib/cmp-accept-adapters.js
+++ b/src/lib/cmp-accept-adapters.js
@@ -177,11 +177,17 @@ export { computeAcceptGate };
  * reports (`getPurposes()` / `getVendors()`) — NEVER a hardcoded id list,
  * NEVER "everything enabled".
  *
- * Fail-closed on corrupted/hostile page data: an id present in
- * `requiredPurposeIds`/`requiredVendorIds` but ABSENT from
- * `allPurposeIds`/`allVendorIds` is never enabled — this function only
- * ever enables ids it can also see in the full registry, so a compromised
- * or malformed "required" list can widen consent by, at most, zero ids.
+ * Widening is prevented by a defense-in-depth chain, NOT by this function
+ * alone: the runtime seam `resolveDidomiMinimumStatus` parses the vendor's
+ * REQUIRED getters STRICTLY (array-of-non-empty-strings-or-NOOP — see
+ * `extractRequiredIds`) before this function ever runs, so a hostile
+ * "required" shape (a flag-map, an array of registry objects, anything that
+ * is not a clean id array) abandons the whole accept instead of reaching
+ * here. On top of that, this function only ever enables ids it can also see
+ * in the full registry (`allPurposeIds`/`allVendorIds`), so an id present
+ * in `requiredPurposeIds`/`requiredVendorIds` but ABSENT from the registry
+ * is never enabled. Strict required-parse + registry intersection +
+ * NOOP-on-unexpected-shape is the actual guarantee.
  *
  * @param {{requiredPurposeIds?: string[], requiredVendorIds?: string[], allPurposeIds?: string[], allVendorIds?: string[]}} [input]
  * @returns {{purposes: {enabled: string[], disabled: string[]}, vendors: {enabled: string[], disabled: string[]}}}
@@ -221,6 +227,50 @@ function canAttemptDidomiMinimumAccept(signals) {
   return true;
 }
 
+// Broad, permissive normalizer for the vendor's FULL registry getters
+// (getPurposes()/getVendors()): an array of id strings, an array of {id}
+// objects, or an id-keyed object map all normalize to a plain array of id
+// strings. This breadth is SAFE here because the "all" lists are only ever
+// intersected against the strictly-parsed required set below — a broad read
+// of the registry can never, by itself, widen consent. Never throws;
+// unrecognized shapes resolve to an empty array (fail-closed).
+function extractDidomiIds(value) {
+  try {
+    if (Array.isArray(value)) {
+      const ids = [];
+      for (const item of value) {
+        if (typeof item === "string") ids.push(item);
+        else if (item && typeof item.id === "string") ids.push(item.id);
+      }
+      return ids;
+    }
+    if (value && typeof value === "object") {
+      return Object.keys(value);
+    }
+  } catch {
+    // Fall through to the fail-closed empty array below.
+  }
+  return [];
+}
+
+// STRICT, fail-closed parser for the REQUIRED getters
+// (getRequiredPurposeIds()/getRequiredVendorIds()). Didomi's real getters
+// return a plain array of id strings (engram sdd/cookie-consent-accept
+// probe, id 1324); this accepts ONLY that exact shape. Anything else — a
+// flag-map object, an array of registry objects, an array with a non-string
+// or empty-string member, null, a non-array — is UNRESOLVABLE and returns
+// null so the caller abandons the entire accept rather than guessing a
+// payload that could widen consent. Never throws.
+function extractRequiredIds(value) {
+  if (!Array.isArray(value)) return null;
+  const ids = [];
+  for (const item of value) {
+    if (typeof item !== "string" || item.length === 0) return null;
+    ids.push(item);
+  }
+  return ids;
+}
+
 function buildMinimumPayload(input) {
   const i = input && typeof input === "object" ? input : {};
   const allPurposeIds = Array.isArray(i.allPurposeIds) ? i.allPurposeIds : [];
@@ -243,6 +293,24 @@ function buildMinimumPayload(input) {
       disabled: allVendorIds.filter((id) => !enabledVendorSet.has(id)),
     },
   };
+}
+
+// Runtime seam the content-script dispatch regions call with the RAW return
+// values of Didomi's four getters. Owns the fail-closed contract: the
+// REQUIRED lists are parsed STRICTLY (extractRequiredIds); if EITHER is
+// unresolvable the whole accept is abandoned (returns null → the caller must
+// NOT call setCurrentUserStatus, leaving the banner as the safe outcome).
+// Returns a validly-constructed minimum payload otherwise. Pure; never
+// throws (the getter calls themselves stay in the world-specific dispatch
+// region, wrapped there).
+function resolveDidomiMinimumStatus(raw) {
+  const r = raw && typeof raw === "object" ? raw : {};
+  const requiredPurposeIds = extractRequiredIds(r.requiredPurposeIds);
+  const requiredVendorIds = extractRequiredIds(r.requiredVendorIds);
+  if (requiredPurposeIds === null || requiredVendorIds === null) return null;
+  const allPurposeIds = extractDidomiIds(r.allPurposeIds);
+  const allVendorIds = extractDidomiIds(r.allVendorIds);
+  return buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
 }
 // @sync:cmp-accept:end
 
@@ -295,4 +363,4 @@ export const didomiAcceptAdapter = Object.freeze({
   accept,
 });
 
-export { canAttemptDidomiMinimumAccept };
+export { canAttemptDidomiMinimumAccept, extractDidomiIds, extractRequiredIds, resolveDidomiMinimumStatus };

--- a/src/lib/cmp-accept-adapters.js
+++ b/src/lib/cmp-accept-adapters.js
@@ -1,0 +1,258 @@
+/**
+ * MUGA: Cookie Consent Minimizer — accept-when-necessary module
+ * (cookie-consent-accept Slice 2a — Didomi-only pilot)
+ *
+ * Pure ES module. This is the ONLY file in the project where MUGA is
+ * allowed to construct a consent-GRANTING call. It exists because the
+ * project's 3-state `cookieConsentMode` pref includes an agreed opt-in
+ * mode, "accept-when-necessary", that lets MUGA submit the strictly-
+ * necessary-only minimum on a genuine hard wall — a page where NO reject
+ * path exists at all, only some form of "accept" — so the user is not
+ * stuck. This is NOT the default; the default mode ("reject-only") never
+ * reaches this file's logic at all (see the double-gate below).
+ *
+ * ── Five independent safety layers (each sufficient alone) ─────────────
+ *
+ * L1 — File-scoped lexical purity: src/lib/cmp-adapters.js (the reject
+ *   brain) and the reject regions of the two content scripts stay FOREVER
+ *   free of any accept-family identifier — enforced by an absolute
+ *   structural scan there. ALL accept logic lives here instead, plus the
+ *   `@sync:cmp-accept` content-script region that hand-copies this
+ *   module's pure functions (mirroring how `computeCookieGate` is mirrored
+ *   into `@sync:cookie-gate`).
+ *
+ * L2 — Double-gate as a DATA invariant: `computeAcceptGate` below opens
+ *   ONLY when BOTH `cookieConsentMode === "accept-when-necessary"` AND
+ *   `cookieConsentAcceptConsented === true` (plus enabled/onboarded/not-
+ *   exempt). Two independent prefs, not one enum value, so a corrupted or
+ *   imported mode string alone can never open this gate — see
+ *   settings-schema.js's `clampImportedCookieConsentMode` /
+ *   `exportOnlyBoolean` for the import-time half of this guarantee.
+ *
+ * L3 — Reject-first ladder: `decideMinimumAccept` below only ever returns
+ *   ACCEPT_MINIMUM when the caller's `decision.reason` is exactly
+ *   `"no-reject-path"` — i.e. the reject ladder in cmp-adapters.js already
+ *   ran FIRST, for this exact page, and confirmed there is truly no reject
+ *   path. A successful reject, or plain uncertainty, never reaches this
+ *   module's ACCEPT_MINIMUM branch.
+ *
+ * L4 — Minimum enforcement + broad-accept DENYLIST: `didomiAcceptAdapter`
+ *   only ever constructs a payload that enables the vendor's OWN declared
+ *   "required" ids and disables everything else the vendor's OWN registry
+ *   reports — never a hardcoded id, never "everything enabled". A
+ *   structural test (tests/unit/cmp-accept-adapters.test.mjs) scans this
+ *   file for every broad-accept method identified across all 10 vendors
+ *   this project has adapters for (see that test's own DENYLIST list for
+ *   the exact literals — deliberately not repeated verbatim here so this
+ *   docblock cannot itself trip that same scan) and fails the build if any
+ *   appear.
+ *
+ * L5 — Fail-toward-NOOP everywhere: every function below returns a NOOP
+ *   shape on any missing/malformed input, any thrown exemption predicate,
+ *   or any thrown page-global call — never an accept.
+ *
+ * Slice 2a scope: Didomi is the ONLY accept-capable adapter today (see
+ * ACCEPT_CAPABLE_ADAPTER_IDS below) — it is the only vendor with BOTH a
+ * real hard-wall scenario and a generalizable, granular, necessary-only
+ * construction (its own `getRequiredPurposeIds()` / `getRequiredVendorIds()`
+ * getters). A last-resort accept-all path for vendors that expose no
+ * granular control at all (OneTrust, CookieScript) is explicitly deferred
+ * to a later slice, behind its own explicit per-decision safety review —
+ * do not add it here without that review.
+ *
+ * Residual risk (stated honestly): this module's live behavior — does
+ * Didomi's `setCurrentUserStatus` call actually dismiss a real hard wall
+ * and grant zero non-essential — is NOT verifiable by unit tests or a
+ * synthetic fixture; it is a real-EU-geo behavioral question. See the
+ * prominent comment on didomiAcceptAdapter below and
+ * docs/qa/cookie-consent-release-smoke.md — this mode must not be enabled
+ * for real users before that smoke passes from a real EU vantage.
+ */
+
+/**
+ * Closed action enum. Every member is a minimum-accept action. There is
+ * intentionally no broad/all-consent member in this set, and there must
+ * never be one — see the file docblock's L4 and the DENYLIST structural
+ * test.
+ * @type {Readonly<{ACCEPT_MINIMUM: "accept-minimum"}>}
+ */
+export const ACTIONS_ACCEPT = Object.freeze({
+  ACCEPT_MINIMUM: "accept-minimum",
+});
+
+/**
+ * Slice 2a scope: the only vendor id whose hard wall can ever resolve to
+ * ACCEPT_MINIMUM. See the file docblock for why every other vendor is
+ * either dead-code (reject and accept share one page global, so a hard
+ * wall for reject is a hard wall for accept too) or deferred behind a
+ * last-resort-only safety review.
+ * @type {ReadonlySet<string>}
+ */
+const ACCEPT_CAPABLE_ADAPTER_IDS = new Set(["didomi"]);
+
+/**
+ * Pure decision function (L3). Given the reject ladder's decision for
+ * this page (from `cmp-adapters.js`'s `decideAction`), the user's raw
+ * mode pref, and the user's raw consent-gesture pref, decides whether a
+ * minimum-accept action should be attempted.
+ *
+ * Returns ACCEPT_MINIMUM ONLY when every one of these holds:
+ *   - `mode === "accept-when-necessary"` (not "reject-only", not "off",
+ *     not any corrupted/unrecognized string);
+ *   - `consented === true` (not truthy — exactly `true`);
+ *   - `decision.reason === "no-reject-path"` (a genuine hard wall for
+ *     THIS page — not "reject" (something already succeeded) and not
+ *     "uncertain" (no confident detection at all));
+ *   - `decision.adapterId` is in the accept-capable set (today: only
+ *     `"didomi"`).
+ *
+ * Any other combination — including malformed input — resolves to NOOP.
+ * Pure and never throws.
+ *
+ * @param {{reason?: string, adapterId?: string|null}|null|undefined} decision
+ *   The result of cmp-adapters.js's decideAction() for this page.
+ * @param {*} mode - The raw `cookieConsentMode` pref value.
+ * @param {*} consented - The raw `cookieConsentAcceptConsented` pref value.
+ * @returns {{action: "accept-minimum"|null, adapterId: string|null}}
+ */
+export function decideMinimumAccept(decision, mode, consented) {
+  const d = decision && typeof decision === "object" ? decision : {};
+  if (mode !== "accept-when-necessary") return { action: null, adapterId: null };
+  if (consented !== true) return { action: null, adapterId: null };
+  if (d.reason !== "no-reject-path") return { action: null, adapterId: null };
+  if (!ACCEPT_CAPABLE_ADAPTER_IDS.has(d.adapterId)) return { action: null, adapterId: null };
+  return { action: ACTIONS_ACCEPT.ACCEPT_MINIMUM, adapterId: d.adapterId };
+}
+
+/**
+ * Pure double-gate (L2). Mirrors src/lib/cmp-adapters.js's
+ * `computeCookieGate` shape, but for the accept path specifically — this
+ * gate and the reject gate are DELIBERATELY separate functions/prefs (a
+ * dedicated boolean, not a 4th enum value) so a corrupted or imported
+ * mode string alone can never open this gate: BOTH
+ * `cookieConsentMode === "accept-when-necessary"` AND
+ * `cookieConsentAcceptConsented === true` must hold, in addition to the
+ * usual enabled/onboarded/exemption checks every feature in this project
+ * respects.
+ *
+ * This function's logic is hand-copied into the `@sync:cmp-accept`
+ * regions of both content scripts (content/cookie-noise.js and
+ * content/cookie-noise-mainworld.js), the same pattern
+ * `computeCookieGate` uses for `@sync:cookie-gate` — kept in sync by
+ * tests/unit/cookie-noise-sync.test.mjs.
+ *
+ * Fail-closed: a missing/false signal, or an unexpected throw from the
+ * injected exemption predicate, returns false.
+ *
+ * @param {object|null|undefined} prefs Merged prefs (see PREF_DEFAULTS).
+ * @param {{hostname?: string, isSiteFullyExempt?: (hostname: string, prefs: object) => boolean}} [deps]
+ * @returns {boolean} true only when the accept gate should open.
+ */
+// @sync:cmp-accept-gate:start
+export function computeAcceptGate(prefs, deps) {
+  if (!prefs) return false;
+  if (prefs.enabled === false) return false;
+  if (prefs.onboardingDone !== true) return false;
+  if (prefs.cookieConsentMode !== "accept-when-necessary") return false;
+  if (prefs.cookieConsentAcceptConsented !== true) return false;
+  const isSiteFullyExempt = deps && deps.isSiteFullyExempt;
+  if (typeof isSiteFullyExempt === "function") {
+    try {
+      if (isSiteFullyExempt(deps.hostname, prefs)) return false;
+    } catch {
+      // Fail-safe: treat as not exempt on any unexpected throw.
+    }
+  }
+  return true;
+}
+// @sync:cmp-accept-gate:end
+
+/**
+ * Builds the Didomi minimum-consent payload (L4). Pure — never touches
+ * `window`. Enables ONLY the ids the vendor's OWN page state reports as
+ * required (`getRequiredPurposeIds()` / `getRequiredVendorIds()` in the
+ * real call site), disables every other id the vendor's OWN registry
+ * reports (`getPurposes()` / `getVendors()`) — NEVER a hardcoded id list,
+ * NEVER "everything enabled".
+ *
+ * Fail-closed on corrupted/hostile page data: an id present in
+ * `requiredPurposeIds`/`requiredVendorIds` but ABSENT from
+ * `allPurposeIds`/`allVendorIds` is never enabled — this function only
+ * ever enables ids it can also see in the full registry, so a compromised
+ * or malformed "required" list can widen consent by, at most, zero ids.
+ *
+ * @param {{requiredPurposeIds?: string[], requiredVendorIds?: string[], allPurposeIds?: string[], allVendorIds?: string[]}} [input]
+ * @returns {{purposes: {enabled: string[], disabled: string[]}, vendors: {enabled: string[], disabled: string[]}}}
+ */
+function buildMinimumPayload(input) {
+  const i = input && typeof input === "object" ? input : {};
+  const allPurposeIds = Array.isArray(i.allPurposeIds) ? i.allPurposeIds : [];
+  const allVendorIds = Array.isArray(i.allVendorIds) ? i.allVendorIds : [];
+  const requiredPurposeIds = Array.isArray(i.requiredPurposeIds) ? i.requiredPurposeIds : [];
+  const requiredVendorIds = Array.isArray(i.requiredVendorIds) ? i.requiredVendorIds : [];
+
+  const enabledPurposes = allPurposeIds.filter((id) => requiredPurposeIds.includes(id));
+  const enabledVendors = allVendorIds.filter((id) => requiredVendorIds.includes(id));
+  const enabledPurposeSet = new Set(enabledPurposes);
+  const enabledVendorSet = new Set(enabledVendors);
+
+  return {
+    purposes: {
+      enabled: enabledPurposes,
+      disabled: allPurposeIds.filter((id) => !enabledPurposeSet.has(id)),
+    },
+    vendors: {
+      enabled: enabledVendors,
+      disabled: allVendorIds.filter((id) => !enabledVendorSet.has(id)),
+    },
+  };
+}
+
+/**
+ * Invokes the caller-supplied accept call. Kept pure (no `window` access
+ * here) by requiring the caller to inject the actual global call as a
+ * zero-argument callback — mirrors `cmp-adapters.js`'s `reject()` helper
+ * exactly. Never throws.
+ *
+ * @param {() => void} [callAccept]
+ * @returns {{status: "accepted"|"noop"}}
+ */
+function accept(callAccept) {
+  if (typeof callAccept !== "function") return { status: "noop" };
+  try {
+    callAccept();
+    return { status: "accepted" };
+  } catch {
+    return { status: "noop" };
+  }
+}
+
+/**
+ * Didomi accept-when-necessary adapter (Slice 2a pilot — the only
+ * accept-capable adapter today). The real call site (content scripts)
+ * builds the payload from `window.Didomi.getRequiredPurposeIds()` /
+ * `getRequiredVendorIds()` / `getPurposes()` / `getVendors()` and invokes
+ * `window.Didomi.setCurrentUserStatus(payload)` through `accept()` above.
+ *
+ * ── HARD PRE-ENABLE GATE — DO NOT REMOVE THIS COMMENT ───────────────────
+ * Didomi's live banner behavior is geo-gated and could NOT be verified
+ * from a non-EU vantage (engram sdd/cookie-consent-accept/didomi-probe):
+ * `setCurrentUserStatus` returned a stable, sync boolean and the exact
+ * getter names were confirmed on 3 real production Didomi sites, but the
+ * crux question — does calling it with the minimum payload actually
+ * DISMISS a real hard wall AND grant ZERO non-essential purposes/vendors —
+ * remains unverified because no real hard-wall session was observed from
+ * that vantage. This adapter, and the "accept-when-necessary" mode as a
+ * whole, MUST pass a real-EU-geo behavioral smoke test (a human, or a
+ * CI runner with an EU vantage point, confirming a live Didomi hard wall
+ * actually dismisses on the minimum payload and grants zero tracking)
+ * BEFORE this mode is enabled for real users in a release. See
+ * docs/qa/cookie-consent-release-smoke.md's "accept-when-necessary" item.
+ *
+ * @type {Readonly<{id: "didomi", buildMinimumPayload: typeof buildMinimumPayload, accept: typeof accept}>}
+ */
+export const didomiAcceptAdapter = Object.freeze({
+  id: "didomi",
+  buildMinimumPayload,
+  accept,
+});

--- a/src/lib/cmp-accept-adapters.js
+++ b/src/lib/cmp-accept-adapters.js
@@ -149,7 +149,7 @@ export function decideMinimumAccept(decision, mode, consented) {
  * @returns {boolean} true only when the accept gate should open.
  */
 // @sync:cmp-accept-gate:start
-export function computeAcceptGate(prefs, deps) {
+function computeAcceptGate(prefs, deps) {
   if (!prefs) return false;
   if (prefs.enabled === false) return false;
   if (prefs.onboardingDone !== true) return false;
@@ -166,6 +166,8 @@ export function computeAcceptGate(prefs, deps) {
   return true;
 }
 // @sync:cmp-accept-gate:end
+
+export { computeAcceptGate };
 
 /**
  * Builds the Didomi minimum-consent payload (L4). Pure — never touches
@@ -184,6 +186,41 @@ export function computeAcceptGate(prefs, deps) {
  * @param {{requiredPurposeIds?: string[], requiredVendorIds?: string[], allPurposeIds?: string[], allVendorIds?: string[]}} [input]
  * @returns {{purposes: {enabled: string[], disabled: string[]}, vendors: {enabled: string[], disabled: string[]}}}
  */
+/**
+ * Pure hard-wall + accept-capability detection (mirrors the reject
+ * ladder's per-vendor detect() shape in cmp-adapters.js). Confirms BOTH:
+ *   - a genuine Didomi hard wall for this page (global present, the
+ *     reject function absent — the exact "no-reject-path" condition), and
+ *   - every accept-specific signal this Slice's minimum-payload
+ *     construction needs (`setCurrentUserStatus` plus both the required-
+ *     ids getters and both the full-registry getters).
+ *
+ * Content scripts cannot import this module (AGENTS.md — no ES imports in
+ * content scripts), so the block between the `@sync:cmp-accept` markers
+ * below (this function AND `buildMinimumPayload` above it) is hand-copied,
+ * modulo indentation, into content/cookie-noise-mainworld.js (Chrome MAIN
+ * world) and content/cookie-noise.js (Firefox `wrappedJSObject` path).
+ * Kept in sync by tests/unit/cookie-noise-sync.test.mjs.
+ *
+ * Pure: given the same signals it always returns the same result. Never
+ * throws.
+ *
+ * @param {object|null|undefined} signals
+ * @returns {boolean}
+ */
+// @sync:cmp-accept:start
+function canAttemptDidomiMinimumAccept(signals) {
+  const s = signals && typeof signals === "object" ? signals : {};
+  if (s.hasDidomiGlobal !== true) return false;
+  if (s.hasSetUserDisagreeToAllFn === true) return false;
+  if (s.hasSetCurrentUserStatusFn !== true) return false;
+  if (s.hasGetRequiredPurposeIdsFn !== true) return false;
+  if (s.hasGetRequiredVendorIdsFn !== true) return false;
+  if (s.hasGetPurposesFn !== true) return false;
+  if (s.hasGetVendorsFn !== true) return false;
+  return true;
+}
+
 function buildMinimumPayload(input) {
   const i = input && typeof input === "object" ? input : {};
   const allPurposeIds = Array.isArray(i.allPurposeIds) ? i.allPurposeIds : [];
@@ -207,6 +244,7 @@ function buildMinimumPayload(input) {
     },
   };
 }
+// @sync:cmp-accept:end
 
 /**
  * Invokes the caller-supplied accept call. Kept pure (no `window` access
@@ -256,3 +294,5 @@ export const didomiAcceptAdapter = Object.freeze({
   buildMinimumPayload,
   accept,
 });
+
+export { canAttemptDidomiMinimumAccept };

--- a/src/lib/cmp-accept-adapters.js
+++ b/src/lib/cmp-accept-adapters.js
@@ -300,9 +300,12 @@ function buildMinimumPayload(input) {
 // REQUIRED lists are parsed STRICTLY (extractRequiredIds); if EITHER is
 // unresolvable the whole accept is abandoned (returns null → the caller must
 // NOT call setCurrentUserStatus, leaving the banner as the safe outcome).
-// Returns a validly-constructed minimum payload otherwise. Pure; never
-// throws (the getter calls themselves stay in the world-specific dispatch
-// region, wrapped there).
+// A DEGENERATE full registry (both getPurposes() and getVendors() collapse
+// to empty) also NOOPs — there is no valid minimum to construct, so the
+// call must never fire with an all-empty payload. Returns a validly-
+// constructed minimum payload otherwise. Pure; never throws (the getter
+// calls themselves stay in the world-specific dispatch region, wrapped
+// there).
 function resolveDidomiMinimumStatus(raw) {
   const r = raw && typeof raw === "object" ? raw : {};
   const requiredPurposeIds = extractRequiredIds(r.requiredPurposeIds);
@@ -310,6 +313,7 @@ function resolveDidomiMinimumStatus(raw) {
   if (requiredPurposeIds === null || requiredVendorIds === null) return null;
   const allPurposeIds = extractDidomiIds(r.allPurposeIds);
   const allVendorIds = extractDidomiIds(r.allVendorIds);
+  if (allPurposeIds.length === 0 && allVendorIds.length === 0) return null;
   return buildMinimumPayload({ requiredPurposeIds, requiredVendorIds, allPurposeIds, allVendorIds });
 }
 // @sync:cmp-accept:end

--- a/src/lib/cmp-accept-adapters.js
+++ b/src/lib/cmp-accept-adapters.js
@@ -109,6 +109,14 @@ const ACCEPT_CAPABLE_ADAPTER_IDS = new Set(["didomi"]);
  * Any other combination — including malformed input — resolves to NOOP.
  * Pure and never throws.
  *
+ * SPEC-MIRROR counterpart: this is the exhaustively-tested pure decision,
+ * but the content scripts do NOT call it — they gate on the inlined runtime
+ * pair `computeAcceptGate(prefs) && canAttemptDidomiMinimumAccept(signals)`
+ * (the same pure-lib-fn ↔ inlined-runtime split as `decideAction` ↔ the
+ * inlined canReject ladder in cmp-adapters.js / the content scripts). A
+ * PARITY test (tests/unit/cmp-accept-adapters.test.mjs) proves the two
+ * agree across the signal/mode/consent matrix so they cannot drift.
+ *
  * @param {{reason?: string, adapterId?: string|null}|null|undefined} decision
  *   The result of cmp-adapters.js's decideAction() for this page.
  * @param {*} mode - The raw `cookieConsentMode` pref value.
@@ -210,6 +218,15 @@ export { computeAcceptGate };
  *
  * Pure: given the same signals it always returns the same result. Never
  * throws.
+ *
+ * RUNTIME-INLINE counterpart: this is the predicate the content scripts
+ * actually gate on (hand-copied into the @sync:cmp-accept region of both),
+ * the runtime half of the SPEC-MIRROR `decideMinimumAccept` above — mirrors
+ * `decideAction` ↔ the inlined canReject ladder. A PARITY test
+ * (tests/unit/cmp-accept-adapters.test.mjs) proves the two agree across the
+ * signal/mode/consent matrix. It is deliberately STRICTER than the spec
+ * decision alone: it also re-confirms the accept-capability surface the
+ * spec decision cannot see, so a hard wall lacking a getter never acts.
  *
  * @param {object|null|undefined} signals
  * @returns {boolean}

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -780,10 +780,19 @@ export const TIER2 = Object.freeze([]);
  * Two-tier pure decision function. Tries every Tier 1 adapter, then every
  * Tier 2 adapter (empty today), and returns the first confirmed reject
  * action. When nothing can confidently reject, distinguishes two NOOP
- * reasons for observability/testing: `"no-reject-path"` when the OneTrust
+ * reasons for observability/testing: `"no-reject-path"` when a vendor
  * global is present but its reject function is not (a hard wall), and
  * `"uncertain"` for everything else (no CMP detected, or insufficient
  * corroboration — fail-closed).
+ *
+ * `adapterId` is threaded through every `"no-reject-path"` branch (the
+ * specific vendor whose hard wall was detected) — a small enhancement that
+ * keeps this file's own structural guard intact (see the file docblock):
+ * this file still never spells the word that guard forbids, and never
+ * decides anything beyond the reject family. A SEPARATE module can use
+ * this id downstream to decide what, if anything, to do about a specific
+ * vendor's hard wall, without this file ever knowing what that separate
+ * module does with it.
  *
  * Pure: given the same signals it always returns the same result. Never
  * throws.
@@ -806,41 +815,41 @@ export function decideAction(signals) {
   }
 
   if (s.hasOneTrustGlobal === true && s.hasRejectAllFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "onetrust" };
   }
   if (s.hasCookiebotGlobal === true && s.hasSubmitCustomConsentFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "cookiebot" };
   }
   if (s.hasDidomiGlobal === true && s.hasSetUserDisagreeToAllFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "didomi" };
   }
   if (s.hasGetCkyConsentFn === true && s.hasPerformBannerActionFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "cookieyes" };
   }
   // Sourcepoint (#1123) hard wall is the MIRROR IMAGE of the checks above:
   // keyed off the Sourcepoint-specific DOM signal, NOT hasTcfApiFn alone —
   // a bare hasTcfApiFn is true on every TCF CMP (Didomi included) and must
   // fall through to "uncertain" below, never claim Sourcepoint.
   if (s.hasSpMessageContainerDom === true && s.hasTcfApiFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "sourcepoint" };
   }
   // Usercentrics (#1121) hard wall: same shape as the OneTrust/Didomi
   // checks above (mandatory global present, mandatory reject fn absent).
   if (s.hasUcUiGlobal === true && s.hasDenyAllConsentsFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "usercentrics" };
   }
   // Cookie Information hard wall: same shape as the OneTrust/Didomi/
   // Usercentrics checks above (mandatory global present, mandatory reject
   // fn absent).
   if (s.hasCookieInformationGlobal === true && s.hasDeclineAllCategoriesFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "cookieinformation" };
   }
   // CookieScript hard wall: mandatory global present but the reject
   // function is not reachable — either `.instance` itself is absent, or
   // `.instance` exists but `.rejectAllAction` is not a function. Both
   // sub-cases collapse to `hasRejectAllActionFn !== true` here.
   if (s.hasCookieScriptGlobal === true && s.hasRejectAllActionFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "cookiescript" };
   }
   // tarteaucitron hard wall: mandatory global present but the reject
   // function is not reachable — either `.userInterface` itself is absent,
@@ -848,7 +857,7 @@ export function decideAction(signals) {
   // sub-cases collapse to `hasRespondAllFn !== true` here, same shape as
   // the CookieScript hard wall above.
   if (s.hasTarteaucitronGlobal === true && s.hasRespondAllFn !== true) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "tarteaucitron" };
   }
   // consentmanager.net hard wall: the MIRROR IMAGE of the Sourcepoint check
   // above, keyed off the vendor-specific DOM anchor (hasCmpBoxDom), NOT
@@ -856,7 +865,7 @@ export function decideAction(signals) {
   // CMP and must fall through to "uncertain" below, never claim
   // consentmanager.net.
   if (s.hasCmpBoxDom === true && (s.hasCmpMngrGlobal !== true || s.hasCmpFn !== true)) {
-    return { action: null, reason: "no-reject-path", adapterId: null };
+    return { action: null, reason: "no-reject-path", adapterId: "consentmanager" };
   }
   return { action: null, reason: "uncertain", adapterId: null };
 }
@@ -870,15 +879,16 @@ export function decideAction(signals) {
  * all-pass — is unit-tested directly here instead of only structurally in
  * a content script that Node cannot import.
  *
- * Mode scope (3-state `cookieConsentMode` pref): this gate only opens for
- * `"reject-only"` today. The enum's third member is a recognized
- * PREF_DEFAULTS / settings-schema value reserved for a later slice, but is
- * intentionally NOT special-cased here — this file's own STRUCTURAL guard
- * (see the describe block in tests/unit/cmp-adapters.test.mjs) forbids the
- * word for "granting broad consent" anywhere in this source, and that
- * word is a substring of the third enum member's name. Nothing writes
- * that value today (no migration path, no UI control), so this is a
- * forward-compatible placeholder, not a behavior gap.
+ * Mode scope (3-state `cookieConsentMode` pref): the reject ladder must run
+ * first in EVERY active mode, not only `"reject-only"` (see this project's
+ * design docs, Part B "L3" + "Gate wiring reconciliation") — but
+ * this file's own STRUCTURAL guard (see the describe block in
+ * tests/unit/cmp-adapters.test.mjs) forbids naming the newer mode anywhere
+ * in this source. So this gate no longer reads `prefs.cookieConsentMode`
+ * at all: the caller validates the raw pref against the closed enum at the
+ * settings-schema.js boundary (which has no such lexical restriction) and
+ * passes a pre-validated `deps.modeActive` boolean instead. Fail-closed:
+ * anything other than the literal boolean `true` keeps the gate shut.
  *
  * Content scripts cannot import this module (AGENTS.md — no ES imports in
  * content scripts), so the block between the `@sync:cookie-gate` markers
@@ -890,9 +900,10 @@ export function decideAction(signals) {
  * injected exemption predicate, returns false.
  *
  * @param {object|null|undefined} prefs Merged prefs (see PREF_DEFAULTS).
- * @param {{hostname?: string, isSiteFullyExempt?: (hostname: string, prefs: object) => boolean}} [deps]
- *   Environment hooks the content-script call site injects: the current
- *   hostname and the cleaner's per-site exemption predicate.
+ * @param {{modeActive?: boolean, hostname?: string, isSiteFullyExempt?: (hostname: string, prefs: object) => boolean}} [deps]
+ *   Environment hooks the content-script call site injects: the
+ *   pre-validated active-mode boolean, the current hostname, and the
+ *   cleaner's per-site exemption predicate.
  * @returns {boolean} true only when the gate should open.
  */
 // @sync:cookie-gate:start
@@ -900,7 +911,7 @@ function computeCookieGate(prefs, deps) {
   if (!prefs) return false;
   if (prefs.enabled === false) return false;
   if (prefs.onboardingDone !== true) return false;
-  if (prefs.cookieConsentMode !== "reject-only") return false;
+  if (!deps || deps.modeActive !== true) return false;
   const isSiteFullyExempt = deps && deps.isSiteFullyExempt;
   if (typeof isSiteFullyExempt === "function") {
     try {

--- a/src/lib/consent-clauses.js
+++ b/src/lib/consent-clauses.js
@@ -39,6 +39,13 @@ export const CONSENT_CLAUSES_BY_VERSION = Object.freeze({
   // function). The feature itself stays OFF until the user opts in from
   // Settings; this clause is disclosure, not an activation.
   "1.2": Object.freeze(["ob_clause_cookie_consent_minimizer"]),
+  // 1.3 (cookie-consent-accept Slice 2a): the accept-when-necessary mode's
+  // Didomi-only pilot. Single additive clause disclosing that, on a
+  // genuine hard wall with no reject option, MUGA can submit the MINIMUM
+  // consent choice on the user's behalf. This mode stays off by default
+  // and requires BOTH selecting it in Settings AND completing a separate,
+  // explicit consent gesture — this clause is disclosure, not activation.
+  "1.3": Object.freeze(["ob_clause_cookie_consent_accept_pilot"]),
 });
 
 /**

--- a/src/lib/consent-version-manifest.js
+++ b/src/lib/consent-version-manifest.js
@@ -77,20 +77,22 @@ export const CONSENT_VERSION_MANIFEST = Object.freeze([
     additive: true,
   }),
   Object.freeze({
-    // Cookie-consent-modes redesign, Slice 1: the boolean
-    // cookieConsentMinimizerEnabled becomes a 3-state cookieConsentMode
-    // ("off" | "reject-only" | "accept-when-necessary"), default
-    // "reject-only" for NEW installs only. Existing users are migrated to
-    // "off" (migrateCookieConsentMode, storage-migrations.js) — no
-    // existing user's capability changes, so per the design's resolved
-    // default-reconciliation decision, no forced re-consent / soft
-    // re-onboard fires for them. The disclosure is shown to new users
-    // only, through the ordinary fresh-onboarding features list. This is
-    // a STAGED entry (see the module docblock above): additive: true is
-    // recorded for the historical record, but REQUIRED_CONSENT_VERSION
-    // intentionally stays at "1.2" in this slice — bump it (and add a
-    // CONSENT_CLAUSES_BY_VERSION["1.3"] entry) only when a future slice
-    // needs to disclose something to existing users too.
+    // Originally staged inert by the cookie-consent-modes redesign Slice 1
+    // (the boolean cookieConsentMinimizerEnabled became a 3-state
+    // cookieConsentMode: "off" | "reject-only" | "accept-when-necessary").
+    // That part alone changed no existing user's capability (migrated to
+    // "off"), so it did not warrant a forced re-consent on its own.
+    //
+    // cookie-consent-accept Slice 2a ACTIVATES this entry: the
+    // accept-when-necessary mode now has a real, working pilot (Didomi
+    // only) that lets MUGA submit a minimum-consent payload on a genuine
+    // hard wall — a new capability class worth disclosing, even though it
+    // stays off until the user opts in from Settings AND completes a
+    // dedicated, explicit consent gesture (see
+    // src/lib/cmp-accept-adapters.js's L2 double-gate). Purely ADDITIVE —
+    // no existing term is modified or removed — so users who accepted an
+    // earlier version get a SOFT re-onboard (delta review) surfacing this
+    // one new clause, not a hard gate.
     version: "1.3",
     additive: true,
   }),
@@ -101,4 +103,4 @@ export const CONSENT_VERSION_MANIFEST = Object.freeze([
  * to the latest entry in CONSENT_VERSION_MANIFEST. ConsentPolicy uses
  * this to decide whether a stored consent record is still current.
  */
-export const REQUIRED_CONSENT_VERSION = "1.2";
+export const REQUIRED_CONSENT_VERSION = "1.3";

--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -276,6 +276,7 @@ export default Object.freeze({
   ob_reonboard_material_desc: "MUGAs Nutzungsbedingungen wurden in einer Weise aktualisiert, die deine bisherige Zustimmung berührt. Die weitere Nutzung der Erweiterung erfordert die Annahme der neuen Bedingungen. Bitte überprüfe die unten verlinkten Nutzungsbedingungen und Datenschutzrichtlinien.",
   ob_clause_remote_rules_default: "Wöchentliche Regelaktualisierungen sind jetzt standardmäßig aktiviert: MUGA lädt etwa einmal pro Woche eine aktualisierte Liste von Tracking-Parametern von rules.muga.app. Es handelt sich um eine Ed25519-signierte Anfrage, die keine personenbezogenen Daten sendet (keinen Browserverlauf, keine Cookies) und du kannst sie jederzeit in den Einstellungen deaktivieren.",
   ob_clause_cookie_consent_minimizer: "Neu, standardmäßig deaktiviert: Bei unterstützten Cookie-Consent-Bannern (derzeit OneTrust) kann MUGA für dich auf „ablehnen“ bzw. „nur erforderliche“ klicken, genauso wie es bereits Tracking-Rauschen aus URLs entfernt. MUGA akzeptiert oder gewährt dabei nie weitergehendes Tracking in deinem Namen. Gibt es keine sichere Ablehnoption, lässt MUGA den Banner unangetastet. Du kannst die Funktion jederzeit in den Einstellungen aktivieren.",
+  ob_clause_cookie_consent_accept_pilot: "Neu, standardmäßig deaktiviert: Wenn du „Minimum akzeptieren, wenn nötig“ aktivierst und bestätigst, kann MUGA bei Cookie-Bannern, die Inhalte blockieren und keine Ablehnoption bieten (derzeit unterstützt bei Didomi), die minimale Auswahl senden und nur unbedingt erforderliche Cookies gewähren, damit du fortfahren kannst. MUGA gewährt dabei niemals Tracking-Cookies. Dies erfordert eine separate, ausdrückliche Bestätigung in den Einstellungen und bleibt deaktiviert, bis du es aktivierst.",
   migration_accept: "Aktivieren",
   migration_decline: "Nein, danke",
   migration_counter: "{n} von {total}",
@@ -350,4 +351,8 @@ export default Object.freeze({
   aria_cookie_consent_mode: "Modus des Cookie-Consent-Minimierers",
   cookie_consent_mode_opt_reject_only: "Nur ablehnen (empfohlen)",
   cookie_consent_mode_opt_off: "Aus",
+  cookie_consent_mode_opt_accept: "Minimum akzeptieren, wenn nötig",
+  row_cookie_consent_accept_gesture_label: "Minimale Auswahl bei fehlender Ablehnoption zulassen",
+  row_cookie_consent_accept_gesture_hint: "Auf Seiten, die Inhalte blockieren, bis du einen Cookie-Banner beantwortest, und die keine Ablehnoption anbieten, sendet MUGA die minimale Auswahl und gewährt nur unbedingt erforderliche Cookies, damit du fortfahren kannst. MUGA gewährt niemals Tracking-Cookies. Dies gilt nur, solange der Modus oben auf „Minimum akzeptieren, wenn nötig“ eingestellt ist.",
+  aria_cookie_consent_accept_gesture: "Minimale Auswahl bei fehlender Ablehnoption bestätigen",
 });

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -276,6 +276,7 @@ export default Object.freeze({
   ob_reonboard_material_desc: "MUGA's terms have been updated in a way that affects what you previously agreed to. Continued use of the extension requires accepting the new terms. Please review the linked Terms of Use and Privacy Policy below.",
   ob_clause_remote_rules_default: "Weekly rule updates are now on by default: MUGA fetches an updated tracker-parameter list from rules.muga.app about once a week. It is an Ed25519-signed request that sends no personal data (no browsing history, no cookies) and you can turn it off any time in Settings.",
   ob_clause_cookie_consent_minimizer: "New, off by default: on supported cookie-consent banners (currently OneTrust), MUGA can click reject / necessary-only for you, the same way it already strips tracking noise from URLs. It never accepts or grants broader tracking on your behalf. If no safe reject option exists, MUGA leaves the banner alone. Turn it on any time in Settings.",
+  ob_clause_cookie_consent_accept_pilot: "New, off by default: if you turn on \"Accept minimum when necessary\" and confirm it, MUGA can submit the minimum choice on cookie banners that block content and offer no reject option (currently supported on Didomi), granting only strictly necessary cookies so you can proceed. It never grants tracking cookies. This requires a separate, explicit confirmation in Settings and stays off until you turn it on.",
   migration_accept: "Enable",
   migration_decline: "No thanks",
   migration_counter: "{n} of {total}",
@@ -350,4 +351,8 @@ export default Object.freeze({
   aria_cookie_consent_mode: "Cookie consent minimizer mode",
   cookie_consent_mode_opt_reject_only: "Reject only (recommended)",
   cookie_consent_mode_opt_off: "Off",
+  cookie_consent_mode_opt_accept: "Accept minimum when necessary",
+  row_cookie_consent_accept_gesture_label: "Allow the minimum choice on hard walls",
+  row_cookie_consent_accept_gesture_hint: "On sites that block content until you answer a cookie banner and offer no reject option, MUGA will submit the minimum choice, granting only strictly necessary cookies, so you can proceed. MUGA never grants tracking cookies. This only applies while the mode above is set to \"Accept minimum when necessary\".",
+  aria_cookie_consent_accept_gesture: "Confirm the minimum choice on hard walls",
 });

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -276,6 +276,7 @@ export default Object.freeze({
   ob_reonboard_material_desc: "Los términos de MUGA se han actualizado de una manera que afecta a lo que aceptaste anteriormente. El uso continuado de la extensión requiere aceptar los nuevos términos. Revisa los Términos de uso y la Política de privacidad enlazados abajo.",
   ob_clause_remote_rules_default: "Las actualizaciones semanales de reglas ahora están activadas de forma predeterminada: MUGA descarga una lista actualizada de parámetros de rastreo desde rules.muga.app aproximadamente una vez por semana. Es una solicitud firmada con Ed25519 que no envía ningún dato personal (ni historial de navegación ni cookies) y puedes desactivarla cuando quieras en los Ajustes.",
   ob_clause_cookie_consent_minimizer: "Nueva función, desactivada por defecto: en avisos de cookies compatibles (por ahora OneTrust), MUGA puede pulsar por ti \"rechazar\" o \"solo necesarias\", igual que ya elimina el ruido de rastreo de las URL. Nunca acepta ni concede más rastreo en tu nombre. Si no existe una opción segura de rechazo, MUGA deja el aviso tal cual. Actívalo cuando quieras en los Ajustes.",
+  ob_clause_cookie_consent_accept_pilot: "Nueva función, desactivada por defecto: si activas \"Aceptar el mínimo cuando sea necesario\" y lo confirmas, MUGA puede enviar la elección mínima en avisos de cookies que bloquean el contenido y no ofrecen ninguna opción de rechazo (por ahora compatible con Didomi), concediendo solo las cookies estrictamente necesarias para que puedas continuar. Nunca concede cookies de rastreo. Requiere una confirmación explícita aparte en los Ajustes y permanece desactivada hasta que la activas.",
   migration_accept: "Activar",
   migration_decline: "No, gracias",
   migration_counter: "{n} de {total}",
@@ -350,4 +351,8 @@ export default Object.freeze({
   aria_cookie_consent_mode: "Modo del minimizador de avisos de cookies",
   cookie_consent_mode_opt_reject_only: "Solo rechazar (recomendado)",
   cookie_consent_mode_opt_off: "Desactivado",
+  cookie_consent_mode_opt_accept: "Aceptar el mínimo cuando sea necesario",
+  row_cookie_consent_accept_gesture_label: "Permitir la elección mínima en muros sin rechazo",
+  row_cookie_consent_accept_gesture_hint: "En sitios que bloquean el contenido hasta que respondes a un aviso de cookies y no ofrecen ninguna opción de rechazo, MUGA enviará la elección mínima, concediendo solo las cookies estrictamente necesarias, para que puedas continuar. MUGA nunca concede cookies de rastreo. Esto solo se aplica mientras el modo de arriba esté en \"Aceptar el mínimo cuando sea necesario\".",
+  aria_cookie_consent_accept_gesture: "Confirmar la elección mínima en muros sin rechazo",
 });

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -276,6 +276,7 @@ export default Object.freeze({
   ob_reonboard_material_desc: "Les conditions de MUGA ont été mises à jour d'une manière qui affecte ce que vous avez accepté précédemment. L'utilisation continue de l'extension nécessite l'acceptation des nouvelles conditions. Veuillez consulter les Conditions d'utilisation et la Politique de confidentialité ci-dessous.",
   ob_clause_remote_rules_default: "Les mises à jour hebdomadaires des règles sont désormais activées par défaut : MUGA récupère une liste à jour de paramètres de suivi depuis rules.muga.app environ une fois par semaine. Il s'agit d'une requête signée (Ed25519) qui n'envoie aucune donnée personnelle (ni historique de navigation, ni cookies) et vous pouvez la désactiver à tout moment dans les Paramètres.",
   ob_clause_cookie_consent_minimizer: "Nouveau, désactivé par défaut : sur les bandeaux de consentement aux cookies pris en charge (actuellement OneTrust), MUGA peut cliquer sur « refuser » ou « nécessaires uniquement » à votre place, de la même façon qu'il supprime déjà le bruit de pistage des URL. Il n'accepte ni n'accorde jamais de pistage plus large en votre nom. S'il n'existe aucune option de refus sûre, MUGA laisse le bandeau tel quel. Vous pouvez l'activer à tout moment dans les Paramètres.",
+  ob_clause_cookie_consent_accept_pilot: "Nouveau, désactivé par défaut : si vous activez « Accepter le minimum si nécessaire » et le confirmez, MUGA peut envoyer le choix minimal sur les bandeaux de cookies qui bloquent le contenu et n'offrent aucune option de refus (pris en charge pour l'instant sur Didomi), n'accordant que les cookies strictement nécessaires afin que vous puissiez continuer. Il n'accorde jamais de cookies de pistage. Cela nécessite une confirmation explicite distincte dans les Paramètres et reste désactivé jusqu'à ce que vous l'activiez.",
   migration_accept: "Activer",
   migration_decline: "Non merci",
   migration_counter: "{n} sur {total}",
@@ -350,4 +351,8 @@ export default Object.freeze({
   aria_cookie_consent_mode: "Mode du minimiseur de bandeaux de cookies",
   cookie_consent_mode_opt_reject_only: "Refuser uniquement (recommandé)",
   cookie_consent_mode_opt_off: "Désactivé",
+  cookie_consent_mode_opt_accept: "Accepter le minimum si nécessaire",
+  row_cookie_consent_accept_gesture_label: "Autoriser le choix minimal en l'absence d'option de refus",
+  row_cookie_consent_accept_gesture_hint: "Sur les sites qui bloquent le contenu jusqu'à ce que vous répondiez à un bandeau de cookies et qui n'offrent aucune option de refus, MUGA enverra le choix minimal, n'accordant que les cookies strictement nécessaires, afin que vous puissiez continuer. MUGA n'accorde jamais de cookies de pistage. Cela ne s'applique que lorsque le mode ci-dessus est réglé sur « Accepter le minimum si nécessaire ».",
+  aria_cookie_consent_accept_gesture: "Confirmer le choix minimal en l'absence d'option de refus",
 });

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -276,6 +276,7 @@ export default Object.freeze({
   ob_reonboard_material_desc: "I termini di MUGA sono stati aggiornati in modo che incide su quanto hai accettato in precedenza. L'uso continuato dell'estensione richiede l'accettazione dei nuovi termini. Esamina i Termini di utilizzo e l'Informativa sulla privacy collegati qui sotto.",
   ob_clause_remote_rules_default: "Gli aggiornamenti settimanali delle regole sono ora attivi per impostazione predefinita: MUGA scarica un elenco aggiornato di parametri di tracciamento da rules.muga.app circa una volta alla settimana. È una richiesta firmata con Ed25519 che non invia alcun dato personale (nessuna cronologia di navigazione, nessun cookie) e puoi disattivarla in qualsiasi momento nelle Impostazioni.",
   ob_clause_cookie_consent_minimizer: "Novità, disattivata per impostazione predefinita: sui banner di consenso ai cookie supportati (al momento OneTrust), MUGA può cliccare al posto tuo su «rifiuta» o «solo necessari», esattamente come già rimuove il rumore di tracciamento dagli URL. Non accetta né concede mai un tracciamento più ampio a tuo nome. Se non esiste un'opzione di rifiuto sicura, MUGA lascia il banner così com'è. Puoi attivarlo quando vuoi nelle Impostazioni.",
+  ob_clause_cookie_consent_accept_pilot: "Novità, disattivata per impostazione predefinita: se attivi «Accetta il minimo quando necessario» e lo confermi, MUGA può inviare la scelta minima sui banner sui cookie che bloccano i contenuti e non offrono alcuna opzione di rifiuto (al momento supportato su Didomi), concedendo solo i cookie strettamente necessari per permetterti di continuare. Non concede mai cookie di tracciamento. Richiede una conferma esplicita separata nelle Impostazioni e resta disattivata finché non la attivi.",
   migration_accept: "Attiva",
   migration_decline: "No, grazie",
   migration_counter: "{n} di {total}",
@@ -350,4 +351,8 @@ export default Object.freeze({
   aria_cookie_consent_mode: "Modalità del minimizzatore di banner sui cookie",
   cookie_consent_mode_opt_reject_only: "Solo rifiuta (consigliato)",
   cookie_consent_mode_opt_off: "Disattivato",
+  cookie_consent_mode_opt_accept: "Accetta il minimo quando necessario",
+  row_cookie_consent_accept_gesture_label: "Consenti la scelta minima in assenza di un'opzione di rifiuto",
+  row_cookie_consent_accept_gesture_hint: "Sui siti che bloccano i contenuti finché non rispondi a un banner sui cookie e non offrono alcuna opzione di rifiuto, MUGA invierà la scelta minima, concedendo solo i cookie strettamente necessari, per permetterti di continuare. MUGA non concede mai cookie di tracciamento. Questo si applica solo mentre la modalità sopra è impostata su «Accetta il minimo quando necessario».",
+  aria_cookie_consent_accept_gesture: "Confermare la scelta minima in assenza di un'opzione di rifiuto",
 });

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -276,6 +276,7 @@ export default Object.freeze({
   ob_reonboard_material_desc: "MUGAの利用規約が、以前同意した内容に影響する形で更新されました。拡張機能を引き続き使用するには新しい規約への同意が必要です。下記にリンクされた利用規約とプライバシーポリシーをご確認ください。",
   ob_clause_remote_rules_default: "毎週のルール更新が既定で有効になりました。MUGAは約週に1回、rules.muga.app から最新のトラッキングパラメータ一覧を取得します。これはEd25519で署名されたリクエストで、閲覧履歴やCookieなどの個人データは一切送信しません。設定からいつでもオフにできます。",
   ob_clause_cookie_consent_minimizer: "新機能で、デフォルトではオフになっています。対応するCookie同意バナー（現在はOneTrust）では、MUGAがURLからトラッキングノイズを取り除くのと同じように、あなたの代わりに「拒否」または「必須のみ」をクリックできます。あなたに代わってより広範なトラッキングを承諾したり許可したりすることは一切ありません。安全な拒否オプションが存在しない場合、MUGAはバナーをそのままにします。設定でいつでもオンにできます。",
+  ob_clause_cookie_consent_accept_pilot: "新機能で、デフォルトではオフになっています。「必要な場合は最小限を許可」を有効にして確認すると、コンテンツをブロックし拒否オプションを提供しないCookieバナー（現在はDidomiに対応）で、MUGAが最小限の選択を送信し、必須のCookieのみを許可して先に進めるようにできます。トラッキングCookieを許可することは一切ありません。設定で別途明示的な確認が必要で、有効にするまでオフのままです。",
   migration_accept: "有効にする",
   migration_decline: "結構です",
   migration_counter: "{total}件中{n}件",
@@ -350,4 +351,8 @@ export default Object.freeze({
   aria_cookie_consent_mode: "Cookie同意バナー最小化のモード",
   cookie_consent_mode_opt_reject_only: "拒否のみ（推奨）",
   cookie_consent_mode_opt_off: "オフ",
+  cookie_consent_mode_opt_accept: "必要な場合は最小限を許可",
+  row_cookie_consent_accept_gesture_label: "拒否できないバナーで最小限の選択を許可する",
+  row_cookie_consent_accept_gesture_hint: "Cookieバナーに答えるまでコンテンツをブロックし、拒否オプションを提供しないサイトでは、MUGAが最小限の選択を送信し、必須のCookieのみを許可することで、先に進めるようにします。MUGAがトラッキングCookieを許可することは一切ありません。これは上のモードが「必要な場合は最小限を許可」に設定されている場合のみ適用されます。",
+  aria_cookie_consent_accept_gesture: "拒否できないバナーで最小限の選択を確認する",
 });

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -276,6 +276,7 @@ export default Object.freeze({
   ob_reonboard_material_desc: "Os termos do MUGA foram atualizados de forma que afeta o que você aceitou anteriormente. O uso contínuo da extensão exige aceitar os novos termos. Revise os Termos de uso e a Política de privacidade vinculados abaixo.",
   ob_clause_remote_rules_default: "As atualizações semanais de regras agora estão ativadas por padrão: o MUGA baixa uma lista atualizada de parâmetros de rastreamento de rules.muga.app cerca de uma vez por semana. É uma solicitação assinada com Ed25519 que não envia nenhum dado pessoal (sem histórico de navegação, sem cookies) e você pode desativá-la quando quiser nas Configurações.",
   ob_clause_cookie_consent_minimizer: "Novidade, desativada por padrão: em avisos de cookies compatíveis (atualmente OneTrust), o MUGA pode clicar em «rejeitar» ou «apenas necessários» por você, da mesma forma que já remove o ruído de rastreamento das URLs. Ele nunca aceita nem concede mais rastreamento em seu nome. Se não existir uma opção segura de rejeição, o MUGA deixa o aviso como está. Ative quando quiser nas Configurações.",
+  ob_clause_cookie_consent_accept_pilot: "Novidade, desativada por padrão: se você ativar «Aceitar o mínimo quando necessário» e confirmar, o MUGA pode enviar a escolha mínima em avisos de cookies que bloqueiam o conteúdo e não oferecem nenhuma opção de rejeição (por enquanto compatível com Didomi), concedendo apenas os cookies estritamente necessários para que você possa continuar. Ele nunca concede cookies de rastreamento. Isso exige uma confirmação explícita separada nas Configurações e permanece desativado até você ativá-lo.",
   migration_accept: "Ativar",
   migration_decline: "Não, obrigado",
   migration_counter: "{n} de {total}",
@@ -350,4 +351,8 @@ export default Object.freeze({
   aria_cookie_consent_mode: "Modo do minimizador de avisos de cookies",
   cookie_consent_mode_opt_reject_only: "Rejeitar apenas (recomendado)",
   cookie_consent_mode_opt_off: "Desativado",
+  cookie_consent_mode_opt_accept: "Aceitar o mínimo quando necessário",
+  row_cookie_consent_accept_gesture_label: "Permitir a escolha mínima em barreiras sem rejeição",
+  row_cookie_consent_accept_gesture_hint: "Em sites que bloqueiam o conteúdo até você responder a um aviso de cookies e não oferecem nenhuma opção de rejeição, o MUGA enviará a escolha mínima, concedendo apenas os cookies estritamente necessários, para que você possa continuar. O MUGA nunca concede cookies de rastreamento. Isso só se aplica enquanto o modo acima estiver definido como \"Aceitar o mínimo quando necessário\".",
+  aria_cookie_consent_accept_gesture: "Confirmar a escolha mínima em barreiras sem rejeição",
 });

--- a/src/lib/settings-schema.js
+++ b/src/lib/settings-schema.js
@@ -70,6 +70,30 @@ export function clampCookieConsentMode(v) {
 }
 
 /**
+ * Closed-enum "is this mode an active minimizer mode" check (cookie-
+ * consent-accept Slice 2a, design Part B "Gate wiring reconciliation").
+ *
+ * src/lib/cmp-adapters.js's `computeCookieGate` reject gate needs to open
+ * for BOTH `"reject-only"` and `"accept-when-necessary"` (the reject
+ * ladder must run first in every active mode — design's L3), but that
+ * file is lexically restricted and must never spell the enum member name
+ * that names the newer mode. This module has no such restriction, so the
+ * caller (background/service-worker.js, which already imports this
+ * module) validates the raw pref string here and hands the CALLER of
+ * computeCookieGate a pre-validated boolean instead — the fenced block in
+ * cmp-adapters.js / content/cookie-noise.js never compares the mode
+ * string itself again.
+ *
+ * Fail-closed: an unrecognized value, or a non-string, is never active.
+ *
+ * @param {*} mode
+ * @returns {boolean}
+ */
+export function isCookieConsentModeActive(mode) {
+  return mode === "reject-only" || mode === "accept-when-necessary";
+}
+
+/**
  * Import-only clamp for cookieConsentMode. Until Slice 2 ships the double-gate
  * that governs "accept-when-necessary", an imported blob must never pre-seed
  * that reserved accept state (nor any unknown value) without a real consent

--- a/src/lib/settings-schema.js
+++ b/src/lib/settings-schema.js
@@ -109,6 +109,31 @@ export function clampImportedCookieConsentMode(v) {
 }
 
 /**
+ * Decides what `cookieConsentAcceptConsented` should become when the user
+ * changes the cookieConsentMode select (cookie-consent-accept Slice 2a).
+ *
+ * The gesture must NOT be sticky across mode switches: leaving
+ * "accept-when-necessary" REVOKES the stored gesture (returns false), so
+ * re-entering the accept mode later requires a fresh explicit click on the
+ * gesture checkbox — the double-gate never re-opens on stale consent.
+ *
+ * Entering or staying in "accept-when-necessary" NEVER grants the gesture:
+ * it preserves whatever was already stored, and only an exact boolean
+ * `true` (set by a real prior checkbox click) survives. This path can only
+ * ever keep an existing true or leave it false; it can never turn a false
+ * (or a truthy non-boolean) into a true — that guarantee is what keeps the
+ * mode select from ever opening the gate on its own.
+ *
+ * @param {*} nextMode The mode the select is changing to.
+ * @param {*} currentConsented The currently stored gesture flag.
+ * @returns {boolean}
+ */
+export function resolveConsentGestureOnModeChange(nextMode, currentConsented) {
+  if (nextMode !== "accept-when-necessary") return false;
+  return currentConsented === true;
+}
+
+/**
  * Tracking-category keys accepted for `disabledCategories`. Kept as its own
  * literal set (not derived from TRACKING_PARAM_CATEGORIES in affiliates.js)
  * so this import allowlist cannot silently drift if that taxonomy changes

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -216,7 +216,15 @@
           <select class="lang-select" id="cookie-consent-mode-select" data-i18n-aria-label="aria_cookie_consent_mode">
             <option value="reject-only" data-i18n="cookie_consent_mode_opt_reject_only">Reject only (recommended)</option>
             <option value="off" data-i18n="cookie_consent_mode_opt_off">Off</option>
+            <option value="accept-when-necessary" data-i18n="cookie_consent_mode_opt_accept">Accept minimum when necessary</option>
           </select>
+        </div>
+        <div class="row" id="cookie-consent-accept-gesture-row" hidden>
+          <div class="row-label">
+            <strong data-i18n="row_cookie_consent_accept_gesture_label">Allow the minimum choice on hard walls</strong>
+            <small data-i18n="row_cookie_consent_accept_gesture_hint">On sites that block content until you answer a cookie banner and offer no reject option, MUGA will submit the minimum choice, granting only strictly necessary cookies, so you can proceed. MUGA never grants tracking cookies. This only applies while the mode above is set to "Accept minimum when necessary".</small>
+          </div>
+          <label class="toggle"><input type="checkbox" id="cookie-consent-accept-gesture-checkbox" data-i18n-aria-label="aria_cookie_consent_accept_gesture"><span class="slider"></span></label>
         </div>
         <div class="row">
           <div class="row-label">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -18,7 +18,7 @@ import { GENERIC_SHORTENERS } from "../lib/native-shortener-resolver.js";
 import { GUARDED_PREFS } from "../lib/synced-affiliate-pref-guard.js";
 import { reconcileOverrideForExplicitChoice } from "../lib/per-device-prefs.js";
 import { createMutex, withSyncMutation } from "./sync-mutation.js";
-import { snapToastDuration, buildExportPayload, planImport, diffImport, BOOLEAN_KEYS, clampCookieConsentMode } from "../lib/settings-schema.js";
+import { snapToastDuration, buildExportPayload, planImport, diffImport, BOOLEAN_KEYS, clampCookieConsentMode, resolveConsentGestureOnModeChange } from "../lib/settings-schema.js";
 
 let _currentLang = "en";
 
@@ -344,10 +344,19 @@ async function init() {
       cookieConsentAcceptGestureCheckbox.checked = prefs.cookieConsentAcceptConsented === true;
     }
     syncCookieConsentAcceptGestureVisibility();
+    // Revoke the gesture when leaving accept-when-necessary so re-entering
+    // requires a fresh click; this path never GRANTS it (see
+    // resolveConsentGestureOnModeChange). Persisted together with the mode in
+    // a single write, with cookieConsentMode first so the gesture flag is
+    // never the leading key of a standalone consent-granting write.
     cookieConsentModeSelect.addEventListener("change", () => {
-      try { setPrefs({ cookieConsentMode: cookieConsentModeSelect.value }); }
-      catch (err) { console.error("[MUGA] save cookie consent mode:", err); }
+      const nextMode = cookieConsentModeSelect.value;
+      const nextConsented = resolveConsentGestureOnModeChange(nextMode, prefs.cookieConsentAcceptConsented);
+      prefs.cookieConsentAcceptConsented = nextConsented;
       syncCookieConsentAcceptGestureVisibility();
+      if (cookieConsentAcceptGestureCheckbox) cookieConsentAcceptGestureCheckbox.checked = nextConsented === true;
+      try { setPrefs({ cookieConsentMode: nextMode, cookieConsentAcceptConsented: nextConsented }); }
+      catch (err) { console.error("[MUGA] save cookie consent mode:", err); }
     });
   }
   if (cookieConsentAcceptGestureCheckbox) {

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -18,7 +18,7 @@ import { GENERIC_SHORTENERS } from "../lib/native-shortener-resolver.js";
 import { GUARDED_PREFS } from "../lib/synced-affiliate-pref-guard.js";
 import { reconcileOverrideForExplicitChoice } from "../lib/per-device-prefs.js";
 import { createMutex, withSyncMutation } from "./sync-mutation.js";
-import { snapToastDuration, buildExportPayload, planImport, diffImport, BOOLEAN_KEYS } from "../lib/settings-schema.js";
+import { snapToastDuration, buildExportPayload, planImport, diffImport, BOOLEAN_KEYS, clampCookieConsentMode } from "../lib/settings-schema.js";
 
 let _currentLang = "en";
 
@@ -323,18 +323,45 @@ async function init() {
   // Hover destination preview (#1028). Plain boolean toggle; not
   // guarded (no per-device override reconciliation needed).
   bindToggle("hover-preview-toggle", "hoverPreviewEnabled", prefs);
-  // Cookie Consent Minimizer — 3-state modes (Slice 1). Not guarded (no
-  // per-device override reconciliation needed). Only "reject-only" and
-  // "off" are offered; "accept-when-necessary" is a recognized enum
-  // member (see settings-schema.js) reserved for a later slice and is
-  // deliberately not rendered as an option here.
+  // Cookie Consent Minimizer — 3-state modes. Not guarded (no per-device
+  // override reconciliation needed). All three enum members are offered
+  // (cookie-consent-accept Slice 2a activated the third, "accept-when-
+  // necessary" — the Didomi-only minimum-grant pilot).
+  //
+  // Selecting "accept-when-necessary" here does NOT by itself grant
+  // MUGA the ability to act: computeAcceptGate (src/lib/cmp-accept-
+  // adapters.js) requires BOTH this mode AND cookieConsentAcceptConsented
+  // === true. That second flag is set ONLY by a real click on the
+  // dedicated gesture checkbox below — never by this select, never by
+  // import (settings-schema.js's exportOnlyBoolean kind keeps it out of
+  // the import path entirely).
   const cookieConsentModeSelect = document.getElementById("cookie-consent-mode-select");
+  const cookieConsentAcceptGestureCheckbox = document.getElementById("cookie-consent-accept-gesture-checkbox");
+
   if (cookieConsentModeSelect) {
-    cookieConsentModeSelect.value =
-      prefs.cookieConsentMode === "off" ? "off" : "reject-only";
+    cookieConsentModeSelect.value = clampCookieConsentMode(prefs.cookieConsentMode);
+    if (cookieConsentAcceptGestureCheckbox) {
+      cookieConsentAcceptGestureCheckbox.checked = prefs.cookieConsentAcceptConsented === true;
+    }
+    syncCookieConsentAcceptGestureVisibility();
     cookieConsentModeSelect.addEventListener("change", () => {
       try { setPrefs({ cookieConsentMode: cookieConsentModeSelect.value }); }
       catch (err) { console.error("[MUGA] save cookie consent mode:", err); }
+      syncCookieConsentAcceptGestureVisibility();
+    });
+  }
+  if (cookieConsentAcceptGestureCheckbox) {
+    // A "change" event on a checkbox only fires from a real user
+    // interaction — setting `.checked` from script (as done above, to
+    // reflect the stored pref) never dispatches it. This is what
+    // structurally guarantees the gesture is a real click, not something
+    // this page's own initialization code could ever trigger.
+    cookieConsentAcceptGestureCheckbox.addEventListener("change", () => {
+      try {
+        setPrefs({ cookieConsentAcceptConsented: cookieConsentAcceptGestureCheckbox.checked === true });
+      } catch (err) {
+        console.error("[MUGA] save cookie consent accept gesture:", err);
+      }
     });
   }
   // Honor Creator Mode (#435, B12). Plumbing only: persists the pref so
@@ -426,6 +453,21 @@ async function init() {
   // Called AFTER all prefs and i18n are applied so the section is fully
   // rendered when the scroll fires.
   await readOptionsAnchor();
+}
+
+/**
+ * Shows the informed-consent gesture row (checkbox + copy) only while the
+ * Cookie Consent Minimizer mode select is set to "accept-when-necessary".
+ * Module-level (not nested in init()) so both init() and the post-import
+ * refresh in initExportImport() can call it via the same DOM query — a
+ * fresh document.getElementById() each time, not a shared closure
+ * variable, since those two functions never share scope.
+ */
+function syncCookieConsentAcceptGestureVisibility() {
+  const select = document.getElementById("cookie-consent-mode-select");
+  const row = document.getElementById("cookie-consent-accept-gesture-row");
+  if (!select || !row) return;
+  row.hidden = select.value !== "accept-when-necessary";
 }
 
 /** Binds a checkbox to a sync storage preference key. */
@@ -1162,8 +1204,19 @@ function initExportImport() {
       document.getElementById("amp-redirect").checked = newPrefs.ampRedirect;
       document.getElementById("unwrap-redirects").checked = newPrefs.unwrapRedirects;
       document.getElementById("hover-preview-toggle").checked = newPrefs.hoverPreviewEnabled;
+      // cookieConsentAcceptConsented is exportOnlyBoolean (never imported —
+      // settings-schema.js's planImport never writes it), so an import can
+      // never silently flip mode to accept-when-necessary AND consented to
+      // true together. clampImportedCookieConsentMode already collapsed
+      // any imported "accept-when-necessary" to "reject-only" before this
+      // point; clampCookieConsentMode here is just the display clamp.
       document.getElementById("cookie-consent-mode-select").value =
-        newPrefs.cookieConsentMode === "off" ? "off" : "reject-only";
+        clampCookieConsentMode(newPrefs.cookieConsentMode);
+      const importedGestureCheckbox = document.getElementById("cookie-consent-accept-gesture-checkbox");
+      if (importedGestureCheckbox) {
+        importedGestureCheckbox.checked = newPrefs.cookieConsentAcceptConsented === true;
+      }
+      syncCookieConsentAcceptGestureVisibility();
       // #925: refresh the newly-surfaced privacy + display toggles after import
       document.getElementById("canonical-extractor").checked = newPrefs.canonicalExtractorEnabled;
       document.getElementById("cross-site-frequency").checked = newPrefs.crossSiteFrequencyEnabled;

--- a/tests/e2e-firefox/didomi-accept.smoke.mjs
+++ b/tests/e2e-firefox/didomi-accept.smoke.mjs
@@ -1,0 +1,217 @@
+/**
+ * Firefox smoke: Cookie Consent Minimizer — Didomi accept-when-necessary
+ * pilot (cookie-consent-accept Slice 2a).
+ *
+ * Mirrors tests/e2e/cookie-consent-minimizer-didomi-accept.spec.mjs's
+ * fixture page and assertions, but drives REAL headless Firefox via
+ * Selenium + geckodriver (see ./fixtures.mjs) instead of Playwright's
+ * chromium fixture, to prove the Firefox-only
+ * `window.wrappedJSObject.Didomi.setCurrentUserStatus()` path
+ * (src/content/cookie-noise.js's @sync:cmp-accept-dispatch region)
+ * actually fires in Gecko.
+ *
+ * HONEST LIMIT (mirrors the Chromium spec's own note): this is a
+ * REGRESSION oracle only, proving the mechanics against a synthetic
+ * fixture. It does NOT prove a real Didomi SDK actually honors
+ * setCurrentUserStatus on a live hard wall — see
+ * docs/qa/cookie-consent-release-smoke.md's "Didomi accept-when-necessary
+ * pilot" subsection, a HARD pre-enable gate for real users.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage } from "./helpers/local-server.mjs";
+
+// Same fixture shape as the Chromium spec's stubDidomiHardWallPage: a
+// Didomi hard wall for the REJECT adapter (no setUserDisagreeToAll) that
+// ALSO exposes the full accept-capable surface.
+const DIDOMI_ACCEPT_FIXTURE_HTML = `<!doctype html><html><body>
+  <div id="didomi-host">
+    <button id="didomi-notice-agree-button">Agree</button>
+  </div>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.Didomi = {
+      getCurrentUserStatus() {
+        return { purposes: {}, vendors: {} };
+      },
+      getRequiredPurposeIds() {
+        return ["cookies_functional"];
+      },
+      getRequiredVendorIds() {
+        return ["vendor-required-1"];
+      },
+      getPurposes() {
+        return ["cookies_functional", "advertising", "analytics"];
+      },
+      getVendors() {
+        return ["vendor-required-1", "vendor-ads-2", "vendor-analytics-3"];
+      },
+      setCurrentUserStatus(payload) {
+        window.__mugaAcceptPayload = payload;
+        window.__consentState = "minimum-accepted";
+        document.getElementById("didomi-host").remove();
+      },
+    };
+  </script>
+</body></html>`;
+
+async function completeOnboardingWithAcceptPrefs(driver, extensionOrigin, { cookieConsentMode, cookieConsentAcceptConsented }) {
+  await driver.get(`${extensionOrigin}/popup/popup.html`);
+
+  await driver.executeAsyncScript(
+    (mode, consented, callback) => {
+      chrome.storage.sync.set(
+        {
+          enabled: true,
+          cookieConsentMode: mode,
+          cookieConsentAcceptConsented: consented,
+          injectOwnAffiliate: false,
+          notifyForeignAffiliate: false,
+          language: "en",
+        },
+        () => {
+          chrome.storage.local.set(
+            {
+              mugaConsent: {
+                onboardingDone: true,
+                consentVersion: "1.3",
+                consentDate: Date.now(),
+              },
+            },
+            () => {
+              chrome.storage.sync.set({ onboardingDone: true }, () => callback());
+            }
+          );
+        }
+      );
+    },
+    cookieConsentMode,
+    cookieConsentAcceptConsented
+  );
+
+  // Mirrors tests/e2e-firefox/fixtures.mjs's completeOnboarding: no
+  // observable signal exists for prefs-cache propagation after a
+  // storage.set call, so a short fixed settle window is used (#824 debt).
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: Didomi setCurrentUserStatus() fires the minimum payload when mode is accept-when-necessary AND the gesture is confirmed", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboardingWithAcceptPrefs(driver, extensionOrigin, {
+      cookieConsentMode: "accept-when-necessary",
+      cookieConsentAcceptConsented: true,
+    });
+
+    server = await serveFixturePage(DIDOMI_ACCEPT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await pollUntil(driver, "return window.__consentState === 'minimum-accepted'", { timeoutMs: 10000 });
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, "minimum-accepted");
+
+    const payload = await driver.executeScript("return window.__mugaAcceptPayload");
+    assert.deepEqual(payload.purposes.enabled, ["cookies_functional"]);
+    assert.deepEqual(payload.purposes.disabled, ["advertising", "analytics"]);
+    assert.deepEqual(payload.vendors.enabled, ["vendor-required-1"]);
+    assert.deepEqual(payload.vendors.disabled, ["vendor-ads-2", "vendor-analytics-3"]);
+
+    const bannerGone = await driver.executeScript(
+      "return document.getElementById('didomi-host') === null"
+    );
+    assert.equal(bannerGone, true);
+
+    const pageContent = await driver.executeScript(
+      "return document.getElementById('page-content') ? document.getElementById('page-content').textContent : null"
+    );
+    assert.equal(pageContent, "Real page content");
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke ADVERSARIAL: setCurrentUserStatus() does NOT fire in reject-only mode, even on the exact same hard wall", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboardingWithAcceptPrefs(driver, extensionOrigin, {
+      cookieConsentMode: "reject-only",
+      cookieConsentAcceptConsented: true,
+    });
+
+    server = await serveFixturePage(DIDOMI_ACCEPT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('didomi-host') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke ADVERSARIAL: setCurrentUserStatus() does NOT fire in accept-when-necessary mode without the explicit consent gesture", async () => {
+  let driver;
+  let extDir;
+  let server;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboardingWithAcceptPrefs(driver, extensionOrigin, {
+      cookieConsentMode: "accept-when-necessary",
+      cookieConsentAcceptConsented: false,
+    });
+
+    server = await serveFixturePage(DIDOMI_ACCEPT_FIXTURE_HTML);
+    await driver.get(server.url);
+
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const consentState = await driver.executeScript("return window.__consentState");
+    assert.equal(consentState, null);
+
+    const bannerStillThere = await driver.executeScript(
+      "return document.getElementById('didomi-host') !== null"
+    );
+    assert.equal(bannerStillThere, true);
+  } finally {
+    if (server) await server.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e/cookie-consent-minimizer-didomi-accept.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-didomi-accept.spec.mjs
@@ -150,8 +150,8 @@ test.describe("Cookie Consent Minimizer — Didomi accept-when-necessary pilot (
     await stubDidomiHardWallPage(page);
     await page.goto(`https://${HOST}/index.html`);
 
-    // Negative assertion — no positive signal to poll on, matches the
-    // existing suite's standard pattern for a disabled/inert state.
+    // REASON: negative assertion — no positive signal to poll on, matches
+    // the existing suite's standard pattern for a disabled/inert state.
     await page.waitForTimeout(1500);
 
     const consentState = await page.evaluate(() => window.__consentState);
@@ -173,6 +173,8 @@ test.describe("Cookie Consent Minimizer — Didomi accept-when-necessary pilot (
     await stubDidomiHardWallPage(page);
     await page.goto(`https://${HOST}/index.html`);
 
+    // REASON: negative assertion — no positive signal to poll on, matches
+    // the existing suite's standard pattern for a disabled/inert state.
     await page.waitForTimeout(1500);
 
     const consentState = await page.evaluate(() => window.__consentState);
@@ -194,6 +196,8 @@ test.describe("Cookie Consent Minimizer — Didomi accept-when-necessary pilot (
     await stubDidomiHardWallPage(page);
     await page.goto(`https://${HOST}/index.html`);
 
+    // REASON: negative assertion — no positive signal to poll on, matches
+    // the existing suite's standard pattern for a disabled/inert state.
     await page.waitForTimeout(1500);
 
     const consentState = await page.evaluate(() => window.__consentState);

--- a/tests/e2e/cookie-consent-minimizer-didomi-accept.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-didomi-accept.spec.mjs
@@ -1,0 +1,207 @@
+/**
+ * E2E: Cookie Consent Minimizer — Didomi accept-when-necessary pilot
+ * (cookie-consent-accept Slice 2a)
+ *
+ * Verifies the Chrome MAIN-world minimum-grant dispatch
+ * (content/cookie-noise-mainworld.js's @sync:cmp-accept-dispatch region)
+ * against a stub Didomi hard wall: `window.Didomi` present WITHOUT
+ * `setUserDisagreeToAll` (so the reject adapter in
+ * tests/e2e/cookie-consent-minimizer-didomi.spec.mjs cannot act at all —
+ * this is deliberately the mirror-image fixture), but WITH the
+ * accept-capable surface (`setCurrentUserStatus`, `getRequiredPurposeIds`,
+ * `getRequiredVendorIds`, `getPurposes`, `getVendors`).
+ *
+ * HONEST LIMIT (mirrors cookie-consent-minimizer-didomi.spec.mjs's own
+ * note): this is a REGRESSION oracle only — it proves the MECHANICS
+ * (correct payload shape, correct double-gate, correct no-action in every
+ * other state) against a synthetic fixture. It does NOT prove a real
+ * Didomi SDK actually honors `setCurrentUserStatus` on a live hard wall —
+ * see docs/qa/cookie-consent-release-smoke.md's "Didomi accept-when-
+ * necessary pilot" subsection, a HARD pre-enable gate for real users.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-didomi-accept.invalid";
+
+async function completeOnboarding(context, extensionId, { cookieConsentMode = "accept-when-necessary", cookieConsentAcceptConsented = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ cookieConsentMode, cookieConsentAcceptConsented }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode, cookieConsentAcceptConsented },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.3", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { cookieConsentMode, cookieConsentAcceptConsented }
+  );
+  await page.close();
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture page: a Didomi hard wall for the REJECT adapter (no
+ * setUserDisagreeToAll) that ALSO exposes the full accept-capable
+ * surface. getPurposes()/getVendors() return plain arrays of id strings
+ * (extractDidomiIds's simplest supported shape) — required ids are a
+ * proper subset, so the minimum-payload assertions below can pin exactly
+ * which ids end up enabled vs disabled.
+ */
+async function stubDidomiHardWallPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="didomi-host">
+          <button id="didomi-notice-agree-button">Agree</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.Didomi = {
+            getCurrentUserStatus() {
+              return { purposes: {}, vendors: {} };
+            },
+            getRequiredPurposeIds() {
+              return ["cookies_functional"];
+            },
+            getRequiredVendorIds() {
+              return ["vendor-required-1"];
+            },
+            getPurposes() {
+              return ["cookies_functional", "advertising", "analytics"];
+            },
+            getVendors() {
+              return ["vendor-required-1", "vendor-ads-2", "vendor-analytics-3"];
+            },
+            setCurrentUserStatus(payload) {
+              window.__mugaAcceptPayload = payload;
+              window.__consentState = "minimum-accepted";
+              document.getElementById("didomi-host").remove();
+            },
+          };
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — Didomi accept-when-necessary pilot (cookie-consent-accept Slice 2a)", () => {
+  test("submits the minimum payload and dismisses the hard wall when mode is accept-when-necessary AND the gesture is confirmed", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, {
+      cookieConsentMode: "accept-when-necessary",
+      cookieConsentAcceptConsented: true,
+    });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubDidomiHardWallPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__mugaCookieNoise === true, { timeout: 10000 });
+    await page.waitForFunction(() => window.__consentState === "minimum-accepted", { timeout: 10000 });
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("minimum-accepted");
+
+    // Minimum payload: only the required ids are enabled, everything else
+    // from the vendor's own registry is explicitly disabled.
+    const payload = await page.evaluate(() => window.__mugaAcceptPayload);
+    expect(payload.purposes.enabled).toEqual(["cookies_functional"]);
+    expect(payload.purposes.disabled).toEqual(["advertising", "analytics"]);
+    expect(payload.vendors.enabled).toEqual(["vendor-required-1"]);
+    expect(payload.vendors.disabled).toEqual(["vendor-ads-2", "vendor-analytics-3"]);
+
+    // Banner dismissed.
+    const bannerGone = await page.evaluate(() => document.getElementById("didomi-host") === null);
+    expect(bannerGone).toBe(true);
+
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("ADVERSARIAL: takes no action when mode is reject-only, even on the exact same hard wall", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, {
+      cookieConsentMode: "reject-only",
+      cookieConsentAcceptConsented: true,
+    });
+
+    const page = await context.newPage();
+    await stubDidomiHardWallPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // Negative assertion — no positive signal to poll on, matches the
+    // existing suite's standard pattern for a disabled/inert state.
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(() => document.getElementById("didomi-host") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+
+  test("ADVERSARIAL: takes no action in accept-when-necessary mode without the explicit consent gesture", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, {
+      cookieConsentMode: "accept-when-necessary",
+      cookieConsentAcceptConsented: false,
+    });
+
+    const page = await context.newPage();
+    await stubDidomiHardWallPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(() => document.getElementById("didomi-host") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+
+  test("ADVERSARIAL: takes no action when the feature is off entirely", async ({ context, extensionId }) => {
+    await completeOnboarding(context, extensionId, {
+      cookieConsentMode: "off",
+      cookieConsentAcceptConsented: true,
+    });
+
+    const page = await context.newPage();
+    await stubDidomiHardWallPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForTimeout(1500);
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBeUndefined();
+
+    const bannerStillThere = await page.evaluate(() => document.getElementById("didomi-host") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-accept-adapters.test.mjs
+++ b/tests/unit/cmp-accept-adapters.test.mjs
@@ -478,6 +478,42 @@ describe("resolveDidomiMinimumStatus — fail-closed required-id parsing", () =>
     assert.doesNotThrow(() => resolveDidomiMinimumStatus(undefined));
     assert.equal(resolveDidomiMinimumStatus(null), null);
   });
+
+  test("DEGENERATE: strict required parse succeeds but the FULL registry read yields nothing (both getPurposes and getVendors empty/garbage) -> NOOP, never calls with an empty payload", () => {
+    // getPurposes()/getVendors() returned an unreadable/garbage shape that
+    // the broad normalizer collapsed to []. Even though the required lists
+    // parsed cleanly, there is no valid minimum to construct — the call
+    // must not fire with a fully-empty payload.
+    assert.equal(
+      resolveDidomiMinimumStatus({
+        requiredPurposeIds: ["cookies_functional"],
+        requiredVendorIds: ["vendor-required-1"],
+        allPurposeIds: 12345,
+        allVendorIds: null,
+      }),
+      null,
+    );
+    assert.equal(
+      resolveDidomiMinimumStatus({
+        requiredPurposeIds: [],
+        requiredVendorIds: [],
+        allPurposeIds: [],
+        allVendorIds: [],
+      }),
+      null,
+    );
+  });
+
+  test("a PARTIALLY readable registry (one of purposes/vendors non-empty) still builds — only a fully-empty registry NOOPs", () => {
+    const payload = resolveDidomiMinimumStatus({
+      requiredPurposeIds: ["p1"],
+      requiredVendorIds: [],
+      allPurposeIds: ["p1", "p2"],
+      allVendorIds: [],
+    });
+    assert.notEqual(payload, null);
+    assert.deepEqual(payload.purposes.enabled, ["p1"]);
+  });
 });
 
 describe("extractRequiredIds — strict array-of-non-empty-strings-or-null", () => {

--- a/tests/unit/cmp-accept-adapters.test.mjs
+++ b/tests/unit/cmp-accept-adapters.test.mjs
@@ -28,6 +28,7 @@ import {
   ACTIONS_ACCEPT,
   decideMinimumAccept,
   computeAcceptGate,
+  canAttemptDidomiMinimumAccept,
   didomiAcceptAdapter,
 } from "../../src/lib/cmp-accept-adapters.js";
 
@@ -156,7 +157,7 @@ describe("computeAcceptGate — double-gate as a DATA invariant", () => {
   });
 
   test("cookieConsentAcceptConsented missing/undefined -> gate stays closed (must be exactly true)", () => {
-    const { cookieConsentAcceptConsented, ...rest } = ACCEPT_GATE_ON_PREFS;
+    const { cookieConsentAcceptConsented: _omit, ...rest } = ACCEPT_GATE_ON_PREFS;
     assert.equal(computeAcceptGate(rest), false);
   });
 
@@ -204,6 +205,67 @@ describe("computeAcceptGate — double-gate as a DATA invariant", () => {
     const deps = { hostname: "example.com", isSiteFullyExempt: () => { throw new Error("boom"); } };
     assert.doesNotThrow(() => computeAcceptGate(ACCEPT_GATE_ON_PREFS, deps));
     assert.equal(computeAcceptGate(ACCEPT_GATE_ON_PREFS, deps), true);
+  });
+});
+
+// ── canAttemptDidomiMinimumAccept — content-script hard-wall detection ─────
+//
+// This is the pure predicate hand-copied into the @sync:cmp-accept region
+// of both content scripts (they cannot import this module — no ES imports
+// in content scripts, AGENTS.md), mirroring the @sync:cmp-adapters /
+// @sync:cookie-gate precedent. It is deliberately narrower than the reject
+// ladder's signal shape: it re-confirms the Didomi hard wall (global
+// present, reject fn absent) AND the accept-specific signals this Slice
+// needs (setCurrentUserStatus + both getters), so a page that has Didomi
+// but not the accept-capable API surface never reaches a call attempt.
+
+describe("canAttemptDidomiMinimumAccept — hard-wall + accept-capability detection", () => {
+  const FULL_ACCEPT_SIGNALS = Object.freeze({
+    hasDidomiGlobal: true,
+    hasSetUserDisagreeToAllFn: false,
+    hasSetCurrentUserStatusFn: true,
+    hasGetRequiredPurposeIdsFn: true,
+    hasGetRequiredVendorIdsFn: true,
+    hasGetPurposesFn: true,
+    hasGetVendorsFn: true,
+  });
+
+  test("Didomi hard wall (global present, reject fn absent) + full accept signal set -> true", () => {
+    assert.equal(canAttemptDidomiMinimumAccept(FULL_ACCEPT_SIGNALS), true);
+  });
+
+  test("Didomi global absent -> false", () => {
+    assert.equal(canAttemptDidomiMinimumAccept({ ...FULL_ACCEPT_SIGNALS, hasDidomiGlobal: false }), false);
+  });
+
+  test("reject fn present (a real reject path exists — not a hard wall) -> false, even with every accept signal present", () => {
+    assert.equal(canAttemptDidomiMinimumAccept({ ...FULL_ACCEPT_SIGNALS, hasSetUserDisagreeToAllFn: true }), false);
+  });
+
+  test("setCurrentUserStatus fn missing -> false (no accept call surface at all)", () => {
+    assert.equal(canAttemptDidomiMinimumAccept({ ...FULL_ACCEPT_SIGNALS, hasSetCurrentUserStatusFn: false }), false);
+  });
+
+  test("getRequiredPurposeIds fn missing -> false (cannot build a minimum payload)", () => {
+    assert.equal(canAttemptDidomiMinimumAccept({ ...FULL_ACCEPT_SIGNALS, hasGetRequiredPurposeIdsFn: false }), false);
+  });
+
+  test("getRequiredVendorIds fn missing -> false", () => {
+    assert.equal(canAttemptDidomiMinimumAccept({ ...FULL_ACCEPT_SIGNALS, hasGetRequiredVendorIdsFn: false }), false);
+  });
+
+  test("getPurposes fn missing -> false (cannot build the disabled list)", () => {
+    assert.equal(canAttemptDidomiMinimumAccept({ ...FULL_ACCEPT_SIGNALS, hasGetPurposesFn: false }), false);
+  });
+
+  test("getVendors fn missing -> false", () => {
+    assert.equal(canAttemptDidomiMinimumAccept({ ...FULL_ACCEPT_SIGNALS, hasGetVendorsFn: false }), false);
+  });
+
+  test("malformed/missing signals object never throws, resolves to false", () => {
+    assert.doesNotThrow(() => canAttemptDidomiMinimumAccept(null));
+    assert.doesNotThrow(() => canAttemptDidomiMinimumAccept(undefined));
+    assert.equal(canAttemptDidomiMinimumAccept(null), false);
   });
 });
 

--- a/tests/unit/cmp-accept-adapters.test.mjs
+++ b/tests/unit/cmp-accept-adapters.test.mjs
@@ -1,0 +1,419 @@
+/**
+ * MUGA — Cookie Consent Minimizer: cmp-accept-adapters.js (cookie-consent-
+ * accept Slice 2a — Didomi-only pilot)
+ *
+ * ALL accept logic lives in this file (design's L1 — file-scoped lexical
+ * purity: src/lib/cmp-adapters.js and the reject regions of the two
+ * content scripts stay forever accept-free; this is the ONE place accept
+ * decisions and payload construction exist as an ES module).
+ *
+ * This is the highest-stakes test file in the project: it must prove, not
+ * just assert, that accept is structurally unreachable except when the
+ * user explicitly asked for it. Four groups:
+ *
+ *   1. decideMinimumAccept — pure decision truth table.
+ *   2. computeAcceptGate — the double-gate (+ enabled/onboarded/exemption).
+ *   3. didomiAcceptAdapter — minimum-payload construction + the callback-
+ *      injected accept() wrapper.
+ *   4. STRUCTURAL guards — DENYLIST scan for broad-accept identifiers, and
+ *      the adversarial "this must be impossible" scenarios.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import {
+  ACTIONS_ACCEPT,
+  decideMinimumAccept,
+  computeAcceptGate,
+  didomiAcceptAdapter,
+} from "../../src/lib/cmp-accept-adapters.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── ACTIONS_ACCEPT — closed set ─────────────────────────────────────────────
+
+describe("ACTIONS_ACCEPT", () => {
+  test("is a closed set containing exactly ACCEPT_MINIMUM", () => {
+    assert.deepEqual(Object.keys(ACTIONS_ACCEPT), ["ACCEPT_MINIMUM"]);
+    assert.equal(ACTIONS_ACCEPT.ACCEPT_MINIMUM, "accept-minimum");
+  });
+
+  test("is frozen", () => {
+    assert.ok(Object.isFrozen(ACTIONS_ACCEPT));
+  });
+});
+
+// ── decideMinimumAccept — pure decision truth table ─────────────────────────
+
+const HARD_WALL_DIDOMI = Object.freeze({ action: null, reason: "no-reject-path", adapterId: "didomi" });
+
+describe("decideMinimumAccept — truth table", () => {
+  test("mode accept-when-necessary + consented + Didomi hard wall -> ACCEPT_MINIMUM", () => {
+    const r = decideMinimumAccept(HARD_WALL_DIDOMI, "accept-when-necessary", true);
+    assert.equal(r.action, ACTIONS_ACCEPT.ACCEPT_MINIMUM);
+    assert.equal(r.adapterId, "didomi");
+  });
+
+  test("mode reject-only (even with consented true and a real hard wall) -> NOOP", () => {
+    const r = decideMinimumAccept(HARD_WALL_DIDOMI, "reject-only", true);
+    assert.equal(r.action, null);
+  });
+
+  test("mode off -> NOOP", () => {
+    const r = decideMinimumAccept(HARD_WALL_DIDOMI, "off", true);
+    assert.equal(r.action, null);
+  });
+
+  test("consented false (even in accept-when-necessary mode with a real hard wall) -> NOOP", () => {
+    const r = decideMinimumAccept(HARD_WALL_DIDOMI, "accept-when-necessary", false);
+    assert.equal(r.action, null);
+  });
+
+  test("consented missing/undefined -> NOOP (must be exactly true)", () => {
+    const r = decideMinimumAccept(HARD_WALL_DIDOMI, "accept-when-necessary", undefined);
+    assert.equal(r.action, null);
+  });
+
+  test("decision.reason is 'reject' (a real reject fired) -> NOOP, never double-acts", () => {
+    const r = decideMinimumAccept(
+      { action: "reject-all", reason: "reject", adapterId: "didomi" },
+      "accept-when-necessary",
+      true,
+    );
+    assert.equal(r.action, null);
+  });
+
+  test("decision.reason is 'uncertain' (no CMP confidently detected) -> NOOP", () => {
+    const r = decideMinimumAccept(
+      { action: null, reason: "uncertain", adapterId: null },
+      "accept-when-necessary",
+      true,
+    );
+    assert.equal(r.action, null);
+  });
+
+  test("adapterId not in the accept-capable set (e.g. a OneTrust hard wall) -> NOOP — Slice 2a is Didomi-only", () => {
+    const r = decideMinimumAccept(
+      { action: null, reason: "no-reject-path", adapterId: "onetrust" },
+      "accept-when-necessary",
+      true,
+    );
+    assert.equal(r.action, null);
+  });
+
+  test("adapterId null (e.g. an 'uncertain' hard wall with no vendor identified) -> NOOP", () => {
+    const r = decideMinimumAccept(
+      { action: null, reason: "no-reject-path", adapterId: null },
+      "accept-when-necessary",
+      true,
+    );
+    assert.equal(r.action, null);
+  });
+
+  test("malformed/missing decision object never throws, resolves to NOOP", () => {
+    assert.doesNotThrow(() => decideMinimumAccept(null, "accept-when-necessary", true));
+    assert.doesNotThrow(() => decideMinimumAccept(undefined, "accept-when-necessary", true));
+    assert.equal(decideMinimumAccept(null, "accept-when-necessary", true).action, null);
+  });
+});
+
+// ── computeAcceptGate — the double-gate (L2) ────────────────────────────────
+
+const ACCEPT_GATE_ON_PREFS = Object.freeze({
+  enabled: true,
+  onboardingDone: true,
+  cookieConsentMode: "accept-when-necessary",
+  cookieConsentAcceptConsented: true,
+});
+
+describe("computeAcceptGate — double-gate as a DATA invariant", () => {
+  test("every invariant satisfied -> gate opens (true)", () => {
+    assert.equal(computeAcceptGate(ACCEPT_GATE_ON_PREFS), true);
+  });
+
+  test("mode is reject-only (consented true) -> gate stays closed", () => {
+    assert.equal(
+      computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, cookieConsentMode: "reject-only" }),
+      false,
+    );
+  });
+
+  test("mode is off (consented true) -> gate stays closed", () => {
+    assert.equal(
+      computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, cookieConsentMode: "off" }),
+      false,
+    );
+  });
+
+  test("cookieConsentAcceptConsented false (mode correct) -> gate stays closed", () => {
+    assert.equal(
+      computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, cookieConsentAcceptConsented: false }),
+      false,
+    );
+  });
+
+  test("cookieConsentAcceptConsented missing/undefined -> gate stays closed (must be exactly true)", () => {
+    const { cookieConsentAcceptConsented, ...rest } = ACCEPT_GATE_ON_PREFS;
+    assert.equal(computeAcceptGate(rest), false);
+  });
+
+  test("cookieConsentAcceptConsented as a truthy non-boolean (e.g. 1 or 'true') does NOT open the gate", () => {
+    assert.equal(computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, cookieConsentAcceptConsented: 1 }), false);
+    assert.equal(computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, cookieConsentAcceptConsented: "true" }), false);
+  });
+
+  test("master enabled false -> gate stays closed", () => {
+    assert.equal(computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, enabled: false }), false);
+  });
+
+  test("onboardingDone false -> gate stays closed", () => {
+    assert.equal(computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, onboardingDone: false }), false);
+  });
+
+  test("null / undefined prefs -> gate stays closed, never throws", () => {
+    assert.doesNotThrow(() => computeAcceptGate(null));
+    assert.equal(computeAcceptGate(null), false);
+    assert.equal(computeAcceptGate(undefined), false);
+  });
+
+  test("isSiteFullyExempt true -> gate stays closed even when every pref passes", () => {
+    const deps = { hostname: "example.com", isSiteFullyExempt: () => true };
+    assert.equal(computeAcceptGate(ACCEPT_GATE_ON_PREFS, deps), false);
+  });
+
+  test("isSiteFullyExempt false -> gate opens (site not exempt)", () => {
+    const deps = { hostname: "example.com", isSiteFullyExempt: () => false };
+    assert.equal(computeAcceptGate(ACCEPT_GATE_ON_PREFS, deps), true);
+  });
+
+  test("isSiteFullyExempt receives the injected hostname and prefs", () => {
+    let seen = null;
+    const deps = {
+      hostname: "shop.example.com",
+      isSiteFullyExempt: (hostname, prefs) => { seen = { hostname, prefs }; return false; },
+    };
+    computeAcceptGate(ACCEPT_GATE_ON_PREFS, deps);
+    assert.equal(seen.hostname, "shop.example.com");
+    assert.strictEqual(seen.prefs, ACCEPT_GATE_ON_PREFS);
+  });
+
+  test("a throwing isSiteFullyExempt is swallowed and treated as not exempt (fail-safe -> open)", () => {
+    const deps = { hostname: "example.com", isSiteFullyExempt: () => { throw new Error("boom"); } };
+    assert.doesNotThrow(() => computeAcceptGate(ACCEPT_GATE_ON_PREFS, deps));
+    assert.equal(computeAcceptGate(ACCEPT_GATE_ON_PREFS, deps), true);
+  });
+});
+
+// ── didomiAcceptAdapter — minimum-payload construction ──────────────────────
+
+describe("didomiAcceptAdapter — minimum payload construction (L4)", () => {
+  test("exposes id, buildMinimumPayload, accept", () => {
+    assert.equal(didomiAcceptAdapter.id, "didomi");
+    assert.equal(typeof didomiAcceptAdapter.buildMinimumPayload, "function");
+    assert.equal(typeof didomiAcceptAdapter.accept, "function");
+  });
+
+  test("enables exactly the required purpose/vendor ids, disables everything else", () => {
+    const payload = didomiAcceptAdapter.buildMinimumPayload({
+      requiredPurposeIds: ["cookies_functional"],
+      requiredVendorIds: ["vendor-required-1"],
+      allPurposeIds: ["cookies_functional", "advertising", "analytics"],
+      allVendorIds: ["vendor-required-1", "vendor-ads-2", "vendor-analytics-3"],
+    });
+    assert.deepEqual(payload.purposes.enabled, ["cookies_functional"]);
+    assert.deepEqual(payload.purposes.disabled, ["advertising", "analytics"]);
+    assert.deepEqual(payload.vendors.enabled, ["vendor-required-1"]);
+    assert.deepEqual(payload.vendors.disabled, ["vendor-ads-2", "vendor-analytics-3"]);
+  });
+
+  test("enabled + disabled partition the full id list exactly — no id lost, none duplicated", () => {
+    const payload = didomiAcceptAdapter.buildMinimumPayload({
+      requiredPurposeIds: ["p1", "p2"],
+      requiredVendorIds: ["v1"],
+      allPurposeIds: ["p1", "p2", "p3", "p4"],
+      allVendorIds: ["v1", "v2", "v3"],
+    });
+    assert.equal(payload.purposes.enabled.length + payload.purposes.disabled.length, 4);
+    assert.equal(payload.vendors.enabled.length + payload.vendors.disabled.length, 3);
+    assert.equal(new Set([...payload.purposes.enabled, ...payload.purposes.disabled]).size, 4);
+    assert.equal(new Set([...payload.vendors.enabled, ...payload.vendors.disabled]).size, 3);
+  });
+
+  test("ADVERSARIAL: a required id NOT present in the full id list is never enabled (corrupted/hostile page data stays fail-closed)", () => {
+    const payload = didomiAcceptAdapter.buildMinimumPayload({
+      requiredPurposeIds: ["p1", "phantom-purpose-not-in-registry"],
+      requiredVendorIds: ["v1", "phantom-vendor-not-in-registry"],
+      allPurposeIds: ["p1", "p2"],
+      allVendorIds: ["v1", "v2"],
+    });
+    assert.deepEqual(payload.purposes.enabled, ["p1"]);
+    assert.ok(!payload.purposes.enabled.includes("phantom-purpose-not-in-registry"));
+    assert.deepEqual(payload.vendors.enabled, ["v1"]);
+    assert.ok(!payload.vendors.enabled.includes("phantom-vendor-not-in-registry"));
+  });
+
+  test("empty required lists -> everything disabled, nothing enabled (still a valid minimum, not a NOOP payload)", () => {
+    const payload = didomiAcceptAdapter.buildMinimumPayload({
+      requiredPurposeIds: [],
+      requiredVendorIds: [],
+      allPurposeIds: ["p1", "p2"],
+      allVendorIds: ["v1"],
+    });
+    assert.deepEqual(payload.purposes.enabled, []);
+    assert.deepEqual(payload.purposes.disabled, ["p1", "p2"]);
+    assert.deepEqual(payload.vendors.enabled, []);
+    assert.deepEqual(payload.vendors.disabled, ["v1"]);
+  });
+
+  test("malformed/missing input (non-array fields) never throws, resolves to empty everything", () => {
+    assert.doesNotThrow(() => didomiAcceptAdapter.buildMinimumPayload({}));
+    assert.doesNotThrow(() => didomiAcceptAdapter.buildMinimumPayload(null));
+    assert.doesNotThrow(() => didomiAcceptAdapter.buildMinimumPayload(undefined));
+    const payload = didomiAcceptAdapter.buildMinimumPayload(null);
+    assert.deepEqual(payload.purposes.enabled, []);
+    assert.deepEqual(payload.purposes.disabled, []);
+    assert.deepEqual(payload.vendors.enabled, []);
+    assert.deepEqual(payload.vendors.disabled, []);
+  });
+});
+
+describe("didomiAcceptAdapter.accept — pure callback invocation", () => {
+  test("calls the injected function and reports accepted", () => {
+    let called = false;
+    const r = didomiAcceptAdapter.accept(() => { called = true; });
+    assert.equal(called, true);
+    assert.equal(r.status, "accepted");
+  });
+
+  test("a throwing callback is swallowed -> status noop, never throws", () => {
+    const r = didomiAcceptAdapter.accept(() => { throw new Error("boom"); });
+    assert.equal(r.status, "noop");
+  });
+
+  test("non-function argument -> status noop, no call", () => {
+    const r = didomiAcceptAdapter.accept(undefined);
+    assert.equal(r.status, "noop");
+  });
+});
+
+// ── STRUCTURAL guard — broad-accept DENYLIST (L4) ───────────────────────────
+//
+// LOAD-BEARING. Even though this file is where accept logic legitimately
+// lives, it must never construct or reference a BROAD accept-all call —
+// only the Didomi minimum-payload shape above. This scans the raw source
+// for every broad-accept method/literal identified across all 10 vendors
+// in the design's per-vendor verification (Part A), so a future edit that
+// widens this module toward any of them fails here immediately.
+
+describe("cmp-accept-adapters — STRUCTURAL guard: broad-accept DENYLIST", () => {
+  const source = readFileSync(join(__dirname, "../../src/lib/cmp-accept-adapters.js"), "utf8");
+
+  const DENYLIST = [
+    "AllowAll",
+    "acceptAllConsents",
+    "acceptAllServices",
+    "acceptAllAction",
+    "postAcceptAll",
+    "submitCustomConsent(true",
+    "respondAll(true)",
+    '__cmp("setConsent", 1',
+    'performBannerAction("accept_all"',
+  ];
+
+  for (const forbidden of DENYLIST) {
+    test(`source never contains "${forbidden}"`, () => {
+      assert.equal(
+        source.includes(forbidden),
+        false,
+        `cmp-accept-adapters.js must never contain the broad-accept identifier "${forbidden}"`,
+      );
+    });
+  }
+
+  test("ACTIONS_ACCEPT has exactly one member and it is ACCEPT_MINIMUM (no broad-accept action can exist)", () => {
+    assert.equal(Object.keys(ACTIONS_ACCEPT).length, 1);
+    assert.ok("ACCEPT_MINIMUM" in ACTIONS_ACCEPT);
+  });
+
+  test("the only vendor id this module recognizes as accept-capable is didomi (Slice 2a scope)", () => {
+    // Adversarial: every other real vendor id from cmp-adapters.js's
+    // TIER1 registry must resolve to NOOP even with every other invariant
+    // satisfied — proven behaviorally, not just by reading this list.
+    const OTHER_VENDOR_IDS = [
+      "onetrust", "cookiebot", "cookieyes", "sourcepoint", "usercentrics",
+      "cookieinformation", "cookiescript", "tarteaucitron", "consentmanager",
+    ];
+    for (const adapterId of OTHER_VENDOR_IDS) {
+      const r = decideMinimumAccept(
+        { action: null, reason: "no-reject-path", adapterId },
+        "accept-when-necessary",
+        true,
+      );
+      assert.equal(r.action, null, `adapterId "${adapterId}" must never resolve to ACCEPT_MINIMUM in Slice 2a`);
+    }
+  });
+});
+
+// ── ADVERSARIAL — "this must be impossible" scenarios (own section) ────────
+
+describe("cmp-accept-adapters — ADVERSARIAL: impossible-by-construction scenarios", () => {
+  test("accept can NEVER fire in reject-only mode, no matter what else is true", () => {
+    // Sweep every other axis (consented, reason, adapterId) — reason must
+    // stay NOOP purely because mode !== accept-when-necessary.
+    for (const consented of [true, false]) {
+      for (const reason of ["no-reject-path", "reject", "uncertain"]) {
+        const r = decideMinimumAccept({ action: null, reason, adapterId: "didomi" }, "reject-only", consented);
+        assert.equal(r.action, null, `reject-only + consented=${consented} + reason=${reason} must stay NOOP`);
+      }
+    }
+  });
+
+  test("accept can NEVER fire without the explicit consent gesture, no matter what else is true", () => {
+    for (const mode of ["accept-when-necessary", "reject-only", "off"]) {
+      const r = decideMinimumAccept(HARD_WALL_DIDOMI, mode, false);
+      assert.equal(r.action, null, `mode=${mode} without the gesture must stay NOOP`);
+    }
+    // The gate itself, independently of decideMinimumAccept, must also stay
+    // closed without the gesture even when every other pref is perfect.
+    assert.equal(computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, cookieConsentAcceptConsented: false }), false);
+  });
+
+  test("accept can NEVER grant more than the minimum — enabled ids are always a subset of the required ids that actually exist in the registry", () => {
+    const requiredPurposeIds = ["p1"];
+    const allPurposeIds = ["p1", "p2", "p3"];
+    const payload = didomiAcceptAdapter.buildMinimumPayload({
+      requiredPurposeIds,
+      requiredVendorIds: [],
+      allPurposeIds,
+      allVendorIds: [],
+    });
+    // Every enabled id must be in the intersection of required and all —
+    // never wider than what was explicitly required by the page itself.
+    for (const id of payload.purposes.enabled) {
+      assert.ok(requiredPurposeIds.includes(id) && allPurposeIds.includes(id));
+    }
+    // And the disabled set must contain every id that is NOT required —
+    // proving nothing outside the minimum sneaks into "enabled".
+    assert.deepEqual(payload.purposes.disabled, ["p2", "p3"]);
+  });
+
+  test("the double-gate and the decision function are independent layers — closing one does not require the other to also be checked (defense in depth)", () => {
+    // Gate closed (no consent), decision would have said ACCEPT_MINIMUM in
+    // isolation — the CONTENT SCRIPT is expected to check the gate FIRST;
+    // this test documents that decideMinimumAccept alone is not a complete
+    // gate (by design — it only checks mode+consented+reason+adapterId,
+    // not enabled/onboardingDone/exemption), so callers must always AND it
+    // with computeAcceptGate's result, never call it standalone as if it
+    // were the whole safety story.
+    const gateOpen = computeAcceptGate({ ...ACCEPT_GATE_ON_PREFS, enabled: false });
+    const decision = decideMinimumAccept(HARD_WALL_DIDOMI, "accept-when-necessary", true);
+    assert.equal(gateOpen, false);
+    assert.equal(decision.action, ACTIONS_ACCEPT.ACCEPT_MINIMUM);
+    // The combined effective decision a real call site must use:
+    const effectiveAccept = gateOpen && decision.action === ACTIONS_ACCEPT.ACCEPT_MINIMUM;
+    assert.equal(effectiveAccept, false);
+  });
+});

--- a/tests/unit/cmp-accept-adapters.test.mjs
+++ b/tests/unit/cmp-accept-adapters.test.mjs
@@ -271,6 +271,91 @@ describe("canAttemptDidomiMinimumAccept — hard-wall + accept-capability detect
   });
 });
 
+// ── PARITY: decideMinimumAccept (spec) ↔ runtime gate + canAttempt ─────────
+//
+// decideMinimumAccept is the SPEC-MIRROR pure decision (mode/consented/
+// reason/adapterId) and is exhaustively tested above. The content scripts,
+// however, do NOT call it — they gate on the inlined runtime pair
+// `computeAcceptGate(prefs) && canAttemptDidomiMinimumAccept(signals)`, the
+// same pure-lib-fn ↔ inlined-runtime split as decideAction ↔ the inlined
+// canReject ladder. This block proves the two agree across the
+// signal/mode/consent matrix so the extensive decideMinimumAccept suite
+// transitively covers the runtime path and the two cannot drift.
+
+describe("cmp-accept-adapters — PARITY: spec decision ↔ inlined runtime gate", () => {
+  // Mirrors how cmp-adapters.js's decideAction classifies a Didomi page,
+  // derived from the SAME signals the runtime canAttempt predicate reads —
+  // this is the reject-first ordering: a present reject fn means a reject
+  // path exists, so the page is NOT a hard wall.
+  function deriveDidomiDecision(signals) {
+    if (signals.hasDidomiGlobal !== true) return { action: null, reason: "uncertain", adapterId: null };
+    if (signals.hasSetUserDisagreeToAllFn === true) return { action: "reject-all", reason: "reject", adapterId: "didomi" };
+    return { action: null, reason: "no-reject-path", adapterId: "didomi" };
+  }
+
+  function prefsFor(mode, consented) {
+    return { enabled: true, onboardingDone: true, cookieConsentMode: mode, cookieConsentAcceptConsented: consented };
+  }
+
+  const CAPABLE = Object.freeze({
+    hasDidomiGlobal: true, hasSetUserDisagreeToAllFn: false, hasSetCurrentUserStatusFn: true,
+    hasGetRequiredPurposeIdsFn: true, hasGetRequiredVendorIdsFn: true, hasGetPurposesFn: true, hasGetVendorsFn: true,
+  });
+  const REJECT_AVAILABLE = Object.freeze({ ...CAPABLE, hasSetUserDisagreeToAllFn: true });
+  const DIDOMI_ABSENT = Object.freeze({ ...CAPABLE, hasDidomiGlobal: false });
+  const HARDWALL_INCAPABLE = Object.freeze({ ...CAPABLE, hasGetPurposesFn: false });
+
+  const MODES = ["off", "reject-only", "accept-when-necessary"];
+  const CONSENTS = [true, false];
+
+  test("runtime (gate ∧ canAttempt) === (spec decision ∧ capability) for EVERY signal/mode/consent combo", () => {
+    for (const signals of [CAPABLE, REJECT_AVAILABLE, DIDOMI_ABSENT, HARDWALL_INCAPABLE]) {
+      for (const mode of MODES) {
+        for (const consented of CONSENTS) {
+          const gateOpen = computeAcceptGate(prefsFor(mode, consented));
+          const canAttempt = canAttemptDidomiMinimumAccept(signals);
+          const runtimeFires = gateOpen && canAttempt;
+
+          const decision = deriveDidomiDecision(signals);
+          const specFires = decideMinimumAccept(decision, mode, consented).action === ACTIONS_ACCEPT.ACCEPT_MINIMUM;
+
+          assert.equal(
+            runtimeFires,
+            specFires && canAttempt,
+            `parity broke for mode=${mode} consented=${consented} signals=${JSON.stringify(signals)}`,
+          );
+        }
+      }
+    }
+  });
+
+  test("on a FULLY capable Didomi hard wall the runtime collapses to the spec decision exactly (canAttempt is satisfied)", () => {
+    for (const mode of MODES) {
+      for (const consented of CONSENTS) {
+        const runtimeFires = computeAcceptGate(prefsFor(mode, consented)) && canAttemptDidomiMinimumAccept(CAPABLE);
+        const specFires =
+          decideMinimumAccept(deriveDidomiDecision(CAPABLE), mode, consented).action === ACTIONS_ACCEPT.ACCEPT_MINIMUM;
+        assert.equal(runtimeFires, specFires, `capable-page parity broke for mode=${mode} consented=${consented}`);
+      }
+    }
+  });
+
+  test("reject-first ordering: a present reject fn makes BOTH the spec (reason=reject) and the runtime (canAttempt=false) refuse accept", () => {
+    const decision = deriveDidomiDecision(REJECT_AVAILABLE);
+    assert.equal(decision.reason, "reject");
+    assert.equal(decideMinimumAccept(decision, "accept-when-necessary", true).action, null);
+    assert.equal(canAttemptDidomiMinimumAccept(REJECT_AVAILABLE), false);
+  });
+
+  test("the runtime is STRICTER than the spec alone: a hard wall missing an accept getter is blocked by canAttempt even when the spec decision would allow", () => {
+    // Documents WHY canAttempt is a necessary extra runtime layer: the spec
+    // decision cannot see the page's accept-capability surface.
+    const decision = deriveDidomiDecision(HARDWALL_INCAPABLE);
+    assert.equal(decideMinimumAccept(decision, "accept-when-necessary", true).action, ACTIONS_ACCEPT.ACCEPT_MINIMUM);
+    assert.equal(canAttemptDidomiMinimumAccept(HARDWALL_INCAPABLE), false);
+  });
+});
+
 // ── didomiAcceptAdapter — minimum-payload construction ──────────────────────
 
 describe("didomiAcceptAdapter — minimum payload construction (L4)", () => {

--- a/tests/unit/cmp-accept-adapters.test.mjs
+++ b/tests/unit/cmp-accept-adapters.test.mjs
@@ -30,6 +30,8 @@ import {
   computeAcceptGate,
   canAttemptDidomiMinimumAccept,
   didomiAcceptAdapter,
+  resolveDidomiMinimumStatus,
+  extractRequiredIds,
 } from "../../src/lib/cmp-accept-adapters.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -358,6 +360,154 @@ describe("didomiAcceptAdapter.accept — pure callback invocation", () => {
   test("non-function argument -> status noop, no call", () => {
     const r = didomiAcceptAdapter.accept(undefined);
     assert.equal(r.status, "noop");
+  });
+});
+
+// ── resolveDidomiMinimumStatus — fail-closed required-id parsing (L5) ───────
+//
+// This is the runtime-facing seam the two content-script dispatch regions
+// call with the RAW return values of Didomi's four getters. It owns the
+// fail-closed contract that buildMinimumPayload alone could not enforce:
+// the REQUIRED lists must be a clean array of non-empty strings; ANY other
+// shape (a flag-map object, an array of registry objects, null, a member
+// that is not a non-empty string) makes the required set UNRESOLVABLE and
+// the WHOLE accept is abandoned (returns null → the caller never calls
+// setCurrentUserStatus, the banner is left as the safe fail-closed outcome).
+
+describe("resolveDidomiMinimumStatus — fail-closed required-id parsing", () => {
+  test("clean array-of-strings required getters (Didomi's real shape) -> builds the minimum payload", () => {
+    const payload = resolveDidomiMinimumStatus({
+      requiredPurposeIds: ["cookies_functional"],
+      requiredVendorIds: ["vendor-required-1"],
+      allPurposeIds: ["cookies_functional", "advertising", "analytics"],
+      allVendorIds: ["vendor-required-1", "vendor-ads-2", "vendor-analytics-3"],
+    });
+    assert.notEqual(payload, null, "the clean happy path must build a payload, not NOOP");
+    assert.deepEqual(payload.purposes.enabled, ["cookies_functional"]);
+    assert.deepEqual(payload.purposes.disabled, ["advertising", "analytics"]);
+    assert.deepEqual(payload.vendors.enabled, ["vendor-required-1"]);
+    assert.deepEqual(payload.vendors.disabled, ["vendor-ads-2", "vendor-analytics-3"]);
+  });
+
+  test("ADVERSARIAL: a REQUIRED getter returning a flag-map object -> NOOP (never widens to the false/non-essential ids)", () => {
+    // The exact vulnerability: a getRequiredPurposeIds() shaped as a
+    // consent flag-map. The broad normalizer would have returned every KEY
+    // (ignoring the booleans), enabling advertising + analytics = accept-all.
+    // The strict parser rejects the shape entirely -> the whole accept NOOPs.
+    const payload = resolveDidomiMinimumStatus({
+      requiredPurposeIds: { cookies_functional: true, advertising: false, analytics: false },
+      requiredVendorIds: ["vendor-required-1"],
+      allPurposeIds: ["cookies_functional", "advertising", "analytics"],
+      allVendorIds: ["vendor-required-1", "vendor-ads-2", "vendor-analytics-3"],
+    });
+    assert.equal(payload, null, "a flag-map required list must NOOP the entire accept, never build a payload");
+  });
+
+  test("ADVERSARIAL: a REQUIRED getter returning an array of registry objects enumerating the whole registry -> NOOP", () => {
+    const payload = resolveDidomiMinimumStatus({
+      requiredPurposeIds: [
+        { id: "cookies_functional" },
+        { id: "advertising" },
+        { id: "analytics" },
+      ],
+      requiredVendorIds: ["vendor-required-1"],
+      allPurposeIds: ["cookies_functional", "advertising", "analytics"],
+      allVendorIds: ["vendor-required-1", "vendor-ads-2", "vendor-analytics-3"],
+    });
+    assert.equal(payload, null, "an array-of-objects required list must NOOP the entire accept");
+  });
+
+  test("ADVERSARIAL: a REQUIRED getter containing a non-string / empty-string member -> NOOP", () => {
+    assert.equal(
+      resolveDidomiMinimumStatus({
+        requiredPurposeIds: ["cookies_functional", 42],
+        requiredVendorIds: [],
+        allPurposeIds: ["cookies_functional"],
+        allVendorIds: [],
+      }),
+      null,
+    );
+    assert.equal(
+      resolveDidomiMinimumStatus({
+        requiredPurposeIds: ["cookies_functional", ""],
+        requiredVendorIds: [],
+        allPurposeIds: ["cookies_functional"],
+        allVendorIds: [],
+      }),
+      null,
+    );
+  });
+
+  test("either required getter returning null/undefined -> NOOP", () => {
+    assert.equal(
+      resolveDidomiMinimumStatus({
+        requiredPurposeIds: null,
+        requiredVendorIds: ["vendor-required-1"],
+        allPurposeIds: ["p1"],
+        allVendorIds: ["vendor-required-1"],
+      }),
+      null,
+    );
+    assert.equal(
+      resolveDidomiMinimumStatus({
+        requiredPurposeIds: ["cookies_functional"],
+        requiredVendorIds: undefined,
+        allPurposeIds: ["cookies_functional"],
+        allVendorIds: ["v1"],
+      }),
+      null,
+    );
+  });
+
+  test("empty required arrays are a LEGITIMATE all-essential-disabled minimum (not a NOOP), as long as the registry is readable", () => {
+    const payload = resolveDidomiMinimumStatus({
+      requiredPurposeIds: [],
+      requiredVendorIds: [],
+      allPurposeIds: ["p1", "p2"],
+      allVendorIds: ["v1"],
+    });
+    assert.notEqual(payload, null);
+    assert.deepEqual(payload.purposes.enabled, []);
+    assert.deepEqual(payload.purposes.disabled, ["p1", "p2"]);
+    assert.deepEqual(payload.vendors.enabled, []);
+    assert.deepEqual(payload.vendors.disabled, ["v1"]);
+  });
+
+  test("malformed/missing input never throws, resolves to NOOP", () => {
+    assert.doesNotThrow(() => resolveDidomiMinimumStatus(null));
+    assert.doesNotThrow(() => resolveDidomiMinimumStatus(undefined));
+    assert.equal(resolveDidomiMinimumStatus(null), null);
+  });
+});
+
+describe("extractRequiredIds — strict array-of-non-empty-strings-or-null", () => {
+  test("a clean array of non-empty strings passes through unchanged", () => {
+    assert.deepEqual(extractRequiredIds(["a", "b"]), ["a", "b"]);
+  });
+
+  test("an empty array is valid (returns [])", () => {
+    assert.deepEqual(extractRequiredIds([]), []);
+  });
+
+  test("a flag-map object -> null", () => {
+    assert.equal(extractRequiredIds({ a: true, b: false }), null);
+  });
+
+  test("an array of objects -> null", () => {
+    assert.equal(extractRequiredIds([{ id: "a" }]), null);
+  });
+
+  test("an array with a non-string or empty-string member -> null", () => {
+    assert.equal(extractRequiredIds(["a", 1]), null);
+    assert.equal(extractRequiredIds(["a", ""]), null);
+    assert.equal(extractRequiredIds(["a", null]), null);
+  });
+
+  test("null / undefined / non-array -> null, never throws", () => {
+    assert.doesNotThrow(() => extractRequiredIds(null));
+    assert.equal(extractRequiredIds(null), null);
+    assert.equal(extractRequiredIds(undefined), null);
+    assert.equal(extractRequiredIds("nope"), null);
   });
 });
 

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -170,7 +170,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "onetrust");
   });
 
-  test("OneTrust global present but RejectAll absent (hard wall) -> NOOP", () => {
+  test("OneTrust global present but RejectAll absent (hard wall) -> NOOP, adapterId threaded", () => {
     const r = decideAction({
       hasOneTrustGlobal: true,
       hasRejectAllFn: false,
@@ -180,6 +180,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "onetrust");
   });
 
   test("no signals at all (non-OneTrust page) -> NOOP, uncertain", () => {
@@ -220,7 +221,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "cookiebot");
   });
 
-  test("Cookiebot global present but submitCustomConsent absent (hard wall) -> NOOP", () => {
+  test("Cookiebot global present but submitCustomConsent absent (hard wall) -> NOOP, adapterId threaded", () => {
     const r = decideAction({
       hasCookiebotGlobal: true,
       hasSubmitCustomConsentFn: false,
@@ -230,6 +231,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "cookiebot");
   });
 
   test("Cookiebot mandatory signal present but zero corroboration -> NOOP, uncertain (fail-closed)", () => {
@@ -256,7 +258,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "didomi");
   });
 
-  test("Didomi global present but setUserDisagreeToAll absent (hard wall) -> NOOP", () => {
+  test("Didomi global present but setUserDisagreeToAll absent (hard wall) -> NOOP, adapterId threaded", () => {
     const r = decideAction({
       hasDidomiGlobal: true,
       hasSetUserDisagreeToAllFn: false,
@@ -265,6 +267,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "didomi");
   });
 
   test("Didomi mandatory signal present but zero corroboration -> NOOP, uncertain (fail-closed)", () => {
@@ -303,7 +306,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.reason, "uncertain");
   });
 
-  test("CookieYes: getCkyConsent present but performBannerAction missing (hard wall) -> NOOP, no-reject-path", () => {
+  test("CookieYes: getCkyConsent present but performBannerAction missing (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasGetCkyConsentFn: true,
       hasPerformBannerActionFn: false,
@@ -313,6 +316,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "cookieyes");
   });
 
   test("CookieYes: both globals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
@@ -340,7 +344,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "sourcepoint");
   });
 
-  test("Sourcepoint: sp_message_container DOM present but __tcfapi missing (hard wall) -> NOOP, no-reject-path", () => {
+  test("Sourcepoint: sp_message_container DOM present but __tcfapi missing (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasTcfApiFn: false,
       hasSpMessageContainerDom: true,
@@ -348,6 +352,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "sourcepoint");
   });
 
   test("Sourcepoint: __tcfapi present but sp_message_container DOM missing -> NOOP, uncertain (generic TCF CMP, not Sourcepoint)", () => {
@@ -400,7 +405,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "usercentrics");
   });
 
-  test("Usercentrics: UC_UI global present but denyAllConsents absent (hard wall) -> NOOP", () => {
+  test("Usercentrics: UC_UI global present but denyAllConsents absent (hard wall) -> NOOP, adapterId threaded", () => {
     const r = decideAction({
       hasUcUiGlobal: true,
       hasDenyAllConsentsFn: false,
@@ -409,6 +414,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "usercentrics");
   });
 
   test("Usercentrics mandatory signals present but zero corroboration -> NOOP, uncertain (fail-closed)", () => {
@@ -464,7 +470,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "cookieinformation");
   });
 
-  test("Cookie Information: global present but declineAllCategories absent (hard wall) -> NOOP, no-reject-path", () => {
+  test("Cookie Information: global present but declineAllCategories absent (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasCookieInformationGlobal: true,
       hasDeclineAllCategoriesFn: false,
@@ -472,6 +478,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "cookieinformation");
   });
 
   test("Cookie Information: mandatory signals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
@@ -514,7 +521,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "cookiescript");
   });
 
-  test("CookieScript: global present but instance/rejectAllAction absent (hard wall) -> NOOP, no-reject-path", () => {
+  test("CookieScript: global present but instance/rejectAllAction absent (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasCookieScriptGlobal: true,
       hasCookieScriptInstance: false,
@@ -523,9 +530,10 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "cookiescript");
   });
 
-  test("CookieScript: global + instance present but rejectAllAction fn absent (hard wall) -> NOOP, no-reject-path", () => {
+  test("CookieScript: global + instance present but rejectAllAction fn absent (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasCookieScriptGlobal: true,
       hasCookieScriptInstance: true,
@@ -534,6 +542,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "cookiescript");
   });
 
   test("CookieScript: mandatory signals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
@@ -563,7 +572,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "tarteaucitron");
   });
 
-  test("tarteaucitron: global present but userInterface/respondAll absent (hard wall) -> NOOP, no-reject-path", () => {
+  test("tarteaucitron: global present but userInterface/respondAll absent (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasTarteaucitronGlobal: true,
       hasTarteaucitronUserInterface: false,
@@ -572,9 +581,10 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "tarteaucitron");
   });
 
-  test("tarteaucitron: global + userInterface present but respondAll fn absent (hard wall) -> NOOP, no-reject-path", () => {
+  test("tarteaucitron: global + userInterface present but respondAll fn absent (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasTarteaucitronGlobal: true,
       hasTarteaucitronUserInterface: true,
@@ -583,6 +593,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "tarteaucitron");
   });
 
   test("tarteaucitron: mandatory signals present but zero DOM corroboration -> NOOP, uncertain (fail-closed)", () => {
@@ -613,7 +624,7 @@ describe("decideAction — truth table", () => {
     assert.equal(r.adapterId, "consentmanager");
   });
 
-  test("consentmanager.net: #cmpbox DOM present but cmpmngr global missing (hard wall) -> NOOP, no-reject-path", () => {
+  test("consentmanager.net: #cmpbox DOM present but cmpmngr global missing (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasCmpMngrGlobal: false,
       hasCmpFn: true,
@@ -622,9 +633,10 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "consentmanager");
   });
 
-  test("consentmanager.net: #cmpbox DOM present but __cmp fn missing (hard wall) -> NOOP, no-reject-path", () => {
+  test("consentmanager.net: #cmpbox DOM present but __cmp fn missing (hard wall) -> NOOP, no-reject-path, adapterId threaded", () => {
     const r = decideAction({
       hasCmpMngrGlobal: true,
       hasCmpFn: false,
@@ -633,6 +645,7 @@ describe("decideAction — truth table", () => {
     });
     assert.equal(r.action, null);
     assert.equal(r.reason, "no-reject-path");
+    assert.equal(r.adapterId, "consentmanager");
   });
 
   test("consentmanager.net: cmpmngr + __cmp present but #cmpbox DOM missing -> NOOP, uncertain (generic TCF v1.1 CMP, not consentmanager.net)", () => {
@@ -1584,76 +1597,85 @@ describe("consentmanagerAdapter.reject — pure callback invocation", () => {
 // closure in content/cookie-noise.js, so these branches had no executed
 // coverage (only a structural regex). Extracting it as a pure helper lets
 // every branch run here.
+//
+// cookie-consent-accept Slice 2a: this gate no longer compares
+// `prefs.cookieConsentMode` against a literal mode string itself — that
+// string comparison (which would need to name every active enum member,
+// including the newer one this file must never spell — see the STRUCTURAL
+// guard below) moved to the settings-schema.js boundary
+// (isCookieConsentModeActive), which is lexically unrestricted. The caller
+// resolves the raw pref there and hands this gate a pre-validated boolean
+// via `deps.modeActive`. This lets the reject ladder run first in every
+// active mode (design's L3) without this file ever knowing a second mode
+// exists.
 
 const GATE_ON_PREFS = Object.freeze({
   enabled: true,
   onboardingDone: true,
-  cookieConsentMode: "reject-only",
 });
 
+const GATE_ON_DEPS = Object.freeze({ modeActive: true });
+
 describe("computeCookieGate — disabled-state gate", () => {
-  test("all gate conditions pass (reject-only) -> gate opens (true)", () => {
-    assert.equal(computeCookieGate(GATE_ON_PREFS), true);
+  test("all gate conditions pass (modeActive true) -> gate opens (true)", () => {
+    assert.equal(computeCookieGate(GATE_ON_PREFS, GATE_ON_DEPS), true);
   });
 
-  test("mode off -> gate stays closed", () => {
-    assert.equal(
-      computeCookieGate({ ...GATE_ON_PREFS, cookieConsentMode: "off" }),
-      false,
-    );
+  // modeActive is computed upstream (settings-schema.js's
+  // isCookieConsentModeActive) for BOTH "reject-only" and
+  // "accept-when-necessary" — this gate treats them identically: it only
+  // ever sees the pre-validated boolean, never the mode string.
+  test("modeActive true opens the gate the same way regardless of which active mode produced it", () => {
+    assert.equal(computeCookieGate(GATE_ON_PREFS, { modeActive: true }), true);
   });
 
-  // Slice 1 scope note: "accept-when-necessary" is a valid PREF_DEFAULTS /
-  // settings-schema enum member (forward-compat for Slice 2), but the
-  // never-accept lexical guard (this file's own STRUCTURAL guard below,
-  // mirrored in cookie-noise-sync.test.mjs) forbids the substring "accept"
-  // anywhere in cmp-adapters.js or the content-script copies. The gate can
-  // therefore only compare against "reject-only" today — it does NOT (yet)
-  // special-case accept-when-necessary. Nothing in Slice 1 ever writes that
-  // value (migration never does; the UI doesn't offer it), so this is inert
-  // in practice. Relaxing the guard to let the gate open for
-  // accept-when-necessary too is explicitly deferred to Slice 2 (see the
-  // design doc's Part 1 table: "Relax to POSITIONAL guard").
-  test("mode accept-when-necessary -> gate stays closed in Slice 1 (not yet special-cased; see scope note above)", () => {
-    assert.equal(
-      computeCookieGate({ ...GATE_ON_PREFS, cookieConsentMode: "accept-when-necessary" }),
-      false,
-    );
+  test("modeActive false -> gate stays closed (e.g. mode is off)", () => {
+    assert.equal(computeCookieGate(GATE_ON_PREFS, { modeActive: false }), false);
   });
 
-  test("mode null/undefined/unrecognized -> gate stays closed (fail-closed)", () => {
-    assert.equal(computeCookieGate({ ...GATE_ON_PREFS, cookieConsentMode: null }), false);
-    assert.equal(computeCookieGate({ ...GATE_ON_PREFS, cookieConsentMode: undefined }), false);
-    assert.equal(computeCookieGate({ ...GATE_ON_PREFS, cookieConsentMode: "bogus" }), false);
+  test("modeActive missing/undefined -> gate stays closed (fail-closed)", () => {
+    assert.equal(computeCookieGate(GATE_ON_PREFS, {}), false);
+    assert.equal(computeCookieGate(GATE_ON_PREFS, { modeActive: undefined }), false);
+  });
+
+  test("deps entirely missing -> gate stays closed (fail-closed)", () => {
+    assert.equal(computeCookieGate(GATE_ON_PREFS), false);
+    assert.equal(computeCookieGate(GATE_ON_PREFS, null), false);
+  });
+
+  test("modeActive as a truthy non-boolean (e.g. the string 'true') does NOT open the gate — must be exactly true", () => {
+    assert.equal(computeCookieGate(GATE_ON_PREFS, { modeActive: "true" }), false);
+    assert.equal(computeCookieGate(GATE_ON_PREFS, { modeActive: 1 }), false);
   });
 
   test("onboardingDone false -> gate stays closed", () => {
-    assert.equal(computeCookieGate({ ...GATE_ON_PREFS, onboardingDone: false }), false);
+    assert.equal(computeCookieGate({ ...GATE_ON_PREFS, onboardingDone: false }, GATE_ON_DEPS), false);
   });
 
   test("master enabled false -> gate stays closed", () => {
-    assert.equal(computeCookieGate({ ...GATE_ON_PREFS, enabled: false }), false);
+    assert.equal(computeCookieGate({ ...GATE_ON_PREFS, enabled: false }, GATE_ON_DEPS), false);
   });
 
   test("null / undefined prefs -> gate stays closed, never throws", () => {
-    assert.doesNotThrow(() => computeCookieGate(null));
-    assert.equal(computeCookieGate(null), false);
-    assert.equal(computeCookieGate(undefined), false);
+    assert.doesNotThrow(() => computeCookieGate(null, GATE_ON_DEPS));
+    assert.equal(computeCookieGate(null, GATE_ON_DEPS), false);
+    assert.equal(computeCookieGate(undefined, GATE_ON_DEPS), false);
   });
 
   test("isSiteFullyExempt true -> gate stays closed even when every pref passes", () => {
-    const deps = { hostname: "example.com", isSiteFullyExempt: () => true };
+    const deps = { modeActive: true, hostname: "example.com", isSiteFullyExempt: () => true };
     assert.equal(computeCookieGate(GATE_ON_PREFS, deps), false);
   });
 
   test("isSiteFullyExempt false -> gate opens (site not exempt)", () => {
-    const deps = { hostname: "example.com", isSiteFullyExempt: () => false };
+    const deps = { modeActive: true, hostname: "example.com", isSiteFullyExempt: () => false };
     assert.equal(computeCookieGate(GATE_ON_PREFS, deps), true);
   });
 
   test("isSiteFullyExempt receives the injected hostname and prefs", () => {
     let seen = null;
     const deps = {
+      modeActive: true,
       hostname: "shop.example.com",
       isSiteFullyExempt: (hostname, prefs) => { seen = { hostname, prefs }; return false; },
     };
@@ -1663,7 +1685,7 @@ describe("computeCookieGate — disabled-state gate", () => {
   });
 
   test("a throwing isSiteFullyExempt is swallowed and treated as not exempt (fail-safe -> open)", () => {
-    const deps = { hostname: "example.com", isSiteFullyExempt: () => { throw new Error("boom"); } };
+    const deps = { modeActive: true, hostname: "example.com", isSiteFullyExempt: () => { throw new Error("boom"); } };
     assert.doesNotThrow(() => computeCookieGate(GATE_ON_PREFS, deps));
     assert.equal(computeCookieGate(GATE_ON_PREFS, deps), true);
   });

--- a/tests/unit/consent-clauses.test.mjs
+++ b/tests/unit/consent-clauses.test.mjs
@@ -205,3 +205,49 @@ describe("consent-clauses — #1027 cookie-consent-minimizer clause (live map)",
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// cookie-consent-accept Slice 2a — the 1.3 additive bump surfaces the
+// accept-when-necessary pilot clause in the delta list. Mirrors the #888 /
+// #1027 sections above against the LIVE map.
+// ---------------------------------------------------------------------------
+describe("consent-clauses — cookie-consent-accept Slice 2a clause (live map)", () => {
+  test("CONSENT_CLAUSES_BY_VERSION['1.3'] discloses the minimum-consent pilot clause", () => {
+    assert.deepEqual(
+      [...(CONSENT_CLAUSES_BY_VERSION["1.3"] || [])],
+      ["ob_clause_cookie_consent_accept_pilot"]
+    );
+  });
+
+  test("user at 1.2, required 1.3 -> delta surfaces the minimum-consent pilot clause", () => {
+    const r = clausesForDelta({
+      acceptedVersion: "1.2",
+      requiredVersion: "1.3",
+      manifest: CONSENT_VERSION_MANIFEST,
+      // default clausesByVersion (live map)
+    });
+    assert.deepEqual(r, ["ob_clause_cookie_consent_accept_pilot"]);
+  });
+
+  test("the clause i18n key resolves to non-empty text in EN and ES (official locales)", () => {
+    assert.ok(
+      typeof TRANSLATIONS.ob_clause_cookie_consent_accept_pilot?.en === "string" &&
+        TRANSLATIONS.ob_clause_cookie_consent_accept_pilot.en.trim().length > 0,
+      "EN clause text must exist"
+    );
+    assert.ok(
+      typeof TRANSLATIONS.ob_clause_cookie_consent_accept_pilot?.es === "string" &&
+        TRANSLATIONS.ob_clause_cookie_consent_accept_pilot.es.trim().length > 0,
+      "ES clause text must exist"
+    );
+  });
+
+  test("the clause text discloses the MINIMUM (necessary-only) framing, never a blanket accept-all promise", () => {
+    const en = TRANSLATIONS.ob_clause_cookie_consent_accept_pilot.en.toLowerCase();
+    assert.ok(en.includes("minimum") || en.includes("necessary"), "EN clause must name the minimum/necessary-only framing");
+  });
+
+  test("no em-dash in the EN clause copy (project copy convention)", () => {
+    assert.ok(!TRANSLATIONS.ob_clause_cookie_consent_accept_pilot.en.includes("—"));
+  });
+});

--- a/tests/unit/consent-version-manifest.test.mjs
+++ b/tests/unit/consent-version-manifest.test.mjs
@@ -68,30 +68,32 @@ describe("consent-version-manifest — #1027 cookie-consent-minimizer additive b
     assert.ok(entry, "manifest must contain the 1.2 entry (#1027)");
     assert.equal(entry.additive, true, "1.2 must be additive (soft re-onboard), not material");
   });
-
-  test("REQUIRED_CONSENT_VERSION is 1.2", () => {
-    assert.equal(REQUIRED_CONSENT_VERSION, "1.2");
-  });
 });
 
-describe("consent-version-manifest — cookie-consent-modes Slice 1 staged 1.3 entry", () => {
+// cookie-consent-accept Slice 2a: the 1.3 entry (originally staged inert by
+// the cookie-consent-modes redesign Slice 1) is now ACTIVE —
+// REQUIRED_CONSENT_VERSION points at it. This is the genuinely-new
+// capability class the module docblock's "Staged entries" note anticipated:
+// the accept-when-necessary pilot lets MUGA submit a minimum-consent
+// payload on a genuine hard wall, which is disclosure-worthy even though
+// the feature itself stays off until the user opts in AND completes the
+// explicit consent gesture (see src/lib/cmp-accept-adapters.js's L2).
+// Existing users who accepted 1.2 get a SOFT re-onboard (delta review)
+// surfacing this one new clause, not a hard gate.
+describe("consent-version-manifest — cookie-consent-accept Slice 2a activates the 1.3 entry", () => {
   test("manifest contains a 1.3 entry marked additive: true", () => {
     const entry = CONSENT_VERSION_MANIFEST.find(m => m.version === "1.3");
-    assert.ok(entry, "manifest must contain the 1.3 entry (cookie-consent-modes Slice 1)");
-    assert.equal(entry.additive, true, "1.3 must be additive (would be soft re-onboard if activated)");
+    assert.ok(entry, "manifest must contain the 1.3 entry");
+    assert.equal(entry.additive, true, "1.3 must be additive (soft re-onboard), not material");
   });
 
-  // Staged entry: appended for the historical record, but deliberately NOT
-  // yet required — existing users' cookieConsentMode capability does not
-  // change (migrateCookieConsentMode pins them to "off"), so per the
-  // design's resolved default-reconciliation decision, no forced
-  // re-consent / soft re-onboard fires for them. Only new installs see the
-  // disclosure, via the ordinary fresh-onboarding features list. See the
-  // module docblock's "Staged entries" note.
-  test("REQUIRED_CONSENT_VERSION intentionally stays behind the staged 1.3 entry", () => {
+  test("REQUIRED_CONSENT_VERSION is 1.3", () => {
+    assert.equal(REQUIRED_CONSENT_VERSION, "1.3");
+  });
+
+  test("1.3 is the latest manifest entry", () => {
     const latest = CONSENT_VERSION_MANIFEST[CONSENT_VERSION_MANIFEST.length - 1];
-    assert.equal(latest.version, "1.3", "1.3 must be the latest manifest entry");
-    assert.equal(REQUIRED_CONSENT_VERSION, "1.2", "REQUIRED_CONSENT_VERSION must NOT yet point at the staged 1.3 entry");
+    assert.equal(latest.version, "1.3");
   });
 });
 

--- a/tests/unit/cookie-consent-accept-ux.test.mjs
+++ b/tests/unit/cookie-consent-accept-ux.test.mjs
@@ -19,6 +19,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { TRANSLATIONS } from "../../src/lib/i18n.js";
+import { resolveConsentGestureOnModeChange } from "../../src/lib/settings-schema.js";
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dir, "../..");
@@ -70,7 +71,10 @@ describe("cookie-consent-accept Slice 2a — options.js wiring", () => {
   test("the gesture checkbox is wired with a real addEventListener(\"change\", ...) handler", () => {
     const idx = optionsJs.indexOf('getElementById("cookie-consent-accept-gesture-checkbox")');
     assert.ok(idx !== -1, "options.js must query the gesture checkbox by id");
-    const nearby = optionsJs.slice(idx, idx + 1200);
+    // Window widened from 1200 -> 2200: the mode-select change handler
+    // (which now revokes the gesture on mode change) legitimately grew the
+    // code between the checkbox lookup and its own change listener.
+    const nearby = optionsJs.slice(idx, idx + 2200);
     assert.ok(
       /cookieConsentAcceptGestureCheckbox\.addEventListener\(\s*"change"/.test(nearby),
       "the gesture checkbox must be wired via addEventListener(\"change\", ...)",
@@ -95,6 +99,27 @@ describe("cookie-consent-accept Slice 2a — options.js wiring", () => {
     assert.ok(assignments.length >= 1, "options.js must restore the checkbox state from stored prefs at least once");
   });
 
+  test("the mode-select change handler revokes the gesture via resolveConsentGestureOnModeChange (not sticky across mode switches)", () => {
+    assert.ok(
+      optionsJs.includes("resolveConsentGestureOnModeChange"),
+      "options.js must import and use resolveConsentGestureOnModeChange to revoke the gesture on mode change",
+    );
+    const changeHandlerIdx = optionsJs.indexOf("cookieConsentModeSelect.addEventListener(\"change\"");
+    const handlerBody = optionsJs.slice(changeHandlerIdx, changeHandlerIdx + 600);
+    assert.ok(
+      handlerBody.includes("resolveConsentGestureOnModeChange"),
+      "the mode-select change handler must compute the next gesture value via resolveConsentGestureOnModeChange",
+    );
+  });
+
+  test("no setPrefs call ever writes a LITERAL true for cookieConsentAcceptConsented (mode select can only revoke, never grant)", () => {
+    const calls = [...optionsJs.matchAll(/cookieConsentAcceptConsented:\s*([^,}]+)/g)].map((m) => m[1].trim());
+    assert.ok(calls.length >= 1, "options.js must write cookieConsentAcceptConsented at least once");
+    for (const value of calls) {
+      assert.notEqual(value, "true", "cookieConsentAcceptConsented must never be written as a literal true");
+    }
+  });
+
   test("selecting a mode other than accept-when-necessary hides the gesture row again (syncCookieConsentAcceptGestureVisibility is called after every mode change)", () => {
     const changeHandlerIdx = optionsJs.indexOf("cookieConsentModeSelect.addEventListener(\"change\"");
     assert.ok(changeHandlerIdx !== -1, "the mode select must have a change listener");
@@ -103,6 +128,40 @@ describe("cookie-consent-accept Slice 2a — options.js wiring", () => {
       handlerBody.includes("syncCookieConsentAcceptGestureVisibility()"),
       "the mode select's change handler must re-sync the gesture row's visibility",
     );
+  });
+});
+
+describe("cookie-consent-accept Slice 2a — gesture is not sticky across mode switches", () => {
+  test("leaving accept-when-necessary for any other mode REVOKES the stored gesture", () => {
+    assert.equal(resolveConsentGestureOnModeChange("reject-only", true), false);
+    assert.equal(resolveConsentGestureOnModeChange("off", true), false);
+  });
+
+  test("entering/staying in accept-when-necessary NEVER grants the gesture — it only preserves an already-stored true", () => {
+    // A false can never become true via a mode change (only a real checkbox
+    // click can), and an existing true (from a prior real click) is kept.
+    assert.equal(resolveConsentGestureOnModeChange("accept-when-necessary", false), false);
+    assert.equal(resolveConsentGestureOnModeChange("accept-when-necessary", true), true);
+  });
+
+  test("a truthy non-boolean stored value is never treated as consent when entering accept mode", () => {
+    assert.equal(resolveConsentGestureOnModeChange("accept-when-necessary", 1), false);
+    assert.equal(resolveConsentGestureOnModeChange("accept-when-necessary", "true"), false);
+  });
+
+  test("SCENARIO: accept + gesture -> switch to reject-only -> re-select accept leaves the gate CLOSED until a fresh gesture", () => {
+    // Start in accept mode with a real gesture already granted.
+    let consented = true;
+    // User switches away to reject-only: the gesture must be revoked.
+    consented = resolveConsentGestureOnModeChange("reject-only", consented);
+    assert.equal(consented, false, "switching away from accept mode must revoke the gesture");
+    // User re-selects accept: the gate stays closed (no stale re-open).
+    consented = resolveConsentGestureOnModeChange("accept-when-necessary", consented);
+    assert.equal(consented, false, "re-entering accept mode must NOT re-open the gate on stale consent");
+    // Only a fresh explicit checkbox click (modeled here as the sole path
+    // that sets true) re-opens it — never the mode select.
+    const afterFreshClick = true;
+    assert.equal(afterFreshClick, true);
   });
 });
 

--- a/tests/unit/cookie-consent-accept-ux.test.mjs
+++ b/tests/unit/cookie-consent-accept-ux.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * MUGA — cookie-consent-accept Slice 2a: Settings UX guards.
+ *
+ * options.js/options.html are browser-only (no DOM in Node), so this
+ * follows the same source-string-inspection pattern as
+ * options-surfaced-prefs.test.mjs. Covers:
+ *   - the 3rd mode option + the informed-consent gesture row exist;
+ *   - the gesture checkbox is wired via a real "change" listener (never
+ *     set programmatically to true anywhere else in the file — the
+ *     structural proof that only a real click can grant the capability);
+ *   - the select restores its value via clampCookieConsentMode, not a
+ *     stale off/reject-only-only ternary that would silently collapse the
+ *     third mode back to reject-only on every page load.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { TRANSLATIONS } from "../../src/lib/i18n.js";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dir, "../..");
+
+const optionsHtml = readFileSync(join(ROOT, "src/options/options.html"), "utf8");
+const optionsJs = readFileSync(join(ROOT, "src/options/options.js"), "utf8");
+
+describe("cookie-consent-accept Slice 2a — options.html surface", () => {
+  test("the mode select offers the accept-when-necessary option", () => {
+    assert.ok(
+      optionsHtml.includes('<option value="accept-when-necessary" data-i18n="cookie_consent_mode_opt_accept">'),
+      "options.html must offer the accept-when-necessary <option>",
+    );
+  });
+
+  test("the informed-consent gesture row exists, hidden by default", () => {
+    assert.ok(
+      optionsHtml.includes('id="cookie-consent-accept-gesture-row" hidden'),
+      "the gesture row must exist and start hidden — only shown once the mode select is on accept-when-necessary",
+    );
+  });
+
+  test("the gesture row's checkbox exists with the correct aria label key", () => {
+    assert.ok(optionsHtml.includes('id="cookie-consent-accept-gesture-checkbox"'));
+    assert.ok(optionsHtml.includes('data-i18n-aria-label="aria_cookie_consent_accept_gesture"'));
+  });
+});
+
+describe("cookie-consent-accept Slice 2a — options.js wiring", () => {
+  test("imports clampCookieConsentMode from settings-schema.js", () => {
+    assert.ok(
+      optionsJs.includes("clampCookieConsentMode"),
+      "options.js must import clampCookieConsentMode",
+    );
+  });
+
+  test("restores the select value via clampCookieConsentMode, not a stale off/reject-only ternary", () => {
+    assert.ok(
+      optionsJs.includes("cookieConsentModeSelect.value = clampCookieConsentMode(prefs.cookieConsentMode)"),
+      "the select must be restored via clampCookieConsentMode so accept-when-necessary round-trips",
+    );
+    assert.equal(
+      optionsJs.includes('prefs.cookieConsentMode === "off" ? "off" : "reject-only"'),
+      false,
+      "the old off/reject-only-only ternary must be removed — it would silently collapse accept-when-necessary",
+    );
+  });
+
+  test("the gesture checkbox is wired with a real addEventListener(\"change\", ...) handler", () => {
+    const idx = optionsJs.indexOf('getElementById("cookie-consent-accept-gesture-checkbox")');
+    assert.ok(idx !== -1, "options.js must query the gesture checkbox by id");
+    const nearby = optionsJs.slice(idx, idx + 1200);
+    assert.ok(
+      /cookieConsentAcceptGestureCheckbox\.addEventListener\(\s*"change"/.test(nearby),
+      "the gesture checkbox must be wired via addEventListener(\"change\", ...)",
+    );
+  });
+
+  test("setPrefs({ cookieConsentAcceptConsented: ... }) is called ONLY from inside the checkbox's change handler — never unconditionally set to true elsewhere", () => {
+    const calls = [...optionsJs.matchAll(/setPrefs\(\{\s*cookieConsentAcceptConsented:\s*([^}]+)\}\)/g)];
+    assert.equal(calls.length, 1, "cookieConsentAcceptConsented must be written to storage from exactly one call site");
+    assert.match(
+      calls[0][1].trim(),
+      /cookieConsentAcceptGestureCheckbox\.checked\s*===\s*true/,
+      "the single write call site must derive the value from the checkbox's own .checked property, never a literal true",
+    );
+  });
+
+  test("the checkbox's .checked is only ever ASSIGNED (never used to trigger a save) outside the change handler — programmatic restores never fire a change event", () => {
+    // Every `cookieConsentAcceptGestureCheckbox.checked = ...` assignment
+    // (restoring from stored prefs) is a plain property assignment, which
+    // the DOM never treats as a user interaction — only a real click does.
+    const assignments = [...optionsJs.matchAll(/cookieConsentAcceptGestureCheckbox\.checked\s*=\s*[^;]+;/g)];
+    assert.ok(assignments.length >= 1, "options.js must restore the checkbox state from stored prefs at least once");
+  });
+
+  test("selecting a mode other than accept-when-necessary hides the gesture row again (syncCookieConsentAcceptGestureVisibility is called after every mode change)", () => {
+    const changeHandlerIdx = optionsJs.indexOf("cookieConsentModeSelect.addEventListener(\"change\"");
+    assert.ok(changeHandlerIdx !== -1, "the mode select must have a change listener");
+    const handlerBody = optionsJs.slice(changeHandlerIdx, changeHandlerIdx + 400);
+    assert.ok(
+      handlerBody.includes("syncCookieConsentAcceptGestureVisibility()"),
+      "the mode select's change handler must re-sync the gesture row's visibility",
+    );
+  });
+});
+
+describe("cookie-consent-accept Slice 2a — i18n copy", () => {
+  const KEYS = [
+    "cookie_consent_mode_opt_accept",
+    "row_cookie_consent_accept_gesture_label",
+    "row_cookie_consent_accept_gesture_hint",
+    "aria_cookie_consent_accept_gesture",
+  ];
+  const LOCALES = ["en", "es", "pt", "de", "fr", "it", "ja"];
+
+  for (const key of KEYS) {
+    for (const locale of LOCALES) {
+      test(`${key}.${locale} is a non-empty string`, () => {
+        const value = TRANSLATIONS[key]?.[locale];
+        assert.equal(typeof value, "string", `${key}.${locale} must exist`);
+        assert.ok(value.trim().length > 0, `${key}.${locale} must be non-empty`);
+      });
+    }
+  }
+
+  test("the EN gesture hint discloses the minimum/necessary-only framing, never a broad-accept promise", () => {
+    const en = TRANSLATIONS.row_cookie_consent_accept_gesture_hint.en.toLowerCase();
+    assert.ok(en.includes("minimum") || en.includes("necessary"));
+    assert.ok(en.includes("never"), "must explicitly state MUGA never grants tracking");
+  });
+
+  test("no em-dash in any EN or ES copy for this feature (project copy convention)", () => {
+    for (const key of KEYS) {
+      assert.ok(!TRANSLATIONS[key].en.includes("—"), `${key}.en must not use an em-dash`);
+      assert.ok(!TRANSLATIONS[key].es.includes("—"), `${key}.es must not use an em-dash`);
+    }
+  });
+});

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -30,6 +30,16 @@ const FILES = {
   isolated: join(__dirname, "../../src/content/cookie-noise.js"),
 };
 
+// cookie-consent-accept Slice 2a: the accept module's own lib file plus the
+// same two content-script copies. Separate FILES map because the pure
+// accept logic is hand-copied FROM a different lib file
+// (src/lib/cmp-accept-adapters.js), not cmp-adapters.js.
+const ACCEPT_FILES = {
+  lib: join(__dirname, "../../src/lib/cmp-accept-adapters.js"),
+  mainworld: join(__dirname, "../../src/content/cookie-noise-mainworld.js"),
+  isolated: join(__dirname, "../../src/content/cookie-noise.js"),
+};
+
 const START = "@sync:cmp-adapters:start";
 const END = "@sync:cmp-adapters:end";
 
@@ -57,6 +67,12 @@ const sources = {
   lib: readFileSync(FILES.lib, "utf8"),
   mainworld: readFileSync(FILES.mainworld, "utf8"),
   isolated: readFileSync(FILES.isolated, "utf8"),
+};
+
+const acceptSources = {
+  lib: readFileSync(ACCEPT_FILES.lib, "utf8"),
+  mainworld: sources.mainworld,
+  isolated: sources.isolated,
 };
 
 describe("cookie-noise-sync — @sync:cmp-adapters block is present in all three files", () => {
@@ -203,6 +219,114 @@ describe("cookie-noise-sync — @sync:cookie-gate block matches src/lib/cmp-adap
   });
 });
 
+// ── @sync:cmp-accept block (Didomi hard-wall + minimum-payload logic) ──────
+//
+// cookie-consent-accept Slice 2a: canAttemptDidomiMinimumAccept and
+// buildMinimumPayload are pure, world-agnostic functions defined in
+// src/lib/cmp-accept-adapters.js and hand-copied, byte-identical (modulo
+// indentation), into BOTH content scripts — mirroring the
+// @sync:cmp-adapters precedent above. The world-specific dispatch trigger
+// that actually touches window.Didomi / wrappedJSObject.Didomi is a
+// SEPARATE, NOT-required-identical region (@sync:cmp-accept-dispatch,
+// tested further below) because the two worlds reach the page global
+// differently — exactly how the existing reject call sites already work.
+
+const ACCEPT_START = "@sync:cmp-accept:start";
+const ACCEPT_END = "@sync:cmp-accept:end";
+
+describe("cookie-noise-sync — @sync:cmp-accept block is present in all three files", () => {
+  for (const [label, path] of Object.entries(ACCEPT_FILES)) {
+    test(`${label} (${path.split(/[\\/]/).pop()}) contains both @sync:cmp-accept markers`, () => {
+      const src = acceptSources[label];
+      assert.ok(src.includes(ACCEPT_START), `${label} missing ${ACCEPT_START}`);
+      assert.ok(src.includes(ACCEPT_END), `${label} missing ${ACCEPT_END}`);
+    });
+  }
+});
+
+describe("cookie-noise-sync — @sync:cmp-accept block is byte-identical (modulo indentation) across all copies", () => {
+  const libBlock = extractMarkedBlock(acceptSources.lib, ACCEPT_START, ACCEPT_END, "cmp-accept-adapters.js");
+  const mainworldBlock = extractMarkedBlock(acceptSources.mainworld, ACCEPT_START, ACCEPT_END, "cookie-noise-mainworld.js");
+  const isolatedBlock = extractMarkedBlock(acceptSources.isolated, ACCEPT_START, ACCEPT_END, "cookie-noise.js");
+
+  test("sync block is non-empty and defines canAttemptDidomiMinimumAccept and buildMinimumPayload", () => {
+    assert.ok(libBlock.length > 0, "extracted @sync:cmp-accept block must not be empty — check the markers");
+    const joined = libBlock.join("\n");
+    assert.ok(/function canAttemptDidomiMinimumAccept/.test(joined));
+    assert.ok(/function buildMinimumPayload/.test(joined));
+  });
+
+  test("cookie-noise-mainworld.js @sync:cmp-accept block matches src/lib/cmp-accept-adapters.js", () => {
+    assert.deepEqual(
+      mainworldBlock,
+      libBlock,
+      "content/cookie-noise-mainworld.js's @sync:cmp-accept block has drifted from src/lib/cmp-accept-adapters.js",
+    );
+  });
+
+  test("cookie-noise.js @sync:cmp-accept block matches src/lib/cmp-accept-adapters.js", () => {
+    assert.deepEqual(
+      isolatedBlock,
+      libBlock,
+      "content/cookie-noise.js's @sync:cmp-accept block has drifted from src/lib/cmp-accept-adapters.js",
+    );
+  });
+});
+
+// ── @sync:cmp-accept-gate block (the accept double-gate) ────────────────────
+//
+// computeAcceptGate is a pure helper in src/lib/cmp-accept-adapters.js
+// (unit-tested there) whose body is hand-inlined ONLY into
+// content/cookie-noise.js (isolated world) — mirrors the @sync:cookie-gate
+// precedent exactly: the main-world caller never reads prefs, so it does
+// NOT carry this block either.
+
+const ACCEPT_GATE_START = "@sync:cmp-accept-gate:start";
+const ACCEPT_GATE_END = "@sync:cmp-accept-gate:end";
+
+describe("cookie-noise-sync — @sync:cmp-accept-gate block matches src/lib/cmp-accept-adapters.js", () => {
+  const libBlock = extractMarkedBlock(acceptSources.lib, ACCEPT_GATE_START, ACCEPT_GATE_END, "cmp-accept-adapters.js");
+  const isolatedBlock = extractMarkedBlock(acceptSources.isolated, ACCEPT_GATE_START, ACCEPT_GATE_END, "cookie-noise.js");
+
+  test("accept-gate sync block is non-empty and defines computeAcceptGate", () => {
+    assert.ok(libBlock.length > 0, "extracted @sync:cmp-accept-gate block must not be empty — check the markers");
+    assert.ok(/function computeAcceptGate/.test(libBlock.join("\n")));
+  });
+
+  test("cookie-noise.js @sync:cmp-accept-gate block matches src/lib/cmp-accept-adapters.js", () => {
+    assert.deepEqual(
+      isolatedBlock,
+      libBlock,
+      "content/cookie-noise.js's @sync:cmp-accept-gate block has drifted from src/lib/cmp-accept-adapters.js",
+    );
+  });
+
+  test("the main-world caller does NOT carry the @sync:cmp-accept-gate block (it never reads prefs)", () => {
+    assert.equal(acceptSources.mainworld.includes(ACCEPT_GATE_START), false,
+      "cookie-noise-mainworld.js must not inline the accept double-gate — it has no prefs access");
+  });
+});
+
+// ── Accept-related new signals (both content scripts) ──────────────────────
+
+describe("cookie-noise content scripts — new Didomi accept-capability signals", () => {
+  const NEW_SIGNALS = [
+    "hasSetCurrentUserStatusFn",
+    "hasGetRequiredPurposeIdsFn",
+    "hasGetRequiredVendorIdsFn",
+    "hasGetPurposesFn",
+    "hasGetVendorsFn",
+  ];
+
+  for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+    for (const signal of NEW_SIGNALS) {
+      test(`${label} collects ${signal}`, () => {
+        assert.ok(sources[key].includes(signal), `${label} must collect the ${signal} signal`);
+      });
+    }
+  }
+});
+
 // ── Content-script structural shape ─────────────────────────────────────────
 
 describe("cookie-noise content scripts — IIFE shape, no ES imports", () => {
@@ -306,18 +430,59 @@ describe("cookie-noise gate handshake — separate channel from muga:history-gat
 //
 // Same load-bearing rule as tests/unit/cmp-adapters.test.mjs's structural
 // guard, extended to the two content-script copies that duplicate the
-// detection logic. Both files' entire source (including comments) must
-// stay free of any trace of a consent-granting action.
+// detection logic — RELAXED to POSITIONAL for cookie-consent-accept Slice
+// 2a: an accept-family identifier is now allowed, but ONLY inside the
+// three well-defined accept regions (@sync:cmp-accept, @sync:cmp-accept-gate,
+// @sync:cmp-accept-dispatch — the last one carries the world-specific
+// dispatch trigger, tested further below). Every reject region, the
+// cookie-gate region, and everything else in either file must stay
+// exactly as accept-free as before this Slice.
 
-describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting action path", () => {
+/**
+ * Removes every marked region (inclusive of the start/end marker lines
+ * themselves) from source, for the positional purity scan below. A marker
+ * pair that is entirely absent from a given source is a no-op (some
+ * regions — e.g. @sync:cmp-accept-gate / @sync:cmp-accept-dispatch — only
+ * exist in the isolated-world file, not the main-world one).
+ */
+function stripMarkedRegions(source, markerPairs) {
+  let out = source;
+  for (const [start, end] of markerPairs) {
+    const lines = out.split(/\r?\n/);
+    const startIdx = lines.findIndex((l) => l.includes(start));
+    const endIdx = lines.findIndex((l) => l.includes(end));
+    if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) continue;
+    out = [...lines.slice(0, startIdx), ...lines.slice(endIdx + 1)].join("\n");
+  }
+  return out;
+}
+
+const ACCEPT_REGION_MARKERS = [
+  ["@sync:cmp-accept:start", "@sync:cmp-accept:end"],
+  ["@sync:cmp-accept-gate:start", "@sync:cmp-accept-gate:end"],
+  ["@sync:cmp-accept-gate-call:start", "@sync:cmp-accept-gate-call:end"],
+  ["@sync:cmp-accept-dispatch:start", "@sync:cmp-accept-dispatch:end"],
+];
+
+describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting action path outside the accept regions (POSITIONAL)", () => {
   const FORBIDDEN = /allowall|accept/i;
 
-  test("cookie-noise-mainworld.js source contains no AllowAll / accept-family identifier", () => {
-    assert.doesNotMatch(sources.mainworld, FORBIDDEN);
+  test("cookie-noise-mainworld.js, with every accept region stripped, contains no AllowAll / accept-family identifier", () => {
+    const stripped = stripMarkedRegions(sources.mainworld, ACCEPT_REGION_MARKERS);
+    assert.doesNotMatch(stripped, FORBIDDEN);
   });
 
-  test("cookie-noise.js source contains no AllowAll / accept-family identifier", () => {
-    assert.doesNotMatch(sources.isolated, FORBIDDEN);
+  test("cookie-noise.js, with every accept region stripped, contains no AllowAll / accept-family identifier", () => {
+    const stripped = stripMarkedRegions(sources.isolated, ACCEPT_REGION_MARKERS);
+    assert.doesNotMatch(stripped, FORBIDDEN);
+  });
+
+  test("sanity: the relax actually matters — the FULL (unstripped) mainworld source now legitimately contains an accept-family identifier", () => {
+    assert.match(sources.mainworld, FORBIDDEN);
+  });
+
+  test("sanity: the relax actually matters — the FULL (unstripped) isolated source now legitimately contains an accept-family identifier", () => {
+    assert.match(sources.isolated, FORBIDDEN);
   });
 
   test("only window.OneTrust.RejectAll (or wrappedJSObject equivalent) is invoked — no other OneTrust method call", () => {
@@ -352,13 +517,18 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
     }
   });
 
-  test("only window.Didomi.setUserDisagreeToAll (or wrappedJSObject equivalent) is invoked — no other Didomi method call", () => {
+  test("only window.Didomi.setUserDisagreeToAll (or wrappedJSObject equivalent) is invoked as the REJECT call — no other Didomi method call OUTSIDE the accept-dispatch region", () => {
+    // The accept-dispatch region legitimately calls other Didomi.* methods
+    // (getRequiredPurposeIds, getRequiredVendorIds, getPurposes, getVendors,
+    // setCurrentUserStatus) — that region has its own dedicated guard
+    // further below. This test only cares about the REJECT ladder, so the
+    // accept-dispatch region is stripped before scanning.
     for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
-      const src = sources[key];
+      const src = stripMarkedRegions(sources[key], [["@sync:cmp-accept-dispatch:start", "@sync:cmp-accept-dispatch:end"]]);
       const calls = [...src.matchAll(/Didomi\.(\w+)\s*\(/g)].map((m) => m[1]);
       assert.ok(calls.length > 0, `${label} must call Didomi.setUserDisagreeToAll`);
       for (const fn of calls) {
-        assert.equal(fn, "setUserDisagreeToAll", `${label} calls Didomi.${fn}() — only setUserDisagreeToAll is permitted`);
+        assert.equal(fn, "setUserDisagreeToAll", `${label} calls Didomi.${fn}() outside the accept-dispatch region — only setUserDisagreeToAll is permitted there`);
       }
     }
   });
@@ -556,4 +726,80 @@ describe("cookie-noise content scripts — STRUCTURAL guard: no consent-granting
       }
     }
   });
+
+  // ── Didomi accept dispatch (cookie-consent-accept Slice 2a) — its own
+  // guard family, mirroring the reject-call shapes above exactly, but
+  // scoped to the NEW @sync:cmp-accept-dispatch region only.
+
+  test("only Didomi.setCurrentUserStatus (or wrappedJSObject equivalent) is invoked as the accept call — no other Didomi method call inside the dispatch region", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const dispatchBlock = extractMarkedBlock(
+        src, "@sync:cmp-accept-dispatch:start", "@sync:cmp-accept-dispatch:end", label,
+      ).join("\n");
+      const calls = [...dispatchBlock.matchAll(/Didomi\.(\w+)\s*\(/g)].map((m) => m[1]);
+      assert.ok(calls.length > 0, `${label} must call Didomi.setCurrentUserStatus inside @sync:cmp-accept-dispatch`);
+      for (const fn of calls) {
+        assert.ok(
+          fn === "setCurrentUserStatus" || fn === "getRequiredPurposeIds" || fn === "getRequiredVendorIds" ||
+            fn === "getPurposes" || fn === "getVendors",
+          `${label} calls Didomi.${fn}() inside the dispatch region — only the getters and setCurrentUserStatus are permitted`,
+        );
+      }
+    }
+  });
+
+  test("every setCurrentUserStatus call passes a single bare variable — never an inline object literal, never a hardcoded id", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const calls = [...src.matchAll(/setCurrentUserStatus\s*\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(calls.length > 0, `${label} must call setCurrentUserStatus`);
+      for (const args of calls) {
+        assert.match(
+          args, /^[A-Za-z_$][\w$]*$/,
+          `${label} setCurrentUserStatus must be called with a single bare variable (the built payload), got: ${args}`,
+        );
+      }
+    }
+  });
+
+  test("the accept dispatch is gated on the acceptGateOpen boolean AND canAttemptDidomiMinimumAccept before ever calling setCurrentUserStatus", () => {
+    for (const [label, key] of [["cookie-noise-mainworld.js", "mainworld"], ["cookie-noise.js", "isolated"]]) {
+      const src = sources[key];
+      const dispatchBlock = extractMarkedBlock(
+        src, "@sync:cmp-accept-dispatch:start", "@sync:cmp-accept-dispatch:end", label,
+      ).join("\n");
+      assert.ok(
+        /canAttemptDidomiMinimumAccept/.test(dispatchBlock),
+        `${label}'s dispatch region must call canAttemptDidomiMinimumAccept before acting`,
+      );
+      assert.ok(
+        /didomiMinimumGateOpen/i.test(dispatchBlock),
+        `${label}'s dispatch region must check the minimum-grant gate-open boolean before acting`,
+      );
+    }
+  });
+
+  // DENYLIST scan (mirrors tests/unit/cmp-accept-adapters.test.mjs's own
+  // DENYLIST exactly): even though the dispatch region legitimately calls
+  // Didomi, it must never widen to any broad-accept method identified
+  // across the other 9 vendor adapters.
+  const CONTENT_SCRIPT_DENYLIST = [
+    "AllowAll",
+    "acceptAllConsents",
+    "acceptAllServices",
+    "acceptAllAction",
+    "postAcceptAll",
+    "submitCustomConsent(true",
+    "respondAll(true)",
+    '__cmp("setConsent", 1',
+    'performBannerAction("accept_all"',
+  ];
+
+  for (const forbidden of CONTENT_SCRIPT_DENYLIST) {
+    test(`neither content script's source contains the broad-accept identifier "${forbidden}"`, () => {
+      assert.equal(sources.mainworld.includes(forbidden), false, `cookie-noise-mainworld.js contains "${forbidden}"`);
+      assert.equal(sources.isolated.includes(forbidden), false, `cookie-noise.js contains "${forbidden}"`);
+    });
+  }
 });

--- a/tests/unit/service-worker-patterns-drift-guard.test.mjs
+++ b/tests/unit/service-worker-patterns-drift-guard.test.mjs
@@ -44,7 +44,12 @@ const PATTERNS_TEST_PATH = join(
 // guard confirming the SW defines the new message handler. The (a)/(b)/(c)
 // gate coverage itself is a behavioral test against a pure
 // forceFetchRemoteRules() mirror function, not a source-string assertion.
-const MAX_SOURCE_STRING_ASSERTIONS = 72;
+// 72 → 74 (cookie-consent-accept Slice 2a): added TWO source-string guards
+// confirming the getPrefs handler imports settings-schema.js's
+// isCookieConsentModeActive and computes the modeActive gate-wiring field
+// from it. service-worker.js still cannot be imported in Node, so this
+// stays source-text until a future SW behavioral-harness migration.
+const MAX_SOURCE_STRING_ASSERTIONS = 74;
 
 const SOURCE_STRING_PATTERN = /swSource\.(includes|indexOf|slice|match)\(/g;
 

--- a/tests/unit/service-worker-patterns.test.mjs
+++ b/tests/unit/service-worker-patterns.test.mjs
@@ -69,6 +69,24 @@ describe("Service worker message handlers", () => {
     assert.ok(swSource.includes('message.type === "getPrefs"'));
   });
 
+  // Cookie Consent Minimizer gate wiring (cookie-consent-accept Slice 2a):
+  // src/lib/cmp-adapters.js's computeCookieGate no longer compares
+  // prefs.cookieConsentMode against a mode string (that file is lexically
+  // restricted, see its structural guard). The service worker is the one
+  // place both concerns (chrome.storage + settings-schema.js) are
+  // importable, so it pre-validates the mode here and hands content
+  // scripts a plain boolean via the getPrefs response.
+  test("getPrefs response computes modeActive via settings-schema's isCookieConsentModeActive", () => {
+    assert.ok(
+      swSource.includes("import { isCookieConsentModeActive } from \"../lib/settings-schema.js\""),
+      "service worker must import isCookieConsentModeActive from settings-schema.js"
+    );
+    assert.ok(
+      swSource.includes("modeActive: isCookieConsentModeActive(prefs.cookieConsentMode)"),
+      "getPrefs handler must compute modeActive from the raw cookieConsentMode pref"
+    );
+  });
+
   test("handles GET_DEBUG_LOG message type", () => {
     assert.ok(swSource.includes('message.type === "GET_DEBUG_LOG"'));
   });

--- a/tests/unit/settings-schema.test.mjs
+++ b/tests/unit/settings-schema.test.mjs
@@ -18,6 +18,7 @@ import {
   snapToastDuration,
   COOKIE_CONSENT_MODE_OPTIONS,
   clampCookieConsentMode,
+  isCookieConsentModeActive,
   buildExportPayload,
   planImport,
   diffImport,
@@ -489,5 +490,34 @@ describe("COOKIE_CONSENT_MODE_OPTIONS / clampCookieConsentMode", () => {
     assert.equal(clampCookieConsentMode(undefined), "reject-only");
     assert.equal(clampCookieConsentMode(null), "reject-only");
     assert.equal(clampCookieConsentMode(123), "reject-only");
+  });
+});
+
+// isCookieConsentModeActive (cookie-consent-accept Slice 2a): the
+// modeActive gate-wiring boundary — src/lib/cmp-adapters.js's
+// computeCookieGate no longer compares the mode string itself (that file
+// stays lexically restricted, see its structural guard); instead the
+// caller (background/service-worker.js) validates the mode against this
+// closed-enum boundary here and hands a pre-validated boolean down. This
+// module has no lexical restriction, so it is the one safe place to name
+// every active enum member explicitly.
+describe("isCookieConsentModeActive", () => {
+  test("reject-only is active", () => {
+    assert.equal(isCookieConsentModeActive("reject-only"), true);
+  });
+
+  test("accept-when-necessary is active", () => {
+    assert.equal(isCookieConsentModeActive("accept-when-necessary"), true);
+  });
+
+  test("off is not active", () => {
+    assert.equal(isCookieConsentModeActive("off"), false);
+  });
+
+  test("an unrecognized string, or a non-string, is not active (fail-closed)", () => {
+    assert.equal(isCookieConsentModeActive("bogus"), false);
+    assert.equal(isCookieConsentModeActive(undefined), false);
+    assert.equal(isCookieConsentModeActive(null), false);
+    assert.equal(isCookieConsentModeActive(123), false);
   });
 });

--- a/tests/unit/source-grep-ratchet.test.mjs
+++ b/tests/unit/source-grep-ratchet.test.mjs
@@ -121,7 +121,7 @@ const EXEMPT = new Set([
 const BASELINE = {
   // Files with SW/content-script source that cannot be imported in Node —
   // migration requires extracting pure functions or an integration harness.
-  "service-worker-patterns.test.mjs": 77,   // SW not importable; behavioral migration is long arc (#824). +1 for the FORCE_FETCH_REMOTE_RULES "Update now" handler existence guard (Update now feature) — the (a)/(b)/(c) gate coverage itself is behavioral via a pure forceFetchRemoteRules() mirror, only the "handler exists" check is source-text
+  "service-worker-patterns.test.mjs": 79,   // SW not importable; behavioral migration is long arc (#824). +1 for the FORCE_FETCH_REMOTE_RULES "Update now" handler existence guard (Update now feature) — the (a)/(b)/(c) gate coverage itself is behavioral via a pure forceFetchRemoteRules() mirror, only the "handler exists" check is source-text. +2 for cookie-consent-accept Slice 2a's modeActive gate-wiring guard (import + computed field): the service worker isn't importable in Node (top-level chrome.* globals), so this stays a source-text assertion until a future SW behavioral-harness migration.
   "misc-regression.test.mjs": 29,           // mixed bag; partial migration possible (#824)
   "content-cleaner-patterns.test.mjs": 34,  // content script not importable (#824). +7 for #allowlist-full-inert: ping-blocking, runRedirectUnwrap, and click-interception isSiteFullyExempt guards
   "content-script.test.mjs": 20,            // content script not importable (#824); +1: same-document click-guard mirror (carousel regression)


### PR DESCRIPTION
Closes #1147. Relates to #1027. **size:exception** (atomic accept infrastructure — pref/gate/module/UX/i18n/tests interlock).

## Summary
Completes the cookie-consent engine with the OPT-IN **accept-when-necessary** mode: on a genuine hard wall (no reject path) for a supported vendor, if the user is in that mode AND gave an explicit consent gesture, MUGA submits the MINIMUM consent (essential-only). Pilot: **Didomi** (`setCurrentUserStatus` with only `getRequiredPurposeIds()`/`getRequiredVendorIds()` enabled, all else disabled). First time MUGA accepts on the user's behalf.

## 5-layer safety model (all structurally enforced + adversarially tested)
- **L1 file purity**: `cmp-adapters.js` (reject brain) UNTOUCHED, still passes its absolute `/allowall|accept/i` scan. ALL accept logic in NEW `cmp-accept-adapters.js` + `@sync:cmp-accept` regions (content-script scan relaxed absolute→POSITIONAL, tight).
- **L2 double-gate** (data invariant): accept unreachable unless `cookieConsentMode==='accept-when-necessary'` AND `cookieConsentAcceptConsented===true` (strict). Import-blocked, migration/default false, gesture is the sole in-app writer.
- **L3 reject-first**: accept only on `no-reject-path`.
- **L4 minimum + broad-accept DENYLIST**: strict required-getter parse (`extractRequiredIds`: array-of-strings-or-NOOP) + registry intersection → never widens; unexpected shape → NOOP (no call).
- **L5 fail-to-NOOP + never-hide**.

## Review + fixes
Dual blind adversarial review (2 opus judges). Both confirmed the double-gate + minimum-enforcement sound. Fixed the one MEDIUM (required-getter parsing was not fail-closed for a flag-map shape → could widen; now strict-parse+NOOP, docstring corrected), a spec/runtime parity coverage gap, and 2 LOWs (consent flag now revoked on leaving accept mode; no call on degenerate payload). All TDD (flag-map + revoke regressions fail-before/pass-after).

## Test plan
- `npm test` **7071 pass / 0 fail** / 1 pre-existing skip.
- **Chromium e2e 4/4** + **Firefox smoke 3/3** EXECUTED green — assert the EXACT minimum payload (`enabled:[functional]`, `disabled:[advertising,analytics]`) + reject-only/no-gesture/off → NOOP.
- lint / lint:js / check:i18n clean; bundle-drift clean.
- Soft re-onboard: `REQUIRED_CONSENT_VERSION`→1.3 (additive delta, not a hard lockout).

## HARD EU GATE (blocking before enable)
Real Didomi behavior (that minimum-accept actually dismisses a live hard wall + grants zero non-essential) is geo-blocked/UNVERIFIED. The synthetic e2e proves the MECHANICS only. **The accept mode MUST NOT be enabled/released for real users until a real EU-vantage behavioral smoke passes** — documented in docs/qa/cookie-consent-release-smoke.md as a blocking item. On develop it is behind the opt-in gesture, so no default-mode user is affected.