### PR TITLE
feat(privacy): Chrome DNR enforcement — referer & beacon suppression (PR 2/4)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -4,14 +4,25 @@
  * and maintains extension state.
  */
 
-import { processUrl, computeNavigationStrip, parseListEntry, getFullyExemptDomains, isSiteFullyExempt } from "../lib/cleaner.js";
+import { processUrl, computeNavigationStrip, parseListEntry, getFullyExemptDomains, isSiteFullyExempt, getFullyBlacklistedDomains } from "../lib/cleaner.js";
 import { getAffiliateDomains, resolveOurTag } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, migrateLegacyProxyPref, migratePerSiteDisableToAllowlist, migrateCookieConsentMode, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules, getRemoteParams } from "../lib/storage.js";
 import { migrateConsentToLocal } from "../lib/sync-migration.js";
 import { evaluate as evaluateConsent } from "../lib/consent-policy.js";
 import { isCookieConsentModeActive } from "../lib/settings-schema.js";
 import { isValidListEntry } from "../lib/validation.js";
-import { DNR_CUSTOM_PARAMS_RULE_ID, DNR_REMOTE_PARAMS_RULE_ID, DNR_ALLOWLIST_RULE_ID_BASE, DNR_ALLOWLIST_MAX_RULES } from "../lib/dnr-ids.js";
+import {
+  DNR_CUSTOM_PARAMS_RULE_ID,
+  DNR_REMOTE_PARAMS_RULE_ID,
+  DNR_ALLOWLIST_RULE_ID_BASE,
+  DNR_ALLOWLIST_MAX_RULES,
+  DNR_SUPPRESS_REFERER_RULE_ID,
+  DNR_BLOCK_BEACONS_RULE_ID,
+  DNR_BLOCKLIST_REFERER_RULE_ID_BASE,
+  DNR_BLOCKLIST_BEACON_RULE_ID_BASE,
+  DNR_BLOCKLIST_MAX_RULES,
+  ALLOWLIST_RESOURCE_TYPES,
+} from "../lib/dnr-ids.js";
 import { partitionRulesets } from "../lib/dnr-ruleset-state.js";
 import { t } from "../lib/i18n.js";
 import {
@@ -621,36 +632,12 @@ const ALLOWLIST_RULE_ID_RANGE = Array.from(
   (_, i) => DNR_ALLOWLIST_RULE_ID_BASE + i,
 );
 
-/**
- * Explicit resourceTypes list for the allowlist "allow" rule.
- *
- * IMPORTANT Chrome DNR gotcha: a rule condition that omits `resourceTypes`
- * (and `excludedResourceTypes`) matches every resource type EXCEPT
- * `main_frame` - main_frame is excluded from the "match everything" default.
- * Every real strip/redirect rule MUGA registers explicitly lists
- * `main_frame` (tracking-params.json, amp-redirect.json,
- * amazon-path-canonical.json, DNR_CUSTOM_PARAMS_RULE_ID in
- * syncCustomParamsDNR() above, wrapper-dnr-rules.json, remote-rules.js), so
- * an allow rule WITHOUT an explicit main_frame entry would never even be
- * considered for the single most common case - a top-level navigation to an
- * allowlisted domain with tracking params in the URL - leaving the exact
- * network-layer bug this feature exists to fix.
- *
- * This list is therefore explicit rather than omitted, at the cost of some
- * future-proofing: a resource type Chrome adds after this list is written
- * would not automatically be covered by the allow rule (it would need to be
- * appended here). That tradeoff is accepted because the alternative -
- * omitting resourceTypes - silently fails on main_frame today, not just in
- * some hypothetical future. Limited to the resource types stable since MV3's
- * initial DNR API to avoid rejecting the whole updateDynamicRules() call on
- * a browser/version that does not recognize a newer enum value (e.g.
- * Firefox MV2's DNR support).
- */
-const ALLOWLIST_RESOURCE_TYPES = [
-  "main_frame", "sub_frame", "stylesheet", "script", "image", "font",
-  "object", "xmlhttprequest", "ping", "csp_report", "media", "websocket",
-  "other",
-];
+// ALLOWLIST_RESOURCE_TYPES is imported from ../lib/dnr-ids.js (task 1.5,
+// referer-beacon-privacy): promoted to a shared constant so the allow rule
+// below and the global/blocklist Referer-suppression rules
+// (syncSuppressRefererDNR / syncBlocklistRefererDNR, PR 2) reference the
+// exact same list and cannot drift apart. See its JSDoc in dnr-ids.js for the
+// main_frame gotcha this list exists to guard against.
 
 /**
  * Syncs one dynamic DNR "allow" rule per fully-exempt domain
@@ -719,6 +706,202 @@ async function syncAllowlistDNR(prefs) {
   }
 }
 
+/**
+ * Syncs the dynamic GLOBAL Referer-suppression rule (referer-beacon-privacy,
+ * PR 2). Removes the `referer` request header on every http(s) request when
+ * `prefs.suppressReferer` is true; removes rule 2500 when false. Modeled on
+ * syncCustomParamsDNR() above: same hasDNR guard, try/catch, and
+ * updateDynamicRules() usage.
+ *
+ * Uses the shared ALLOWLIST_RESOURCE_TYPES list (same list syncAllowlistDNR's
+ * allow rule uses) so that rule, registered at priority 1000, deterministically
+ * shadows this one (priority 1) on allowlisted domains — see D3 in design.md.
+ * On a domain that is also on the blacklist, syncBlocklistRefererDNR's
+ * priority-2 rule fires the same action regardless of this rule/pref.
+ *
+ * @param {{ suppressReferer?: boolean }} prefs
+ */
+async function syncSuppressRefererDNR(prefs) {
+  if (!hasDNR) return;
+  try {
+    if (!prefs.suppressReferer) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: [DNR_SUPPRESS_REFERER_RULE_ID],
+        addRules: [],
+      });
+      return;
+    }
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: [DNR_SUPPRESS_REFERER_RULE_ID],
+      addRules: [{
+        id: DNR_SUPPRESS_REFERER_RULE_ID,
+        priority: 1,
+        action: {
+          type: "modifyHeaders",
+          requestHeaders: [{ header: "referer", operation: "remove" }],
+        },
+        condition: { urlFilter: "*", resourceTypes: ALLOWLIST_RESOURCE_TYPES },
+      }],
+    });
+  } catch (err) {
+    console.error("[MUGA] syncSuppressRefererDNR failed:", err);
+  }
+}
+
+/**
+ * Syncs the dynamic GLOBAL beacon-block rule (referer-beacon-privacy, PR 2).
+ * Blocks every "ping"-resourceType request (covers both `<a ping>` hyperlink
+ * auditing and `sendBeacon()`, the network-layer gap the DOM-layer
+ * `blockPings` pref cannot reach) when `prefs.blockBeacons` is true; removes
+ * rule 2600 when false. Modeled on syncCustomParamsDNR() above.
+ *
+ * @param {{ blockBeacons?: boolean }} prefs
+ */
+async function syncBlockBeaconsDNR(prefs) {
+  if (!hasDNR) return;
+  try {
+    if (!prefs.blockBeacons) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: [DNR_BLOCK_BEACONS_RULE_ID],
+        addRules: [],
+      });
+      return;
+    }
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: [DNR_BLOCK_BEACONS_RULE_ID],
+      addRules: [{
+        id: DNR_BLOCK_BEACONS_RULE_ID,
+        priority: 1,
+        action: { type: "block" },
+        condition: { resourceTypes: ["ping"] },
+      }],
+    });
+  } catch (err) {
+    console.error("[MUGA] syncBlockBeaconsDNR failed:", err);
+  }
+}
+
+// Full range of blocklist Referer-force rule IDs ever handed out (referer-
+// beacon-privacy, PR 2), mirroring ALLOWLIST_RULE_ID_RANGE above: a resync
+// always clears every previously-added rule so no stale force rule survives
+// a domain being removed from the blacklist.
+const BLOCKLIST_REFERER_RULE_ID_RANGE = Array.from(
+  { length: DNR_BLOCKLIST_MAX_RULES },
+  (_, i) => DNR_BLOCKLIST_REFERER_RULE_ID_BASE + i,
+);
+
+// Same as above, for the beacon-block force rule range.
+const BLOCKLIST_BEACON_RULE_ID_RANGE = Array.from(
+  { length: DNR_BLOCKLIST_MAX_RULES },
+  (_, i) => DNR_BLOCKLIST_BEACON_RULE_ID_BASE + i,
+);
+
+/**
+ * Syncs one dynamic DNR Referer force-suppress rule per bare-domain
+ * blacklist entry (referer-beacon-privacy, PR 2; D2 in design.md: the
+ * blocklist ALSO governs this feature). ACTIVE REGARDLESS of
+ * `prefs.suppressReferer` — a blacklisted domain forces Referer removal even
+ * when the global toggle is off, matching the blocklist's existing "be
+ * aggressive on this domain" meaning (Scenario D). Shadowed on a domain that
+ * is ALSO allowlisted by syncAllowlistDNR's priority-1000 allow rule
+ * (allowlist always wins).
+ *
+ * Structural clone of syncAllowlistDNR()'s clear-then-register pattern:
+ * clears the full BLOCKLIST_REFERER_RULE_ID_RANGE on every resync, caps at
+ * DNR_BLOCKLIST_MAX_RULES, and logs dropped domains rather than silently
+ * truncating.
+ *
+ * @param {{ blacklist?: string[] }} prefs
+ */
+async function syncBlocklistRefererDNR(prefs) {
+  if (!hasDNR) return;
+  try {
+    const domains = getFullyBlacklistedDomains(prefs);
+
+    if (domains.length === 0) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: BLOCKLIST_REFERER_RULE_ID_RANGE,
+        addRules: [],
+      });
+      return;
+    }
+
+    let syncedDomains = domains;
+    if (domains.length > DNR_BLOCKLIST_MAX_RULES) {
+      const dropped = domains.slice(DNR_BLOCKLIST_MAX_RULES);
+      syncedDomains = domains.slice(0, DNR_BLOCKLIST_MAX_RULES);
+      console.warn(
+        `[MUGA] syncBlocklistRefererDNR: ${domains.length} blacklisted domains exceed the ` +
+        `${DNR_BLOCKLIST_MAX_RULES}-rule cap; dropped from Referer force-suppress rules:`,
+        dropped,
+      );
+    }
+
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: BLOCKLIST_REFERER_RULE_ID_RANGE,
+      addRules: syncedDomains.map((domain, i) => ({
+        id: DNR_BLOCKLIST_REFERER_RULE_ID_BASE + i,
+        priority: 2,
+        action: {
+          type: "modifyHeaders",
+          requestHeaders: [{ header: "referer", operation: "remove" }],
+        },
+        condition: { requestDomains: [domain], resourceTypes: ALLOWLIST_RESOURCE_TYPES },
+      })),
+    });
+  } catch (err) {
+    console.error("[MUGA] syncBlocklistRefererDNR failed:", err);
+  }
+}
+
+/**
+ * Syncs one dynamic DNR beacon-block force rule per bare-domain blacklist
+ * entry (referer-beacon-privacy, PR 2; same D2 rationale as
+ * syncBlocklistRefererDNR above). ACTIVE REGARDLESS of `prefs.blockBeacons`.
+ * Referer removal and beacon blocking are distinct DNR action types, so a
+ * blacklisted domain needs a rule from both this function and
+ * syncBlocklistRefererDNR — they cannot be merged into one rule.
+ *
+ * @param {{ blacklist?: string[] }} prefs
+ */
+async function syncBlocklistBeaconsDNR(prefs) {
+  if (!hasDNR) return;
+  try {
+    const domains = getFullyBlacklistedDomains(prefs);
+
+    if (domains.length === 0) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: BLOCKLIST_BEACON_RULE_ID_RANGE,
+        addRules: [],
+      });
+      return;
+    }
+
+    let syncedDomains = domains;
+    if (domains.length > DNR_BLOCKLIST_MAX_RULES) {
+      const dropped = domains.slice(DNR_BLOCKLIST_MAX_RULES);
+      syncedDomains = domains.slice(0, DNR_BLOCKLIST_MAX_RULES);
+      console.warn(
+        `[MUGA] syncBlocklistBeaconsDNR: ${domains.length} blacklisted domains exceed the ` +
+        `${DNR_BLOCKLIST_MAX_RULES}-rule cap; dropped from beacon-block force rules:`,
+        dropped,
+      );
+    }
+
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: BLOCKLIST_BEACON_RULE_ID_RANGE,
+      addRules: syncedDomains.map((domain, i) => ({
+        id: DNR_BLOCKLIST_BEACON_RULE_ID_BASE + i,
+        priority: 2,
+        action: { type: "block" },
+        condition: { requestDomains: [domain], resourceTypes: ["ping"] },
+      })),
+    });
+  } catch (err) {
+    console.error("[MUGA] syncBlocklistBeaconsDNR failed:", err);
+  }
+}
+
 async function applyDnrState(prefs) {
   if (!hasDNR) return;
   // Gate DNR on onboardingDone too (#consent-gate). Content scripts
@@ -759,6 +942,16 @@ async function applyDnrState(prefs) {
     // live (see the storage.onChanged handler below and the mugaConsent /
     // mugaPerDevicePrefs branches, all of which call applyDnrState).
     await syncAllowlistDNR(prefs);
+    // Referer/beacon privacy layer (referer-beacon-privacy, PR 2): two
+    // global rules gated on their own pref (suppressReferer/blockBeacons)
+    // plus two per-domain blocklist-force rule families that are ACTIVE
+    // REGARDLESS of those prefs (D2 in design.md). Order here matches the
+    // priority scheme documented in dnr-ids.js and design.md: allowlist
+    // allow (1000, synced above) > blocklist force (2) > global suppress (1).
+    await syncSuppressRefererDNR(prefs);
+    await syncBlockBeaconsDNR(prefs);
+    await syncBlocklistRefererDNR(prefs);
+    await syncBlocklistBeaconsDNR(prefs);
     // Re-arm the dynamic remote-params rule (id 1001). The gate-closed branch
     // removes it (#921), so a close→open cycle — or a wake where the weekly
     // signed fetch is time-gated and skips re-adding it — would otherwise leave
@@ -780,6 +973,16 @@ async function applyDnrState(prefs) {
     // out-prioritize - leaving them registered would just be a stale,
     // unnecessary MUGA network footprint while the extension is off.
     await syncAllowlistDNR({ whitelist: [], blacklist: [] });
+    // Clear the referer/beacon privacy rules too (referer-beacon-privacy,
+    // PR 2): the two global rules (2500/2600) AND the full per-domain
+    // blocklist-force ranges (2700-2899/2900-3099). "Always aggressive on
+    // this domain" (blocklist-force) still yields to "extension not yet
+    // accepted / disabled" — no Referer removal or beacon block, global or
+    // blocklist-forced, may run before onboardingDone or while disabled.
+    await syncSuppressRefererDNR({ suppressReferer: false });
+    await syncBlockBeaconsDNR({ blockBeacons: false });
+    await syncBlocklistRefererDNR({ blacklist: [] });
+    await syncBlocklistBeaconsDNR({ blacklist: [] });
     // Disabling the static rulesets and clearing rule 1000 is NOT enough: the
     // remote-params rule (dynamic id 1001) is a DNR redirect that keeps
     // stripping params for a disabled or non-consented extension. Remove it so
@@ -1161,10 +1364,13 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
   _invalidatePrefsCache();
   if (changes.customParams || changes.dnrEnabled || changes.enabled ||
       changes.ampRedirect || changes.unwrapRedirects ||
-      changes.whitelist || changes.blacklist) {
+      changes.whitelist || changes.blacklist ||
+      changes.suppressReferer || changes.blockBeacons) {
     // whitelist/blacklist (#allowlist-full-inert): toggling the allowlist or
     // the per-site pause must re-sync the DNR allow rules live, without
-    // requiring the user to also flip an unrelated pref.
+    // requiring the user to also flip an unrelated pref. suppressReferer /
+    // blockBeacons (referer-beacon-privacy, PR 2) need the same live re-sync
+    // once a future UI (PR 4) lets a user flip them.
     const prefs = await getPrefsWithCache();
     await applyDnrState(prefs);
   }

--- a/src/lib/dnr-ids.js
+++ b/src/lib/dnr-ids.js
@@ -160,3 +160,41 @@ export const DNR_BLOCKLIST_BEACON_RULE_ID_BASE = 2900;
  * dropped rather than truncating silently.
  */
 export const DNR_BLOCKLIST_MAX_RULES = 200;
+
+/**
+ * Shared `resourceTypes` list for every dynamic DNR rule that must cover the
+ * same surface as the allowlist "allow" rule (#allowlist-full-inert) — the
+ * global/blocklist Referer-suppression rules (referer-beacon-privacy, PR 2)
+ * AND `syncAllowlistDNR()`'s allow rule itself. Promoted here (task 1.5) as
+ * the single source of truth so the two can never drift: if they did, a
+ * domain could be allowlisted for one resource type but still have its
+ * Referer stripped for another, silently breaking the "allowlist always
+ * wins" guarantee (D2/D3 in design.md).
+ *
+ * IMPORTANT Chrome DNR gotcha: a rule condition that omits `resourceTypes`
+ * (and `excludedResourceTypes`) matches every resource type EXCEPT
+ * `main_frame` - main_frame is excluded from the "match everything" default.
+ * Every real strip/redirect rule MUGA registers explicitly lists
+ * `main_frame` (tracking-params.json, amp-redirect.json,
+ * amazon-path-canonical.json, DNR_CUSTOM_PARAMS_RULE_ID in
+ * syncCustomParamsDNR(), wrapper-dnr-rules.json, remote-rules.js), so an
+ * allow/suppress rule WITHOUT an explicit main_frame entry would never even
+ * be considered for the single most common case - a top-level navigation to
+ * an allowlisted or Referer-suppressed domain - leaving the exact
+ * network-layer bug this feature exists to fix.
+ *
+ * This list is therefore explicit rather than omitted, at the cost of some
+ * future-proofing: a resource type Chrome adds after this list is written
+ * would not automatically be covered by rules that reference it (it would
+ * need to be appended here). That tradeoff is accepted because the
+ * alternative - omitting resourceTypes - silently fails on main_frame today,
+ * not just in some hypothetical future. Limited to the resource types stable
+ * since MV3's initial DNR API to avoid rejecting the whole
+ * updateDynamicRules() call on a browser/version that does not recognize a
+ * newer enum value (e.g. Firefox MV2's DNR support).
+ */
+export const ALLOWLIST_RESOURCE_TYPES = [
+  "main_frame", "sub_frame", "stylesheet", "script", "image", "font",
+  "object", "xmlhttprequest", "ping", "csp_report", "media", "websocket",
+  "other",
+];

--- a/tests/unit/allowlist-dnr.test.mjs
+++ b/tests/unit/allowlist-dnr.test.mjs
@@ -19,7 +19,13 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { getFullyExemptDomains } from "../../src/lib/cleaner.js";
-import { DNR_ALLOWLIST_RULE_ID_BASE, DNR_ALLOWLIST_MAX_RULES, DNR_CUSTOM_PARAMS_RULE_ID, DNR_REMOTE_PARAMS_RULE_ID } from "../../src/lib/dnr-ids.js";
+import {
+  DNR_ALLOWLIST_RULE_ID_BASE,
+  DNR_ALLOWLIST_MAX_RULES,
+  DNR_CUSTOM_PARAMS_RULE_ID,
+  DNR_REMOTE_PARAMS_RULE_ID,
+  ALLOWLIST_RESOURCE_TYPES as IMPORTED_ALLOWLIST_RESOURCE_TYPES,
+} from "../../src/lib/dnr-ids.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const swSource = readFileSync(
@@ -223,9 +229,12 @@ describe("syncAllowlistDNR — cap and warn, no silent truncation", () => {
 // regions are extracted ONCE each and every subsequent check runs against
 // the extracted (non-"...Source"-named) local, keeping this file's
 // source-grep footprint minimal per the #824 ratchet.
-
-const resourceTypesStart = swSource.indexOf("const ALLOWLIST_RESOURCE_TYPES = [");
-const resourceTypesBlock = swSource.slice(resourceTypesStart, resourceTypesStart + 300);
+//
+// ALLOWLIST_RESOURCE_TYPES was promoted to a shared export in dnr-ids.js
+// (referer-beacon-privacy task 1.5), so its main_frame-inclusion check is now
+// a BEHAVIORAL assertion against the real import (IMPORTED_ALLOWLIST_RESOURCE_TYPES
+// above) instead of a source-string scrape — this LOWERS this file's
+// source-grep footprint by one, per the #824 ratchet's stated goal.
 
 const syncFnStart = swSource.indexOf("async function syncAllowlistDNR(");
 const syncFnBlock = swSource.slice(syncFnStart, syncFnStart + 1800);
@@ -251,7 +260,7 @@ describe("service-worker.js source guards — syncAllowlistDNR present and wired
     assert.ok(syncFnBlock.includes("priority: 1000"));
     assert.ok(syncFnBlock.includes("requestDomains: [domain]"));
     assert.ok(syncFnBlock.includes("resourceTypes: ALLOWLIST_RESOURCE_TYPES"), "the allow rule must use the explicit resourceTypes list (Chrome excludes main_frame by default otherwise)");
-    assert.ok(resourceTypesBlock.includes('"main_frame"'), "ALLOWLIST_RESOURCE_TYPES must explicitly include main_frame");
+    assert.ok(IMPORTED_ALLOWLIST_RESOURCE_TYPES.includes("main_frame"), "ALLOWLIST_RESOURCE_TYPES must explicitly include main_frame");
   });
 
   test("applyDnrState calls syncAllowlistDNR after syncCustomParamsDNR in the gate-open branch, and clears it in the gate-closed branch", () => {

--- a/tests/unit/referer-beacon-privacy-dnr.test.mjs
+++ b/tests/unit/referer-beacon-privacy-dnr.test.mjs
@@ -1,0 +1,531 @@
+/**
+ * MUGA — referer-beacon-privacy, PR 2 (Chrome DNR Enforcement): unit tests
+ * for the four new dynamic-rule sync functions and their applyDnrState()
+ * wiring (tasks 2.6-2.9).
+ *
+ * The service worker has no behavioral unit harness (Chrome API bindings at
+ * module scope), so this file follows the established pattern from
+ * tests/unit/allowlist-dnr.test.mjs and tests/unit/dnr-consent-gate.test.mjs:
+ * a pure extraction of each sync algorithm exercised against a fake
+ * declarativeNetRequest facade, plus source guards confirming the production
+ * service-worker.js actually wires the real functions in with the same
+ * shapes/priorities/ranges.
+ *
+ * getFullyBlacklistedDomains() itself is NOT reimplemented here — it is
+ * imported directly from src/lib/cleaner.js, so these tests exercise the
+ * real domain-selection logic and only stub the chrome.* boundary.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { getFullyExemptDomains, getFullyBlacklistedDomains } from "../../src/lib/cleaner.js";
+import {
+  DNR_SUPPRESS_REFERER_RULE_ID,
+  DNR_BLOCK_BEACONS_RULE_ID,
+  DNR_BLOCKLIST_REFERER_RULE_ID_BASE,
+  DNR_BLOCKLIST_BEACON_RULE_ID_BASE,
+  DNR_BLOCKLIST_MAX_RULES,
+  DNR_ALLOWLIST_RULE_ID_BASE,
+  DNR_ALLOWLIST_MAX_RULES,
+  ALLOWLIST_RESOURCE_TYPES,
+} from "../../src/lib/dnr-ids.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const swSource = readFileSync(
+  join(__dirname, "../../src/background/service-worker.js"),
+  "utf8",
+);
+
+// ── Pure implementations under test ──────────────────────────────────────────
+//
+// Each mirrors its service-worker.js counterpart exactly (same removeRuleIds
+// range, same rule shape, same cap-and-warn behavior) but wired to a fake DNR
+// facade so the exact calls can be asserted without a browser.
+
+async function syncSuppressRefererDNRLogic(prefs, dnrApi) {
+  if (!prefs.suppressReferer) {
+    await dnrApi.updateDynamicRules({ removeRuleIds: [DNR_SUPPRESS_REFERER_RULE_ID], addRules: [] });
+    return;
+  }
+  await dnrApi.updateDynamicRules({
+    removeRuleIds: [DNR_SUPPRESS_REFERER_RULE_ID],
+    addRules: [{
+      id: DNR_SUPPRESS_REFERER_RULE_ID,
+      priority: 1,
+      action: { type: "modifyHeaders", requestHeaders: [{ header: "referer", operation: "remove" }] },
+      condition: { urlFilter: "*", resourceTypes: ALLOWLIST_RESOURCE_TYPES },
+    }],
+  });
+}
+
+async function syncBlockBeaconsDNRLogic(prefs, dnrApi) {
+  if (!prefs.blockBeacons) {
+    await dnrApi.updateDynamicRules({ removeRuleIds: [DNR_BLOCK_BEACONS_RULE_ID], addRules: [] });
+    return;
+  }
+  await dnrApi.updateDynamicRules({
+    removeRuleIds: [DNR_BLOCK_BEACONS_RULE_ID],
+    addRules: [{
+      id: DNR_BLOCK_BEACONS_RULE_ID,
+      priority: 1,
+      action: { type: "block" },
+      condition: { resourceTypes: ["ping"] },
+    }],
+  });
+}
+
+const BLOCKLIST_REFERER_RULE_ID_RANGE = Array.from(
+  { length: DNR_BLOCKLIST_MAX_RULES },
+  (_, i) => DNR_BLOCKLIST_REFERER_RULE_ID_BASE + i,
+);
+const BLOCKLIST_BEACON_RULE_ID_RANGE = Array.from(
+  { length: DNR_BLOCKLIST_MAX_RULES },
+  (_, i) => DNR_BLOCKLIST_BEACON_RULE_ID_BASE + i,
+);
+
+async function syncBlocklistRefererDNRLogic(prefs, dnrApi, warn) {
+  const domains = getFullyBlacklistedDomains(prefs);
+  if (domains.length === 0) {
+    await dnrApi.updateDynamicRules({ removeRuleIds: BLOCKLIST_REFERER_RULE_ID_RANGE, addRules: [] });
+    return;
+  }
+  let syncedDomains = domains;
+  if (domains.length > DNR_BLOCKLIST_MAX_RULES) {
+    const dropped = domains.slice(DNR_BLOCKLIST_MAX_RULES);
+    syncedDomains = domains.slice(0, DNR_BLOCKLIST_MAX_RULES);
+    warn?.(dropped);
+  }
+  await dnrApi.updateDynamicRules({
+    removeRuleIds: BLOCKLIST_REFERER_RULE_ID_RANGE,
+    addRules: syncedDomains.map((domain, i) => ({
+      id: DNR_BLOCKLIST_REFERER_RULE_ID_BASE + i,
+      priority: 2,
+      action: { type: "modifyHeaders", requestHeaders: [{ header: "referer", operation: "remove" }] },
+      condition: { requestDomains: [domain], resourceTypes: ALLOWLIST_RESOURCE_TYPES },
+    })),
+  });
+}
+
+async function syncBlocklistBeaconsDNRLogic(prefs, dnrApi, warn) {
+  const domains = getFullyBlacklistedDomains(prefs);
+  if (domains.length === 0) {
+    await dnrApi.updateDynamicRules({ removeRuleIds: BLOCKLIST_BEACON_RULE_ID_RANGE, addRules: [] });
+    return;
+  }
+  let syncedDomains = domains;
+  if (domains.length > DNR_BLOCKLIST_MAX_RULES) {
+    const dropped = domains.slice(DNR_BLOCKLIST_MAX_RULES);
+    syncedDomains = domains.slice(0, DNR_BLOCKLIST_MAX_RULES);
+    warn?.(dropped);
+  }
+  await dnrApi.updateDynamicRules({
+    removeRuleIds: BLOCKLIST_BEACON_RULE_ID_RANGE,
+    addRules: syncedDomains.map((domain, i) => ({
+      id: DNR_BLOCKLIST_BEACON_RULE_ID_BASE + i,
+      priority: 2,
+      action: { type: "block" },
+      condition: { requestDomains: [domain], resourceTypes: ["ping"] },
+    })),
+  });
+}
+
+// Mirrors syncAllowlistDNR() exactly (see tests/unit/allowlist-dnr.test.mjs) —
+// needed here only for the precedence tests (2.8), which must prove the
+// allow rule still registers even when a domain is ALSO blacklisted.
+const ALLOWLIST_RULE_ID_RANGE = Array.from(
+  { length: DNR_ALLOWLIST_MAX_RULES },
+  (_, i) => DNR_ALLOWLIST_RULE_ID_BASE + i,
+);
+async function syncAllowlistDNRLogic(prefs, dnrApi) {
+  const domains = getFullyExemptDomains(prefs);
+  if (domains.length === 0) {
+    await dnrApi.updateDynamicRules({ removeRuleIds: ALLOWLIST_RULE_ID_RANGE, addRules: [] });
+    return;
+  }
+  await dnrApi.updateDynamicRules({
+    removeRuleIds: ALLOWLIST_RULE_ID_RANGE,
+    addRules: domains.map((domain, i) => ({
+      id: DNR_ALLOWLIST_RULE_ID_BASE + i,
+      priority: 1000,
+      action: { type: "allow" },
+      condition: { requestDomains: [domain], resourceTypes: ALLOWLIST_RESOURCE_TYPES },
+    })),
+  });
+}
+
+// Mirrors the applyDnrState() gate-open/gate-closed wiring for JUST the four
+// new sync fns (task 2.5), so the consent-gate behavior (task 2.9) can be
+// asserted without a browser.
+async function applyReferBeaconGateLogic(prefs, gateOpen, dnrApi, warn) {
+  if (gateOpen) {
+    await syncSuppressRefererDNRLogic(prefs, dnrApi);
+    await syncBlockBeaconsDNRLogic(prefs, dnrApi);
+    await syncBlocklistRefererDNRLogic(prefs, dnrApi, warn);
+    await syncBlocklistBeaconsDNRLogic(prefs, dnrApi, warn);
+  } else {
+    await syncSuppressRefererDNRLogic({ suppressReferer: false }, dnrApi);
+    await syncBlockBeaconsDNRLogic({ blockBeacons: false }, dnrApi);
+    await syncBlocklistRefererDNRLogic({ blacklist: [] }, dnrApi);
+    await syncBlocklistBeaconsDNRLogic({ blacklist: [] }, dnrApi);
+  }
+}
+
+function makeFakeDnr() {
+  const calls = [];
+  return {
+    calls,
+    updateDynamicRules(opts) {
+      calls.push(structuredClone(opts));
+      return Promise.resolve();
+    },
+  };
+}
+
+// ── 2.6: global rule shapes ──────────────────────────────────────────────────
+
+describe("syncSuppressRefererDNR — global Referer-suppress rule (2500)", () => {
+  test("suppressReferer:true registers id 2500, priority 1, modifyHeaders remove referer, shared resourceTypes", async () => {
+    const dnr = makeFakeDnr();
+    await syncSuppressRefererDNRLogic({ suppressReferer: true }, dnr);
+
+    assert.strictEqual(dnr.calls.length, 1);
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 1);
+    const rule = call.addRules[0];
+    assert.strictEqual(rule.id, DNR_SUPPRESS_REFERER_RULE_ID);
+    assert.strictEqual(rule.priority, 1);
+    assert.strictEqual(rule.action.type, "modifyHeaders");
+    assert.deepEqual(rule.action.requestHeaders, [{ header: "referer", operation: "remove" }]);
+    assert.strictEqual(rule.condition.urlFilter, "*");
+    assert.deepEqual(rule.condition.resourceTypes, ALLOWLIST_RESOURCE_TYPES);
+  });
+
+  test("suppressReferer:false removes rule 2500, adds nothing", async () => {
+    const dnr = makeFakeDnr();
+    await syncSuppressRefererDNRLogic({ suppressReferer: false }, dnr);
+
+    const call = dnr.calls[0];
+    assert.deepEqual(call.removeRuleIds, [DNR_SUPPRESS_REFERER_RULE_ID]);
+    assert.strictEqual(call.addRules.length, 0);
+  });
+});
+
+describe("syncBlockBeaconsDNR — global beacon-block rule (2600)", () => {
+  test("blockBeacons:true registers id 2600, priority 1, block, resourceTypes [\"ping\"]", async () => {
+    const dnr = makeFakeDnr();
+    await syncBlockBeaconsDNRLogic({ blockBeacons: true }, dnr);
+
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 1);
+    const rule = call.addRules[0];
+    assert.strictEqual(rule.id, DNR_BLOCK_BEACONS_RULE_ID);
+    assert.strictEqual(rule.priority, 1);
+    assert.strictEqual(rule.action.type, "block");
+    assert.deepEqual(rule.condition.resourceTypes, ["ping"]);
+  });
+
+  test("blockBeacons:false removes rule 2600, adds nothing", async () => {
+    const dnr = makeFakeDnr();
+    await syncBlockBeaconsDNRLogic({ blockBeacons: false }, dnr);
+
+    const call = dnr.calls[0];
+    assert.deepEqual(call.removeRuleIds, [DNR_BLOCK_BEACONS_RULE_ID]);
+    assert.strictEqual(call.addRules.length, 0);
+  });
+});
+
+// ── 2.7: per-domain blocklist rules ──────────────────────────────────────────
+
+describe("syncBlocklistRefererDNR / syncBlocklistBeaconsDNR — per-domain force rules", () => {
+  test("one bare-domain blacklist entry yields a Referer force rule (2700+, priority 2, requestDomains-scoped)", async () => {
+    const dnr = makeFakeDnr();
+    await syncBlocklistRefererDNRLogic({ blacklist: ["blocked.com"] }, dnr);
+
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 1);
+    const rule = call.addRules[0];
+    assert.ok(rule.id >= DNR_BLOCKLIST_REFERER_RULE_ID_BASE && rule.id < DNR_BLOCKLIST_REFERER_RULE_ID_BASE + DNR_BLOCKLIST_MAX_RULES);
+    assert.strictEqual(rule.priority, 2);
+    assert.strictEqual(rule.action.type, "modifyHeaders");
+    assert.deepEqual(rule.action.requestHeaders, [{ header: "referer", operation: "remove" }]);
+    assert.deepEqual(rule.condition.requestDomains, ["blocked.com"]);
+    assert.deepEqual(rule.condition.resourceTypes, ALLOWLIST_RESOURCE_TYPES);
+  });
+
+  test("the SAME bare-domain blacklist entry ALSO yields a beacon force rule (2900+, priority 2, block, [\"ping\"])", async () => {
+    const dnr = makeFakeDnr();
+    await syncBlocklistBeaconsDNRLogic({ blacklist: ["blocked.com"] }, dnr);
+
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 1);
+    const rule = call.addRules[0];
+    assert.ok(rule.id >= DNR_BLOCKLIST_BEACON_RULE_ID_BASE && rule.id < DNR_BLOCKLIST_BEACON_RULE_ID_BASE + DNR_BLOCKLIST_MAX_RULES);
+    assert.strictEqual(rule.priority, 2);
+    assert.strictEqual(rule.action.type, "block");
+    assert.deepEqual(rule.condition.requestDomains, ["blocked.com"]);
+    assert.deepEqual(rule.condition.resourceTypes, ["ping"]);
+  });
+
+  test("a param-scoped blacklist entry produces NEITHER a Referer nor a beacon force rule", async () => {
+    const refererDnr = makeFakeDnr();
+    const beaconDnr = makeFakeDnr();
+    await syncBlocklistRefererDNRLogic({ blacklist: ["booking.com::aid::123456"] }, refererDnr);
+    await syncBlocklistBeaconsDNRLogic({ blacklist: ["booking.com::aid::123456"] }, beaconDnr);
+
+    assert.strictEqual(refererDnr.calls[0].addRules.length, 0);
+    assert.strictEqual(beaconDnr.calls[0].addRules.length, 0);
+  });
+
+  test("every resync clears the FULL id range for both families before adding the current set", async () => {
+    const refererDnr = makeFakeDnr();
+    const beaconDnr = makeFakeDnr();
+    await syncBlocklistRefererDNRLogic({ blacklist: ["a.com"] }, refererDnr);
+    await syncBlocklistBeaconsDNRLogic({ blacklist: ["a.com"] }, beaconDnr);
+
+    assert.strictEqual(refererDnr.calls[0].removeRuleIds.length, DNR_BLOCKLIST_MAX_RULES);
+    assert.ok(refererDnr.calls[0].removeRuleIds.includes(DNR_BLOCKLIST_REFERER_RULE_ID_BASE));
+    assert.ok(refererDnr.calls[0].removeRuleIds.includes(DNR_BLOCKLIST_REFERER_RULE_ID_BASE + DNR_BLOCKLIST_MAX_RULES - 1));
+
+    assert.strictEqual(beaconDnr.calls[0].removeRuleIds.length, DNR_BLOCKLIST_MAX_RULES);
+    assert.ok(beaconDnr.calls[0].removeRuleIds.includes(DNR_BLOCKLIST_BEACON_RULE_ID_BASE));
+    assert.ok(beaconDnr.calls[0].removeRuleIds.includes(DNR_BLOCKLIST_BEACON_RULE_ID_BASE + DNR_BLOCKLIST_MAX_RULES - 1));
+  });
+
+  test("a domain removed from the blacklist drops its force rules on the next resync (empty blacklist -> addRules empty, range still cleared)", async () => {
+    const dnr = makeFakeDnr();
+    await syncBlocklistRefererDNRLogic({ blacklist: [] }, dnr);
+
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 0);
+    assert.strictEqual(call.removeRuleIds.length, DNR_BLOCKLIST_MAX_RULES);
+  });
+
+  test("blacklisted-domain count over DNR_BLOCKLIST_MAX_RULES: only the cap is added, excess reported via warn (not silently dropped)", async () => {
+    const dnr = makeFakeDnr();
+    const many = Array.from({ length: DNR_BLOCKLIST_MAX_RULES + 5 }, (_, i) => `d${i}.com`);
+    let warnedDropped = null;
+    await syncBlocklistRefererDNRLogic({ blacklist: many }, dnr, (dropped) => { warnedDropped = dropped; });
+
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, DNR_BLOCKLIST_MAX_RULES);
+    assert.ok(Array.isArray(warnedDropped), "cap overflow must be reported, not silently dropped");
+    assert.strictEqual(warnedDropped.length, 5);
+  });
+
+  test("blacklisted-domain count under the cap: warn callback is never invoked", async () => {
+    const dnr = makeFakeDnr();
+    let warnCalled = false;
+    await syncBlocklistBeaconsDNRLogic({ blacklist: ["only-one.com"] }, dnr, () => { warnCalled = true; });
+    assert.strictEqual(warnCalled, false);
+  });
+
+  test("multiple blacklisted domains each get their own rule with distinct ids", async () => {
+    const dnr = makeFakeDnr();
+    await syncBlocklistBeaconsDNRLogic({ blacklist: ["a.com", "b.com"] }, dnr);
+
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 2);
+    const ids = call.addRules.map((r) => r.id);
+    assert.strictEqual(new Set(ids).size, ids.length, "rule ids must be unique");
+  });
+});
+
+// ── 2.8: precedence — allowlist wins ────────────────────────────────────────
+
+describe("Precedence — allowlist allow (1000) shadows blocklist-force (2) and global-suppress (1)", () => {
+  test("a domain-only whitelist entry produces the priority-1000 allow rule covering the SAME resourceTypes as the global Referer rule", async () => {
+    const allowDnr = makeFakeDnr();
+    const globalDnr = makeFakeDnr();
+    await syncAllowlistDNRLogic({ whitelist: ["example.com"], blacklist: [] }, allowDnr);
+    await syncSuppressRefererDNRLogic({ suppressReferer: true }, globalDnr);
+
+    const allowRule = allowDnr.calls[0].addRules[0];
+    const globalRule = globalDnr.calls[0].addRules[0];
+    assert.strictEqual(allowRule.priority, 1000);
+    assert.strictEqual(globalRule.priority, 1);
+    assert.ok(allowRule.priority > globalRule.priority);
+    assert.deepEqual(allowRule.condition.resourceTypes, globalRule.condition.resourceTypes,
+      "allow rule and global suppress rule must share the exact same resourceTypes list so the allow shadows it on every type");
+  });
+
+  test("a domain-only whitelist entry produces the priority-1000 allow rule covering the SAME resourceTypes as the blocklist Referer-force rule", async () => {
+    const allowDnr = makeFakeDnr();
+    const forceDnr = makeFakeDnr();
+    await syncAllowlistDNRLogic({ whitelist: ["example.com"], blacklist: [] }, allowDnr);
+    await syncBlocklistRefererDNRLogic({ blacklist: ["example.com"] }, forceDnr);
+
+    const allowRule = allowDnr.calls[0].addRules[0];
+    const forceRule = forceDnr.calls[0].addRules[0];
+    assert.strictEqual(allowRule.priority, 1000);
+    assert.strictEqual(forceRule.priority, 2);
+    assert.ok(allowRule.priority > forceRule.priority);
+    assert.deepEqual(allowRule.condition.resourceTypes, forceRule.condition.resourceTypes);
+  });
+
+  test("a domain on BOTH the whitelist and the blacklist still registers the allow rule (allowlist wins)", async () => {
+    const dnr = makeFakeDnr();
+    await syncAllowlistDNRLogic({ whitelist: ["both.com"], blacklist: ["both.com"] }, dnr);
+
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 1, "the allow rule must still register even though the domain is also blacklisted");
+    assert.strictEqual(call.addRules[0].condition.requestDomains[0], "both.com");
+    assert.strictEqual(call.addRules[0].action.type, "allow");
+  });
+
+  test("a domain on BOTH lists still yields a blocklist force rule too (force rule is pref-independent; the ALLOW rule is what shadows it, not the force sync itself omitting it)", async () => {
+    const dnr = makeFakeDnr();
+    await syncBlocklistRefererDNRLogic({ blacklist: ["both.com"] }, dnr);
+
+    // getFullyBlacklistedDomains only reads prefs.blacklist — it has no
+    // knowledge of the whitelist, so the force rule is generated regardless.
+    // Chrome's real engine is what makes the priority-1000 allow rule win;
+    // that precedence is asserted via priority comparison above.
+    const call = dnr.calls[0];
+    assert.strictEqual(call.addRules.length, 1);
+    assert.strictEqual(call.addRules[0].condition.requestDomains[0], "both.com");
+  });
+});
+
+// ── 2.9: consent gate ────────────────────────────────────────────────────────
+
+describe("Consent gate — gate-closed removes all four rule families; global pref-OFF keeps blocklist force rules", () => {
+  test("gate-closed removes rule 2500, rule 2600, and clears the full 2700-2899/2900-3099 ranges", async () => {
+    const dnr = makeFakeDnr();
+    await applyReferBeaconGateLogic(
+      { suppressReferer: true, blockBeacons: true, blacklist: ["forced.com"] },
+      false,
+      dnr,
+    );
+
+    // 4 calls: suppress-referer clear, block-beacons clear, blocklist-referer clear, blocklist-beacon clear.
+    assert.strictEqual(dnr.calls.length, 4);
+    const [suppressCall, beaconCall, blocklistRefererCall, blocklistBeaconCall] = dnr.calls;
+
+    assert.deepEqual(suppressCall.removeRuleIds, [DNR_SUPPRESS_REFERER_RULE_ID]);
+    assert.strictEqual(suppressCall.addRules.length, 0);
+
+    assert.deepEqual(beaconCall.removeRuleIds, [DNR_BLOCK_BEACONS_RULE_ID]);
+    assert.strictEqual(beaconCall.addRules.length, 0);
+
+    assert.strictEqual(blocklistRefererCall.removeRuleIds.length, DNR_BLOCKLIST_MAX_RULES);
+    assert.strictEqual(blocklistRefererCall.addRules.length, 0,
+      "gate-closed must clear blocklist-force rules too, even though a domain IS blacklisted — consent gate wins over 'always aggressive here'");
+
+    assert.strictEqual(blocklistBeaconCall.removeRuleIds.length, DNR_BLOCKLIST_MAX_RULES);
+    assert.strictEqual(blocklistBeaconCall.addRules.length, 0);
+  });
+
+  test("gate-open + global pref OFF: removes only the global rule but KEEPS blocklist force rules active", async () => {
+    const dnr = makeFakeDnr();
+    await applyReferBeaconGateLogic(
+      { suppressReferer: false, blockBeacons: false, blacklist: ["forced.com"] },
+      true,
+      dnr,
+    );
+
+    assert.strictEqual(dnr.calls.length, 4);
+    const [suppressCall, beaconCall, blocklistRefererCall, blocklistBeaconCall] = dnr.calls;
+
+    assert.strictEqual(suppressCall.addRules.length, 0, "global Referer rule must be removed when suppressReferer is false");
+    assert.strictEqual(beaconCall.addRules.length, 0, "global beacon rule must be removed when blockBeacons is false");
+
+    assert.strictEqual(blocklistRefererCall.addRules.length, 1,
+      "blocklist Referer force rule must STILL be registered even though the global pref is OFF (D2 override)");
+    assert.strictEqual(blocklistRefererCall.addRules[0].condition.requestDomains[0], "forced.com");
+
+    assert.strictEqual(blocklistBeaconCall.addRules.length, 1,
+      "blocklist beacon force rule must STILL be registered even though the global pref is OFF (D2 override)");
+    assert.strictEqual(blocklistBeaconCall.addRules[0].condition.requestDomains[0], "forced.com");
+  });
+
+  test("gate-open + global prefs ON + no blacklisted domains: both global rules register, blocklist ranges are cleared with no rules added", async () => {
+    const dnr = makeFakeDnr();
+    await applyReferBeaconGateLogic(
+      { suppressReferer: true, blockBeacons: true, blacklist: [] },
+      true,
+      dnr,
+    );
+
+    const [suppressCall, beaconCall, blocklistRefererCall, blocklistBeaconCall] = dnr.calls;
+    assert.strictEqual(suppressCall.addRules.length, 1);
+    assert.strictEqual(beaconCall.addRules.length, 1);
+    assert.strictEqual(blocklistRefererCall.addRules.length, 0);
+    assert.strictEqual(blocklistBeaconCall.addRules.length, 0);
+  });
+});
+
+// ── Source-level guards: verify the production SW was updated ───────────────
+
+const swFnStart = swSource.indexOf("async function syncSuppressRefererDNR(");
+const swFnBlock = swSource.slice(swFnStart, swFnStart + 6500); // covers all four fns
+const applyFnStart = swSource.indexOf("async function applyDnrState(");
+const applyFnBlock = swSource.slice(applyFnStart, applyFnStart + 6000);
+const gateClosedBlock = applyFnBlock.slice(applyFnBlock.indexOf("Gate closed:"));
+
+describe("service-worker.js source guards — the four new sync fns exist and are wired", () => {
+  test("all four sync functions exist, guard on hasDNR, and use try/catch", () => {
+    assert.ok(swFnStart !== -1, "syncSuppressRefererDNR must exist in the service worker");
+    for (const name of [
+      "async function syncSuppressRefererDNR(",
+      "async function syncBlockBeaconsDNR(",
+      "async function syncBlocklistRefererDNR(",
+      "async function syncBlocklistBeaconsDNR(",
+    ]) {
+      assert.ok(swSource.includes(name), `${name} must exist`);
+    }
+    assert.ok(swFnBlock.includes("if (!hasDNR) return;"));
+    assert.ok(swFnBlock.includes("try {") && swFnBlock.includes("catch (err)"));
+  });
+
+  test("syncBlocklistRefererDNR / syncBlocklistBeaconsDNR derive domains via getFullyBlacklistedDomains, not a reimplementation", () => {
+    assert.ok(swFnBlock.includes("getFullyBlacklistedDomains"),
+      "must derive blacklisted domains via getFullyBlacklistedDomains, not reimplement domain matching");
+  });
+
+  test("global Referer rule uses the shared ALLOWLIST_RESOURCE_TYPES import (task 1.5) and id 2500", () => {
+    assert.ok(swFnBlock.includes("DNR_SUPPRESS_REFERER_RULE_ID"));
+    assert.ok(swFnBlock.includes("resourceTypes: ALLOWLIST_RESOURCE_TYPES"));
+  });
+
+  test("ALLOWLIST_RESOURCE_TYPES is imported from ../lib/dnr-ids.js, not re-declared locally", () => {
+    assert.ok(
+      swSource.includes('ALLOWLIST_RESOURCE_TYPES,') && swSource.includes('from "../lib/dnr-ids.js"'),
+      "ALLOWLIST_RESOURCE_TYPES must be imported from dnr-ids.js (task 1.5)",
+    );
+    assert.ok(
+      !swSource.includes("const ALLOWLIST_RESOURCE_TYPES = ["),
+      "service-worker.js must not re-declare ALLOWLIST_RESOURCE_TYPES locally after promoting it to dnr-ids.js",
+    );
+  });
+
+  test("applyDnrState gate-open branch calls all four sync fns after syncAllowlistDNR", () => {
+    const allowIdx = applyFnBlock.indexOf("await syncAllowlistDNR(prefs);");
+    const suppressIdx = applyFnBlock.indexOf("await syncSuppressRefererDNR(prefs);");
+    const beaconIdx = applyFnBlock.indexOf("await syncBlockBeaconsDNR(prefs);");
+    const blocklistRefererIdx = applyFnBlock.indexOf("await syncBlocklistRefererDNR(prefs);");
+    const blocklistBeaconIdx = applyFnBlock.indexOf("await syncBlocklistBeaconsDNR(prefs);");
+    assert.ok(allowIdx !== -1 && suppressIdx !== -1 && beaconIdx !== -1 && blocklistRefererIdx !== -1 && blocklistBeaconIdx !== -1,
+      "all gate-open calls must be present");
+    assert.ok(suppressIdx > allowIdx, "syncSuppressRefererDNR must be called after syncAllowlistDNR");
+    assert.ok(beaconIdx > suppressIdx);
+    assert.ok(blocklistRefererIdx > beaconIdx);
+    assert.ok(blocklistBeaconIdx > blocklistRefererIdx);
+  });
+
+  test("applyDnrState gate-closed branch explicitly clears 2500, 2600, and both blocklist ranges", () => {
+    assert.ok(gateClosedBlock.includes("syncSuppressRefererDNR({ suppressReferer: false })"));
+    assert.ok(gateClosedBlock.includes("syncBlockBeaconsDNR({ blockBeacons: false })"));
+    assert.ok(gateClosedBlock.includes("syncBlocklistRefererDNR({ blacklist: [] })"));
+    assert.ok(gateClosedBlock.includes("syncBlocklistBeaconsDNR({ blacklist: [] })"));
+  });
+
+  test("storage.onChanged re-syncs DNR when suppressReferer or blockBeacons change", () => {
+    const storageListenerStart = swSource.lastIndexOf("chrome.storage.onChanged.addListener");
+    const storageListenerBlock = swSource.slice(storageListenerStart, storageListenerStart + 2700);
+    assert.ok(storageListenerBlock.includes("changes.suppressReferer"));
+    assert.ok(storageListenerBlock.includes("changes.blockBeacons"));
+  });
+});

--- a/tests/unit/referer-beacon-privacy-foundation.test.mjs
+++ b/tests/unit/referer-beacon-privacy-foundation.test.mjs
@@ -34,6 +34,8 @@ import {
   DNR_REMOTE_PARAMS_RULE_ID,
   DNR_ALLOWLIST_RULE_ID_BASE,
   DNR_ALLOWLIST_MAX_RULES,
+  DNR_DOMAIN_PRESERVE_RULE_ID_BASE,
+  DNR_DOMAIN_PRESERVE_MAX_RULES,
 } from "../../src/lib/dnr-ids.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -147,8 +149,17 @@ describe("dnr-ids.js — referer/beacon rule ID allocation", () => {
   });
 
   test("all new/pre-existing dynamic IDs and ranges are mutually distinct (no collision)", () => {
+    // Includes the pre-existing static-ruleset IDs (100-102: AMP unwrap
+    // redirects; 200: Amazon /dp/ SEO-slug strip) even though they have no
+    // exported JS constant (they live only in JSON ruleset files) — this
+    // guard is the ONLY place that would catch a future low-ID dynamic rule
+    // colliding with them, per the DNR collision-test hardening item.
     const singleIds = [
       DNR_STATIC_RULE_ID,
+      100,
+      101,
+      102,
+      200,
       DNR_CUSTOM_PARAMS_RULE_ID,
       DNR_REMOTE_PARAMS_RULE_ID,
       DNR_SUPPRESS_REFERER_RULE_ID,
@@ -157,6 +168,7 @@ describe("dnr-ids.js — referer/beacon rule ID allocation", () => {
     assert.strictEqual(new Set(singleIds).size, singleIds.length, "single rule IDs must be unique");
 
     const ranges = [
+      { name: "domain-preserve", start: DNR_DOMAIN_PRESERVE_RULE_ID_BASE, len: DNR_DOMAIN_PRESERVE_MAX_RULES },
       { name: "allowlist", start: DNR_ALLOWLIST_RULE_ID_BASE, len: DNR_ALLOWLIST_MAX_RULES },
       { name: "blocklist-referer", start: DNR_BLOCKLIST_REFERER_RULE_ID_BASE, len: DNR_BLOCKLIST_MAX_RULES },
       { name: "blocklist-beacon", start: DNR_BLOCKLIST_BEACON_RULE_ID_BASE, len: DNR_BLOCKLIST_MAX_RULES },

--- a/tests/unit/source-grep-ratchet.test.mjs
+++ b/tests/unit/source-grep-ratchet.test.mjs
@@ -137,6 +137,7 @@ const BASELINE = {
   "url-regex-sync.test.mjs": 2,            // verifies SW + cleaner regex are byte-identical (#824)
   "docs-prefs-table.test.mjs": 1,          // reads storage source to verify docs table (#824)
   "options-write-path-override.test.mjs": 2, // SW ENABLE/DISABLE_REMOTE_RULES handlers not importable in Node; 2 guards pin the reconcile wiring (#888 write-path follow-up, #824)
+  "referer-beacon-privacy-dnr.test.mjs": 9, // SW not importable; syncSuppressRefererDNR/syncBlockBeaconsDNR/syncBlocklistRefererDNR/syncBlocklistBeaconsDNR existence + applyDnrState gate-open/gate-closed wiring + storage.onChanged guards, mirroring allowlist-dnr.test.mjs's pattern (referer-beacon-privacy PR 2, #824)
 };
 
 // ── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## PR 2/4 — Chrome DNR Enforcement (stacked on PR 1, merged)

Wires the Chrome MV3 declarativeNetRequest rules behind the (still **default-OFF**) `suppressReferer` / `blockBeacons` prefs. The feature is fully wired at the DNR layer but **not user-reachable** until PR 4 adds the options UI — safe to merge.

### What's in this slice
- `syncSuppressRefererDNR` — rule **2500**, priority 1, `modifyHeaders` remove `referer`, `urlFilter:"*"`, resourceTypes = shared list; gated on `suppressReferer`.
- `syncBlockBeaconsDNR` — rule **2600**, priority 1, `block`, resourceTypes `["ping"]`; gated on `blockBeacons`.
- `syncBlocklistRefererDNR` / `syncBlocklistBeaconsDNR` — one force rule per fully-blacklisted domain (**2700-2899** / **2900-3099**, priority 2, `requestDomains`-scoped), **active regardless of the global toggle** (blocklist governs); full-range clear on every resync, `DNR_BLOCKLIST_MAX_RULES`=200 cap with dropped-domain logging.
- Precedence: **allowlist allow (1000) > blocklist force (2) > global (1)**. Promoted `ALLOWLIST_RESOURCE_TYPES` to a shared `dnr-ids.js` export (includes `"ping"`) so allowlisted sites are exempt from both referer-strip and beacon-block.
- Wired into `applyDnrState()` gate-open/closed + `storage.onChanged` re-sync. Gate-closed removes 2500/2600 + both full ranges (no consent-gate leak).
- Hardened the dnr-ids collision test with the pre-existing ranges (100-102/200/300-799).

### Not in this PR
- PR 3: Firefox MV2 `webRequest` enforcement
- PR 4: options UI, opt-in disclosure, i18n
- Phase 5: real-Chromium E2E (allow-beats-block, ping/sendBeacon mapping) — tied to PR 4

### Verification
- `npm test` 7382 pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0
- `cleaner.js` untouched → no bundle rebuild
- Fresh adversarial review: CLEAN — rule shapes valid, precedence holds, no gate leak, tests honest, inert while OFF
- Mechanism pre-verified by real-Chromium spike (DNR remove-Referer confirmed)

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9