### PR TITLE
fix(consent): CookieScript detection fails on real sites (global is a function)

### DIFF
--- a/src/content/cookie-noise-mainworld.js
+++ b/src/content/cookie-noise-mainworld.js
@@ -556,13 +556,20 @@
     // not directly on the vendor global — hasCookieScriptInstance must be
     // confirmed an object BEFORE probing .rejectAllAction, otherwise reading
     // a property off `undefined` would throw inside this try block (still
-    // caught, but the intent is explicit here).
+    // caught, but the intent is explicit here). The vendor global itself
+    // can be EITHER an object OR a callable function with `.instance` hung
+    // off it (real-site verification found cookie-script.com ships the
+    // function-shaped variant) — allow both shapes for the global itself;
+    // `.instance` and `.rejectAllAction` are the real discriminators and
+    // stay strictly object/function-typed, so this does not loosen
+    // detection against any other CMP.
     let hasCookieScriptGlobal = false;
     let hasCookieScriptInstance = false;
     let hasRejectAllActionFn = false;
     try {
-      hasCookieScriptGlobal = typeof window.CookieScript === "object" && window.CookieScript !== null;
-      const instance = hasCookieScriptGlobal && window.CookieScript.instance;
+      const cs = window.CookieScript;
+      hasCookieScriptGlobal = (typeof cs === "object" || typeof cs === "function") && cs !== null;
+      const instance = hasCookieScriptGlobal && cs.instance;
       hasCookieScriptInstance = typeof instance === "object" && instance !== null;
       hasRejectAllActionFn = hasCookieScriptInstance && typeof instance.rejectAllAction === "function";
     } catch {

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -629,14 +629,20 @@
     }
     // CookieScript: the reject call lives on window.CookieScript.instance,
     // not directly on the vendor global, reached via wrappedJSObject — same
-    // Xray-safety pattern as the other Firefox signal reads above.
+    // Xray-safety pattern as the other Firefox signal reads above. The
+    // vendor global itself can be EITHER an object OR a callable function
+    // with `.instance` hung off it (real-site verification found
+    // cookie-script.com ships the function-shaped variant) — allow both
+    // shapes for the global itself; `.instance` and `.rejectAllAction`
+    // remain the real, strictly object/function-typed discriminators, so
+    // this does not loosen detection against any other CMP.
     let hasCookieScriptGlobal = false;
     let hasCookieScriptInstance = false;
     let hasRejectAllActionFn = false;
     try {
       const wrapped = window.wrappedJSObject;
       const cs = wrapped && wrapped.CookieScript;
-      hasCookieScriptGlobal = typeof cs === "object" && cs !== null;
+      hasCookieScriptGlobal = (typeof cs === "object" || typeof cs === "function") && cs !== null;
       const instance = hasCookieScriptGlobal && cs.instance;
       hasCookieScriptInstance = typeof instance === "object" && instance !== null;
       hasRejectAllActionFn = hasCookieScriptInstance && typeof instance.rejectAllAction === "function";

--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -113,7 +113,12 @@
  *   present in the DOM. Secondary/corroborating signal.
  * @property {boolean} [hasCoiConsentSummaryDom] - `.coi-consent-summary`
  *   present in the DOM. Secondary/corroborating signal.
- * @property {boolean} [hasCookieScriptGlobal] - `typeof window.CookieScript === "object"`.
+ * @property {boolean} [hasCookieScriptGlobal] - `typeof window.CookieScript === "object" || typeof window.CookieScript === "function"`.
+ *   Real-site verification (2026-07-17) found cookie-script.com ships the
+ *   vendor global as a callable FUNCTION with `.instance` hung off it, not
+ *   a plain object — the global itself may be either shape; the real
+ *   discriminators are `.instance` and `.instance.rejectAllAction` below,
+ *   which stay strictly object/function-typed.
  * @property {boolean} [hasCookieScriptInstance] - `typeof window.CookieScript.instance === "object"`.
  *   Mandatory signal: the reject call lives on `.instance`, so this must be
  *   present before probing for the reject function itself.
@@ -247,8 +252,18 @@ export const ACTIONS = Object.freeze({
  * `hasRejectAllActionFn` — because `.instance` can be present-but-not-yet
  * populated (or absent) even when the vendor global itself already exists,
  * and probing `.rejectAllAction` before confirming `.instance` is an object
- * would either throw or silently read `undefined`. The usual >=1
- * corroborating DOM secondary (`#cookiescript_injected`,
+ * would either throw or silently read `undefined`. Real-site verification
+ * (2026-07-17, EU sweep) found cookie-script.com exposes `window.CookieScript`
+ * as a callable FUNCTION (with `.instance` and `.init` as its own
+ * properties), not a plain object as originally assumed — the signal
+ * collectors in the content-script copies (`collectSignals`/
+ * `fxCollectSignals`) allow EITHER `typeof === "object"` OR
+ * `typeof === "function"` for the bare global while `hasCookieScriptGlobal`
+ * itself stays a plain boolean here, so this pure detect function's shape
+ * is unaffected — only what feeds it changed. `.instance` and
+ * `.rejectAllAction` remain the real, strictly object/function-typed
+ * discriminators; this does not loosen detection against any other CMP.
+ * The usual >=1 corroborating DOM secondary (`#cookiescript_injected`,
  * `#cookiescript_description`) still gates the same fail-closed
  * CONFIDENCE_THRESHOLD as every other adapter here.
  *

--- a/tests/e2e-firefox/cookiescript.smoke.mjs
+++ b/tests/e2e-firefox/cookiescript.smoke.mjs
@@ -18,7 +18,10 @@ import { serveFixturePage } from "./helpers/local-server.mjs";
 // tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs's
 // stubCookieScriptPage: all three mandatory signals (global, instance,
 // rejectAllAction fn) plus the #cookiescript_injected DOM anchor as the
-// corroborating secondary signal.
+// corroborating secondary signal. `window.CookieScript` is a callable
+// FUNCTION with `.instance` hung off it — the real vendor shape confirmed
+// on cookie-script.com via real-site verification (2026-07-17), not the
+// plain object this fixture originally (incorrectly) modeled.
 const COOKIESCRIPT_FIXTURE_HTML = `<!doctype html><html><body>
   <div id="cookiescript_injected">
     <button id="cookiescript_accept">Accept</button>
@@ -27,13 +30,12 @@ const COOKIESCRIPT_FIXTURE_HTML = `<!doctype html><html><body>
   <p id="page-content">Real page content</p>
   <script>
     window.__csCalls = [];
-    window.CookieScript = {
-      instance: {
-        rejectAllAction: function () {
-          window.__csCalls.push("rejectAllAction");
-          window.__consentState = "necessary-only";
-          document.getElementById("cookiescript_injected").remove();
-        },
+    window.CookieScript = function CookieScript() {};
+    window.CookieScript.instance = {
+      rejectAllAction: function () {
+        window.__csCalls.push("rejectAllAction");
+        window.__consentState = "necessary-only";
+        document.getElementById("cookiescript_injected").remove();
       },
     };
   </script>

--- a/tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-cookiescript.spec.mjs
@@ -2,11 +2,14 @@
  * E2E: Cookie Consent Minimizer — CookieScript Tier 1 adapter
  *
  * Verifies the CookieScript reject path against a real Chromium with the
- * extension loaded. The fixture page mimics a CookieScript banner: a
- * `window.CookieScript.instance` object with a `rejectAllAction()` method
- * plus the `#cookiescript_injected` DOM anchor — the triple-mandatory
- * (global + instance + fn) plus corroboration signal combination the
- * dispatcher requires before acting (src/lib/cmp-adapters.js).
+ * extension loaded. The fixture page mimics a CookieScript banner:
+ * `window.CookieScript` is a callable FUNCTION (matching the real
+ * cookie-script.com deployment confirmed via real-site verification,
+ * 2026-07-17 — `typeof window.CookieScript === "function"`, NOT
+ * `"object"`) with an `.instance` object exposing `rejectAllAction()`, plus
+ * the `#cookiescript_injected` DOM anchor — the triple-mandatory (global +
+ * instance + fn) plus corroboration signal combination the dispatcher
+ * requires before acting (src/lib/cmp-adapters.js).
  *
  * Mirrors tests/e2e/cookie-consent-minimizer-cookieinformation.spec.mjs's
  * structure exactly (same onboarding helper shape, same feature pref, same
@@ -61,11 +64,14 @@ async function completeOnboarding(context, extensionId, { enableFeature = true }
 
 /**
  * Fixture page: a CookieScript banner offering a reject-all via
- * `CookieScript.instance.rejectAllAction()`. All three mandatory signals
- * (global, instance, rejectAllAction fn) are present alongside the
- * `#cookiescript_injected` DOM anchor — the confidence gate in
- * cmp-adapters.js requires the mandatory triple plus at least one
- * corroborating DOM secondary.
+ * `CookieScript.instance.rejectAllAction()`. `window.CookieScript` is a
+ * callable FUNCTION with `.instance` hung off it — the real vendor shape
+ * confirmed on cookie-script.com via real-site verification (2026-07-17),
+ * not the plain object this fixture originally (incorrectly) modeled. All
+ * three mandatory signals (global, instance, rejectAllAction fn) are
+ * present alongside the `#cookiescript_injected` DOM anchor — the
+ * confidence gate in cmp-adapters.js requires the mandatory triple plus at
+ * least one corroborating DOM secondary.
  */
 async function stubCookieScriptPage(page) {
   await page.route(`**://${HOST}/**`, (route) =>
@@ -80,13 +86,12 @@ async function stubCookieScriptPage(page) {
         <p id="page-content">Real page content</p>
         <script>
           window.__csCalls = [];
-          window.CookieScript = {
-            instance: {
-              rejectAllAction: function () {
-                window.__csCalls.push("rejectAllAction");
-                window.__consentState = "necessary-only";
-                document.getElementById("cookiescript_injected").remove();
-              },
+          window.CookieScript = function CookieScript() {};
+          window.CookieScript.instance = {
+            rejectAllAction: function () {
+              window.__csCalls.push("rejectAllAction");
+              window.__consentState = "necessary-only";
+              document.getElementById("cookiescript_injected").remove();
             },
           };
         </script>
@@ -224,12 +229,14 @@ test.describe("Cookie Consent Minimizer — CookieScript", () => {
     extensionId,
   }) => {
     // Regression guard for the exact TypeError hazard the triple-mandatory
-    // gate exists to prevent: window.CookieScript is a truthy object but has
-    // NO `.instance` (the vendor SDK attaches the global before the instance
-    // is constructed). Reading `window.CookieScript.instance.rejectAllAction`
-    // naively would throw "Cannot read properties of undefined". The signal
-    // collector short-circuits on the missing instance, so detection must
-    // fail closed and the adapter must NOOP — with zero page errors captured.
+    // gate exists to prevent: window.CookieScript is a truthy FUNCTION (the
+    // real vendor shape, confirmed via real-site verification 2026-07-17)
+    // but has NO `.instance` (the vendor SDK attaches the global before the
+    // instance is constructed). Reading
+    // `window.CookieScript.instance.rejectAllAction` naively would throw
+    // "Cannot read properties of undefined". The signal collector
+    // short-circuits on the missing instance, so detection must fail closed
+    // and the adapter must NOOP — with zero page errors captured.
     await completeOnboarding(context, extensionId, { enableFeature: true });
 
     const NO_INSTANCE_HOST = "muga-test-cookie-consent-cookiescript-no-instance.invalid";
@@ -248,9 +255,10 @@ test.describe("Cookie Consent Minimizer — CookieScript", () => {
           </div>
           <p id="page-content">Real page content</p>
           <script>
-            // Truthy CookieScript global WITHOUT an .instance — the exact
+            // Truthy CookieScript global (function-shaped, the real vendor
+            // shape) WITHOUT an .instance — the exact
             // present-but-not-yet-populated shape the triple gate guards.
-            window.CookieScript = {};
+            window.CookieScript = function CookieScript() {};
           </script>
         </body></html>`,
       })
@@ -278,13 +286,13 @@ test.describe("Cookie Consent Minimizer — CookieScript", () => {
     );
     expect(bannerStillThere).toBe(true);
 
-    // The global is still the instance-less object we planted (no crash
+    // The global is still the instance-less function we planted (no crash
     // mid-collection that would have aborted the script).
     const csShape = await page.evaluate(() => ({
-      isObject: typeof window.CookieScript === "object" && window.CookieScript !== null,
+      isFunction: typeof window.CookieScript === "function",
       hasInstance: typeof window.CookieScript?.instance !== "undefined",
     }));
-    expect(csShape).toEqual({ isObject: true, hasInstance: false });
+    expect(csShape).toEqual({ isFunction: true, hasInstance: false });
 
     // The whole point: reading `.instance.rejectAllAction` never threw.
     expect(pageErrors).toHaveLength(0);

--- a/tests/unit/cookiescript-real-shape.test.mjs
+++ b/tests/unit/cookiescript-real-shape.test.mjs
@@ -1,0 +1,203 @@
+/**
+ * MUGA — CookieScript Tier 1 adapter: real-site detection regression.
+ *
+ * EU real-site verification (2026-07-17, engram
+ * sdd/cookie-consent-coverage/eu-real-site-verification) found that on the
+ * real cookie-script.com deployment `typeof window.CookieScript` is
+ * `"function"`, NOT `"object"`. MUGA's mandatory detection gate computed
+ * `hasCookieScriptGlobal` as `typeof window.CookieScript === "object"`
+ * (src/content/cookie-noise-mainworld.js's `collectSignals`, and the
+ * `wrappedJSObject`-mediated equivalent in src/content/cookie-noise.js's
+ * `fxCollectSignals`) — so the mandatory gate NEVER fires on the real
+ * vendor shape, even though `window.CookieScript.instance.rejectAllAction()`
+ * works and would successfully reject.
+ *
+ * This test loads the REAL `collectSignals`/`fxCollectSignals` functions
+ * (extracted verbatim from the content-script source, not re-typed) against
+ * a synthetic `window` shaped exactly like the real cookie-script.com
+ * deployment, then threads the result through the real
+ * `cookieScriptAdapter` from src/lib/cmp-adapters.js — proving the full,
+ * real detection pipeline (not just hand-typed boolean signals) now
+ * recognizes the vendor's actual shape while still rejecting non-matches.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { cookieScriptAdapter, didomiAdapter } from "../../src/lib/cmp-adapters.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const MAINWORLD_SRC = readFileSync(
+  resolve(__dirname, "../../src/content/cookie-noise-mainworld.js"),
+  "utf8"
+);
+const ISOLATED_SRC = readFileSync(resolve(__dirname, "../../src/content/cookie-noise.js"), "utf8");
+
+/**
+ * Extracts a named function's full source (from `function <name>(` through
+ * its matching closing brace) via string-aware brace counting. Used instead
+ * of a hardcoded line range so the test keeps working across unrelated
+ * edits elsewhere in the file.
+ */
+function extractFunction(source, name) {
+  const anchor = `function ${name}(`;
+  const start = source.indexOf(anchor);
+  assert.ok(start !== -1, `could not find "${anchor}" in source`);
+  const braceStart = source.indexOf("{", start);
+  assert.ok(braceStart !== -1, `could not find opening brace for ${name}`);
+
+  let depth = 0;
+  let inString = null;
+  let i = braceStart;
+  for (; i < source.length; i++) {
+    const ch = source[i];
+    const prev = source[i - 1];
+    if (inString) {
+      if (ch === inString && prev !== "\\") inString = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inString = ch;
+      continue;
+    }
+    if (ch === "{") depth++;
+    if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        i++;
+        break;
+      }
+    }
+  }
+  assert.ok(depth === 0, `unbalanced braces while extracting ${name}`);
+  return source.slice(start, i);
+}
+
+/** Runs the real, extracted `collectSignals()` against a fake window/document. */
+function runCollectSignals(window, document) {
+  const fnSrc = extractFunction(MAINWORLD_SRC, "collectSignals");
+  const run = new Function("window", "document", `${fnSrc}\nreturn collectSignals();`);
+  return run(window, document);
+}
+
+/** Runs the real, extracted `fxCollectSignals()` against a fake window/document. */
+function runFxCollectSignals(window, document) {
+  const fnSrc = extractFunction(ISOLATED_SRC, "fxCollectSignals");
+  const run = new Function("window", "document", `${fnSrc}\nreturn fxCollectSignals();`);
+  return run(window, document);
+}
+
+/** Minimal DOM stub exposing only what collectSignals reads. */
+function makeDocument({ injected = false, description = false } = {}) {
+  return {
+    getElementById(id) {
+      if (id === "cookiescript_injected") return injected ? {} : null;
+      if (id === "cookiescript_description") return description ? {} : null;
+      return null;
+    },
+    querySelector() {
+      return null;
+    },
+    body: { classList: { contains: () => false } },
+  };
+}
+
+/** The real cookie-script.com shape: window.CookieScript is a FUNCTION with .instance. */
+function makeRealShapeCookieScriptGlobal() {
+  const rejectCalls = [];
+  function CookieScript() {}
+  CookieScript.instance = {
+    rejectAllAction() {
+      rejectCalls.push("rejectAllAction");
+    },
+  };
+  return { CookieScript, rejectCalls };
+}
+
+describe("cookie-noise-mainworld.js collectSignals — CookieScript real-site shape (function, not object)", () => {
+  test("window.CookieScript as a FUNCTION with .instance.rejectAllAction -> hasCookieScriptGlobal true", () => {
+    const { CookieScript } = makeRealShapeCookieScriptGlobal();
+    const window = { CookieScript };
+    const document = makeDocument({ injected: true, description: true });
+
+    const signals = runCollectSignals(window, document);
+
+    assert.equal(signals.hasCookieScriptGlobal, true);
+    assert.equal(signals.hasCookieScriptInstance, true);
+    assert.equal(signals.hasRejectAllActionFn, true);
+  });
+
+  test("real-shape signals threaded through the real cookieScriptAdapter -> detect + canReject true", () => {
+    const { CookieScript } = makeRealShapeCookieScriptGlobal();
+    const window = { CookieScript };
+    const document = makeDocument({ injected: true, description: true });
+
+    const signals = runCollectSignals(window, document);
+
+    assert.ok(cookieScriptAdapter.detect(signals) >= 1);
+    assert.equal(cookieScriptAdapter.canReject(signals), true);
+  });
+
+  test("discrimination preserved: bare object global with NO .instance still fails closed", () => {
+    const window = { CookieScript: {} };
+    const document = makeDocument({ injected: true, description: true });
+
+    const signals = runCollectSignals(window, document);
+
+    assert.equal(signals.hasCookieScriptGlobal, true);
+    assert.equal(signals.hasCookieScriptInstance, false);
+    assert.equal(cookieScriptAdapter.canReject(signals), false);
+  });
+
+  test("discrimination preserved: no CookieScript global at all (Didomi-shaped page) never crosses over", () => {
+    const window = {
+      Didomi: {
+        setUserDisagreeToAll() {},
+        getCurrentUserStatus() {
+          return {};
+        },
+      },
+    };
+    const document = makeDocument({ injected: false, description: false });
+
+    const signals = runCollectSignals(window, document);
+
+    assert.equal(signals.hasCookieScriptGlobal, false);
+    assert.equal(cookieScriptAdapter.canReject(signals), false);
+    // The point here is solely that the CookieScript adapter never claims a
+    // non-CookieScript page (a real Didomi-shaped page, in this case) —
+    // Didomi's own adapter firing on its own page is expected and unrelated
+    // to this regression.
+    assert.equal(didomiAdapter.canReject(signals), true);
+  });
+});
+
+describe("cookie-noise.js fxCollectSignals — CookieScript real-site shape via wrappedJSObject (Firefox)", () => {
+  test("wrappedJSObject.CookieScript as a FUNCTION with .instance.rejectAllAction -> hasCookieScriptGlobal true", () => {
+    const { CookieScript } = makeRealShapeCookieScriptGlobal();
+    const window = { wrappedJSObject: { CookieScript } };
+    const document = makeDocument({ injected: true, description: true });
+
+    const signals = runFxCollectSignals(window, document);
+
+    assert.equal(signals.hasCookieScriptGlobal, true);
+    assert.equal(signals.hasCookieScriptInstance, true);
+    assert.equal(signals.hasRejectAllActionFn, true);
+    assert.equal(cookieScriptAdapter.canReject(signals), true);
+  });
+
+  test("discrimination preserved: bare function global with NO .instance still fails closed (Firefox)", () => {
+    function CookieScript() {}
+    const window = { wrappedJSObject: { CookieScript } };
+    const document = makeDocument({ injected: true, description: true });
+
+    const signals = runFxCollectSignals(window, document);
+
+    assert.equal(signals.hasCookieScriptGlobal, true);
+    assert.equal(signals.hasCookieScriptInstance, false);
+    assert.equal(cookieScriptAdapter.canReject(signals), false);
+  });
+});


### PR DESCRIPTION
Closes #1149. Relates to #1027.

## Bug (found by EU real-site verification)
On cookie-script.com, `window.CookieScript` is a callable **function** (own keys `init`,`instance`), not an object. The signal-collection gate used `typeof window.CookieScript === "object"` → false → the adapter never detected real CookieScript deployments, despite `instance.rejectAllAction()` working. Passed synthetic tests (which wrongly modeled a plain object), failed reality.

## Fix
`collectSignals`/`fxCollectSignals` (both content scripts): `hasCookieScriptGlobal = (typeof cs === "object" || typeof cs === "function") && cs !== null`. `.instance` (object) + `.instance.rejectAllAction` (function) + `#cookiescript_injected`/`#cookiescript_description` DOM stay the strict discriminators — no other CMP loosened, no misfire hole. Pure detect functions in the @sync block unchanged (they consume a boolean).

## Test plan
- New `tests/unit/cookiescript-real-shape.test.mjs` extracts the real collectSignals source, runs it against a function-shaped stub: **4/6 fail before, 6/6 after**. Discrimination negatives held both runs.
- Corrected the synthetic e2e/FF fixtures (were plain-object, never exercised the bug) to the real function shape.
- `npm test` 7078 pass / 0 fail; lint/lint:js/check:i18n clean; bundle-drift clean.
- Chromium e2e 4/4 + Firefox smoke 2/2 (real Gecko).
- @sync byte-identity + never-accept spine intact.