### PR TITLE
feat(consent): Tier 2 isolated-world DOM reject dispatcher (PR 2/3)

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1353,6 +1353,83 @@
   }
   // @sync:cmp-sp-reject-click:end
 
+  // ── Tier 2 declarative reject-click rule data (#1027, Slice 1) ────────────
+  //
+  // Hand-copied, byte-for-byte modulo indentation (and the `export` keyword,
+  // which content scripts cannot use — see the site-exempt precedent above),
+  // from src/lib/cmp-tier2-rules.js. Kept in sync by
+  // tests/unit/cookie-noise-sync.test.mjs. See that file's docblock for the
+  // full reject-only-vocabulary rationale and the seed-candidate
+  // verification notes — not repeated here to avoid a second place that can
+  // drift out of prose sync with the data itself.
+  // @sync:cmp-tier2-rules:start
+  const TIER2_RULES = Object.freeze([
+    /**
+     * Complianz (cmplz) — API-less, WordPress plugin. Real-site verification
+     * (doaj.org, 2026-07) confirmed a direct first-layer reject control:
+     * `.cmplz-deny` inside `#cmplz-cookiebanner-container`.
+     *
+     * Complianz's "manage options" / "save preferences" panel was
+     * DELIBERATELY NOT modeled as an `openSettings` two-step hop: that panel's
+     * save action commits whatever categories are CURRENTLY checked, which is
+     * not guaranteed to be reject/necessary-only — the toggles' default state
+     * is theme/installation-dependent, so clicking "save" there could commit
+     * an unknown consent state. That is not an unambiguous reject path, so
+     * this rule stays single-layer for Slice 1 and relies solely on the
+     * direct `.cmplz-deny` control (fail-closed no-op if that control is
+     * absent on a given installation).
+     */
+    Object.freeze({
+      id: "complianz",
+      present: Object.freeze(["#cmplz-cookiebanner-container"]),
+      reject: Object.freeze([".cmplz-deny"]),
+      openSettings: Object.freeze([]),
+    }),
+
+    /**
+     * Cookie Notice (dFactory) — API-less, WordPress plugin. Refuse control:
+     * `#cn-refuse-cookie` (also reachable via
+     * `.cn-set-cookie[data-cookie-set="refuse"]`, kept as a single curated
+     * selector for now — see the id-selector precedent above). The refuse
+     * button is an admin-optional setting: not every installation renders it.
+     * That is fine — the fail-closed 0-match branch already no-ops gracefully
+     * when it is absent, exactly like every other rule here.
+     */
+    Object.freeze({
+      id: "cookie-notice",
+      present: Object.freeze(["#cookie-notice"]),
+      reject: Object.freeze(["#cn-refuse-cookie"]),
+      openSettings: Object.freeze([]),
+    }),
+  ]);
+  // @sync:cmp-tier2-rules:end
+
+  // ── Tier 2 fail-closed reject resolution (#1027, Slice 1) ─────────────────
+  //
+  // Hand-copied, byte-for-byte modulo indentation, from
+  // src/lib/cmp-adapters.js. Kept in sync by
+  // tests/unit/cookie-noise-sync.test.mjs. See that file's docblock
+  // (immediately above `resolveTier2Reject`) for the full fail-closed
+  // contract rationale — byte-identical shape/return-type contract to
+  // findSpRejectTarget above. Pure; never throws.
+  // @sync:cmp-tier2:start
+  function resolveTier2Reject(presentMatched, rejectCandidates) {
+    if (presentMatched !== true) return { status: "noop", target: null };
+    const list = Array.isArray(rejectCandidates) ? rejectCandidates : [];
+    // Filter malformed entries (null/non-object) so garbage fails CLOSED to
+    // noop, byte-identical to findSpRejectTarget — a null/non-element never
+    // becomes a "single" clickable target the PR-2 dispatcher would trust.
+    const matches = [];
+    for (const candidate of list) {
+      if (!candidate || typeof candidate !== "object") continue;
+      matches.push(candidate);
+    }
+    if (matches.length === 0) return { status: "noop", target: null };
+    if (matches.length > 1) return { status: "ambiguous", target: null };
+    return { status: "single", target: matches[0] };
+  }
+  // @sync:cmp-tier2:end
+
   let _spRejectActed = false;
   let _spPmOpened = false;
   let _spRejectGateOpen = false;
@@ -1471,6 +1548,231 @@
     _spRejectObserver = null;
   }
 
+  // ── Tier 2 declarative reject-click dispatch (#1027, Slice 1) ─────────────
+  //
+  // Isolated-world DOM query-and-click execution for the reject-only
+  // click-rule registry hand-copied above (@sync:cmp-tier2-rules /
+  // @sync:cmp-tier2) — see Decision 3 in
+  // openspec/changes/cookie-consent-tier2/design.md. This is the DOM half
+  // deferred from src/lib/cmp-adapters.js's makeTier2Adapter: that pure
+  // adapter's canReject(signals) reads signals.tier2Confirmed[rule.id],
+  // exercised only by decideAction's truth-table unit tests in
+  // tests/unit/cmp-adapters.test.mjs — this content script never calls
+  // decideAction itself, exactly like the Tier-1 ladder above
+  // (canRejectOneTrust() etc. are called directly, not through decideAction
+  // either — decideAction has no runtime call site anywhere in this
+  // extension, only a lib-level pure decision surface exercised by tests).
+  // This dispatcher IS the thing that would produce a true
+  // tier2Confirmed[rule.id] signal: it queries the DOM for the rule's
+  // curated `present`/`reject` selectors, resolves the fail-closed match via
+  // the hand-copied resolveTier2Reject above, and clicks the confirmed
+  // single target directly.
+  //
+  // Mirrors runSpRejectClickDispatcher's shape closely (reuses
+  // collectAcceptCandidates() for actionable, classified DOM nodes; a
+  // confirmed reject click is the ONLY thing that marks a rule acted; the
+  // open-settings hop is monotone-safe and never marks acted). Unlike the
+  // single-CMP SP dispatcher, TIER2_RULES holds MULTIPLE independent rules
+  // (Complianz, Cookie Notice) — every piece of per-rule state below is
+  // therefore keyed by rule.id, not a single flat boolean.
+  //
+  // Never-accept invariant: `rule.reject` / `rule.openSettings` are the ONLY
+  // selector lists this dispatcher ever queries or clicks — there is no
+  // field on a Tier2Rule capable of expressing a broad-consent path (see
+  // src/lib/cmp-tier2-rules.js's file docblock), so this dispatcher cannot
+  // click one even by a future editing mistake without first inventing a
+  // new field name, which the structural guard in
+  // tests/unit/cmp-adapters.test.mjs scans for. Fail-closed everywhere: no
+  // confirmed reject candidate means this loop iteration does nothing and
+  // leaves the banner exactly as-is.
+
+  const _tier2Acted = {};
+  const _tier2PmOpened = {};
+  const _tier2Warned = {};
+  let _tier2GateOpen = false;
+  let _tier2Observer = null;
+  const TIER2_GIVE_UP_AFTER_DOM_READY_MS = 10000;
+  let _tier2GiveUpArmed = false;
+  let _tier2GiveUpTimer = null;
+  let _tier2GiveUpFallbackTimer = null;
+
+  // Drift signal (Decision 7): console-only, warned at most ONCE per rule id
+  // — no network call, no telemetry. Covers BOTH: (a) a confirmed reject was
+  // clicked but the banner never cleared, and (b) the banner's `present`
+  // anchor stayed matched but the resolver never reached a confirmed single
+  // reject through the whole give-up window (selector drift on either the
+  // reject or the present anchor).
+  function tier2WarnDrift(ruleId) {
+    if (_tier2Warned[ruleId]) return;
+    _tier2Warned[ruleId] = true;
+    try {
+      console.warn(
+        "[MUGA] cookie-consent: tier2:" + ruleId +
+        " reject clicked but banner did not clear (possible selector drift)"
+      );
+    } catch {
+      // console unavailable — nothing else to do.
+    }
+  }
+
+  // Reuses the SAME bounded-poll mechanics as confirmRejectDismissal above
+  // (REJECT_CONFIRM_WINDOW_MS / REJECT_CONFIRM_INTERVAL_MS, deadline +
+  // interval, fail-safe-gone-on-error) — confirmRejectDismissal's own
+  // message text is pinned to the Tier-1 vendor-API-drift wording, so this
+  // small parallel version reuses its constants/timing but reports through
+  // tier2WarnDrift's Tier-2-specific wording instead of parameterizing the
+  // shared helper.
+  function confirmTier2RejectDismissal(ruleId, isBannerGone) {
+    const deadline = Date.now() + REJECT_CONFIRM_WINDOW_MS;
+    const tick = () => {
+      let gone = true;
+      try {
+        gone = !!isBannerGone();
+      } catch {
+        gone = true;
+      }
+      if (gone) return; // confirmed dismissal — stay silent
+      if (Date.now() >= deadline) {
+        tier2WarnDrift(ruleId);
+        return;
+      }
+      setTimeout(tick, REJECT_CONFIRM_INTERVAL_MS);
+    };
+    tick();
+  }
+
+  function tier2BannerGoneBy(rule) {
+    return bannerGoneBy(rule.present.join(","));
+  }
+
+  // Filters collectAcceptCandidates()'s full button/link scan down to the
+  // ones matching one of `selectors` (a rule's `reject` or `openSettings`
+  // list) AND currently actionable — the same conservative bar
+  // findSpRejectTarget applies inline above; resolveTier2Reject itself stays
+  // generic/caller-agnostic (see its docblock in src/lib/cmp-adapters.js),
+  // so this filtering lives at the call site, not inside the shared
+  // @sync:cmp-tier2 resolver. Never throws.
+  function tier2FilterCandidates(candidates, selectors) {
+    if (!Array.isArray(selectors) || selectors.length === 0) return [];
+    const joined = selectors.join(",");
+    const matches = [];
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate !== "object" || candidate.actionable !== true) continue;
+      try {
+        if (candidate.ref && typeof candidate.ref.matches === "function" && candidate.ref.matches(joined)) {
+          matches.push(candidate);
+        }
+      } catch {
+        // A malformed/hostile selector or element must never break the page.
+      }
+    }
+    return matches;
+  }
+
+  function runTier2RejectDispatcher() {
+    if (!_tier2GateOpen) return;
+    const candidates = collectAcceptCandidates();
+    for (const rule of TIER2_RULES) {
+      if (_tier2Acted[rule.id]) continue;
+      let present = false;
+      try {
+        present = !!document.querySelector(rule.present.join(","));
+      } catch {
+        present = false;
+      }
+      if (!present) continue;
+      const rejectCandidates = tier2FilterCandidates(candidates, rule.reject);
+      const result = resolveTier2Reject(present, rejectCandidates);
+      if (result.status === "single") {
+        _tier2Acted[rule.id] = true;
+        try {
+          result.target.ref.click();
+        } catch {
+          // A throwing/hostile page element must never break the page.
+        }
+        confirmTier2RejectDismissal(rule.id, tier2BannerGoneBy(rule));
+        continue;
+      }
+      // Single open-settings hop (Decision 3 / SP precedent): monotone-safe
+      // (opening a settings panel grants nothing), NOT marked acted — the
+      // revealed reject control is re-resolved on the observer's next pass.
+      // Dormant for both Slice-1 seed rules (openSettings: []).
+      if (_tier2PmOpened[rule.id]) continue;
+      const openCandidates = tier2FilterCandidates(candidates, rule.openSettings);
+      if (openCandidates.length !== 1) continue;
+      _tier2PmOpened[rule.id] = true;
+      try {
+        openCandidates[0].ref.click();
+      } catch {
+        // A throwing/hostile page element must never break the page.
+      }
+    }
+  }
+
+  // Bounded give-up window — same rationale and shape as the other
+  // dispatchers' give-up windows above. Also the drift-check point for
+  // "resolver stuck at noop through the give-up window" (Decision 7): a rule
+  // whose `present` anchor is still matched but never reached a confirmed
+  // reject click gets exactly one console warning here before the observer
+  // disconnects.
+  function tier2ArmGiveUp() {
+    if (_tier2GiveUpArmed) return;
+    _tier2GiveUpArmed = true;
+    const giveUp = () => {
+      for (const rule of TIER2_RULES) {
+        if (_tier2Acted[rule.id]) continue;
+        let present = false;
+        try {
+          present = !!document.querySelector(rule.present.join(","));
+        } catch {
+          present = false;
+        }
+        if (present) tier2WarnDrift(rule.id);
+      }
+      tier2StopObserver();
+    };
+    const schedule = () => {
+      _tier2GiveUpTimer = setTimeout(giveUp, TIER2_GIVE_UP_AFTER_DOM_READY_MS);
+    };
+    if (document.readyState === "loading") {
+      _tier2GiveUpFallbackTimer = setTimeout(giveUp, TIER2_GIVE_UP_AFTER_DOM_READY_MS);
+      document.addEventListener("DOMContentLoaded", schedule, { once: true });
+    } else {
+      schedule();
+    }
+  }
+
+  function tier2StartObserver() {
+    if (_tier2Observer) return;
+    if (!document || !document.documentElement) return;
+    try {
+      _tier2Observer = new MutationObserver(() => runTier2RejectDispatcher());
+      _tier2Observer.observe(document.documentElement, { childList: true, subtree: true });
+    } catch {
+      _tier2Observer = null;
+    }
+    tier2ArmGiveUp();
+  }
+
+  function tier2StopObserver() {
+    if (_tier2GiveUpTimer !== null) {
+      clearTimeout(_tier2GiveUpTimer);
+      _tier2GiveUpTimer = null;
+    }
+    if (_tier2GiveUpFallbackTimer !== null) {
+      clearTimeout(_tier2GiveUpFallbackTimer);
+      _tier2GiveUpFallbackTimer = null;
+    }
+    _tier2GiveUpArmed = false;
+    if (!_tier2Observer) return;
+    try {
+      _tier2Observer.disconnect();
+    } catch {
+      // already disconnected
+    }
+    _tier2Observer = null;
+  }
+
   function readPrefsAndGate() {
     try {
       chrome.runtime.sendMessage({ type: "getPrefs" }, (prefs) => {
@@ -1497,6 +1799,19 @@
           spRejectStartObserver();
         } else {
           spRejectStopObserver();
+        }
+        // Tier 2 declarative reject-click dispatch — reuses the SAME reject
+        // master gate (`open`) as the Tier-1 API ladder and the Sourcepoint
+        // DOM fallback above; no separate Tier 2 toggle exists (Decision 4,
+        // task 3.6). `open` already encodes cookieConsentMode === "reject-only"
+        // (via deps.modeActive) AND not-allowlisted/exempted (via
+        // isSiteFullyExempt) — see computeCookieGate above.
+        _tier2GateOpen = open;
+        if (_tier2GateOpen) {
+          runTier2RejectDispatcher(); // initial sweep — the banner may already exist
+          tier2StartObserver();
+        } else {
+          tier2StopObserver();
         }
       });
     } catch {

--- a/tests/unit/cookie-noise-giveup-fallback.test.mjs
+++ b/tests/unit/cookie-noise-giveup-fallback.test.mjs
@@ -151,15 +151,18 @@ describe("cookie-noise.js fxArmGiveUp() — bounded fallback (FIX C, Firefox pat
     vm.createContext(sandbox);
     vm.runInContext(isolatedSource, sandbox, { filename: "content/cookie-noise.js" });
 
-    // TWO observers start on an open reject gate: the Firefox fxRunDispatcher
-    // observer (index 0, started first in readPrefsAndGate) AND the
-    // Sourcepoint reject-click DOM-fallback observer (index 1, gated by the
-    // SAME reject master gate, independent of _isFirefox — see
-    // content/cookie-noise.js's runSpRejectClickDispatcher()).
-    assert.equal(FakeMutationObserver.instances.length, 2, "an active gate on Firefox must start both the fx reject observer and the SP reject-click observer");
-    const [observer, spRejectObserver] = FakeMutationObserver.instances;
+    // THREE observers start on an open reject gate: the Firefox
+    // fxRunDispatcher observer (index 0, started first in readPrefsAndGate),
+    // the Sourcepoint reject-click DOM-fallback observer (index 1, gated by
+    // the SAME reject master gate, independent of _isFirefox — see
+    // content/cookie-noise.js's runSpRejectClickDispatcher()), and the Tier 2
+    // declarative reject-click dispatcher observer (index 2, same gate — see
+    // runTier2RejectDispatcher()).
+    assert.equal(FakeMutationObserver.instances.length, 3, "an active gate on Firefox must start the fx reject observer, the SP reject-click observer, and the Tier 2 reject-click observer");
+    const [observer, spRejectObserver, tier2Observer] = FakeMutationObserver.instances;
     assert.equal(observer.disconnected, false, "must not be disconnected immediately after arming");
     assert.equal(spRejectObserver.disconnected, false, "the SP reject-click observer must not be disconnected immediately after arming either");
+    assert.equal(tier2Observer.disconnected, false, "the Tier 2 reject-click observer must not be disconnected immediately after arming either");
 
     t.mock.timers.tick(GIVE_UP_AFTER_DOM_READY_MS);
 
@@ -172,6 +175,11 @@ describe("cookie-noise.js fxArmGiveUp() — bounded fallback (FIX C, Firefox pat
       spRejectObserver.disconnected,
       true,
       "the SP reject-click observer must ALSO disconnect within its own give-up window",
+    );
+    assert.equal(
+      tier2Observer.disconnected,
+      true,
+      "the Tier 2 reject-click observer must ALSO disconnect within its own give-up window",
     );
   });
 });

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -333,6 +333,188 @@ describe("cookie-noise-sync — @sync:cmp-sp-reject-click block matches src/lib/
   });
 });
 
+// ── @sync:cmp-tier2-rules block (Tier 2 declarative reject-click rule data) ─
+//
+// TIER2_RULES is a frozen array in src/lib/cmp-tier2-rules.js (unit-tested
+// there) whose body is hand-inlined ONLY into content/cookie-noise.js
+// (isolated world) — mirrors the @sync:site-exempt precedent: the lib copy
+// carries an `export` keyword content scripts cannot use, so the comparison
+// strips a leading `export ` token from each line before comparing.
+
+const TIER2_RULES_FILES = {
+  lib: join(__dirname, "../../src/lib/cmp-tier2-rules.js"),
+  isolated: FILES.isolated,
+};
+
+const tier2RulesSources = {
+  lib: readFileSync(TIER2_RULES_FILES.lib, "utf8"),
+  isolated: sources.isolated,
+};
+
+const TIER2_RULES_START = "@sync:cmp-tier2-rules:start";
+const TIER2_RULES_END = "@sync:cmp-tier2-rules:end";
+
+function extractTier2RulesBlock(source, label) {
+  return extractMarkedBlock(source, TIER2_RULES_START, TIER2_RULES_END, label)
+    .map((l) => l.replace(/^export\s+/, ""));
+}
+
+describe("cookie-noise-sync — @sync:cmp-tier2-rules block matches src/lib/cmp-tier2-rules.js", () => {
+  const libBlock = extractTier2RulesBlock(tier2RulesSources.lib, "cmp-tier2-rules.js");
+  const isolatedBlock = extractTier2RulesBlock(tier2RulesSources.isolated, "cookie-noise.js");
+
+  test("tier2-rules sync block is non-empty and defines TIER2_RULES", () => {
+    assert.ok(libBlock.length > 0, "extracted @sync:cmp-tier2-rules block must not be empty — check the markers");
+    assert.ok(/const TIER2_RULES\s*=\s*Object\.freeze/.test(libBlock.join("\n")));
+  });
+
+  test("cookie-noise.js @sync:cmp-tier2-rules block matches src/lib/cmp-tier2-rules.js (modulo the export keyword)", () => {
+    assert.deepEqual(
+      isolatedBlock,
+      libBlock,
+      "content/cookie-noise.js's @sync:cmp-tier2-rules block has drifted from src/lib/cmp-tier2-rules.js",
+    );
+  });
+
+  test("the main-world caller does NOT carry the @sync:cmp-tier2-rules block (Tier 2 is isolated-world only)", () => {
+    assert.equal(sources.mainworld.includes(TIER2_RULES_START), false,
+      "cookie-noise-mainworld.js must not inline the Tier 2 rule data — this mechanism is isolated-world only");
+  });
+
+  test("neither seed rule defines an accept-family field (no field beyond id/present/reject/openSettings)", () => {
+    const joined = libBlock.join("\n");
+    assert.doesNotMatch(joined, /allowall|accept/i);
+  });
+});
+
+// ── @sync:cmp-tier2 block (Tier 2 fail-closed reject resolution) ───────────
+//
+// resolveTier2Reject is a pure helper in src/lib/cmp-adapters.js (unit-tested
+// there) whose body is hand-inlined ONLY into content/cookie-noise.js
+// (isolated world) — mirrors the @sync:cmp-sp-reject-click precedent: a DOM
+// click needs neither a page-authored global nor the MAIN world.
+
+const TIER2_START = "@sync:cmp-tier2:start";
+const TIER2_END = "@sync:cmp-tier2:end";
+
+describe("cookie-noise-sync — @sync:cmp-tier2 block matches src/lib/cmp-adapters.js", () => {
+  const libBlock = extractMarkedBlock(sources.lib, TIER2_START, TIER2_END, "cmp-adapters.js");
+  const isolatedBlock = extractMarkedBlock(sources.isolated, TIER2_START, TIER2_END, "cookie-noise.js");
+
+  test("tier2 resolver sync block is non-empty and defines resolveTier2Reject", () => {
+    assert.ok(libBlock.length > 0, "extracted @sync:cmp-tier2 block must not be empty — check the markers");
+    assert.ok(/function resolveTier2Reject/.test(libBlock.join("\n")));
+  });
+
+  test("cookie-noise.js @sync:cmp-tier2 block matches src/lib/cmp-adapters.js", () => {
+    assert.deepEqual(
+      isolatedBlock,
+      libBlock,
+      "content/cookie-noise.js's @sync:cmp-tier2 block has drifted from src/lib/cmp-adapters.js",
+    );
+  });
+
+  test("the main-world caller does NOT carry the @sync:cmp-tier2 block (Tier 2 is isolated-world only)", () => {
+    assert.equal(sources.mainworld.includes(TIER2_START), false,
+      "cookie-noise-mainworld.js must not inline the Tier 2 resolver — this mechanism is isolated-world only");
+  });
+});
+
+// ── Tier 2 dispatch — main-world exclusion (task 3.3) ───────────────────────
+//
+// Tier 2's DOM query-and-click capability must live ONLY in the isolated
+// content-script world (content/cookie-noise.js), never in
+// content/cookie-noise-mainworld.js — mirrors the identical guard for the
+// Sourcepoint reject-click dispatch above.
+
+describe("cookie-noise-mainworld.js — no Tier 2 query/click logic of any kind", () => {
+  const TIER2_IDENTIFIERS = [
+    "runTier2RejectDispatcher",
+    "resolveTier2Reject",
+    "TIER2_RULES",
+    "tier2Confirmed",
+    "tier2StartObserver",
+    "tier2StopObserver",
+    "confirmTier2RejectDismissal",
+    "tier2WarnDrift",
+  ];
+
+  for (const identifier of TIER2_IDENTIFIERS) {
+    test(`cookie-noise-mainworld.js does not contain "${identifier}"`, () => {
+      assert.equal(sources.mainworld.includes(identifier), false,
+        `cookie-noise-mainworld.js must not contain "${identifier}" — Tier 2 is isolated-world only`);
+    });
+  }
+});
+
+// ── Tier 2 reject-click dispatch — structural guards ────────────────────────
+//
+// Mirrors the Sourcepoint reject-click structural guards above: prove the
+// click call site is gated on a confirmed single target before ever
+// clicking, marks a rule acted only after a real click (never on mere
+// detection or on opening the settings hop), and the drift-warning path
+// makes no network/telemetry call of any kind (console-only, per Decision 7).
+
+describe("cookie-noise.js — Tier 2 reject-click dispatch structural guards", () => {
+  test("runTier2RejectDispatcher gates on resolveTier2Reject's single status before ever clicking", () => {
+    const src = sources.isolated;
+    const fnMatch = /function runTier2RejectDispatcher\(\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define runTier2RejectDispatcher()");
+    const body = fnMatch[1];
+    const resolveIdx = body.indexOf("resolveTier2Reject(");
+    const clickIdx = body.indexOf(".ref.click(");
+    assert.ok(resolveIdx !== -1, "must call resolveTier2Reject");
+    assert.ok(clickIdx !== -1, "must call .ref.click()");
+    assert.ok(resolveIdx < clickIdx, "runTier2RejectDispatcher must resolve resolveTier2Reject before ever clicking");
+  });
+
+  test("the dispatcher marks a rule's _tier2Acted only INSIDE the confirmed-single reject branch, never on mere detection or on opening the settings hop (no false success)", () => {
+    const src = sources.isolated;
+    const fnMatch = /function runTier2RejectDispatcher\(\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    const body = fnMatch[1];
+    const singleBranchIdx = body.indexOf('if (result.status === "single") {');
+    const actedIdx = body.indexOf("_tier2Acted[rule.id] = true;");
+    const pmOpenedIdx = body.indexOf("_tier2PmOpened[rule.id] = true;");
+    assert.ok(singleBranchIdx !== -1, "the reject click must be gated on a confirmed single target");
+    assert.ok(actedIdx !== -1, "must set _tier2Acted[rule.id] = true");
+    assert.equal(body.split("_tier2Acted[rule.id] = true;").length - 1, 1, "_tier2Acted must be set in exactly one place");
+    assert.ok(singleBranchIdx < actedIdx, "_tier2Acted must only be set AFTER confirming a single reject target");
+    assert.ok(pmOpenedIdx !== -1, "the open-settings hop must be guarded by _tier2PmOpened");
+    assert.ok(actedIdx < pmOpenedIdx, "the open-settings branch comes after the reject branch and must not set _tier2Acted");
+  });
+
+  test("the Tier 2 gate (_tier2GateOpen, from the same reject master gate as the Tier-1 API ladder and the Sourcepoint fallback) is checked before the dispatch runs", () => {
+    assert.ok(/_tier2GateOpen/.test(sources.isolated));
+  });
+
+  test("Tier 2 dispatch reuses the existing reject master gate (`open`) — no separate Tier 2 pref/toggle is read", () => {
+    const src = sources.isolated;
+    // Excludes the `let _tier2GateOpen = false;` declaration — only the
+    // real wiring assignment (inside readPrefsAndGate) is relevant here.
+    const assignments = [...src.matchAll(/(?<!let )_tier2GateOpen\s*=\s*(\w+);/g)].map((m) => m[1]);
+    assert.ok(assignments.length > 0, "cookie-noise.js must assign _tier2GateOpen from a variable");
+    assert.ok(
+      assignments.includes("open"),
+      "_tier2GateOpen must be assigned from the same `open` gate value as _spRejectGateOpen — no new gate",
+    );
+  });
+
+  test("the drift-warning path (tier2WarnDrift, confirmTier2RejectDismissal, tier2ArmGiveUp) makes no network/telemetry call — console-only", () => {
+    const src = sources.isolated;
+    const NETWORK_PATTERN = /sendMessage|fetch\s*\(|XMLHttpRequest|sendBeacon/;
+    for (const fnName of ["tier2WarnDrift", "confirmTier2RejectDismissal", "tier2ArmGiveUp"]) {
+      const fnMatch = new RegExp(`function ${fnName}\\([^)]*\\)\\s*\\{([\\s\\S]*?)\\n  \\}`).exec(src);
+      assert.ok(fnMatch, `cookie-noise.js must define ${fnName}()`);
+      assert.doesNotMatch(fnMatch[1], NETWORK_PATTERN, `${fnName} must not make any network/telemetry call`);
+    }
+  });
+
+  test("tier2WarnDrift only ever warns once per rule id (guarded by _tier2Warned)", () => {
+    assert.ok(/_tier2Warned\[ruleId\]/.test(sources.isolated));
+  });
+});
+
 // ── Content-script structural shape ─────────────────────────────────────────
 
 describe("cookie-noise content scripts — IIFE shape, no ES imports", () => {


### PR DESCRIPTION
## PR 2/3 — Tier 2 declarative reject-only cookie-consent adapters (#1027)

The runtime DOM execution for the reject-only click-rules landed in PR 1 (data + pure resolver). Isolated-world only.

### What's in this slice
- Hand-copied `@sync:cmp-tier2` (resolver) + `@sync:cmp-tier2-rules` (data) into `src/content/cookie-noise.js`, byte-for-byte (enforced by `cookie-noise-sync.test.mjs`).
- **`runTier2RejectDispatcher`**: two live call sites (initial sweep + MutationObserver), runs AFTER the Tier 1 API ladder + SP dispatcher. Per rule: gate on `rule.present`, filter `collectAcceptCandidates()` down to actionable elements matching `rule.reject`, `resolveTier2Reject`, and click the **single** confirmed reject target. Fail-closed on 0/>1/malformed.
- **Never-accept holds in the real click path**: a candidate can only be clicked if it matches a curated `rule.reject` selector — an accept button gathered by the broad collector can never reach the click.
- Single open-settings hop mirrors the Sourcepoint `_spPmOpened` precedent (monotone-safe, never marks acted, observer re-entry, ~10s give-up). Dormant for both seed rules (`openSettings:[]`).
- **Gate reuse**: `_tier2GateOpen` = the same `computeGate(prefs)` `open` that gates Tier 1 (`reject-only` + not allowlisted/exempt). No new toggle.
- Drift warning is `console.warn`-only — no network/telemetry (regex-scanned test). Observer teardown verified in real-VM execution (Firefox 3-observer test).

### Verification
- `npm test` 7528 pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0
- `cleaner.js` untouched → no bundle rebuild; the cmp↔content-script `@sync` mirror is byte-for-byte green
- Fresh adversarial review: CLEAN — wired, never-accept in the real click path, gate reuse, fail-closed, zero telemetry all confirmed

### Noted for later (non-blocking)
When a future rule populates `openSettings`, consider mirroring SP's "options-only wall" guard (don't open settings when other decision controls are present). Dormant today; Tier 2's per-rule curation is the current safety model.

### Not in this PR
- PR 3: `tools/build-tier2-rules.mjs` offline transform (discards accept fields) + `THIRD_PARTY_NOTICES.md` (Consent-O-Matic MIT)

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9