### PR TITLE
chore(consent): Tier 2 transform tool + third-party attribution (PR 3/3)

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,68 @@
+# Third-Party Notices
+
+MUGA is licensed under the GNU General Public License v3.0 (see `LICENSE`). This file lists
+third-party software whose code or data was used to derive material now bundled with MUGA,
+together with the attribution and license text each requires.
+
+---
+
+## Consent-O-Matic (cavi-au/Consent-O-Matic)
+
+**Copyright (c) 2019,2020,2021,2022 Janus Bager Kristensen and Rolf Bagge, CAVI - Center for Advanced Visualization and Interaction, Aarhus University**
+(https://github.com/cavi-au/Consent-O-Matic)
+
+**License: MIT**
+
+MUGA's Cookie Consent Minimizer Tier 2 rule data (`src/lib/cmp-tier2-rules.js`) is **derived and
+adapted from Consent-O-Matic's cookie-management ruleset — it is not a verbatim redistribution.**
+Every entry is produced through a one-way, hand-reviewed transform tool
+(`tools/build-tier2-rules.mjs`) that:
+
+- reads a locally vetted copy of Consent-O-Matic `rules/*.json` files (the Consent-O-Matic
+  repository itself is **not vendored** into MUGA — the tool takes a local path as an argument);
+- applies a hard field-allowlist on ingestion: only reject/necessary-only selector data and
+  banner-presence selector data survive the transform. Every accept-path field, toggle/consent
+  matcher, and save/persist field on the source rule (e.g. Consent-O-Matic's `trueAction`,
+  `DO_CONSENT` consent matchers, and `SAVE_CONSENT` method) is discarded on ingestion and never
+  reaches MUGA's rule data — see `tools/build-tier2-rules.mjs`'s docblock and its unit tests
+  (`tests/unit/build-tier2-rules.test.mjs`) for the enforced allowlist; and
+- requires a maintainer to manually review and hand-merge the tool's output into
+  `src/lib/cmp-tier2-rules.js` — the tool itself never writes to that file, or to any file.
+
+This is consistent with MUGA's own never-accept-by-construction data model: `src/lib/
+cmp-tier2-rules.js`'s rule shape (`{id, present, reject, openSettings}`) has no field capable of
+expressing an accept/allow-all action in the first place, so a Consent-O-Matic-derived rule
+cannot carry one forward even by mistake.
+
+MIT is compatible with, and does not restrict, redistribution under GPLv3; attribution is the
+license's only ongoing obligation, satisfied by this file.
+
+### MIT License text
+
+> The copyright line below was verified byte-for-byte against the upstream `LICENSE` file
+> (https://github.com/cavi-au/Consent-O-Matic/blob/master/LICENSE) on 2026-07-25. Re-confirm it
+> if a future upstream release changes the holder or year range.
+
+```
+MIT License
+
+Copyright (c) 2019,2020,2021,2022 Janus Bager Kristensen and Rolf Bagge, CAVI - Center for Advanced Visualization and Interaction, Aarhus University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/tests/unit/build-tier2-rules.test.mjs
+++ b/tests/unit/build-tier2-rules.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * MUGA: Unit tests for the offline Tier 2 rule transform tool (#1027 Phase 4).
+ *
+ * `tools/build-tier2-rules.mjs` is a MAINTAINER tool, never wired into CI,
+ * that turns locally vetted Consent-O-Matic-shaped rule files into MUGA's
+ * Tier 2 reject-only rule shape. These tests only import the module's pure
+ * reducer -- the module's `main()` (filesystem reads + stdout) is guarded so
+ * importing it here never touches the filesystem or process.argv beyond the
+ * test runner's own invocation (see the entry-guard at the bottom of the
+ * tool, mirroring tools/probe-shortener-redirect.mjs).
+ *
+ * The safety-critical property under test: given a source rule object that
+ * carries BOTH accept-path fields (trueAction, a DO_CONSENT toggle/consent
+ * matcher, a SAVE_CONSENT method, and a top-level accept selector) AND
+ * reject/present fields, the reducer's output contains ONLY the four
+ * MUGA-allowlisted keys and not one token from the accept-path survives.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { reduceTier2Rule } from "../../tools/build-tier2-rules.mjs";
+
+describe("build-tier2-rules — reduceTier2Rule pure field-allowlist reducer", () => {
+  // A single fixture carrying BOTH accept-path fields (trueAction, the
+  // DO_CONSENT toggle/consent matcher, SAVE_CONSENT, acceptSelector) and
+  // reject/present fields (declineSelector, detectors, OPEN_OPTIONS), per
+  // task 4.1.
+  const sourceRuleWithBothPaths = Object.freeze({
+    id: "examplecmp",
+    detectors: [{ presentMatcher: { target: { selector: "#examplecmp-banner" } } }],
+    methods: [
+      {
+        name: "DO_CONSENT",
+        consents: [
+          { type: "ANALYTICS", toggleAction: { slide: { selector: ".examplecmp-analytics-toggle" } } },
+        ],
+        trueAction: { click: { selector: ".examplecmp-accept-all" } },
+      },
+      { name: "SAVE_CONSENT", action: { click: { selector: ".examplecmp-save-choices" } } },
+      { name: "OPEN_OPTIONS", action: { click: { selector: ".examplecmp-manage-options" } } },
+    ],
+    declineSelector: ".examplecmp-decline-all",
+    acceptSelector: ".examplecmp-accept-all",
+  });
+
+  test("output contains ONLY the allowlisted {id, present, reject, openSettings} keys", () => {
+    const out = reduceTier2Rule(sourceRuleWithBothPaths);
+    assert.deepEqual(Object.keys(out).sort(), ["id", "openSettings", "present", "reject"]);
+  });
+
+  test("reject holds only the curated decline selector, never the accept selector", () => {
+    const out = reduceTier2Rule(sourceRuleWithBothPaths);
+    assert.deepEqual(out.reject, [".examplecmp-decline-all"]);
+  });
+
+  test("present is derived from the detectors' presentMatcher selectors", () => {
+    const out = reduceTier2Rule(sourceRuleWithBothPaths);
+    assert.deepEqual(out.present, ["#examplecmp-banner"]);
+  });
+
+  test("openSettings is derived only from OPEN_OPTIONS, never DO_CONSENT/SAVE_CONSENT", () => {
+    const out = reduceTier2Rule(sourceRuleWithBothPaths);
+    assert.deepEqual(out.openSettings, [".examplecmp-manage-options"]);
+  });
+
+  test("id is copied from the source rule id", () => {
+    const out = reduceTier2Rule(sourceRuleWithBothPaths);
+    assert.equal(out.id, "examplecmp");
+  });
+
+  test("zero accept/allowall/trueAction/save token survives anywhere in the emitted object", () => {
+    const out = reduceTier2Rule(sourceRuleWithBothPaths);
+    const serialized = JSON.stringify(out);
+    assert.doesNotMatch(serialized, /accept|allowall|trueaction|save/i);
+  });
+
+  test("missing declineSelector -> reject is empty, never falls back to the accept selector", () => {
+    const noReject = { ...sourceRuleWithBothPaths, declineSelector: undefined };
+    const out = reduceTier2Rule(noReject);
+    assert.deepEqual(out.reject, []);
+  });
+
+  test("a source rule with ONLY accept-path fields (no declineSelector at all) never leaks one into reject", () => {
+    const acceptOnly = {
+      id: "acceptonlycmp",
+      detectors: [{ presentMatcher: { target: { selector: "#acceptonlycmp-banner" } } }],
+      methods: [
+        { name: "DO_CONSENT", trueAction: { click: { selector: ".acceptonlycmp-accept-all" } } },
+        { name: "SAVE_CONSENT", action: { click: { selector: ".acceptonlycmp-save" } } },
+      ],
+      acceptSelector: ".acceptonlycmp-accept-all",
+    };
+    const out = reduceTier2Rule(acceptOnly);
+    assert.deepEqual(out.reject, []);
+    assert.deepEqual(out.openSettings, []);
+  });
+
+  test("garbage/empty input never throws and produces the allowlisted shape with empty arrays", () => {
+    assert.doesNotThrow(() => reduceTier2Rule({}));
+    const out = reduceTier2Rule({});
+    assert.deepEqual(Object.keys(out).sort(), ["id", "openSettings", "present", "reject"]);
+    assert.deepEqual(out.present, []);
+    assert.deepEqual(out.reject, []);
+    assert.deepEqual(out.openSettings, []);
+    assert.equal(out.id, "");
+  });
+
+  test("null/undefined input never throws", () => {
+    assert.doesNotThrow(() => reduceTier2Rule(null));
+    assert.doesNotThrow(() => reduceTier2Rule(undefined));
+  });
+
+  test("output arrays are frozen (defense in depth, matches cmp-tier2-rules.js's own frozen shape)", () => {
+    const out = reduceTier2Rule(sourceRuleWithBothPaths);
+    assert.ok(Object.isFrozen(out));
+    assert.ok(Object.isFrozen(out.present));
+    assert.ok(Object.isFrozen(out.reject));
+    assert.ok(Object.isFrozen(out.openSettings));
+  });
+});

--- a/tests/unit/cmp-tier2-gate-reuse.test.mjs
+++ b/tests/unit/cmp-tier2-gate-reuse.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * MUGA: Tier 2 gate-reuse guard (#1027 Phase 4, task 4.4).
+ *
+ * Tier 2 (src/lib/cmp-tier2-rules.js, cmp-adapters.js's TIER2 adapters, and
+ * cookie-noise.js's runTier2RejectDispatcher) rides the SAME
+ * `cookieConsentMode` pref and the SAME allowlist/blocklist exemption check
+ * Tier 1 already uses (see src/lib/cmp-adapters.js's computeCookieGate and
+ * cookie-noise.js's `_tier2GateOpen = open` wiring, both from PR 1/PR 2 of
+ * this chain). This file asserts, structurally, that no Tier 2-specific
+ * toggle/pref/manifest entry was ever introduced -- Tier 2 must stay
+ * completely silent within the existing consent feature, per spec.md's
+ * "Tier 2 rides the existing consent gate" requirement.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { PREF_DEFAULTS } from "../../src/lib/prefs.js";
+import { COOKIE_CONSENT_MODE_OPTIONS, SETTINGS_FIELDS, BOOLEAN_KEYS } from "../../src/lib/settings-schema.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "../..");
+
+// Case-insensitive: catches "tier2", "Tier 2", "tier_2", "tierTwo", etc. in
+// one pass. Selector/id strings inside cmp-tier2-rules.js legitimately
+// contain "tier2"-shaped substrings (the file itself), so that file is
+// intentionally excluded from this particular scan -- this guard is about
+// TOGGLE/PREF/MANIFEST surface, not the rule-data file's own naming.
+const TIER2_TOKEN = /tier[\s_-]?2|tiertwo/i;
+
+describe("Tier 2 gate reuse — no new toggle/pref/manifest entry", () => {
+  test("PREF_DEFAULTS has no tier2-specific key", () => {
+    for (const key of Object.keys(PREF_DEFAULTS)) {
+      assert.doesNotMatch(key, TIER2_TOKEN, `PREF_DEFAULTS must not gain a Tier 2-specific key: ${key}`);
+    }
+  });
+
+  test("PREF_DEFAULTS still carries the existing cookieConsentMode key Tier 2 reuses", () => {
+    assert.ok("cookieConsentMode" in PREF_DEFAULTS, "cookieConsentMode must exist -- Tier 2 has no gate of its own");
+    assert.equal(PREF_DEFAULTS.cookieConsentMode, "reject-only");
+  });
+
+  test("cookieConsentMode stays a 2-state enum (no tier2-aware third mode was added)", () => {
+    assert.deepEqual([...COOKIE_CONSENT_MODE_OPTIONS].sort(), ["off", "reject-only"]);
+  });
+
+  test("SETTINGS_FIELDS has exactly one cookieConsentMode row, no tier2-specific settings row", () => {
+    const cookieRows = SETTINGS_FIELDS.filter((f) => f.key === "cookieConsentMode");
+    assert.equal(cookieRows.length, 1, "cookieConsentMode must be declared exactly once in SETTINGS_FIELDS");
+    for (const field of SETTINGS_FIELDS) {
+      assert.doesNotMatch(field.key, TIER2_TOKEN, `SETTINGS_FIELDS must not gain a Tier 2-specific field: ${field.key}`);
+    }
+  });
+
+  test("BOOLEAN_KEYS has no tier2-specific boolean toggle", () => {
+    for (const key of BOOLEAN_KEYS) {
+      assert.doesNotMatch(key, TIER2_TOKEN, `BOOLEAN_KEYS must not gain a Tier 2-specific toggle: ${key}`);
+    }
+  });
+
+  test("manifest.json (MV3) declares no tier2-specific permission, WAR entry, or key", () => {
+    const manifest = readFileSync(join(REPO_ROOT, "src/manifest.json"), "utf8");
+    assert.doesNotMatch(manifest, TIER2_TOKEN, "src/manifest.json must not reference Tier 2 -- it rides the existing content-script/permission surface");
+  });
+
+  test("manifest.v2.json (Firefox) declares no tier2-specific permission, WAR entry, or key", () => {
+    const manifest = readFileSync(join(REPO_ROOT, "src/manifest.v2.json"), "utf8");
+    assert.doesNotMatch(manifest, TIER2_TOKEN, "src/manifest.v2.json must not reference Tier 2 -- it rides the existing content-script/permission surface");
+  });
+
+  test("options.js (Settings UI wiring) introduces no tier2-specific DOM id/pref reference", () => {
+    const optionsJs = readFileSync(join(REPO_ROOT, "src/options/options.js"), "utf8");
+    assert.doesNotMatch(optionsJs, TIER2_TOKEN, "options.js must not reference Tier 2 -- it is silent within the existing cookieConsentMode row");
+  });
+
+  test("onboarding.js introduces no tier2-specific step, pref, or copy key", () => {
+    const onboardingJs = readFileSync(join(REPO_ROOT, "src/onboarding/onboarding.js"), "utf8");
+    assert.doesNotMatch(onboardingJs, TIER2_TOKEN, "onboarding.js must not reference Tier 2 -- no new onboarding step was added");
+  });
+
+  test("cookie-noise.js's Tier 2 dispatcher reuses the same _tier2GateOpen assignment sourced from computeGate's `open`, not a new gate variable", () => {
+    const cookieNoise = readFileSync(join(REPO_ROOT, "src/content/cookie-noise.js"), "utf8");
+    // Mirrors the PR 2 sync-test precedent: a negative lookbehind skips the
+    // `let _tier2GateOpen = false;` declaration and asserts the REAL
+    // assignment inside readPrefsAndGate() sets it from the literal `open`
+    // variable that already encodes cookieConsentMode + allowlist/blocklist.
+    assert.match(
+      cookieNoise,
+      /(?<!let )_tier2GateOpen\s*=\s*open;/,
+      "_tier2GateOpen must be assigned from the same `open` boolean computeGate() already produces for Tier 1 -- not a separate Tier 2 gate"
+    );
+  });
+});

--- a/tools/build-tier2-rules.mjs
+++ b/tools/build-tier2-rules.mjs
@@ -1,0 +1,274 @@
+/**
+ * MUGA: Offline Consent-O-Matic -> Tier 2 rule transform tool (#1027 Phase 4)
+ *
+ * A MAINTAINER tool, mirroring `tools/probe-shortener-redirect.mjs` and
+ * `tools/probe-cmp-surface.mjs`: NOT shipped with the extension, NOT
+ * imported by any `src/` module, and NOT wired into CI. It is the pipeline
+ * for FUTURE Tier 2 rule additions -- see `src/lib/cmp-tier2-rules.js`'s
+ * docblock for the shipped rule format `{id, present, reject, openSettings}`
+ * this tool produces, and `docs/DESIGN-cookie-consent-tier2.md` for why
+ * Slice 1 only supports direct single/two-step click rules (no multi-step
+ * toggle+save flows -- see the SKIP note in `main()` below).
+ *
+ * ── The never-accept invariant, enforced at the TOOL boundary too ──────────
+ *
+ * `reduceTier2Rule` is a pure, HARD FIELD-ALLOWLIST reducer: the output
+ * object is built key-by-key from four named output fields (`id`, `present`,
+ * `reject`, `openSettings`), each populated by its own narrow extraction
+ * helper that reads from exactly one source location. Nothing on the input
+ * is ever spread or copied wholesale. Concretely, this reducer NEVER reads:
+ *   - `trueAction` (Consent-O-Matic's accept-branch action on a consent
+ *     matcher),
+ *   - any `DO_CONSENT` toggle/consent matcher (that is the accept-granting
+ *     and multi-step-toggle path, not a reject control),
+ *   - `SAVE_CONSENT` (persists whatever toggle state is currently set --
+ *     not an unambiguous reject action; MUGA's shipped rule format has no
+ *     `save` concept at all),
+ *   - a generic `acceptSelector`-style field.
+ * So even a source file that carries every one of those fields cannot leak
+ * a single accept-path token into the emitted rule -- there is no code path
+ * that reads them. This mirrors the never-accept-by-construction model
+ * documented in `src/lib/cmp-tier2-rules.js`'s own docblock (a rule literally
+ * cannot express an accept action, because no field exists to hold one).
+ *
+ * ── I/O boundary (why importing this module for unit tests is pure) ────────
+ *
+ * `reduceTier2Rule` and its extraction helpers perform ZERO I/O -- pure
+ * functions over a plain object, exhaustively unit-tested in
+ * `tests/unit/build-tier2-rules.test.mjs`. All I/O (`readdirSync`,
+ * `readFileSync`, `console.log`) lives inside `main()`, which only runs
+ * behind the `process.argv[1]` entry-guard at the bottom of this file --
+ * the same guard `tools/probe-shortener-redirect.mjs` uses. `main()` never
+ * WRITES a file: it only reads the maintainer-supplied Consent-O-Matic rule
+ * directory and prints formatted, ready-to-review rule literals to stdout.
+ * A maintainer must manually verify each selector on a live page (this tool
+ * cannot confirm a selector is a real reject control -- see the existing
+ * verification-spike precedent in `src/lib/cmp-tier2-rules.js`'s docblock)
+ * and hand-merge the reviewed entry into `src/lib/cmp-tier2-rules.js`. The
+ * two existing hand-curated seed rules (`complianz`, `cookie-notice`) are
+ * therefore never at risk of being clobbered by running this tool.
+ *
+ * Run with: node tools/build-tier2-rules.mjs <path-to-consent-o-matic-rules-dir>
+ * The Consent-O-Matic repository (cavi-au/Consent-O-Matic, MIT) is NOT
+ * vendored into MUGA -- point this at a local checkout's `rules/` directory.
+ * See THIRD_PARTY_NOTICES.md for the required attribution.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * @typedef {object} SourceDetector
+ * @property {{target?: {selector?: string}}} [presentMatcher] Banner-anchor
+ *   matcher; only `.target.selector` is read.
+ *
+ * @typedef {object} SourceMethod
+ * @property {string} [name] e.g. "DO_CONSENT" | "SAVE_CONSENT" |
+ *   "OPEN_OPTIONS" | "HIDE_CMP". Only a method literally named
+ *   `"OPEN_OPTIONS"` is ever read by this reducer.
+ * @property {{click?: {selector?: string}}} [action]
+ * @property {Array<object>} [consents] Accept/toggle-consent matchers --
+ *   NEVER read by this reducer.
+ * @property {object} [trueAction] Accept-branch action -- NEVER read.
+ *
+ * @typedef {object} SourceRule
+ * @property {string} [id]
+ * @property {string} [slug]
+ * @property {string} [name]
+ * @property {Array<SourceDetector>} [detectors]
+ * @property {Array<SourceMethod>} [methods]
+ * @property {string} [declineSelector] The ONLY field this reducer accepts
+ *   as a confirmed direct reject/necessary-only control. A maintainer must
+ *   populate this (by hand, from the vetted upstream rule) before running
+ *   the tool for a rule to survive with a non-empty `reject`.
+ * @property {string} [acceptSelector] Accept-path field -- NEVER read.
+ */
+
+/**
+ * @param {SourceRule|null|undefined} sourceRule
+ * @returns {string}
+ */
+function extractId(sourceRule) {
+  if (typeof sourceRule?.id === "string" && sourceRule.id) return sourceRule.id;
+  if (typeof sourceRule?.slug === "string" && sourceRule.slug) return sourceRule.slug;
+  if (typeof sourceRule?.name === "string" && sourceRule.name) {
+    return sourceRule.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+  return "";
+}
+
+/**
+ * Reads ONLY `detectors[].presentMatcher.target.selector`. This is the
+ * banner-anchor / presence signal, symmetric with MUGA's `present` field --
+ * it carries no accept/reject semantics of its own.
+ *
+ * @param {SourceRule|null|undefined} sourceRule
+ * @returns {string[]}
+ */
+function extractPresentSelectors(sourceRule) {
+  const detectors = Array.isArray(sourceRule?.detectors) ? sourceRule.detectors : [];
+  const out = [];
+  for (const d of detectors) {
+    const selector = d?.presentMatcher?.target?.selector;
+    if (typeof selector === "string" && selector) out.push(selector);
+  }
+  return out;
+}
+
+/**
+ * Reads ONLY the top-level `declineSelector` string -- the single field this
+ * reducer treats as a maintainer-vetted, confirmed direct reject control.
+ * Deliberately does NOT read `methods[].name === "DO_CONSENT"` /
+ * `"SAVE_CONSENT"`, any `trueAction`/`consents`/toggle field, or a generic
+ * `acceptSelector` -- those are accept-path or multi-step-toggle concepts
+ * this reducer must never surface into MUGA's reject-only, single/two-step
+ * click schema (see the file docblock).
+ *
+ * @param {SourceRule|null|undefined} sourceRule
+ * @returns {string[]}
+ */
+function extractRejectSelectors(sourceRule) {
+  const selector = sourceRule?.declineSelector;
+  return typeof selector === "string" && selector ? [selector] : [];
+}
+
+/**
+ * Reads ONLY `methods[]` entries whose `name` is literally `"OPEN_OPTIONS"`,
+ * extracting `.action.click.selector`. Never reads `DO_CONSENT`,
+ * `SAVE_CONSENT`, or `trueAction` -- those never populate `openSettings`.
+ *
+ * @param {SourceRule|null|undefined} sourceRule
+ * @returns {string[]}
+ */
+function extractOpenSettingsSelectors(sourceRule) {
+  const methods = Array.isArray(sourceRule?.methods) ? sourceRule.methods : [];
+  const out = [];
+  for (const m of methods) {
+    if (m?.name !== "OPEN_OPTIONS") continue;
+    const selector = m?.action?.click?.selector;
+    if (typeof selector === "string" && selector) out.push(selector);
+  }
+  return out;
+}
+
+/**
+ * Pure reducer: transforms one raw Consent-O-Matic-shaped source rule into
+ * MUGA's Tier 2 reject-only rule shape. See the file docblock for the
+ * HARD FIELD-ALLOWLIST guarantee this function provides. Never throws --
+ * garbage/`null`/`undefined` input produces the allowlisted shape with
+ * empty arrays and an empty `id`.
+ *
+ * @param {SourceRule|null|undefined} sourceRule
+ * @returns {{id: string, present: ReadonlyArray<string>, reject: ReadonlyArray<string>, openSettings: ReadonlyArray<string>}}
+ */
+export function reduceTier2Rule(sourceRule) {
+  return Object.freeze({
+    id: extractId(sourceRule),
+    present: Object.freeze(extractPresentSelectors(sourceRule)),
+    reject: Object.freeze(extractRejectSelectors(sourceRule)),
+    openSettings: Object.freeze(extractOpenSettingsSelectors(sourceRule)),
+  });
+}
+
+/**
+ * Formats a reduced Tier 2 rule as a ready-to-review JS literal matching
+ * `src/lib/cmp-tier2-rules.js`'s existing `Object.freeze({...})` entry
+ * shape, so a maintainer can visually diff and hand-paste it in.
+ *
+ * @param {{id: string, present: ReadonlyArray<string>, reject: ReadonlyArray<string>, openSettings: ReadonlyArray<string>}} rule
+ * @returns {string}
+ */
+export function formatRuleForReview(rule) {
+  return [
+    "  Object.freeze({",
+    `    id: ${JSON.stringify(rule.id)},`,
+    `    present: Object.freeze(${JSON.stringify(rule.present)}),`,
+    `    reject: Object.freeze(${JSON.stringify(rule.reject)}),`,
+    `    openSettings: Object.freeze(${JSON.stringify(rule.openSettings)}),`,
+    "  }),",
+  ].join("\n");
+}
+
+/**
+ * Reads every `*.json` file in the given directory, reduces each through
+ * `reduceTier2Rule`, and prints a maintainer-review report to stdout. Never
+ * writes a file -- see the file docblock's I/O boundary section.
+ *
+ * @param {string} rulesDir
+ */
+function main(rulesDir = process.argv[2]) {
+  if (!rulesDir) {
+    console.error("[muga] build-tier2-rules — maintainer transform tool (#1027 Phase 4)\n");
+    console.error("Usage: node tools/build-tier2-rules.mjs <path-to-consent-o-matic-rules-dir>");
+    console.error(
+      "  Point this at a local checkout of cavi-au/Consent-O-Matic's rules/ directory " +
+        "(NOT vendored into MUGA). This tool reads that directory only -- it never writes " +
+        "any file. See THIRD_PARTY_NOTICES.md for the required attribution."
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let files;
+  try {
+    files = readdirSync(rulesDir).filter((f) => extname(f) === ".json");
+  } catch (err) {
+    console.error(`[muga] build-tier2-rules: could not read "${rulesDir}": ${err.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("[muga] build-tier2-rules — maintainer transform tool (#1027 Phase 4)\n");
+  console.log(`Read ${files.length} candidate rule file(s) from ${rulesDir}\n`);
+  console.log(
+    "Review each entry below, VERIFY the selectors on a live page (this tool cannot confirm a\n" +
+      "selector is a real reject control -- see src/lib/cmp-tier2-rules.js's verification-spike\n" +
+      "precedent), then hand-merge into src/lib/cmp-tier2-rules.js. This tool never writes any file.\n"
+  );
+
+  let emitted = 0;
+  for (const file of files) {
+    let sourceRule;
+    try {
+      sourceRule = JSON.parse(readFileSync(join(rulesDir, file), "utf8"));
+    } catch (err) {
+      console.log(`  SKIP ${file}: not valid JSON (${err.message})`);
+      continue;
+    }
+
+    const rule = reduceTier2Rule(sourceRule);
+    if (!rule.reject.length) {
+      // Most Consent-O-Matic rules express reject via a multi-step
+      // DO_CONSENT-toggle-off + SAVE_CONSENT flow, which MUGA's shipped
+      // rule format does not model (see docs/DESIGN-cookie-consent-tier2.md
+      // §6 -- multi-step save flows are explicitly out of scope). Only
+      // rules with a maintainer-curated `declineSelector` (a confirmed
+      // direct reject control) survive this tool; everything else is
+      // honestly reported as skipped rather than silently guessed at.
+      console.log(
+        `  SKIP ${file}: no vetted "declineSelector" direct-reject field found (this tool only ` +
+          "derives single/two-step click rules; multi-step toggle+save CMPs are out of scope for " +
+          "MUGA's shipped rule format)."
+      );
+      continue;
+    }
+
+    console.log(`// ---- ${file} ----`);
+    console.log(formatRuleForReview(rule));
+    console.log("");
+    emitted += 1;
+  }
+
+  console.log(`Done. ${emitted}/${files.length} file(s) produced a reviewable rule.`);
+}
+
+// Only run the filesystem-reading/stdout main() when invoked directly, so
+// the pure reducer can be imported by unit tests without touching the
+// filesystem (mirrors tools/probe-shortener-redirect.mjs's entry-guard).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}


### PR DESCRIPTION
## PR 3/3 — final slice of the Tier 2 cookie-consent adapter chain (#1027)

Maintainer tooling + attribution. No shipping runtime change (the dispatcher landed in PR 2). Completes the feature.

### What's in this slice
- **`tools/build-tier2-rules.mjs`** — a **maintainer-only** offline transform (NOT wired into CI; entry-guard so unit import is pure, stdout-only, never writes a file, never clobbers the hand-curated seed rules). Reads a locally-vetted Consent-O-Matic `rules/*.json` subset and applies a **hard field-allowlist**: only `{id, present, reject, openSettings}` survive — every accept-path field (`trueAction`, `DO_CONSENT` consent matchers, `SAVE_CONSENT`, accept selectors) is discarded on ingestion. The never-accept invariant holds at the data-ingestion boundary too, not just the shape.
- **`THIRD_PARTY_NOTICES.md`** (repo root) — CAVI/Aarhus MIT, full license text, and a "derived/adapted, not verbatim, accept-path discarded" statement referencing the tool. Copyright line **verified byte-for-byte against upstream** (`Copyright (c) 2019,2020,2021,2022 Janus Bager Kristensen and Rolf Bagge, CAVI - ... Aarhus University`).
- **Gate-reuse test** — proves Tier 2 added no toggle/pref/manifest/onboarding surface; `cookieConsentMode` stays the sole 2-state gate.
- Final guard/sync sweep: zero `accept`/`allowall` token in the data + its `@sync` copy.

### Verification
- `npm test` 7551 pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0
- 11 reducer tests (accept-strip proven on serialized output, RED→GREEN) + 10 gate-reuse tests
- `cleaner.js` untouched → no bundle rebuild; seed rules + dispatcher untouched
- Fresh adversarial review + upstream-copyright web verification

Completes the cookie-consent-tier2 change (3 stacked PRs: #1164 data+resolver, #1165 dispatcher, this).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9