### PR TITLE
test(e2e-firefox): force-destroy keep-alive sockets on close (S1 follow-up)

### DIFF
--- a/tests/e2e-firefox/helpers/local-server.mjs
+++ b/tests/e2e-firefox/helpers/local-server.mjs
@@ -9,6 +9,30 @@
 import http from "node:http";
 
 /**
+ * Tracks live sockets on a server and force-destroys them on close().
+ *
+ * Node's http.Server#close() only stops accepting NEW connections — it waits
+ * for existing (keep-alive) sockets to end before its callback fires. A real
+ * browser keeps its HTTP/1.1 connection to 127.0.0.1 alive by default, so
+ * without this, `close()` would hang indefinitely. Mirrors the Chromium e2e
+ * helper (tests/e2e/helpers/local-server.mjs); the FF suite has not tripped it
+ * only because its request cadence differs — fix it here too (verify S1).
+ * @param {import('node:http').Server} server
+ */
+function forceDestroyOnClose(server) {
+  const sockets = new Set();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  return () =>
+    new Promise((resolve) => {
+      server.close(resolve);
+      for (const socket of sockets) socket.destroy();
+    });
+}
+
+/**
  * Starts a local HTTP server on 127.0.0.1 that serves `html` for every
  * request path.
  *
@@ -17,16 +41,18 @@ import http from "node:http";
  */
 export async function serveFixturePage(html) {
   const server = http.createServer((_req, res) => {
+    res.setHeader("Connection", "close");
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
     res.end(html);
   });
 
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address();
+  const close = forceDestroyOnClose(server);
 
   return {
     url: `http://127.0.0.1:${port}/index.html`,
-    close: () => new Promise((resolve) => server.close(resolve)),
+    close,
   };
 }
 
@@ -46,17 +72,19 @@ export async function serveCapturingServer() {
   const requests = [];
   const server = http.createServer((req, res) => {
     requests.push({ method: req.method, path: req.url, headers: req.headers });
+    res.setHeader("Connection", "close");
     res.writeHead(204);
     res.end();
   });
 
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address();
+  const close = forceDestroyOnClose(server);
 
   return {
     url: `http://127.0.0.1:${port}/index.html`,
     origin: `http://127.0.0.1:${port}`,
     requests,
-    close: () => new Promise((resolve) => server.close(resolve)),
+    close,
   };
 }


### PR DESCRIPTION
Applies the Chromium e2e helper's keep-alive teardown fix to the Firefox helper (`tests/e2e-firefox/helpers/local-server.mjs`) — the S1 non-blocking suggestion from the referer-beacon-privacy verify report.

`http.Server#close()` only stops accepting new connections and waits for existing keep-alive sockets to end; a real browser holds its HTTP/1.1 connection to 127.0.0.1 open, so teardown could hang until the test timeout. Adds `forceDestroyOnClose()` (socket tracking + destroy) and `Connection: close` to both `serveFixturePage` and `serveCapturingServer`, mirroring `tests/e2e/helpers/local-server.mjs`.

Test-helper only, no source change. FF smoke suite: 24/24 pass, clean teardown. eslint clean.

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9