### PR TITLE
feat(privacy): Firefox MV2 referer & beacon enforcement (PR 3/4)

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -4,7 +4,7 @@
  * and maintains extension state.
  */
 
-import { processUrl, computeNavigationStrip, parseListEntry, getFullyExemptDomains, isSiteFullyExempt, getFullyBlacklistedDomains } from "../lib/cleaner.js";
+import { processUrl, computeNavigationStrip, parseListEntry, getFullyExemptDomains, isSiteFullyExempt, getFullyBlacklistedDomains, isSiteFullyBlacklisted } from "../lib/cleaner.js";
 import { getAffiliateDomains, resolveOurTag } from "../lib/affiliates.js";
 import { getPrefs, setPrefs, incrementStat, getStats, setStats, migrateStatsToLocal, migrateLegacyProxyPref, migratePerSiteDisableToAllowlist, migrateCookieConsentMode, sessionStorage, incrementDomainStat, cacheDomainRules, getCachedDomainRules, getRemoteParams } from "../lib/storage.js";
 import { migrateConsentToLocal } from "../lib/sync-migration.js";
@@ -495,6 +495,87 @@ function onBeforeNavigateStrip(details) {
   return { redirectUrl: decision.cleanUrl };
 }
 
+/**
+ * Blocking onBeforeSendHeaders handler (Firefox MV2 only, referer-beacon-privacy
+ * PR 3). Removes the `referer` request header when the destination host is NOT
+ * fully exempt (allowlist) AND either the global `suppressReferer` pref is ON
+ * or the host is fully blacklisted (force-suppress regardless of the global
+ * pref, per design D2). Encodes the SAME precedence as the Chrome DNR rule
+ * priorities from PR 2: allowlist allow (1000) always wins; blocklist
+ * force-suppress (2) fires even with the global toggle OFF; the global rule
+ * (1) only fires when its own pref is ON.
+ *
+ * MUST return synchronously (a BlockingResponse or undefined), like
+ * onBeforeNavigateStrip above. Reads the warm `cachedPrefs` directly — unlike
+ * the param stripper, this listener needs no domain/path rules, so
+ * `cachedPrefs` itself is the readiness signal. Fails OPEN (returns
+ * undefined, leaving `requestHeaders` untouched) on a cold cache, a malformed
+ * URL, or an exempt/blacklist-check throw — an internal error must never
+ * strip a header a real user relies on.
+ *
+ * @param {{url:string, requestHeaders?:Array<{name:string,value?:string}>}} details
+ * @returns {{requestHeaders: Array}|undefined}
+ */
+function onBeforeSendHeadersSuppressReferer(details) {
+  if (!cachedPrefs) { getPrefsWithCache(); return; }
+
+  let host;
+  try {
+    host = new URL(details.url).hostname;
+  } catch {
+    return; // malformed URL -> pass through unchanged
+  }
+
+  try {
+    if (isSiteFullyExempt(host, cachedPrefs)) return; // allowlist always wins
+    if (cachedPrefs.suppressReferer !== true && !isSiteFullyBlacklisted(host, cachedPrefs)) return;
+  } catch {
+    return; // exempt/blacklist check threw -> pass through unchanged
+  }
+
+  const requestHeaders = (details.requestHeaders || []).filter(
+    (header) => header.name.toLowerCase() !== "referer",
+  );
+  return { requestHeaders };
+}
+
+/**
+ * Blocking onBeforeRequest handler for beacon traffic (Firefox MV2 only,
+ * referer-beacon-privacy PR 3). Registered filtered to `types:["ping","beacon"]`
+ * below: unlike Chrome (which folds both into "ping"), Firefox emits a distinct
+ * "beacon" resourceType for `navigator.sendBeacon()` and reserves "ping" for
+ * `<a ping>`, so BOTH types must be listed or real sendBeacon() calls slip
+ * through (caught by beacon-block.smoke.mjs). Cancels the request under the
+ * IDENTICAL precedence as the Referer listener above:
+ * allowlist always wins; blocklist force-blocks even with the global
+ * `blockBeacons` toggle OFF.
+ *
+ * Fails OPEN (returns undefined, letting the beacon through) on a cold cache,
+ * malformed URL, or exempt/blacklist-check throw.
+ *
+ * @param {{url:string}} details
+ * @returns {{cancel:true}|undefined}
+ */
+function onBeforeRequestBlockBeacons(details) {
+  if (!cachedPrefs) { getPrefsWithCache(); return; }
+
+  let host;
+  try {
+    host = new URL(details.url).hostname;
+  } catch {
+    return;
+  }
+
+  try {
+    if (isSiteFullyExempt(host, cachedPrefs)) return;
+    if (cachedPrefs.blockBeacons !== true && !isSiteFullyBlacklisted(host, cachedPrefs)) return;
+  } catch {
+    return;
+  }
+
+  return { cancel: true };
+}
+
 if (isFirefoxMV2) {
   // Warm the caches the blocking listener reads synchronously, then arm it. Only
   // strip once domain/path rules have settled so a startup navigation can never
@@ -508,6 +589,27 @@ if (isFirefoxMV2) {
   chrome.webRequest.onBeforeRequest.addListener(
     onBeforeNavigateStrip,
     { urls: ["<all_urls>"], types: ["main_frame"] },
+    ["blocking"],
+  );
+  // referer-beacon-privacy PR 3: Referer suppression, no resource-type filter
+  // (Referer matters across every request type, not just navigations).
+  chrome.webRequest.onBeforeSendHeaders.addListener(
+    onBeforeSendHeadersSuppressReferer,
+    { urls: ["<all_urls>"] },
+    ["blocking", "requestHeaders"],
+  );
+  // referer-beacon-privacy PR 3: beacon block. Unlike Chrome (which folds
+  // BOTH `<a ping>` navigations and navigator.sendBeacon() into a single
+  // "ping" resourceType), Firefox's webRequest classifies sendBeacon() under
+  // its OWN "beacon" resourceType and reserves "ping" for `<a ping>` only
+  // (verified empirically via tests/e2e-firefox/beacon-block.smoke.mjs — the
+  // design.md D4 claim that both surface as "ping" in FF holds for Chrome's
+  // vocabulary, not Firefox's; a "ping"-only filter silently let every real
+  // sendBeacon() call through). Both types must be listed so this listener
+  // covers the full beacon surface on Firefox.
+  chrome.webRequest.onBeforeRequest.addListener(
+    onBeforeRequestBlockBeacons,
+    { urls: ["<all_urls>"], types: ["ping", "beacon"] },
     ["blocking"],
   );
 }

--- a/tests/e2e-firefox/beacon-block.smoke.mjs
+++ b/tests/e2e-firefox/beacon-block.smoke.mjs
@@ -1,0 +1,118 @@
+/**
+ * Firefox smoke: referer-beacon-privacy PR 3 — beacon block (task 3.4).
+ *
+ * Drives REAL headless Firefox via Selenium + geckodriver (see ./fixtures.mjs)
+ * to prove the blocking `onBeforeRequest` listener filtered to
+ * `types:["ping","beacon"]` (onBeforeRequestBlockBeacons,
+ * src/background/service-worker.js) actually cancels `navigator.sendBeacon()`
+ * traffic on the wire, not just in a unit-test mirror
+ * (tests/unit/referer-beacon-privacy-ff.test.mjs). Firefox emits a distinct
+ * "beacon" resourceType for `sendBeacon()` (reserving "ping" for `<a ping>`),
+ * unlike Chrome which folds both into "ping" — this smoke test is exactly what
+ * caught that; sendBeacon() is used here because it fires without a
+ * user-gesture-driven navigation.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, setStorageSync, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage, serveCapturingServer } from "./helpers/local-server.mjs";
+
+function beaconPageHtml(destUrl) {
+  return `<!doctype html><html><body>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__beaconSent = navigator.sendBeacon(${JSON.stringify(destUrl)}, "ping-payload");
+  </script>
+</body></html>`;
+}
+
+async function pollUntilRequestArrives(server, { timeoutMs = 3000, intervalMs = 150 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (server.requests.length === 0) {
+    if (Date.now() > deadline) return false;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return true;
+}
+
+test("Firefox smoke: onBeforeRequest cancels a ping-type request (sendBeacon) on a blocklisted host", async () => {
+  let driver;
+  let extDir;
+  let pageServer;
+  let destServer;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    destServer = await serveCapturingServer();
+    const destHost = new URL(destServer.origin).hostname;
+
+    // Global toggle OFF, destination BLOCKLISTED — D2 force-block must still
+    // fire even though blockBeacons itself is off.
+    await setStorageSync(driver, extensionOrigin, {
+      suppressReferer: false,
+      blockBeacons: false,
+      whitelist: [],
+      blacklist: [destHost],
+    });
+
+    pageServer = await serveFixturePage(beaconPageHtml(destServer.url));
+    await driver.get(pageServer.url);
+
+    // LOW-2-style residual limit (see didomi.smoke.mjs): a wrongly-open gate
+    // could let the beacon through slowly; poll the whole window and fail if
+    // it EVER arrives. A beacon slower than this window is the acknowledged
+    // residual limit of a poll-based proof (no observable "was cancelled"
+    // signal exists client-side for a webRequest-blocked request).
+    const arrived = await pollUntilRequestArrives(destServer, { timeoutMs: 3000 });
+    assert.strictEqual(arrived, false, "the beacon must be CANCELLED on a blocklisted destination, never reaching the server");
+
+    const beaconSent = await driver.executeScript("return window.__beaconSent");
+    assert.strictEqual(beaconSent, true, "sendBeacon() itself must return true (queued) — the block happens at the network layer, not the API call");
+  } finally {
+    if (pageServer) await pageServer.close();
+    if (destServer) await destServer.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: onBeforeRequest does NOT cancel a ping-type request (sendBeacon) on an exempt (allowlisted) host", async () => {
+  let driver;
+  let extDir;
+  let pageServer;
+  let destServer;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    destServer = await serveCapturingServer();
+    const destHost = new URL(destServer.origin).hostname;
+
+    // Global toggle ON, destination ALLOWLISTED — allowlist must win over the
+    // global toggle (mirrors the Chrome DNR allow-rule precedence, D3).
+    await setStorageSync(driver, extensionOrigin, {
+      suppressReferer: false,
+      blockBeacons: true,
+      whitelist: [destHost],
+      blacklist: [],
+    });
+
+    pageServer = await serveFixturePage(beaconPageHtml(destServer.url));
+    await driver.get(pageServer.url);
+
+    const arrived = await pollUntilRequestArrives(destServer, { timeoutMs: 10000 });
+    assert.strictEqual(arrived, true, "the beacon must reach the server on an exempt (allowlisted) destination even with blockBeacons ON");
+    assert.strictEqual(destServer.requests.length, 1);
+  } finally {
+    if (pageServer) await pageServer.close();
+    if (destServer) await destServer.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/e2e-firefox/fixtures.mjs
+++ b/tests/e2e-firefox/fixtures.mjs
@@ -186,6 +186,33 @@ export async function completeOnboarding(driver, extensionOrigin, { enableFeatur
 }
 
 /**
+ * Writes arbitrary keys directly into chrome.storage.sync (referer-beacon-privacy
+ * PR 3). Separate from completeOnboarding (which only seeds the fixed set of
+ * onboarding/consent keys shared with the cookie-consent smoke suite) so new
+ * prefs (suppressReferer, blockBeacons, whitelist, blacklist) can be layered on
+ * top without touching that shared fixture's contract.
+ *
+ * @param {import('selenium-webdriver').WebDriver} driver
+ * @param {string} extensionOrigin - e.g. "moz-extension://<uuid>"
+ * @param {object} values - plain object merged into chrome.storage.sync
+ */
+export async function setStorageSync(driver, extensionOrigin, values) {
+  await driver.get(`${extensionOrigin}/popup/popup.html`);
+
+  await driver.executeAsyncScript(
+    (valuesArg, callback) => {
+      chrome.storage.sync.set(valuesArg, () => callback());
+    },
+    values
+  );
+
+  // Mirrors completeOnboarding's settle-window comment: no observable signal
+  // exists for prefs-cache invalidation / FF listener re-read after a
+  // storage.set call, so a short fixed settle window is used (#824 debt).
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+/**
  * Tears down the driver and removes the temp extension directory.
  */
 export async function teardown(driver, extDir) {

--- a/tests/e2e-firefox/helpers/local-server.mjs
+++ b/tests/e2e-firefox/helpers/local-server.mjs
@@ -29,3 +29,34 @@ export async function serveFixturePage(html) {
     close: () => new Promise((resolve) => server.close(resolve)),
   };
 }
+
+/**
+ * Starts a local HTTP server on 127.0.0.1 that serves `html` for every
+ * request path AND records every incoming request's method/path/headers
+ * (referer-beacon-privacy PR 3, tasks 3.3/3.4). Used as a real network
+ * "destination" that FF smoke specs can allowlist/blocklist by hostname and
+ * inspect for header presence (Referer) or arrival (ping/sendBeacon).
+ *
+ * Responds 204 to every request (no body needed by the fixture pages; also
+ * satisfies navigator.sendBeacon()'s expectation of a quick, cheap response).
+ *
+ * @returns {Promise<{url:string, origin:string, requests: Array<{method:string, path:string, headers: object}>, close: () => Promise<void>}>}
+ */
+export async function serveCapturingServer() {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    requests.push({ method: req.method, path: req.url, headers: req.headers });
+    res.writeHead(204);
+    res.end();
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    url: `http://127.0.0.1:${port}/index.html`,
+    origin: `http://127.0.0.1:${port}`,
+    requests,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}

--- a/tests/e2e-firefox/referer-suppression.smoke.mjs
+++ b/tests/e2e-firefox/referer-suppression.smoke.mjs
@@ -1,0 +1,122 @@
+/**
+ * Firefox smoke: referer-beacon-privacy PR 3 — Referer suppression
+ * (task 3.3).
+ *
+ * Drives REAL headless Firefox via Selenium + geckodriver (see ./fixtures.mjs)
+ * to prove the blocking `onBeforeSendHeaders` listener
+ * (onBeforeSendHeadersSuppressReferer, src/background/service-worker.js)
+ * actually removes the `Referer` header on the wire, not just in a unit-test
+ * mirror (tests/unit/referer-beacon-privacy-ff.test.mjs).
+ *
+ * Two local HTTP servers on 127.0.0.1 (different ports = different origins,
+ * so the browser attaches a cross-origin Referer by default): one serves the
+ * PAGE, the other is the request DESTINATION and records every request it
+ * receives (method/path/headers) via serveCapturingServer.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { launchFirefoxWithExtension, completeOnboarding, setStorageSync, teardown, FIXED_EXTENSION_UUID } from "./fixtures.mjs";
+import { serveFixturePage, serveCapturingServer } from "./helpers/local-server.mjs";
+
+function fetchPageHtml(destUrl) {
+  return `<!doctype html><html><body>
+  <p id="page-content">Real page content</p>
+  <script>
+    window.__fetchDone = false;
+    fetch(${JSON.stringify(destUrl)}, { mode: "no-cors" })
+      .then(() => { window.__fetchDone = true; })
+      .catch(() => { window.__fetchDone = true; });
+  </script>
+</body></html>`;
+}
+
+async function pollUntil(driver, predicateFn, { timeoutMs = 10000, intervalMs = 200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await driver.executeScript(predicateFn);
+    if (result) return result;
+    if (Date.now() > deadline) {
+      throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting on: ${predicateFn}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+test("Firefox smoke: onBeforeSendHeaders removes Referer on a blocklisted host with the global toggle OFF", async () => {
+  let driver;
+  let extDir;
+  let pageServer;
+  let destServer;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    destServer = await serveCapturingServer();
+    const destHost = new URL(destServer.origin).hostname;
+
+    // Global toggle OFF, destination is bare-domain BLOCKLISTED — D2
+    // force-suppress must still fire (the core precedence proof for FF).
+    await setStorageSync(driver, extensionOrigin, {
+      suppressReferer: false,
+      blockBeacons: false,
+      whitelist: [],
+      blacklist: [destHost],
+    });
+
+    pageServer = await serveFixturePage(fetchPageHtml(destServer.url));
+    await driver.get(pageServer.url);
+
+    await pollUntil(driver, "return window.__fetchDone === true", { timeoutMs: 10000 });
+
+    assert.strictEqual(destServer.requests.length, 1, "the destination server must have received exactly one request");
+    const referer = destServer.requests[0].headers.referer || destServer.requests[0].headers.referrer;
+    assert.strictEqual(referer, undefined, "Referer must be ABSENT on a blocklisted destination even with the global toggle OFF");
+  } finally {
+    if (pageServer) await pageServer.close();
+    if (destServer) await destServer.close();
+    await teardown(driver, extDir);
+  }
+});
+
+test("Firefox smoke: onBeforeSendHeaders keeps Referer on an allowlisted host even with the global toggle ON", async () => {
+  let driver;
+  let extDir;
+  let pageServer;
+  let destServer;
+
+  try {
+    ({ driver, extDir } = await launchFirefoxWithExtension());
+    const extensionOrigin = `moz-extension://${FIXED_EXTENSION_UUID}`;
+
+    await completeOnboarding(driver, extensionOrigin, { enableFeature: true });
+
+    destServer = await serveCapturingServer();
+    const destHost = new URL(destServer.origin).hostname;
+
+    // Global toggle ON, destination is ALLOWLISTED — allowlist must win over
+    // the global toggle (mirrors the Chrome DNR allow-rule precedence, D3).
+    await setStorageSync(driver, extensionOrigin, {
+      suppressReferer: true,
+      blockBeacons: false,
+      whitelist: [destHost],
+      blacklist: [],
+    });
+
+    pageServer = await serveFixturePage(fetchPageHtml(destServer.url));
+    await driver.get(pageServer.url);
+
+    await pollUntil(driver, "return window.__fetchDone === true", { timeoutMs: 10000 });
+
+    assert.strictEqual(destServer.requests.length, 1, "the destination server must have received exactly one request");
+    const referer = destServer.requests[0].headers.referer || destServer.requests[0].headers.referrer;
+    assert.ok(referer, "Referer must be PRESENT on an allowlisted destination even with the global toggle ON");
+  } finally {
+    if (pageServer) await pageServer.close();
+    if (destServer) await destServer.close();
+    await teardown(driver, extDir);
+  }
+});

--- a/tests/unit/referer-beacon-privacy-ff.test.mjs
+++ b/tests/unit/referer-beacon-privacy-ff.test.mjs
@@ -1,0 +1,260 @@
+/**
+ * MUGA — referer-beacon-privacy, PR 3 (Firefox MV2 Enforcement): unit tests
+ * for the two new blocking webRequest listeners (tasks 3.1-3.2).
+ *
+ * The service worker has no behavioral unit harness (Chrome/webRequest API
+ * bindings at module scope + top-level listener registration), so this file
+ * follows the established pattern from tests/unit/referer-beacon-privacy-dnr.test.mjs
+ * (PR 2): a pure extraction of each listener's DECISION logic, exercised
+ * behaviorally against the REAL isSiteFullyExempt/isSiteFullyBlacklisted
+ * predicates (imported, not reimplemented), plus source guards confirming the
+ * production service-worker.js actually wires the real listener functions
+ * with the same predicate/fail-open/registration shape.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { isSiteFullyExempt, isSiteFullyBlacklisted } from "../../src/lib/cleaner.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const swSource = readFileSync(
+  join(__dirname, "../../src/background/service-worker.js"),
+  "utf8",
+);
+
+// ── Pure decision logic under test ──────────────────────────────────────────
+//
+// Mirrors onBeforeSendHeadersSuppressReferer / onBeforeRequestBlockBeacons in
+// service-worker.js exactly: same exempt-first check, same OR-of-global-or-
+// blacklisted predicate, same fail-open-on-error/cache-miss/malformed-URL
+// behavior. The two REAL predicates (isSiteFullyExempt/isSiteFullyBlacklisted)
+// are imported directly from src/lib/cleaner.js — nothing about list matching
+// is reimplemented here, only the glue decision.
+
+function computeSuppressRefererDecision(url, cachedPrefs) {
+  if (!cachedPrefs) return "pass"; // cache-miss -> fail open
+
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return "pass"; // malformed URL -> fail open
+  }
+
+  try {
+    if (isSiteFullyExempt(host, cachedPrefs)) return "pass";
+    if (cachedPrefs.suppressReferer === true || isSiteFullyBlacklisted(host, cachedPrefs)) {
+      return "remove";
+    }
+    return "pass";
+  } catch {
+    return "pass"; // exempt-check throw -> fail open
+  }
+}
+
+function computeBlockBeaconDecision(url, cachedPrefs) {
+  if (!cachedPrefs) return "pass";
+
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return "pass";
+  }
+
+  try {
+    if (isSiteFullyExempt(host, cachedPrefs)) return "pass";
+    if (cachedPrefs.blockBeacons === true || isSiteFullyBlacklisted(host, cachedPrefs)) {
+      return "cancel";
+    }
+    return "pass";
+  } catch {
+    return "pass";
+  }
+}
+
+// ── 3.1: onBeforeSendHeaders — Referer suppression decision ────────────────
+
+describe("computeSuppressRefererDecision — Firefox onBeforeSendHeaders predicate", () => {
+  test("suppressReferer:true, plain (non-listed) host -> remove", () => {
+    const decision = computeSuppressRefererDecision(
+      "https://plain.example/path",
+      { suppressReferer: true, whitelist: [], blacklist: [] },
+    );
+    assert.strictEqual(decision, "remove");
+  });
+
+  test("suppressReferer:false, plain host -> pass (baseline: Referer untouched)", () => {
+    const decision = computeSuppressRefererDecision(
+      "https://plain.example/path",
+      { suppressReferer: false, whitelist: [], blacklist: [] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("suppressReferer:false, bare-domain blocklisted host -> remove (D2 force-suppress, global OFF)", () => {
+    const decision = computeSuppressRefererDecision(
+      "https://blocked.example/x",
+      { suppressReferer: false, whitelist: [], blacklist: ["blocked.example"] },
+    );
+    assert.strictEqual(decision, "remove");
+  });
+
+  test("suppressReferer:true, allowlisted host -> pass (allowlist wins over the global toggle)", () => {
+    const decision = computeSuppressRefererDecision(
+      "https://safe.example/x",
+      { suppressReferer: true, whitelist: ["safe.example"], blacklist: [] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("host on BOTH the allowlist and the blocklist -> pass (allowlist wins, mirrors Chrome DNR precedence)", () => {
+    const decision = computeSuppressRefererDecision(
+      "https://both.example/x",
+      { suppressReferer: true, whitelist: ["both.example"], blacklist: ["both.example"] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("param-scoped blacklist entry does NOT force-suppress a plain host with the global toggle OFF", () => {
+    const decision = computeSuppressRefererDecision(
+      "https://example.com/x",
+      { suppressReferer: false, whitelist: [], blacklist: ["example.com::aid::123456"] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("cache-miss (cachedPrefs null) -> pass (fail open)", () => {
+    const decision = computeSuppressRefererDecision("https://plain.example/x", null);
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("malformed URL -> pass (fail open)", () => {
+    const decision = computeSuppressRefererDecision(
+      "not-a-valid-url",
+      { suppressReferer: true, whitelist: [], blacklist: [] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+});
+
+// ── 3.2: onBeforeRequest (types:["ping"]) — beacon block decision ──────────
+
+describe("computeBlockBeaconDecision — Firefox onBeforeRequest(types:[\"ping\"]) predicate", () => {
+  test("blockBeacons:true, plain host -> cancel", () => {
+    const decision = computeBlockBeaconDecision(
+      "https://plain.example/beacon",
+      { blockBeacons: true, whitelist: [], blacklist: [] },
+    );
+    assert.strictEqual(decision, "cancel");
+  });
+
+  test("blockBeacons:false, plain host -> pass (baseline)", () => {
+    const decision = computeBlockBeaconDecision(
+      "https://plain.example/beacon",
+      { blockBeacons: false, whitelist: [], blacklist: [] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("blockBeacons:false, bare-domain blocklisted host -> cancel (D2 force-block, global OFF)", () => {
+    const decision = computeBlockBeaconDecision(
+      "https://blocked.example/beacon",
+      { blockBeacons: false, whitelist: [], blacklist: ["blocked.example"] },
+    );
+    assert.strictEqual(decision, "cancel");
+  });
+
+  test("blockBeacons:true, exempt (allowlisted) host -> pass (allowlist wins)", () => {
+    const decision = computeBlockBeaconDecision(
+      "https://safe.example/beacon",
+      { blockBeacons: true, whitelist: ["safe.example"], blacklist: [] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("cache-miss -> pass (fail open)", () => {
+    const decision = computeBlockBeaconDecision("https://plain.example/beacon", null);
+    assert.strictEqual(decision, "pass");
+  });
+
+  test("malformed URL -> pass (fail open)", () => {
+    const decision = computeBlockBeaconDecision(
+      "not-a-valid-url",
+      { blockBeacons: true, whitelist: [], blacklist: [] },
+    );
+    assert.strictEqual(decision, "pass");
+  });
+});
+
+// ── Source-level guards: verify the production SW was updated ──────────────
+
+const isFxIdx = swSource.indexOf("const isFirefoxMV2 =");
+const suppressFnStart = swSource.indexOf("function onBeforeSendHeadersSuppressReferer(");
+const suppressFnBlock = swSource.slice(suppressFnStart, suppressFnStart + 1400);
+const beaconFnStart = swSource.indexOf("function onBeforeRequestBlockBeacons(");
+const beaconFnBlock = swSource.slice(beaconFnStart, beaconFnStart + 1400);
+const fxGateStart = swSource.indexOf("if (isFirefoxMV2) {");
+const fxGateBlock = swSource.slice(fxGateStart, fxGateStart + 2000);
+
+describe("service-worker.js source guards — the two new FF listeners exist and are wired", () => {
+  test("both listener functions exist, after the isFirefoxMV2 gate declaration", () => {
+    assert.ok(isFxIdx !== -1, "isFirefoxMV2 gate must exist");
+    assert.ok(suppressFnStart !== -1, "onBeforeSendHeadersSuppressReferer must exist in the service worker");
+    assert.ok(beaconFnStart !== -1, "onBeforeRequestBlockBeacons must exist in the service worker");
+    assert.ok(suppressFnStart > isFxIdx);
+    assert.ok(beaconFnStart > isFxIdx);
+  });
+
+  test("onBeforeSendHeadersSuppressReferer checks isSiteFullyExempt first and uses suppressReferer / isSiteFullyBlacklisted", () => {
+    assert.ok(suppressFnBlock.includes("isSiteFullyExempt("));
+    assert.ok(suppressFnBlock.includes("cachedPrefs.suppressReferer"));
+    assert.ok(suppressFnBlock.includes("isSiteFullyBlacklisted("));
+  });
+
+  test("onBeforeSendHeadersSuppressReferer fails open on cache-miss and returns a mutated requestHeaders array", () => {
+    assert.ok(suppressFnBlock.includes("if (!cachedPrefs)"), "must fail open on cache-miss");
+    assert.ok(suppressFnBlock.includes("requestHeaders"), "must return a requestHeaders array");
+  });
+
+  test("onBeforeRequestBlockBeacons checks isSiteFullyExempt first and uses blockBeacons / isSiteFullyBlacklisted", () => {
+    assert.ok(beaconFnBlock.includes("isSiteFullyExempt("));
+    assert.ok(beaconFnBlock.includes("cachedPrefs.blockBeacons"));
+    assert.ok(beaconFnBlock.includes("isSiteFullyBlacklisted("));
+  });
+
+  test("onBeforeRequestBlockBeacons fails open on cache-miss and returns { cancel: true } when blocking", () => {
+    assert.ok(beaconFnBlock.includes("if (!cachedPrefs)"), "must fail open on cache-miss");
+    assert.ok(beaconFnBlock.includes("cancel: true"));
+  });
+
+  test("both catch blocks are non-empty / fail open (no rethrow)", () => {
+    assert.ok(suppressFnBlock.includes("catch"));
+    assert.ok(beaconFnBlock.includes("catch"));
+  });
+
+  test("isFirefoxMV2 gate registers onBeforeSendHeaders with [\"blocking\",\"requestHeaders\"], <all_urls>, no types filter", () => {
+    const registrationIdx = fxGateBlock.indexOf("chrome.webRequest.onBeforeSendHeaders.addListener(");
+    assert.ok(registrationIdx !== -1, "onBeforeSendHeaders must be registered inside the isFirefoxMV2 gate");
+    const registrationBlock = fxGateBlock.slice(registrationIdx, registrationIdx + 300);
+    assert.ok(registrationBlock.includes("onBeforeSendHeadersSuppressReferer"));
+    assert.ok(registrationBlock.includes('urls: ["<all_urls>"]'));
+    assert.ok(registrationBlock.includes('["blocking", "requestHeaders"]'));
+    assert.ok(!registrationBlock.includes("types:"), "the Referer listener must NOT filter by resource type");
+  });
+
+  test("isFirefoxMV2 gate registers onBeforeRequest for beacons filtered to types:[\"ping\",\"beacon\"]", () => {
+    const beaconRefIdx = fxGateBlock.indexOf("onBeforeRequestBlockBeacons,");
+    assert.ok(beaconRefIdx !== -1, "onBeforeRequestBlockBeacons must be registered inside the isFirefoxMV2 gate");
+    const registrationBlock = fxGateBlock.slice(Math.max(0, beaconRefIdx - 60), beaconRefIdx + 300);
+    assert.ok(registrationBlock.includes("chrome.webRequest.onBeforeRequest.addListener("));
+    // Firefox splits sendBeacon() into its OWN "beacon" resourceType, distinct
+    // from "ping" (<a ping> only) — both must be listed (see the production
+    // comment above this registration for why "ping" alone is insufficient).
+    assert.ok(registrationBlock.includes('types: ["ping", "beacon"]'));
+    assert.ok(registrationBlock.includes('["blocking"]'));
+  });
+});

--- a/tests/unit/source-grep-ratchet.test.mjs
+++ b/tests/unit/source-grep-ratchet.test.mjs
@@ -138,6 +138,7 @@ const BASELINE = {
   "docs-prefs-table.test.mjs": 1,          // reads storage source to verify docs table (#824)
   "options-write-path-override.test.mjs": 2, // SW ENABLE/DISABLE_REMOTE_RULES handlers not importable in Node; 2 guards pin the reconcile wiring (#888 write-path follow-up, #824)
   "referer-beacon-privacy-dnr.test.mjs": 9, // SW not importable; syncSuppressRefererDNR/syncBlockBeaconsDNR/syncBlocklistRefererDNR/syncBlocklistBeaconsDNR existence + applyDnrState gate-open/gate-closed wiring + storage.onChanged guards, mirroring allowlist-dnr.test.mjs's pattern (referer-beacon-privacy PR 2, #824)
+  "referer-beacon-privacy-ff.test.mjs": 7,  // SW not importable; onBeforeSendHeadersSuppressReferer/onBeforeRequestBlockBeacons existence + fail-open + isFirefoxMV2 listener-registration wiring guards, mirroring referer-beacon-privacy-dnr.test.mjs's pattern (referer-beacon-privacy PR 3, #824)
 };
 
 // ── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## PR 3/4 — Firefox MV2 Enforcement (stacked on PR 2, merged)

The Firefox MV2 counterpart to PR 2's Chrome DNR path, via blocking `webRequest` under the existing `isFirefoxMV2` gate. Prefs `suppressReferer`/`blockBeacons` still **default-OFF**; the only currently-reachable effect for a real FF user is that existing blocklist entries now also get Referer stripped + beacons blocked (same D2 blocklist-governs override as the Chrome side).

### What's in this slice
- `onBeforeSendHeaders` (blocking, `<all_urls>`): removes the `referer` header (case-insensitive) when host is **NOT `isSiteFullyExempt`** AND (`suppressReferer` OR `isSiteFullyBlacklisted`). Fails **open** on cache-miss / malformed URL / exempt-check throw.
- `onBeforeRequest` (blocking, `types:["ping","beacon"]`): cancels beacons under the identical precedence.
- Precedence parity with Chrome: **allowlist wins > blocklist forces (global-OFF) > global toggle**.

### Bug caught by the mandatory FF smoke test
`design.md` D4 assumed `<a ping>` and `sendBeacon()` both surface as `"ping"` in Firefox. **False** — Firefox emits a distinct `"beacon"` resourceType for `sendBeacon()` (Chrome folds both into `"ping"`). A `["ping"]`-only filter silently let every real `sendBeacon()` through while the unit mirror stayed green. Fixed to `["ping","beacon"]`; the Chrome side's `["ping"]` remains correct (Chrome has no `"beacon"` type).

### Tests
- `referer-suppression.smoke.mjs` + `beacon-block.smoke.mjs`: drive **real headless Firefox**, assert server-side outcomes (Referer absent / beacon cancelled) for the blocklist-force-with-global-OFF and allowlist-wins-with-global-ON cases. Local run: FF smoke 24/24.
- `referer-beacon-privacy-ff.test.mjs`: pure-logic mirror (22 tests) against the real predicates.

### Verification
- `npm test` 7405 pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0
- `cleaner.js` untouched → no bundle rebuild
- Fresh adversarial review: CLEAN (no functional defects; stale docstring flagged + fixed)

### Not in this PR
- PR 4: options UI, opt-in disclosure, i18n + Phase 5 real-Chromium E2E

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9