### PR TITLE
feat(consent): Tier 2 reject-only click-rule foundation (PR 1/3)

### DIFF
--- a/src/lib/cmp-adapters.js
+++ b/src/lib/cmp-adapters.js
@@ -9,10 +9,15 @@
  * content-script copies are checked against this file by a dedicated sync
  * test (tests/unit/cookie-noise-sync.test.mjs).
  *
- * Scope: Tier 1 only (API adapters — calling a page-authored global
- * directly, e.g. `window.OneTrust.RejectAll()`). A Tier 2 registry slot
- * exists (declarative click-rule adapters, Consent-O-Matic-style) but
- * ships EMPTY in this slice — see design decisions.
+ * Scope: Tier 1 (API adapters — calling a page-authored global directly,
+ * e.g. `window.OneTrust.RejectAll()`) PLUS a Tier 2 registry (declarative
+ * click-rule adapters, Consent-O-Matic-style) seeded in Slice 1 with two
+ * genuinely API-less bespoke banners (Complianz, Cookie Notice) — see
+ * src/lib/cmp-tier2-rules.js and `resolveTier2Reject` below. Tier 2's DOM
+ * query-and-click execution itself lives only in the isolated-world content
+ * script (a later slice), never here — this file stays pure (no DOM,
+ * no `window`) and only resolves the pure fail-closed decision given
+ * caller-supplied candidates.
  *
  * ── The ethical spine (never-auto-*-the-user's-consent-away rule) ─────────
  *
@@ -35,6 +40,8 @@
  * block in tests/unit/cmp-adapters.test.mjs. Do not introduce that word
  * into this file, ever, including in comments.
  */
+
+import { TIER2_RULES } from "./cmp-tier2-rules.js";
 
 /**
  * @typedef {object} CmpSignals
@@ -158,6 +165,12 @@
  *   in the DOM. Secondary/corroborating signal.
  * @property {boolean} [hasCmpBoxBtnDom] - `#cmpbox .cmpboxbtn` present in
  *   the DOM. Secondary/corroborating signal.
+ * @property {Object<string, boolean>} [tier2Confirmed] - Map of Tier 2 rule
+ *   id (see src/lib/cmp-tier2-rules.js) to whether a single confirmed
+ *   reject target was resolved for that rule in the current frame. This
+ *   file never computes this map itself — it is pure and touches no DOM;
+ *   the isolated-world content script computes it (via `resolveTier2Reject`
+ *   below, fed real DOM query results) before calling `decideAction`.
  */
 
 /**
@@ -601,6 +614,85 @@ function findSpOpenSettingsTarget(candidates) {
 export { findSpRejectTarget, findSpOpenSettingsTarget };
 
 /**
+ * Tier 2 fail-closed reject resolution (#1027, Slice 1). Byte-identical
+ * contract to `findSpRejectTarget` above: `presentMatched !== true` OR zero
+ * candidates -> `"noop"`; more than one candidate -> `"ambiguous"` (still a
+ * no-op — never guesses between multiple matches); exactly one -> `"single"`
+ * with that candidate as the target.
+ *
+ * A "confirmed reject candidate" is identified POSITIVELY: the caller (the
+ * isolated-world content script) queries the DOM ONLY for a specific rule's
+ * curated `reject` selector list (see src/lib/cmp-tier2-rules.js) and passes
+ * the resulting element wrapper(s) in here — this function never scans for,
+ * vetoes, or reasons about the broad-consent control this file's structural
+ * guard forbids naming (see the file docblock). `rejectCandidates` is only
+ * ever fed matches for the one curated reject selector list; no broader DOM
+ * query result should ever reach this function.
+ *
+ * Content scripts cannot import this module (AGENTS.md — no ES imports in
+ * content scripts), so the block between the @sync:cmp-tier2 markers is
+ * hand-copied, modulo indentation, into content/cookie-noise.js (a later
+ * slice — see tests/unit/cookie-noise-sync.test.mjs once that copy exists).
+ *
+ * Pure; never throws.
+ *
+ * @param {boolean} presentMatched - Whether the rule's `present` banner-
+ *   anchor selector list matched in the current frame.
+ * @param {Array<{ref?: *}>} [rejectCandidates] - Elements matching the
+ *   rule's curated `reject` selector list.
+ * @returns {{status: "single"|"noop"|"ambiguous", target: object|null}}
+ */
+// @sync:cmp-tier2:start
+function resolveTier2Reject(presentMatched, rejectCandidates) {
+  if (presentMatched !== true) return { status: "noop", target: null };
+  const list = Array.isArray(rejectCandidates) ? rejectCandidates : [];
+  // Filter malformed entries (null/non-object) so garbage fails CLOSED to
+  // noop, byte-identical to findSpRejectTarget — a null/non-element never
+  // becomes a "single" clickable target the PR-2 dispatcher would trust.
+  const matches = [];
+  for (const candidate of list) {
+    if (!candidate || typeof candidate !== "object") continue;
+    matches.push(candidate);
+  }
+  if (matches.length === 0) return { status: "noop", target: null };
+  if (matches.length > 1) return { status: "ambiguous", target: null };
+  return { status: "single", target: matches[0] };
+}
+// @sync:cmp-tier2:end
+
+export { resolveTier2Reject };
+
+/**
+ * Builds a Tier 2 registry entry from a declarative rule (see
+ * src/lib/cmp-tier2-rules.js). Unlike the Tier 1 adapters above, a Tier 2
+ * entry never touches a page-authored global and has no `reject` callback
+ * of its own here: the actual DOM query + resolve + click sequence runs in
+ * the isolated-world content script (a later slice), which pre-computes
+ * `signals.tier2Confirmed[rule.id]` (true only after `resolveTier2Reject`
+ * above returned `"single"` for that rule) and passes it into
+ * `decideAction`. This keeps `decideAction` a single pure decision surface
+ * with zero DOM coupling, matching Tier 1's shape.
+ *
+ * @param {import("./cmp-tier2-rules.js").Tier2Rule} rule
+ * @returns {Readonly<{id: string, tier: 2, detect: (signals: CmpSignals) => number, canReject: (signals: CmpSignals) => boolean}>}
+ */
+function makeTier2Adapter(rule) {
+  const id = rule.id;
+  return Object.freeze({
+    id,
+    tier: 2,
+    detect(signals) {
+      return signals && signals.tier2Confirmed && signals.tier2Confirmed[id] === true ? 1 : 0;
+    },
+    canReject(signals) {
+      return signals?.tier2Confirmed?.[id] === true;
+    },
+  });
+}
+
+export { makeTier2Adapter };
+
+/**
  * Invokes the caller-supplied reject call. Kept pure (no `window` access
  * here) by requiring the caller to inject the actual global call as a
  * zero-argument callback — the content-script shell is the one place that
@@ -901,16 +993,21 @@ export const TIER1 = Object.freeze([
 
 /**
  * Tier 2 registry: declarative click-rule adapters (Consent-O-Matic-style).
- * Ships EMPTY in this slice — the dispatcher below already iterates it so
- * a later slice can populate it with zero dispatcher rewrite.
+ * Seeded in Slice 1 with two genuinely API-less bespoke banners (Complianz,
+ * Cookie Notice — see src/lib/cmp-tier2-rules.js). `decideAction` below
+ * already iterated an (empty) TIER2 array before this slice, so populating
+ * it here needed zero decision-loop rewrite.
  */
-export const TIER2 = Object.freeze([]);
+export const TIER2 = Object.freeze(TIER2_RULES.map(makeTier2Adapter));
 
 /**
  * Two-tier pure decision function. Tries every Tier 1 adapter, then every
- * Tier 2 adapter (empty today), and returns the first confirmed reject
- * action. When nothing can confidently reject, distinguishes two NOOP
- * reasons for observability/testing: `"no-reject-path"` when a vendor
+ * Tier 2 adapter (Slice 1 seed: Complianz, Cookie Notice — see
+ * src/lib/cmp-tier2-rules.js), and returns the first confirmed reject
+ * action. Tier 1 always loops first, so a confirmed vendor-API reject wins
+ * over a Tier 2 DOM-click confirmation on any page where both could
+ * theoretically apply. When nothing can confidently reject, distinguishes
+ * two NOOP reasons for observability/testing: `"no-reject-path"` when a vendor
  * global is present but its reject function is not (a hard wall), and
  * `"uncertain"` for everything else (no CMP detected, or insufficient
  * corroboration — fail-closed).

--- a/src/lib/cmp-tier2-rules.js
+++ b/src/lib/cmp-tier2-rules.js
@@ -1,0 +1,103 @@
+/**
+ * MUGA: Cookie Consent Minimizer — Tier 2 declarative reject-only click-rule
+ * data (#1027, Slice 1)
+ *
+ * Pure data module. NOT loaded as a content script — see AGENTS.md (content
+ * scripts cannot use ES module imports). Consumed by src/lib/cmp-adapters.js
+ * (`makeTier2Adapter` maps each entry here to a `TIER2` adapter) and, from a
+ * later slice (Phase 3), hand-copied into content/cookie-noise.js for the
+ * isolated-world DOM click dispatcher.
+ *
+ * ── Reject-only vocabulary, closed shape ───────────────────────────────────
+ *
+ * Each rule has EXACTLY three fields: `present` (banner-anchor selectors,
+ * OR-matched — confirms the banner is actually on the page before anything
+ * else happens), `reject` (confirmed reject/necessary-only control
+ * selectors — the ONLY thing this file is ever allowed to identify
+ * positively), and `openSettings` (optional single hop to reveal a deeper
+ * reject control; `[]` means no two-step path is used). There is
+ * intentionally NO field capable of expressing the broad-consent-granting
+ * path this project's structural guard forbids naming (see
+ * src/lib/cmp-adapters.js's file docblock for the naming convention this
+ * follows) — the never-auto-consent-away rule holds here structurally, by
+ * construction, not by convention: a future edit cannot add such a
+ * selector without inventing a new field name, which the dedicated
+ * structural guard in tests/unit/cmp-adapters.test.mjs scans this file for.
+ *
+ * A "confirmed reject control" is identified POSITIVELY, by a curated
+ * `reject` selector for that specific rule — never by scanning for or
+ * vetoing a broad-consent-granting control. See `resolveTier2Reject` in
+ * src/lib/cmp-adapters.js for the fail-closed matching contract this data
+ * feeds.
+ *
+ * ── Seed candidates verified 2026-07 (Task 1.1 spike) ──────────────────────
+ *
+ * Three API-less bespoke-banner candidates were considered for this Slice 1
+ * seed; only two shipped:
+ *
+ * - Axeptio: DROPPED. Confirmed API-less, but its banner renders inside a
+ *   CLOSED Shadow DOM behind a randomized custom-element host name on every
+ *   page load — a content script cannot reliably reach into a closed shadow
+ *   root at all, let alone with a stable selector. No rule is added for it.
+ * - Complianz (cmplz): SEED — see the rule below.
+ * - Cookie Notice (dFactory): SEED — see the rule below.
+ *
+ * Coverage claimed here is a modest, honest long-tail increment — two
+ * genuinely API-less bespoke banners, verified against real production
+ * markup, neither overlapping any of the 10 Tier 1 vendor-API adapters.
+ *
+ * @typedef {object} Tier2Rule
+ * @property {string} id - Stable identifier, used as the `TIER2` adapter id
+ *   and the `signals.tier2Confirmed` map key.
+ * @property {ReadonlyArray<string>} present - OR-matched banner-anchor
+ *   selectors; the banner must be confirmed present before any reject
+ *   candidate is considered.
+ * @property {ReadonlyArray<string>} reject - Curated reject/necessary-only
+ *   control selectors. Fail-closed: 0 matches or more than 1 (ambiguous) is
+ *   a no-op; exactly 1 is the confirmed target.
+ * @property {ReadonlyArray<string>} openSettings - Optional single hop to
+ *   open a settings panel before re-resolving `reject` in the revealed
+ *   panel. `[]` when no two-step path is used.
+ */
+
+// @sync:cmp-tier2-rules:start
+export const TIER2_RULES = Object.freeze([
+  /**
+   * Complianz (cmplz) — API-less, WordPress plugin. Real-site verification
+   * (doaj.org, 2026-07) confirmed a direct first-layer reject control:
+   * `.cmplz-deny` inside `#cmplz-cookiebanner-container`.
+   *
+   * Complianz's "manage options" / "save preferences" panel was
+   * DELIBERATELY NOT modeled as an `openSettings` two-step hop: that panel's
+   * save action commits whatever categories are CURRENTLY checked, which is
+   * not guaranteed to be reject/necessary-only — the toggles' default state
+   * is theme/installation-dependent, so clicking "save" there could commit
+   * an unknown consent state. That is not an unambiguous reject path, so
+   * this rule stays single-layer for Slice 1 and relies solely on the
+   * direct `.cmplz-deny` control (fail-closed no-op if that control is
+   * absent on a given installation).
+   */
+  Object.freeze({
+    id: "complianz",
+    present: Object.freeze(["#cmplz-cookiebanner-container"]),
+    reject: Object.freeze([".cmplz-deny"]),
+    openSettings: Object.freeze([]),
+  }),
+
+  /**
+   * Cookie Notice (dFactory) — API-less, WordPress plugin. Refuse control:
+   * `#cn-refuse-cookie` (also reachable via
+   * `.cn-set-cookie[data-cookie-set="refuse"]`, kept as a single curated
+   * selector for now — see the id-selector precedent above). The refuse
+   * button is an admin-optional setting: not every installation renders it.
+   * That is fine — the fail-closed 0-match branch already no-ops gracefully
+   * when it is absent, exactly like every other rule here.
+   */
+  Object.freeze({
+    id: "cookie-notice",
+    present: Object.freeze(["#cookie-notice"]),
+    reject: Object.freeze(["#cn-refuse-cookie"]),
+    openSettings: Object.freeze([]),
+  }),
+]);
+// @sync:cmp-tier2-rules:end

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -37,7 +37,10 @@ import {
   computeCookieGate,
   findSpRejectTarget,
   findSpOpenSettingsTarget,
+  resolveTier2Reject,
+  makeTier2Adapter,
 } from "../../src/lib/cmp-adapters.js";
+import { TIER2_RULES } from "../../src/lib/cmp-tier2-rules.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -58,9 +61,15 @@ describe("cmp-adapters — registry shape", () => {
     assert.strictEqual(TIER1[9], consentmanagerAdapter);
   });
 
-  test("TIER2 ships empty in this slice", () => {
+  test("TIER2 ships with the Slice 1 seed rules (Complianz, Cookie Notice)", () => {
     assert.ok(Array.isArray(TIER2));
-    assert.equal(TIER2.length, 0);
+    assert.equal(TIER2.length, 2);
+    assert.deepEqual(TIER2.map((a) => a.id), ["complianz", "cookie-notice"]);
+    for (const adapter of TIER2) {
+      assert.equal(adapter.tier, 2);
+      assert.equal(typeof adapter.detect, "function");
+      assert.equal(typeof adapter.canReject, "function");
+    }
   });
 
   test("TIER1 and TIER2 are frozen", () => {
@@ -696,6 +705,177 @@ describe("decideAction — truth table", () => {
     assert.equal(r.action, ACTIONS.REJECT_ALL);
     assert.equal(r.reason, "reject");
     assert.equal(r.adapterId, "sourcepoint");
+  });
+
+  test("Tier 1 confirmed AND a Tier 2 signal also present -> Tier 1 wins (Tier 1 loops first)", () => {
+    const r = decideAction({
+      ...FULL_SIGNALS,
+      tier2Confirmed: { complianz: true, "cookie-notice": true },
+    });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "onetrust");
+  });
+
+  test("no Tier 1 signal, Tier 2 confirmed -> Tier 2 adapter wins as the DOM fallback", () => {
+    const r = decideAction({ tier2Confirmed: { complianz: true } });
+    assert.equal(r.action, ACTIONS.REJECT_ALL);
+    assert.equal(r.reason, "reject");
+    assert.equal(r.adapterId, "complianz");
+  });
+
+  test("tier2Confirmed present but false for every rule id -> NOOP, uncertain", () => {
+    const r = decideAction({ tier2Confirmed: { complianz: false, "cookie-notice": false } });
+    assert.equal(r.action, null);
+    assert.equal(r.reason, "uncertain");
+  });
+});
+
+// ── Tier 2 rule data (src/lib/cmp-tier2-rules.js) — shape ───────────────────
+
+describe("TIER2_RULES — closed reject-only shape (#1027 Slice 1)", () => {
+  test("TIER2_RULES contains exactly the Complianz and Cookie Notice seed rules, in order", () => {
+    assert.equal(TIER2_RULES.length, 2);
+    assert.equal(TIER2_RULES[0].id, "complianz");
+    assert.equal(TIER2_RULES[1].id, "cookie-notice");
+  });
+
+  test("TIER2_RULES and every rule entry are frozen", () => {
+    assert.ok(Object.isFrozen(TIER2_RULES));
+    for (const rule of TIER2_RULES) {
+      assert.ok(Object.isFrozen(rule), `rule "${rule.id}" must be frozen`);
+      assert.ok(Object.isFrozen(rule.present), `rule "${rule.id}".present must be frozen`);
+      assert.ok(Object.isFrozen(rule.reject), `rule "${rule.id}".reject must be frozen`);
+      assert.ok(Object.isFrozen(rule.openSettings), `rule "${rule.id}".openSettings must be frozen`);
+    }
+  });
+
+  test("every rule has EXACTLY the id/present/reject/openSettings keys — no accept/allow field can exist", () => {
+    const ALLOWED_KEYS = new Set(["id", "present", "reject", "openSettings"]);
+    for (const rule of TIER2_RULES) {
+      const keys = Object.keys(rule);
+      for (const key of keys) {
+        assert.ok(ALLOWED_KEYS.has(key), `rule "${rule.id}" has an unexpected key: ${key}`);
+      }
+      assert.equal(keys.length, 4, `rule "${rule.id}" must have exactly 4 keys`);
+    }
+  });
+
+  test("every rule's present/reject/openSettings are string arrays", () => {
+    for (const rule of TIER2_RULES) {
+      assert.ok(Array.isArray(rule.present) && rule.present.every((s) => typeof s === "string"));
+      assert.ok(Array.isArray(rule.reject) && rule.reject.every((s) => typeof s === "string"));
+      assert.ok(rule.reject.length > 0, `rule "${rule.id}".reject must not be empty`);
+      assert.ok(Array.isArray(rule.openSettings) && rule.openSettings.every((s) => typeof s === "string"));
+    }
+  });
+
+  test("Slice 1 seed ships with no two-step openSettings path (both rules rely on a direct reject control)", () => {
+    for (const rule of TIER2_RULES) {
+      assert.deepEqual(rule.openSettings, [], `rule "${rule.id}".openSettings must be empty in Slice 1`);
+    }
+  });
+
+  test("Complianz rule matches the verified real-site selectors", () => {
+    const rule = TIER2_RULES.find((r) => r.id === "complianz");
+    assert.deepEqual([...rule.present], ["#cmplz-cookiebanner-container"]);
+    assert.deepEqual([...rule.reject], [".cmplz-deny"]);
+  });
+
+  test("Cookie Notice rule matches the verified real-site selectors", () => {
+    const rule = TIER2_RULES.find((r) => r.id === "cookie-notice");
+    assert.deepEqual([...rule.present], ["#cookie-notice"]);
+    assert.deepEqual([...rule.reject], ["#cn-refuse-cookie"]);
+  });
+});
+
+// ── resolveTier2Reject — fail-closed contract (byte-identical to findSpRejectTarget) ─
+
+describe("resolveTier2Reject — fail-closed matching", () => {
+  test("presentMatched !== true -> noop, regardless of candidates", () => {
+    assert.deepEqual(resolveTier2Reject(false, [{ ref: "a" }]), { status: "noop", target: null });
+    assert.deepEqual(resolveTier2Reject(undefined, [{ ref: "a" }]), { status: "noop", target: null });
+    assert.deepEqual(resolveTier2Reject(null, [{ ref: "a" }]), { status: "noop", target: null });
+  });
+
+  test("presentMatched true + zero candidates -> noop", () => {
+    assert.deepEqual(resolveTier2Reject(true, []), { status: "noop", target: null });
+    assert.deepEqual(resolveTier2Reject(true, undefined), { status: "noop", target: null });
+    assert.deepEqual(resolveTier2Reject(true, null), { status: "noop", target: null });
+  });
+
+  test("presentMatched true + exactly one candidate -> single, target is that candidate", () => {
+    const candidate = { ref: "the-button" };
+    const r = resolveTier2Reject(true, [candidate]);
+    assert.equal(r.status, "single");
+    assert.strictEqual(r.target, candidate);
+  });
+
+  test("presentMatched true + more than one candidate -> ambiguous, never guesses", () => {
+    const r = resolveTier2Reject(true, [{ ref: "a" }, { ref: "b" }]);
+    assert.equal(r.status, "ambiguous");
+    assert.equal(r.target, null);
+  });
+
+  test("never throws on malformed input", () => {
+    assert.doesNotThrow(() => resolveTier2Reject());
+    assert.doesNotThrow(() => resolveTier2Reject(true, "not-an-array"));
+    assert.doesNotThrow(() => resolveTier2Reject(true, 42));
+  });
+
+  test("malformed candidate ENTRIES are filtered -> fail closed, never a null 'single' target", () => {
+    // Matches findSpRejectTarget's object-filter: a null/non-object entry must
+    // never become a clickable "single" target the PR-2 dispatcher would trust.
+    assert.deepEqual(resolveTier2Reject(true, [null]), { status: "noop", target: null });
+    assert.deepEqual(resolveTier2Reject(true, [undefined, "x", 7]), { status: "noop", target: null });
+    // A single VALID entry alongside garbage still resolves to that one entry.
+    const valid = { ref: "the-button" };
+    const r = resolveTier2Reject(true, [null, valid]);
+    assert.equal(r.status, "single");
+    assert.strictEqual(r.target, valid);
+    // Two valid entries + garbage stays ambiguous (never guesses).
+    assert.equal(resolveTier2Reject(true, [null, { ref: "a" }, { ref: "b" }]).status, "ambiguous");
+  });
+});
+
+// ── makeTier2Adapter — registry entry builder ───────────────────────────────
+
+describe("makeTier2Adapter", () => {
+  const rule = Object.freeze({
+    id: "example-tier2-rule",
+    present: Object.freeze(["#example"]),
+    reject: Object.freeze([".reject"]),
+    openSettings: Object.freeze([]),
+  });
+
+  test("built adapter exposes id, tier:2, detect, canReject — no reject callback (Tier 2 has no vendor-global call)", () => {
+    const adapter = makeTier2Adapter(rule);
+    assert.equal(adapter.id, "example-tier2-rule");
+    assert.equal(adapter.tier, 2);
+    assert.equal(typeof adapter.detect, "function");
+    assert.equal(typeof adapter.canReject, "function");
+    assert.equal("reject" in adapter, false, "Tier 2 adapters must not expose a reject() callback");
+  });
+
+  test("built adapter is frozen", () => {
+    assert.ok(Object.isFrozen(makeTier2Adapter(rule)));
+  });
+
+  test("canReject(signals) returns true only when signals.tier2Confirmed[rule.id] === true", () => {
+    const adapter = makeTier2Adapter(rule);
+    assert.equal(adapter.canReject({ tier2Confirmed: { "example-tier2-rule": true } }), true);
+    assert.equal(adapter.canReject({ tier2Confirmed: { "example-tier2-rule": false } }), false);
+    assert.equal(adapter.canReject({ tier2Confirmed: {} }), false);
+    assert.equal(adapter.canReject({}), false);
+    assert.equal(adapter.canReject(null), false);
+    assert.equal(adapter.canReject(undefined), false);
+    assert.doesNotThrow(() => adapter.canReject(null));
+  });
+
+  test("canReject is undefined-safe against a non-boolean tier2Confirmed value (fail-closed)", () => {
+    const adapter = makeTier2Adapter(rule);
+    assert.equal(adapter.canReject({ tier2Confirmed: { "example-tier2-rule": "yes" } }), false);
+    assert.equal(adapter.canReject({ tier2Confirmed: null }), false);
   });
 });
 
@@ -1892,6 +2072,7 @@ describe("computeCookieGate — disabled-state gate", () => {
 
 describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () => {
   const source = readFileSync(join(__dirname, "../../src/lib/cmp-adapters.js"), "utf8");
+  const tier2RulesSource = readFileSync(join(__dirname, "../../src/lib/cmp-tier2-rules.js"), "utf8");
   const FORBIDDEN = /allowall|accept/i;
 
   test("cmp-adapters.js source contains no AllowAll / accept-family identifier", () => {
@@ -1899,6 +2080,21 @@ describe("cmp-adapters — STRUCTURAL guard: closed reject-only action set", () 
       source,
       FORBIDDEN,
       "cmp-adapters.js must never reference AllowAll/accept — the action registry is reject-only",
+    );
+  });
+
+  // #1027 Slice 1: the Tier 2 rule DATA file (src/lib/cmp-tier2-rules.js) is
+  // a separate module from cmp-adapters.js — the guard above never scanned
+  // it (it did not exist before this slice). A future edit could otherwise
+  // smuggle an accept-labelled selector into a rule's `reject` array without
+  // this describe block ever noticing. Scanned the same way, same forbidden
+  // pattern, own assertion so a failure here points straight at the data
+  // file rather than the adapter/decision logic.
+  test("cmp-tier2-rules.js source contains no AllowAll / accept-family identifier", () => {
+    assert.doesNotMatch(
+      tier2RulesSource,
+      FORBIDDEN,
+      "cmp-tier2-rules.js must never reference AllowAll/accept — Tier 2 rules are reject-only by construction",
     );
   });
 


### PR DESCRIPTION
## PR 1/3 — Tier 2 declarative reject-only cookie-consent adapters (#1027 follow-up)

Foundation slice: **data + pure decision logic + guard**. No DOM execution yet (PR 2), no maintainer transform tool / attribution (PR 3). Reject-only **by construction**.

### What's in this slice
- **`src/lib/cmp-tier2-rules.js`** (new): frozen `TIER2_RULES`, rule shape `{id, present, reject, openSettings}` — **no accept field exists** (the never-accept guarantee is a structural invariant, not a review rule). Seed = 2 verified API-less banners: **Complianz** (`.cmplz-deny`) + **Cookie Notice** (`#cn-refuse-cookie`). Axeptio dropped (closed Shadow DOM + randomized host — unreachable from a content script).
- **`resolveTier2Reject`**: pure, DOM-free, **fail-closed** (banner-absent / 0 / >1 / malformed entries → noop; exactly 1 → single), byte-identical contract to the shipped `findSpRejectTarget`.
- **`makeTier2Adapter`** wired into `decideAction`'s existing `TIER2` loop — Tier 1 (API adapters) still tried FIRST; Tier 2 only when no Tier 1 confirmed.
- **Structural guard extended**: the `/allowall|accept/i` scan now also reads `cmp-tier2-rules.js`, so an accept token can never ship in the data.
- Rides the existing `cookieConsentMode` gate + allowlist/blocklist. **No new toggle/pref.**

### Not in this PR
- PR 2: isolated-world DOM click dispatcher (`runTier2RejectDispatcher`) + `@sync` content-script mirror + open-settings hop
- PR 3: `tools/build-tier2-rules.mjs` offline transform (discards accept fields) + `THIRD_PARTY_NOTICES.md` (Consent-O-Matic MIT)
- Slice 2 (remote delivery of rules) — future

### Verification
- `npm test` 7506+ pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0
- `cleaner.js` untouched → no bundle rebuild; `cookie-noise-sync.test.mjs` green (cmp-tier2 mirror is legitimately deferred to PR 2)
- Fresh adversarial review: CLEAN — never-accept structural invariant holds, resolver fail-closed, dispatch order correct, guard genuinely scans the data file. One LOW finding (malformed-entry robustness vs the cited precedent) fixed in this PR.

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9