### PR TITLE
feat(consent): runtime semantic click-veto for Tier 2 (PR A — safety gate)

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1430,6 +1430,229 @@
   }
   // @sync:cmp-tier2:end
 
+  // ── Tier 2 runtime semantic click-veto (#1027, Slice 2 / PR A) ────────────
+  //
+  // Hand-copied, byte-for-byte modulo indentation, from
+  // src/lib/cmp-tier2-veto.js. Kept in sync by
+  // tests/unit/cookie-noise-sync.test.mjs. See that file's docblock for the
+  // full load-bearing-safety-piece rationale, the BUNDLED-never-remote
+  // word-list distribution decision, and the guard-exemption note — not
+  // repeated here to avoid a second place that can drift out of prose sync
+  // with the data itself. Pure; never throws. Wired into
+  // runTier2RejectDispatcher below, immediately before both the reject and
+  // openSettings `.click()` calls.
+  // @sync:cmp-tier2-veto:start
+
+  /**
+   * NFC-normalizes, lowercases, and whitespace-collapses `raw` into `name`;
+   * `folded` additionally strips Unicode combining diacritical marks (NFD +
+   * `/\p{Diacritic}/gu` removal) so accented and de-accented variants of the
+   * same word both match. Never throws — a non-string or unnormalizable input
+   * degrades to `{ name: "", folded: "" }`, which the empty-name veto branch
+   * in computeClickVeto below already treats as VETO.
+   * @param {*} raw
+   * @returns {{ name: string, folded: string }}
+   */
+  function normalizeAccessibleName(raw) {
+    const input = typeof raw === "string" ? raw : "";
+    let name = "";
+    try {
+      name = input.normalize("NFC").toLowerCase().replace(/\s+/g, " ").trim();
+    } catch {
+      name = "";
+    }
+    let folded = name;
+    try {
+      folded = name.normalize("NFD").replace(/\p{Diacritic}/gu, "").replace(/\s+/g, " ").trim();
+    } catch {
+      folded = name;
+    }
+    return { name, folded };
+  }
+
+  // Accept/agree words across every covered locale (en/es/de/fr/it/ja/pt).
+  // THIS IS THE VETO'S TEETH — see the file docblock's guard-exemption note
+  // above and the teeth test in tests/unit/cmp-tier2-veto.test.mjs. Any word
+  // here matching a candidate's accessible name is an ABSOLUTE veto,
+  // role-independent — it wins over every allowlist match below. Every entry
+  // is already lowercase and diacritic-normalized (no combining marks), the
+  // same shape normalizeAccessibleName produces, so a bare `folded` substring
+  // check is always sufficient regardless of the source text's own accents.
+  const DENY_WORDS = Object.freeze([
+    // en
+    "accept",
+    "accept all",
+    "allow",
+    "allow all",
+    "agree",
+    "i agree",
+    // es
+    "aceptar",
+    "aceptar todo",
+    "aceptar todas",
+    // de
+    "akzeptieren",
+    "alle akzeptieren",
+    "zustimmen",
+    // fr
+    "accepter",
+    "tout accepter",
+    // it
+    "accetta",
+    "accetta tutti",
+    // pt
+    "aceitar",
+    "aceitar tudo",
+    // ja
+    "同意",
+    "同意する",
+    "すべてに同意",
+  ]);
+
+  // Reject/decline/necessary-only words — REQUIRED positive match for a
+  // `role: "reject"` candidate (see computeClickVeto's precedence below).
+  // DISJOINT from DENY_WORDS by construction (asserted by the teeth test).
+  const REJECT_WORDS = Object.freeze([
+    // en
+    "reject",
+    "reject all",
+    "decline",
+    "decline all",
+    "refuse",
+    "necessary only",
+    "only necessary",
+    // es
+    "rechazar",
+    "rechazar todo",
+    "solo necesarias",
+    // de
+    "ablehnen",
+    "alle ablehnen",
+    "nur notwendige",
+    // fr
+    "refuser",
+    "tout refuser",
+    // it
+    "rifiuta",
+    "solo necessari",
+    // pt
+    "recusar",
+    "somente necessarios",
+    // ja
+    "拒否",
+    "すべて拒否",
+  ]);
+
+  // Settings/preferences/manage words — REQUIRED positive match for a
+  // `role: "openSettings"` candidate. DISJOINT from DENY_WORDS by
+  // construction (asserted by the teeth test).
+  const SETTINGS_WORDS = Object.freeze([
+    // en
+    "settings",
+    "preferences",
+    "manage",
+    "manage options",
+    "customize",
+    "more options",
+    // es
+    "ajustes",
+    "preferencias",
+    "gestionar",
+    // de
+    "einstellungen",
+    "verwalten",
+    // fr
+    "gerer",
+    "personnaliser",
+    // it
+    "impostazioni",
+    "personalizza",
+    // pt
+    "gerenciar",
+    // ja
+    "設定",
+    "環境設定",
+  ]);
+
+  /**
+   * The veto's bundled word lists (see the file docblock's "Word-list
+   * distribution" section — BUNDLED, never remote). Passed explicitly into
+   * computeClickVeto (dependency-injected, not read as a module-level
+   * implicit global) so the pure function stays trivially testable with
+   * adversarial fixtures.
+   */
+  const VETO_WORDS = Object.freeze({
+    deny: DENY_WORDS,
+    reject: REJECT_WORDS,
+    settings: SETTINGS_WORDS,
+  });
+
+  /**
+   * True when the normalized `w` occurs as a substring of either `name` or
+   * `folded` — substring (not word-boundary/token) matching is deliberate: it
+   * is the safe/greedy direction for the absolute DENY set ("Accept only
+   * necessary" must veto on the substring "accept" even though "necessary" is
+   * a reject hint) and is the only workable form for CJK scripts, which have
+   * no word boundaries. Never throws.
+   * @param {string} name
+   * @param {string} folded
+   * @param {ReadonlyArray<string>} words
+   * @returns {boolean}
+   */
+  function matchesAny(name, folded, words) {
+    const list = Array.isArray(words) ? words : [];
+    for (const w of list) {
+      if (typeof w !== "string" || w.length === 0) continue;
+      if (name.indexOf(w) !== -1 || folded.indexOf(w) !== -1) return true;
+    }
+    return false;
+  }
+
+  /**
+   * The semantic click-veto (LOAD-BEARING — see the file docblock). Decides
+   * whether a candidate control is safe to click, given its full accessible
+   * name and the ROLE the dispatcher intends to use it for.
+   *
+   * Precedence, evaluated strictly in order — first hit returns:
+   *   1. Empty/whitespace-only `accessibleName` -> VETO ("empty-name").
+   *      Covers icon-only / no-text controls and detached/hostile elements.
+   *   2. Any `wordLists.deny` entry matches -> VETO ("accept-word"). Absolute
+   *      and role-independent — wins over every allowlist match below.
+   *   3. Role-specific positive gate (the required word must be PRESENT):
+   *      - `role === "reject"` requires a `wordLists.reject` match, else
+   *        VETO ("no-reject-word").
+   *      - `role === "openSettings"` requires a `wordLists.settings` match,
+   *        else VETO ("no-settings-word").
+   *      - any other role -> VETO ("unknown-role").
+   *   4. Otherwise -> ALLOW ("ok").
+   *
+   * The only allow path is: non-empty name AND no accept word AND the role's
+   * required positive word present. Absence of signal always resolves to "do
+   * not click" — fail-closed by construction. Pure; never throws.
+   * @param {*} accessibleName
+   * @param {"reject"|"openSettings"} role
+   * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string> }} wordLists
+   * @returns {ClickVetoResult}
+   */
+  function computeClickVeto(accessibleName, role, wordLists) {
+    const { name, folded } = normalizeAccessibleName(accessibleName);
+    if (name.length === 0) return { allow: false, reason: "empty-name" };
+
+    const lists = wordLists && typeof wordLists === "object" ? wordLists : {};
+    if (matchesAny(name, folded, lists.deny)) return { allow: false, reason: "accept-word" };
+
+    if (role === "reject") {
+      if (!matchesAny(name, folded, lists.reject)) return { allow: false, reason: "no-reject-word" };
+      return { allow: true, reason: "ok" };
+    }
+    if (role === "openSettings") {
+      if (!matchesAny(name, folded, lists.settings)) return { allow: false, reason: "no-settings-word" };
+      return { allow: true, reason: "ok" };
+    }
+    return { allow: false, reason: "unknown-role" };
+  }
+  // @sync:cmp-tier2-veto:end
+
   let _spRejectActed = false;
   let _spPmOpened = false;
   let _spRejectGateOpen = false;
@@ -1615,6 +1838,28 @@
     }
   }
 
+  // Semantic click-veto drift signal (#1027, Slice 2 / PR A): console-only,
+  // warned at most ONCE per rule id + role — no network call, no telemetry
+  // (mirrors tier2WarnDrift's contract above). Fires when computeClickVeto
+  // rejects a resolved single target (bundled OR remote-origin selector
+  // resolved to an element whose accessible name did not clear the veto) so
+  // a maintainer can investigate selector drift without MUGA ever clicking
+  // the ambiguous/mislabeled control.
+  const _tier2VetoWarned = {};
+  function tier2WarnVeto(ruleId, role, reason) {
+    const key = ruleId + ":" + role;
+    if (_tier2VetoWarned[key]) return;
+    _tier2VetoWarned[key] = true;
+    try {
+      console.warn(
+        "[MUGA] cookie-consent: tier2:" + ruleId + " " + role +
+        " click vetoed (" + reason + ") — target not clicked"
+      );
+    } catch {
+      // console unavailable — nothing else to do.
+    }
+  }
+
   // Reuses the SAME bounded-poll mechanics as confirmRejectDismissal above
   // (REJECT_CONFIRM_WINDOW_MS / REJECT_CONFIRM_INTERVAL_MS, deadline +
   // interval, fail-safe-gone-on-error) — confirmRejectDismissal's own
@@ -1684,6 +1929,19 @@
       const rejectCandidates = tier2FilterCandidates(candidates, rule.reject);
       const result = resolveTier2Reject(present, rejectCandidates);
       if (result.status === "single") {
+        // Semantic click-veto (#1027, Slice 2 / PR A — LOAD-BEARING): a
+        // confirmed single target is STILL not clicked unless its real
+        // accessible name clears the veto. This is what makes a
+        // wrongly-matched selector (bundled OR remote) safe — see
+        // computeClickVeto's docblock above. Fail-closed: on veto, do NOT
+        // set _tier2Acted (a later observer pass may find a correctly
+        // labelled target once the DOM settles), warn once, and continue —
+        // the existing bounded give-up window already stops churn.
+        const veto = computeClickVeto(result.target.fullText, "reject", VETO_WORDS);
+        if (!veto.allow) {
+          tier2WarnVeto(rule.id, "reject", veto.reason);
+          continue;
+        }
         _tier2Acted[rule.id] = true;
         try {
           result.target.ref.click();
@@ -1700,6 +1958,16 @@
       if (_tier2PmOpened[rule.id]) continue;
       const openCandidates = tier2FilterCandidates(candidates, rule.openSettings);
       if (openCandidates.length !== 1) continue;
+      // Same semantic click-veto, role "openSettings" — its OWN positive
+      // settings-word set, stricter than Slice 1's "monotone-safe, click
+      // freely" stance because Slice 2 adds untrusted remote selectors to
+      // this same code path. Fail-closed: on veto, do NOT set
+      // _tier2PmOpened, warn once, continue.
+      const openVeto = computeClickVeto(openCandidates[0].fullText, "openSettings", VETO_WORDS);
+      if (!openVeto.allow) {
+        tier2WarnVeto(rule.id, "openSettings", openVeto.reason);
+        continue;
+      }
       _tier2PmOpened[rule.id] = true;
       try {
         openCandidates[0].ref.click();

--- a/src/lib/cmp-tier2-veto.js
+++ b/src/lib/cmp-tier2-veto.js
@@ -1,0 +1,275 @@
+/**
+ * MUGA: Cookie Consent Minimizer — Tier 2 runtime semantic click-veto
+ * (#1027, Slice 2 / PR A — cookie-consent-tier2-remote)
+ *
+ * Pure, DOM-free module. NOT loaded as a content script — see AGENTS.md
+ * (content scripts cannot use ES module imports). Hand-copied, byte-for-byte
+ * modulo indentation, into src/content/cookie-noise.js under a
+ * `@sync:cmp-tier2-veto` block, kept in sync by
+ * tests/unit/cookie-noise-sync.test.mjs — same pattern as the existing
+ * `@sync:cmp-tier2` copy of `resolveTier2Reject` in src/lib/cmp-adapters.js.
+ *
+ * ── The load-bearing safety piece ───────────────────────────────────────────
+ *
+ * This is the ONLY layer in the Tier 2 reject-click chain that inspects the
+ * real-world CONSEQUENCE of a click (what the target control's accessible
+ * name says it does) rather than rule/selector metadata. Every other layer
+ * (closed rule shape, structural guards, runtime shape/cap validation for
+ * remote data) constrains metadata; a CSS selector string carries no
+ * inherent meaning of its own, so only this veto generalizes across unknown
+ * selectors and CMPs — including a selector that is well-formed, signed, and
+ * within every cap, but simply resolves to the wrong element (e.g. a
+ * mis-curated remote rule pointing `reject` at an "Accept all" button).
+ * Applies IDENTICALLY to bundled and remote-origin rules — there is no
+ * exemption path for either origin (design.md ADR-1).
+ *
+ * ── EXEMPT from the `/allowall|accept/i` structural guard ───────────────────
+ *
+ * tests/unit/cmp-adapters.test.mjs's closed-action structural guard scans
+ * EXACTLY two files: src/lib/cmp-adapters.js and src/lib/cmp-tier2-rules.js
+ * (the rule/adapter DATA and decision files, which must never name an
+ * accept-family action). This file is DELIBERATELY NOT in that scan and
+ * must NEVER be added to it: `VETO_WORDS.deny` legitimately contains
+ * accept/agree words in every covered locale — they are this module's
+ * TEETH, not a violation. A future maintainer who "helpfully" adds this
+ * file to that scan would break the build; a future maintainer who instead
+ * strips the accept words to make such a scan pass would silently disable
+ * the absolute accept-veto. The teeth test in
+ * tests/unit/cmp-tier2-veto.test.mjs guards against exactly that: it
+ * asserts `deny` is non-empty and contains known accept words, and that
+ * `reject`/`settings` are DISJOINT from `deny`.
+ *
+ * ── Word-list distribution: BUNDLED, never remote (design.md ADR-2) ────────
+ *
+ * `VETO_WORDS` ships bundled in the extension, exactly like this file — it
+ * is never fetched, never remote-signed. The safety ORACLE (is this click
+ * safe?) must not be remotely mutable: a signing-key compromise that could
+ * ship an empty `deny` list (disabling the absolute veto) or an
+ * accept-poisoned `reject` list would defeat the entire never-accept chain
+ * in a single payload. Coverage data (which selectors to look at) can be
+ * remote; the safety decision itself must not be. Adding a new locale's
+ * words is therefore a release event — acceptable, because the positive
+ * "require a role word" gate degrades an uncovered locale to a coverage
+ * gap (fail-closed no-op), never a wrong click.
+ *
+ * @typedef {object} ClickVetoResult
+ * @property {boolean} allow - true only when the accessible name is
+ *   non-empty, matches no accept/agree word, AND matches the role's
+ *   required positive word.
+ * @property {string} reason - one of "empty-name", "accept-word",
+ *   "no-reject-word", "no-settings-word", "unknown-role", "ok".
+ */
+
+// @sync:cmp-tier2-veto:start
+
+/**
+ * NFC-normalizes, lowercases, and whitespace-collapses `raw` into `name`;
+ * `folded` additionally strips Unicode combining diacritical marks (NFD +
+ * `/\p{Diacritic}/gu` removal) so accented and de-accented variants of the
+ * same word both match. Never throws — a non-string or unnormalizable input
+ * degrades to `{ name: "", folded: "" }`, which the empty-name veto branch
+ * in computeClickVeto below already treats as VETO.
+ * @param {*} raw
+ * @returns {{ name: string, folded: string }}
+ */
+function normalizeAccessibleName(raw) {
+  const input = typeof raw === "string" ? raw : "";
+  let name = "";
+  try {
+    name = input.normalize("NFC").toLowerCase().replace(/\s+/g, " ").trim();
+  } catch {
+    name = "";
+  }
+  let folded = name;
+  try {
+    folded = name.normalize("NFD").replace(/\p{Diacritic}/gu, "").replace(/\s+/g, " ").trim();
+  } catch {
+    folded = name;
+  }
+  return { name, folded };
+}
+
+// Accept/agree words across every covered locale (en/es/de/fr/it/ja/pt).
+// THIS IS THE VETO'S TEETH — see the file docblock's guard-exemption note
+// above and the teeth test in tests/unit/cmp-tier2-veto.test.mjs. Any word
+// here matching a candidate's accessible name is an ABSOLUTE veto,
+// role-independent — it wins over every allowlist match below. Every entry
+// is already lowercase and diacritic-normalized (no combining marks), the
+// same shape normalizeAccessibleName produces, so a bare `folded` substring
+// check is always sufficient regardless of the source text's own accents.
+const DENY_WORDS = Object.freeze([
+  // en
+  "accept",
+  "accept all",
+  "allow",
+  "allow all",
+  "agree",
+  "i agree",
+  // es
+  "aceptar",
+  "aceptar todo",
+  "aceptar todas",
+  // de
+  "akzeptieren",
+  "alle akzeptieren",
+  "zustimmen",
+  // fr
+  "accepter",
+  "tout accepter",
+  // it
+  "accetta",
+  "accetta tutti",
+  // pt
+  "aceitar",
+  "aceitar tudo",
+  // ja
+  "同意",
+  "同意する",
+  "すべてに同意",
+]);
+
+// Reject/decline/necessary-only words — REQUIRED positive match for a
+// `role: "reject"` candidate (see computeClickVeto's precedence below).
+// DISJOINT from DENY_WORDS by construction (asserted by the teeth test).
+const REJECT_WORDS = Object.freeze([
+  // en
+  "reject",
+  "reject all",
+  "decline",
+  "decline all",
+  "refuse",
+  "necessary only",
+  "only necessary",
+  // es
+  "rechazar",
+  "rechazar todo",
+  "solo necesarias",
+  // de
+  "ablehnen",
+  "alle ablehnen",
+  "nur notwendige",
+  // fr
+  "refuser",
+  "tout refuser",
+  // it
+  "rifiuta",
+  "solo necessari",
+  // pt
+  "recusar",
+  "somente necessarios",
+  // ja
+  "拒否",
+  "すべて拒否",
+]);
+
+// Settings/preferences/manage words — REQUIRED positive match for a
+// `role: "openSettings"` candidate. DISJOINT from DENY_WORDS by
+// construction (asserted by the teeth test).
+const SETTINGS_WORDS = Object.freeze([
+  // en
+  "settings",
+  "preferences",
+  "manage",
+  "manage options",
+  "customize",
+  "more options",
+  // es
+  "ajustes",
+  "preferencias",
+  "gestionar",
+  // de
+  "einstellungen",
+  "verwalten",
+  // fr
+  "gerer",
+  "personnaliser",
+  // it
+  "impostazioni",
+  "personalizza",
+  // pt
+  "gerenciar",
+  // ja
+  "設定",
+  "環境設定",
+]);
+
+/**
+ * The veto's bundled word lists (see the file docblock's "Word-list
+ * distribution" section — BUNDLED, never remote). Passed explicitly into
+ * computeClickVeto (dependency-injected, not read as a module-level
+ * implicit global) so the pure function stays trivially testable with
+ * adversarial fixtures.
+ */
+const VETO_WORDS = Object.freeze({
+  deny: DENY_WORDS,
+  reject: REJECT_WORDS,
+  settings: SETTINGS_WORDS,
+});
+
+/**
+ * True when the normalized `w` occurs as a substring of either `name` or
+ * `folded` — substring (not word-boundary/token) matching is deliberate: it
+ * is the safe/greedy direction for the absolute DENY set ("Accept only
+ * necessary" must veto on the substring "accept" even though "necessary" is
+ * a reject hint) and is the only workable form for CJK scripts, which have
+ * no word boundaries. Never throws.
+ * @param {string} name
+ * @param {string} folded
+ * @param {ReadonlyArray<string>} words
+ * @returns {boolean}
+ */
+function matchesAny(name, folded, words) {
+  const list = Array.isArray(words) ? words : [];
+  for (const w of list) {
+    if (typeof w !== "string" || w.length === 0) continue;
+    if (name.indexOf(w) !== -1 || folded.indexOf(w) !== -1) return true;
+  }
+  return false;
+}
+
+/**
+ * The semantic click-veto (LOAD-BEARING — see the file docblock). Decides
+ * whether a candidate control is safe to click, given its full accessible
+ * name and the ROLE the dispatcher intends to use it for.
+ *
+ * Precedence, evaluated strictly in order — first hit returns:
+ *   1. Empty/whitespace-only `accessibleName` -> VETO ("empty-name").
+ *      Covers icon-only / no-text controls and detached/hostile elements.
+ *   2. Any `wordLists.deny` entry matches -> VETO ("accept-word"). Absolute
+ *      and role-independent — wins over every allowlist match below.
+ *   3. Role-specific positive gate (the required word must be PRESENT):
+ *      - `role === "reject"` requires a `wordLists.reject` match, else
+ *        VETO ("no-reject-word").
+ *      - `role === "openSettings"` requires a `wordLists.settings` match,
+ *        else VETO ("no-settings-word").
+ *      - any other role -> VETO ("unknown-role").
+ *   4. Otherwise -> ALLOW ("ok").
+ *
+ * The only allow path is: non-empty name AND no accept word AND the role's
+ * required positive word present. Absence of signal always resolves to "do
+ * not click" — fail-closed by construction. Pure; never throws.
+ * @param {*} accessibleName
+ * @param {"reject"|"openSettings"} role
+ * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string> }} wordLists
+ * @returns {ClickVetoResult}
+ */
+function computeClickVeto(accessibleName, role, wordLists) {
+  const { name, folded } = normalizeAccessibleName(accessibleName);
+  if (name.length === 0) return { allow: false, reason: "empty-name" };
+
+  const lists = wordLists && typeof wordLists === "object" ? wordLists : {};
+  if (matchesAny(name, folded, lists.deny)) return { allow: false, reason: "accept-word" };
+
+  if (role === "reject") {
+    if (!matchesAny(name, folded, lists.reject)) return { allow: false, reason: "no-reject-word" };
+    return { allow: true, reason: "ok" };
+  }
+  if (role === "openSettings") {
+    if (!matchesAny(name, folded, lists.settings)) return { allow: false, reason: "no-settings-word" };
+    return { allow: true, reason: "ok" };
+  }
+  return { allow: false, reason: "unknown-role" };
+}
+// @sync:cmp-tier2-veto:end
+
+export { normalizeAccessibleName, computeClickVeto, VETO_WORDS };

--- a/tests/unit/cmp-tier2-veto.test.mjs
+++ b/tests/unit/cmp-tier2-veto.test.mjs
@@ -1,0 +1,343 @@
+/**
+ * MUGA — Cookie Consent Minimizer: cmp-tier2-veto.js (#1027, Slice 2 / PR A)
+ *
+ * Pure-logic tests for the Tier 2 runtime semantic click-veto — the
+ * load-bearing safety piece described in design.md ADR-1. No DOM, no
+ * chrome.*, no globals; accessible names are injected as plain strings,
+ * matching the pure-module contract described in src/lib/cmp-tier2-veto.js.
+ *
+ * Four groups:
+ *   1. normalizeAccessibleName — NFC/lowercase/whitespace-collapse + NFD
+ *      diacritic-stripped `folded` form.
+ *   2. computeClickVeto adversarial battery — the four fail-closed cases
+ *      (empty, icon-only, both-match, neither-match) plus multi-locale
+ *      (en/es/de/fr/it/ja/pt) reject/settings/deny coverage.
+ *   3. TEETH/shape test — `deny` is non-empty and contains known accept
+ *      words; `reject`/`settings` are DISJOINT from `deny`; every entry is
+ *      lowercase and diacritic-normalized (load-bearing — protects the
+ *      veto's teeth from ever being silently emptied).
+ *   4. Guard-exemption confirmation — the `/allowall|accept/i` structural
+ *      guard in tests/unit/cmp-adapters.test.mjs scans ONLY
+ *      cmp-adapters.js and cmp-tier2-rules.js, never this file.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { normalizeAccessibleName, computeClickVeto, VETO_WORDS } from "../../src/lib/cmp-tier2-veto.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── normalizeAccessibleName ──────────────────────────────────────────────
+
+describe("normalizeAccessibleName", () => {
+  test("lowercases and trims", () => {
+    const { name } = normalizeAccessibleName("  Reject All  ");
+    assert.equal(name, "reject all");
+  });
+
+  test("collapses internal whitespace runs to a single space", () => {
+    const { name } = normalizeAccessibleName("Reject\n\t  All");
+    assert.equal(name, "reject all");
+  });
+
+  test("folded strips diacritics via NFD + combining-mark removal", () => {
+    const { name, folded } = normalizeAccessibleName("Acceptér");
+    assert.equal(name, "acceptér");
+    assert.equal(folded, "accepter");
+  });
+
+  test("folded of an already-unaccented string equals name", () => {
+    const { name, folded } = normalizeAccessibleName("Reject all");
+    assert.equal(folded, name);
+  });
+
+  test("non-string input never throws, degrades to empty strings", () => {
+    for (const input of [null, undefined, 42, {}, []]) {
+      assert.doesNotThrow(() => normalizeAccessibleName(input));
+      const { name, folded } = normalizeAccessibleName(input);
+      assert.equal(name, "");
+      assert.equal(folded, "");
+    }
+  });
+
+  test("whitespace-only input normalizes to an empty name", () => {
+    const { name } = normalizeAccessibleName("   \n\t  ");
+    assert.equal(name, "");
+  });
+});
+
+// ── computeClickVeto — adversarial battery ───────────────────────────────
+
+describe("computeClickVeto — the four required fail-closed cases", () => {
+  test("empty accessible name -> VETO (empty-name)", () => {
+    const result = computeClickVeto("", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "empty-name");
+  });
+
+  test("whitespace-only accessible name -> VETO (empty-name)", () => {
+    const result = computeClickVeto("   ", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "empty-name");
+  });
+
+  test("icon-only control (no accessible name at all) -> VETO (empty-name)", () => {
+    const result = computeClickVeto(undefined, "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "empty-name");
+  });
+
+  test("name matching BOTH deny and reject words -> DENY wins -> VETO (accept-word)", () => {
+    const result = computeClickVeto("Reject all / Accept all", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test("name matching NEITHER deny nor the role's positive set -> VETO (no-reject-word)", () => {
+    const result = computeClickVeto("Learn more", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "no-reject-word");
+  });
+
+  test("neutral name on an openSettings role -> VETO (no-settings-word)", () => {
+    const result = computeClickVeto("Learn more", "openSettings", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "no-settings-word");
+  });
+
+  test("unknown role -> VETO (unknown-role), even with an otherwise-clean reject name", () => {
+    const result = computeClickVeto("Reject all", "save", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "unknown-role");
+  });
+});
+
+describe("computeClickVeto — reject role: selector-wrongly-matches-accept-labelled aborted", () => {
+  test("a reject-role candidate honestly labelled 'Reject all' -> allow", () => {
+    const result = computeClickVeto("Reject all", "reject", VETO_WORDS);
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("a reject-role candidate whose selector resolved to 'Accept all' -> VETO, never clicked", () => {
+    const result = computeClickVeto("Accept all", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test('"Accept only necessary" vetoes on the accept substring even though "necessary" is a reject hint', () => {
+    const result = computeClickVeto("Accept only necessary", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test("a generic selector (e.g. .btn-primary) resolving to an 'Accept all' button is vetoed identically to a reject-labelled selector mismatch", () => {
+    // Simulates the spec's hostile-payload scenario: the selector itself
+    // carries no semantic meaning, only the resolved accessible name does.
+    const result = computeClickVeto("Accept all", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+  });
+});
+
+describe("computeClickVeto — openSettings role", () => {
+  test("a settings-labelled opener -> allow", () => {
+    const result = computeClickVeto("Manage options", "openSettings", VETO_WORDS);
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("an opener also labelled with an accept word -> VETO (accept-deny still applies)", () => {
+    const result = computeClickVeto("Accept and manage settings", "openSettings", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test("an opener with neither a settings word nor an accept word -> VETO (no-settings-word)", () => {
+    const result = computeClickVeto("Continue", "openSettings", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "no-settings-word");
+  });
+});
+
+describe("computeClickVeto — multi-locale reject coverage (en/es/de/fr/it/ja/pt)", () => {
+  const REJECT_ALLOWS = [
+    ["en", "Reject all"],
+    ["en", "Decline all"],
+    ["en", "Only necessary"],
+    ["es", "Rechazar todo"],
+    ["es", "Solo necesarias"],
+    ["de", "Alle ablehnen"],
+    ["de", "Nur notwendige"],
+    ["fr", "Tout refuser"],
+    ["it", "Rifiuta"],
+    ["it", "Solo necessari"],
+    ["pt", "Recusar"],
+    ["ja", "拒否"],
+    ["ja", "すべて拒否"],
+  ];
+
+  for (const [locale, label] of REJECT_ALLOWS) {
+    test(`${locale}: "${label}" -> allow (reject role)`, () => {
+      const result = computeClickVeto(label, "reject", VETO_WORDS);
+      assert.equal(result.allow, true, `expected "${label}" to be allowed, got reason "${result.reason}"`);
+    });
+  }
+});
+
+describe("computeClickVeto — multi-locale deny (accept) coverage (en/es/de/fr/it/ja/pt)", () => {
+  const DENY_LABELS = [
+    ["en", "Accept all"],
+    ["es", "Aceptar todo"],
+    ["de", "Alle akzeptieren"],
+    ["fr", "Tout accepter"],
+    ["it", "Accetta tutti"],
+    ["pt", "Aceitar tudo"],
+    ["ja", "同意する"],
+  ];
+
+  for (const [locale, label] of DENY_LABELS) {
+    test(`${locale}: "${label}" -> VETO (accept-word) on a reject role`, () => {
+      const result = computeClickVeto(label, "reject", VETO_WORDS);
+      assert.equal(result.allow, false);
+      assert.equal(result.reason, "accept-word");
+    });
+
+    test(`${locale}: "${label}" -> VETO (accept-word) on an openSettings role`, () => {
+      const result = computeClickVeto(label, "openSettings", VETO_WORDS);
+      assert.equal(result.allow, false);
+      assert.equal(result.reason, "accept-word");
+    });
+  }
+});
+
+describe("computeClickVeto — multi-locale settings coverage (en/es/de/fr/it/pt/ja)", () => {
+  const SETTINGS_ALLOWS = [
+    ["en", "Settings"],
+    ["en", "Manage options"],
+    ["es", "Ajustes"],
+    ["es", "Preferencias"],
+    ["de", "Einstellungen"],
+    ["fr", "Gérer"],
+    ["it", "Impostazioni"],
+    ["pt", "Gerenciar"],
+    ["ja", "設定"],
+  ];
+
+  for (const [locale, label] of SETTINGS_ALLOWS) {
+    test(`${locale}: "${label}" -> allow (openSettings role)`, () => {
+      const result = computeClickVeto(label, "openSettings", VETO_WORDS);
+      assert.equal(result.allow, true, `expected "${label}" to be allowed, got reason "${result.reason}"`);
+    });
+  }
+});
+
+describe("computeClickVeto — malformed input fails closed, never throws", () => {
+  test("garbage wordLists (null/undefined/non-object) -> VETO, never throws", () => {
+    for (const garbage of [null, undefined, 42, "x", []]) {
+      assert.doesNotThrow(() => computeClickVeto("Reject all", "reject", garbage));
+      const result = computeClickVeto("Reject all", "reject", garbage);
+      assert.equal(result.allow, false);
+    }
+  });
+
+  test("wordLists with non-array fields -> VETO, never throws", () => {
+    assert.doesNotThrow(() => computeClickVeto("Reject all", "reject", { deny: null, reject: "x", settings: 42 }));
+  });
+
+  test("wordLists arrays containing non-string/empty entries are skipped, never throw", () => {
+    const weird = { deny: [null, "", 42, "accept"], reject: [undefined, "reject"], settings: ["settings"] };
+    assert.doesNotThrow(() => computeClickVeto("Reject all", "reject", weird));
+    const result = computeClickVeto("Reject all", "reject", weird);
+    assert.equal(result.allow, true);
+  });
+});
+
+// ── TEETH / shape test (load-bearing) ────────────────────────────────────
+
+describe("VETO_WORDS — teeth/shape guard (load-bearing)", () => {
+  test("deny is non-empty", () => {
+    assert.ok(Array.isArray(VETO_WORDS.deny) && VETO_WORDS.deny.length > 0);
+  });
+
+  test("deny contains known accept words across covered locales", () => {
+    const KNOWN_ACCEPT_WORDS = ["accept", "aceptar", "akzeptieren", "accepter", "accetta", "aceitar", "同意"];
+    for (const word of KNOWN_ACCEPT_WORDS) {
+      assert.ok(VETO_WORDS.deny.includes(word), `deny must contain the known accept word "${word}"`);
+    }
+  });
+
+  test("reject is non-empty and DISJOINT from deny", () => {
+    assert.ok(Array.isArray(VETO_WORDS.reject) && VETO_WORDS.reject.length > 0);
+    const denySet = new Set(VETO_WORDS.deny);
+    for (const word of VETO_WORDS.reject) {
+      assert.ok(!denySet.has(word), `reject word "${word}" must not also be a deny word`);
+    }
+  });
+
+  test("settings is non-empty and DISJOINT from deny", () => {
+    assert.ok(Array.isArray(VETO_WORDS.settings) && VETO_WORDS.settings.length > 0);
+    const denySet = new Set(VETO_WORDS.deny);
+    for (const word of VETO_WORDS.settings) {
+      assert.ok(!denySet.has(word), `settings word "${word}" must not also be a deny word`);
+    }
+  });
+
+  test("every entry in every list is already lowercase", () => {
+    for (const list of [VETO_WORDS.deny, VETO_WORDS.reject, VETO_WORDS.settings]) {
+      for (const word of list) {
+        assert.equal(word, word.toLowerCase(), `"${word}" must be lowercase`);
+      }
+    }
+  });
+
+  // Scoped to Latin-script entries: `\p{Diacritic}` also matches Japanese
+  // dakuten/handakuten (voiced-sound combining marks), so naively NFD-folding
+  // a precomposed CJK entry (e.g. "べ") would alter it into a DIFFERENT kana
+  // ("へ") rather than merely stripping an accent — that is not the "already
+  // folded" property this check is after. Real matching is unaffected
+  // (computeClickVeto checks the candidate's unfolded `name` first, which
+  // never decomposes CJK), so this is a test-scoping fix, not a veto bug.
+  test("every Latin-script entry is already diacritic-normalized (folding is a no-op)", () => {
+    const hasCJK = (s) => /[぀-ヿ㐀-鿿]/.test(s);
+    for (const list of [VETO_WORDS.deny, VETO_WORDS.reject, VETO_WORDS.settings]) {
+      for (const word of list) {
+        if (hasCJK(word)) continue;
+        const folded = word.normalize("NFD").replace(/\p{Diacritic}/gu, "");
+        assert.equal(folded, word, `"${word}" must already be diacritic-normalized`);
+      }
+    }
+  });
+
+  test("all three lists are frozen (immutable at the object and array level)", () => {
+    assert.ok(Object.isFrozen(VETO_WORDS));
+    assert.ok(Object.isFrozen(VETO_WORDS.deny));
+    assert.ok(Object.isFrozen(VETO_WORDS.reject));
+    assert.ok(Object.isFrozen(VETO_WORDS.settings));
+  });
+});
+
+// ── Guard-exemption confirmation (task 3.1) ──────────────────────────────
+//
+// The closed-action structural guard in tests/unit/cmp-adapters.test.mjs
+// scans EXACTLY src/lib/cmp-adapters.js and src/lib/cmp-tier2-rules.js (see
+// its own `FORBIDDEN = /allowall|accept/i` describe block) — it must never
+// be widened to include this file (see this module's own file docblock
+// below). Manually confirmed during PR A implementation: the guard's two
+// `readFileSync(...)` targets are unchanged and do not include
+// cmp-tier2-veto.js. A dedicated regression test for a SIBLING test file's
+// scan scope was deliberately NOT added here — it would be a source-string
+// assertion against test-suite structure, blocked by the #824
+// source-grep ratchet (tests/unit/source-grep-ratchet.test.mjs); the teeth
+// test above already gives cmp-tier2-veto.js its own strong regression
+// coverage (deny non-empty + contains accept words + disjoint allowlists),
+// which is the actual safety property this exemption protects.
+
+describe("cmp-tier2-veto.js — confirmed EXEMPT from the /allowall|accept/i structural guard", () => {
+  test("this module's own docblock documents the exemption", () => {
+    const source = readFileSync(join(__dirname, "../../src/lib/cmp-tier2-veto.js"), "utf8");
+    assert.ok(source.includes("EXEMPT from the `/allowall|accept/i` structural guard"));
+  });
+});

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -420,6 +420,61 @@ describe("cookie-noise-sync — @sync:cmp-tier2 block matches src/lib/cmp-adapte
   });
 });
 
+// ── @sync:cmp-tier2-veto block (Tier 2 runtime semantic click-veto) ───────
+//
+// normalizeAccessibleName / computeClickVeto / VETO_WORDS are pure exports
+// in src/lib/cmp-tier2-veto.js (unit-tested there, including the load-bearing
+// teeth test) whose body is hand-inlined ONLY into content/cookie-noise.js
+// (isolated world) — mirrors the @sync:cmp-tier2 precedent immediately
+// above: a DOM click needs neither a page-authored global nor the MAIN
+// world.
+
+const TIER2_VETO_FILES = {
+  lib: join(__dirname, "../../src/lib/cmp-tier2-veto.js"),
+  isolated: FILES.isolated,
+};
+
+const tier2VetoSources = {
+  lib: readFileSync(TIER2_VETO_FILES.lib, "utf8"),
+  isolated: sources.isolated,
+};
+
+const TIER2_VETO_START = "@sync:cmp-tier2-veto:start";
+const TIER2_VETO_END = "@sync:cmp-tier2-veto:end";
+
+describe("cookie-noise-sync — @sync:cmp-tier2-veto block matches src/lib/cmp-tier2-veto.js", () => {
+  const libBlock = extractMarkedBlock(tier2VetoSources.lib, TIER2_VETO_START, TIER2_VETO_END, "cmp-tier2-veto.js");
+  const isolatedBlock = extractMarkedBlock(tier2VetoSources.isolated, TIER2_VETO_START, TIER2_VETO_END, "cookie-noise.js");
+
+  test("tier2-veto sync block is non-empty and defines normalizeAccessibleName, computeClickVeto, and VETO_WORDS", () => {
+    assert.ok(libBlock.length > 0, "extracted @sync:cmp-tier2-veto block must not be empty — check the markers");
+    const joined = libBlock.join("\n");
+    assert.ok(/function normalizeAccessibleName/.test(joined));
+    assert.ok(/function computeClickVeto/.test(joined));
+    assert.ok(/const VETO_WORDS\s*=\s*Object\.freeze/.test(joined));
+  });
+
+  test("cookie-noise.js @sync:cmp-tier2-veto block matches src/lib/cmp-tier2-veto.js", () => {
+    assert.deepEqual(
+      isolatedBlock,
+      libBlock,
+      "content/cookie-noise.js's @sync:cmp-tier2-veto block has drifted from src/lib/cmp-tier2-veto.js",
+    );
+  });
+
+  test("the main-world caller does NOT carry the @sync:cmp-tier2-veto block (Tier 2 is isolated-world only)", () => {
+    assert.equal(sources.mainworld.includes(TIER2_VETO_START), false,
+      "cookie-noise-mainworld.js must not inline the Tier 2 veto — this mechanism is isolated-world only");
+  });
+
+  test("the veto's deny word list contains known accept words (its teeth), mirroring the lib teeth test", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/"accept"/.test(joined));
+    assert.ok(/"aceptar"/.test(joined));
+    assert.ok(/"akzeptieren"/.test(joined));
+  });
+});
+
 // ── Tier 2 dispatch — main-world exclusion (task 3.3) ───────────────────────
 //
 // Tier 2's DOM query-and-click capability must live ONLY in the isolated
@@ -512,6 +567,89 @@ describe("cookie-noise.js — Tier 2 reject-click dispatch structural guards", (
 
   test("tier2WarnDrift only ever warns once per rule id (guarded by _tier2Warned)", () => {
     assert.ok(/_tier2Warned\[ruleId\]/.test(sources.isolated));
+  });
+});
+
+// ── Tier 2 semantic click-veto wiring (#1027, Slice 2 / PR A) ──────────────
+//
+// LOAD-BEARING. computeClickVeto must run BEFORE both the reject and the
+// openSettings `.click()` calls, and a veto must fail closed exactly like
+// the pre-existing "single" resolution guards above: no `_tier2Acted` /
+// `_tier2PmOpened` write on a vetoed target, console-only warn-once, and a
+// `continue` back to the observer loop (a later pass may find a correctly
+// labelled target once the DOM settles).
+
+describe("cookie-noise.js — Tier 2 semantic click-veto wiring", () => {
+  function tier2DispatcherBody() {
+    const fnMatch = /function runTier2RejectDispatcher\(\)\s*\{([\s\S]*?)\n  \}/.exec(sources.isolated);
+    assert.ok(fnMatch, "cookie-noise.js must define runTier2RejectDispatcher()");
+    return fnMatch[1];
+  }
+
+  test('computeClickVeto is called with role "reject" BEFORE the reject .ref.click()', () => {
+    const body = tier2DispatcherBody();
+    const vetoIdx = body.indexOf('computeClickVeto(result.target.fullText, "reject", VETO_WORDS)');
+    const clickIdx = body.indexOf("result.target.ref.click()");
+    assert.ok(vetoIdx !== -1, 'must call computeClickVeto(..., "reject", VETO_WORDS) before the reject click');
+    assert.ok(clickIdx !== -1);
+    assert.ok(vetoIdx < clickIdx, "the reject veto must be evaluated before ref.click()");
+  });
+
+  test('computeClickVeto is called with role "openSettings" BEFORE the openSettings .ref.click()', () => {
+    const body = tier2DispatcherBody();
+    const vetoIdx = body.indexOf('computeClickVeto(openCandidates[0].fullText, "openSettings", VETO_WORDS)');
+    const clickIdx = body.indexOf("openCandidates[0].ref.click()");
+    assert.ok(vetoIdx !== -1, 'must call computeClickVeto(..., "openSettings", VETO_WORDS) before the openSettings click');
+    assert.ok(clickIdx !== -1);
+    assert.ok(vetoIdx < clickIdx, "the openSettings veto must be evaluated before ref.click()");
+  });
+
+  test("on reject veto, _tier2Acted is NOT set — the veto check happens before the acted-assignment and continues", () => {
+    const body = tier2DispatcherBody();
+    const vetoIdx = body.indexOf('const veto = computeClickVeto(result.target.fullText, "reject", VETO_WORDS);');
+    const actedIdx = body.indexOf("_tier2Acted[rule.id] = true;");
+    assert.ok(vetoIdx !== -1 && actedIdx !== -1);
+    assert.ok(vetoIdx < actedIdx, "the reject veto must be checked before _tier2Acted is ever set");
+    assert.ok(
+      /if\s*\(!veto\.allow\)\s*\{[\s\S]*?continue;[\s\S]*?\}/.test(body),
+      "a reject veto must continue without falling through to the click/acted branch",
+    );
+  });
+
+  test("on openSettings veto, _tier2PmOpened is NOT set — the veto check happens before the pmOpened-assignment and continues", () => {
+    const body = tier2DispatcherBody();
+    const vetoIdx = body.indexOf('const openVeto = computeClickVeto(openCandidates[0].fullText, "openSettings", VETO_WORDS);');
+    const pmOpenedIdx = body.indexOf("_tier2PmOpened[rule.id] = true;");
+    assert.ok(vetoIdx !== -1 && pmOpenedIdx !== -1);
+    assert.ok(vetoIdx < pmOpenedIdx, "the openSettings veto must be checked before _tier2PmOpened is ever set");
+    assert.ok(
+      /if\s*\(!openVeto\.allow\)\s*\{[\s\S]*?continue;[\s\S]*?\}/.test(body),
+      "an openSettings veto must continue without falling through to the click/pmOpened branch",
+    );
+  });
+
+  test("a vetoed reject/openSettings target warns via tier2WarnVeto, which makes no network/telemetry call", () => {
+    const src = sources.isolated;
+    const fnMatch = /function tier2WarnVeto\([^)]*\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define tier2WarnVeto()");
+    const NETWORK_PATTERN = /sendMessage|fetch\s*\(|XMLHttpRequest|sendBeacon/;
+    assert.doesNotMatch(fnMatch[1], NETWORK_PATTERN, "tier2WarnVeto must not make any network/telemetry call");
+  });
+
+  test("tier2WarnVeto warns at most once per rule id + role (guarded by _tier2VetoWarned)", () => {
+    assert.ok(/_tier2VetoWarned\[key\]/.test(sources.isolated));
+  });
+
+  test("the veto applies identically regardless of rule origin — exactly one veto call site per role, no conditional skip", () => {
+    // Spec scenario 5 / design ADR-1: the veto call sites take no
+    // origin/source parameter and there is no per-rule conditional that
+    // skips computeClickVeto for any subset of TIER2_RULES — every rule in
+    // the single shared TIER2_RULES loop goes through the same two calls.
+    const body = tier2DispatcherBody();
+    const rejectVetoCalls = body.split('computeClickVeto(result.target.fullText, "reject", VETO_WORDS)').length - 1;
+    const openVetoCalls = body.split('computeClickVeto(openCandidates[0].fullText, "openSettings", VETO_WORDS)').length - 1;
+    assert.equal(rejectVetoCalls, 1, "exactly one unconditional reject veto call site, shared by every rule");
+    assert.equal(openVetoCalls, 1, "exactly one unconditional openSettings veto call site, shared by every rule");
   });
 });
 


### PR DESCRIPTION
## PR A of the cookie-consent-tier2-remote chain — the safety gate (must merge before any remote-delivery PR)

The load-bearing **never-accept** layer for Tier 2. Tier 2 clicks a "reject" button found by a CSS selector; a wrong/too-generic selector could match an **Accept** button and grant consent. This veto reads the target's accessible name before every click and refuses unless it's unambiguously a reject/settings control. **Hardens the already-live bundled rules today; prerequisite for remote rule delivery.**

### What's in this slice
- **`src/lib/cmp-tier2-veto.js`** — pure `normalizeAccessibleName` + `computeClickVeto(accessibleName, role, wordLists)`. Precedence: **empty → deny (absolute) → role-positive-gate → allow**. Bundled `deny`/`reject`/`settings` word lists across 7 locales (en/es/de/fr/it/ja/pt). Substring match over the name + a diacritic-folded form.
- Wired before **both** `.click()` sites in `runTier2RejectDispatcher` (reject + openSettings hop). On veto: no `_tier2Acted`/`_tier2PmOpened` write, warn-once (console-only), `continue`.
- `@sync:cmp-tier2-veto` byte-for-byte copy into `cookie-noise.js` + sync test. Adversarial battery (67 tests) + teeth/shape test (deny non-empty + contains accept words; reject/settings disjoint from deny). The veto module is intentionally EXEMPT from the `/allowall|accept/` guard (accept words are its teeth) — documented.

### Verification
- `npm test` 7630 pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0
- Fresh adversarial review: **AIRTIGHT** — veto fires before every click unconditionally, deny absolute, all fail-closed cases hold, no cross-locale substring false-negative, normalization can't dodge deny, no telemetry.

### Follow-up (required before remote openSettings is enabled, PR B2)
The `openSettings` role currently allows "Save my preferences"-style labels (contains "preferences"). Dormant today (no rule uses `openSettings`). Before any remote `openSettings` selector is honored, add a `save`-family exclusion to the openSettings gate so a Save button can't pass as a panel-opener.

### Not in this PR (must not merge before this lands)
- PR B1/B2/B3: signed `tier2.json` fetch + validator + transport + ADD-only merge + CI signing (reusing the existing key + workflow with a domain-tagged canonical message)

`size:exception` (~1024 lines — 7-locale word lists ×2 via `@sync` + adversarial battery; one atomic safety unit, not split from its tests).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9