### PR TITLE
feat(consent): Tier 2 remote-rule content transport + merge + dispatch (PR B2/B)

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1574,6 +1574,43 @@
     "環境設定",
   ]);
 
+  // Save/persist words — checked ONLY for a `role: "openSettings"` candidate,
+  // IN ADDITION TO the SETTINGS_WORDS positive gate (see the file docblock's
+  // "openSettings ALSO vetoes on a save-family word" section). A
+  // settings-OPENER must not double as a consent-committing "Save" action.
+  // DISJOINT from DENY_WORDS and REJECT_WORDS by construction (asserted by
+  // the teeth test) — it deliberately overlaps with SETTINGS_WORDS in
+  // spirit (a "save preferences" phrase legitimately contains a settings
+  // word too), which is expected: the save check runs as an ADDITIONAL veto
+  // step, not a replacement for the settings gate.
+  const SAVE_WORDS = Object.freeze([
+    // en
+    "save",
+    "save preferences",
+    "save settings",
+    "save my preferences",
+    "save choices",
+    // es
+    "guardar",
+    "guardar preferencias",
+    "guardar mis preferencias",
+    // de
+    "speichern",
+    "einstellungen speichern",
+    // fr
+    "enregistrer",
+    "enregistrer mes preferences",
+    // it
+    "salva",
+    "salva le preferenze",
+    // pt
+    "salvar",
+    "salvar preferencias",
+    // ja
+    "保存",
+    "保存する",
+  ]);
+
   /**
    * The veto's bundled word lists (see the file docblock's "Word-list
    * distribution" section — BUNDLED, never remote). Passed explicitly into
@@ -1585,6 +1622,7 @@
     deny: DENY_WORDS,
     reject: REJECT_WORDS,
     settings: SETTINGS_WORDS,
+    save: SAVE_WORDS,
   });
 
   /**
@@ -1622,16 +1660,23 @@
    *      - `role === "reject"` requires a `wordLists.reject` match, else
    *        VETO ("no-reject-word").
    *      - `role === "openSettings"` requires a `wordLists.settings` match,
-   *        else VETO ("no-settings-word").
+   *        else VETO ("no-settings-word"); IN ADDITION, if `wordLists.save`
+   *        also matches -> VETO ("save-word") — a settings-OPENER must not
+   *        double as a consent-committing "Save" action (see the file
+   *        docblock's "openSettings ALSO vetoes on a save-family word"
+   *        section). Checked AFTER the settings-word gate passes, since a
+   *        save-labelled control (e.g. "Save my preferences") typically
+   *        also contains a settings word and would otherwise clear step 3.
    *      - any other role -> VETO ("unknown-role").
    *   4. Otherwise -> ALLOW ("ok").
    *
    * The only allow path is: non-empty name AND no accept word AND the role's
-   * required positive word present. Absence of signal always resolves to "do
-   * not click" — fail-closed by construction. Pure; never throws.
+   * required positive word present (AND, for openSettings, no save word
+   * present). Absence of signal always resolves to "do not click" —
+   * fail-closed by construction. Pure; never throws.
    * @param {*} accessibleName
    * @param {"reject"|"openSettings"} role
-   * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string> }} wordLists
+   * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string>, save: ReadonlyArray<string> }} wordLists
    * @returns {ClickVetoResult}
    */
   function computeClickVeto(accessibleName, role, wordLists) {
@@ -1647,6 +1692,7 @@
     }
     if (role === "openSettings") {
       if (!matchesAny(name, folded, lists.settings)) return { allow: false, reason: "no-settings-word" };
+      if (matchesAny(name, folded, lists.save)) return { allow: false, reason: "save-word" };
       return { allow: true, reason: "ok" };
     }
     return { allow: false, reason: "unknown-role" };
@@ -1914,10 +1960,115 @@
     return matches;
   }
 
+  // ── Tier 2 remote-rule content-side merge (#1027, Slice 2 / PR B2) ────────
+  //
+  // The background pipeline (src/lib/remote-tier2-rules.js, PR B1) fetches,
+  // signature-verifies, and shape/cap/token-validates a signed Tier2
+  // payload, then writes it storage-only to chrome.storage.local under
+  // remoteTier2Rules — there is no DOM in a service worker, so CSS
+  // parseability could not be checked there (design ADR-4/ADR-7). Every
+  // remote selector is therefore re-checked HERE, content-side, at
+  // gate-open and again on every chrome.storage.onChanged(local) update to
+  // remoteTier2Rules, via a REAL document.querySelector(...) call wrapped
+  // in try/catch: an unparseable or throwing selector is dropped,
+  // fail-closed, and is never used to match a DOM element. ADD-only merge
+  // (design ADR-5): a remote rule whose id collides with a bundled
+  // TIER2_RULES id is dropped entirely (bundled wins) — defense-in-depth on
+  // top of remote-tier2-rules.js's own ID_COLLISION rejection at fetch
+  // time, so a bundled rule can never be shadowed by a remote one even if a
+  // future bug let a colliding id slip past the background validator.
+  // runTier2RejectDispatcher and tier2ArmGiveUp below iterate `mergedRules`
+  // (bundled + filtered remote), never TIER2_RULES directly, once this
+  // module has run at least once — `mergedRules` starts equal to
+  // TIER2_RULES so a page that never reads storage (e.g. chrome.storage
+  // unavailable) still gets full bundled-rule behavior.
+
+  const BUNDLED_TIER2_IDS = new Set(TIER2_RULES.map((r) => r.id));
+  let mergedRules = TIER2_RULES;
+
+  // True when `sel` parses as valid CSS, proven by a real DOM query rather
+  // than a regex/heuristic guess. A syntax error (or any other exception)
+  // is treated as unparseable. A selector that parses but matches nothing
+  // on the current page still returns true here — this is a SYNTAX check,
+  // not a match check. Never throws.
+  function tier2SelectorParses(sel) {
+    if (typeof sel !== "string" || sel.length === 0) return false;
+    try {
+      document.querySelector(sel);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function tier2FilterSelectorArray(arr) {
+    if (!Array.isArray(arr)) return [];
+    return arr.filter((sel) => tier2SelectorParses(sel));
+  }
+
+  // Fail-closed content-side gate for a single remote rule: drops it
+  // entirely on a bundled-id collision (ADD-only, bundled wins) or once its
+  // `reject` array has zero usable (CSS-parseable) selectors left — a rule
+  // with no reject target left is pointless to keep around. `present` and
+  // `openSettings` are also filtered but are allowed to end up empty: an
+  // empty `present` already fails closed via the existing
+  // document.querySelector(rule.present.join(",")) try/catch in
+  // runTier2RejectDispatcher below (an empty join(",") throws a syntax
+  // error -> present=false -> the rule is skipped for that pass, exactly
+  // like an absent anchor). Never throws.
+  function tier2FilterRemoteRule(rule) {
+    if (!rule || typeof rule !== "object") return null;
+    if (typeof rule.id !== "string" || BUNDLED_TIER2_IDS.has(rule.id)) return null;
+    const reject = tier2FilterSelectorArray(rule.reject);
+    if (reject.length === 0) return null;
+    const present = tier2FilterSelectorArray(rule.present);
+    const openSettings = tier2FilterSelectorArray(rule.openSettings);
+    return Object.freeze({
+      id: rule.id,
+      present: Object.freeze(present),
+      reject: Object.freeze(reject),
+      openSettings: Object.freeze(openSettings),
+    });
+  }
+
+  function tier2RecomputeMergedRules(rawRemoteRules) {
+    const list = Array.isArray(rawRemoteRules) ? rawRemoteRules : [];
+    const filtered = [];
+    for (const raw of list) {
+      const rule = tier2FilterRemoteRule(raw);
+      if (rule) filtered.push(rule);
+    }
+    mergedRules = Object.freeze([...TIER2_RULES, ...filtered]);
+  }
+
+  // Reads chrome.storage.local.remoteTier2Rules and recomputes
+  // `mergedRules`. Fails closed to the bundled-only set on any error or
+  // absent chrome.storage — a broken/unavailable storage read never
+  // blocks bundled Tier 2 dispatch, it just means no remote rules are
+  // active for this pass. `callback` (optional) runs after the recompute,
+  // whether it resolved via storage or via a fail-closed fallback.
+  function tier2ReadRemoteRulesAndMerge(callback) {
+    try {
+      if (typeof chrome === "undefined" || !chrome.storage || !chrome.storage.local) {
+        tier2RecomputeMergedRules([]);
+        if (callback) callback();
+        return;
+      }
+      chrome.storage.local.get({ remoteTier2Rules: [] }, (result) => {
+        void chrome.runtime.lastError;
+        tier2RecomputeMergedRules(result && result.remoteTier2Rules);
+        if (callback) callback();
+      });
+    } catch {
+      tier2RecomputeMergedRules([]);
+      if (callback) callback();
+    }
+  }
+
   function runTier2RejectDispatcher() {
     if (!_tier2GateOpen) return;
     const candidates = collectAcceptCandidates();
-    for (const rule of TIER2_RULES) {
+    for (const rule of mergedRules) {
       if (_tier2Acted[rule.id]) continue;
       let present = false;
       try {
@@ -1987,7 +2138,7 @@
     if (_tier2GiveUpArmed) return;
     _tier2GiveUpArmed = true;
     const giveUp = () => {
-      for (const rule of TIER2_RULES) {
+      for (const rule of mergedRules) {
         if (_tier2Acted[rule.id]) continue;
         let present = false;
         try {
@@ -2076,8 +2227,15 @@
         // isSiteFullyExempt) — see computeCookieGate above.
         _tier2GateOpen = open;
         if (_tier2GateOpen) {
-          runTier2RejectDispatcher(); // initial sweep — the banner may already exist
-          tier2StartObserver();
+          // #1027 Slice 2 / PR B2: read chrome.storage.local.remoteTier2Rules
+          // and CSS-parse-filter + ADD-only merge it with TIER2_RULES BEFORE
+          // the initial dispatch sweep, so a page whose gate opens after the
+          // background pipeline (PR B1) has already cached remote rules gets
+          // them from the very first sweep.
+          tier2ReadRemoteRulesAndMerge(() => {
+            runTier2RejectDispatcher(); // initial sweep — the banner may already exist
+            tier2StartObserver();
+          });
         } else {
           tier2StopObserver();
         }
@@ -2095,8 +2253,16 @@
   if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.onChanged) {
     if (!_storageListenerInstalled) {
       _storageListenerInstalled = true;
-      chrome.storage.onChanged.addListener((_changes, area) => {
+      chrome.storage.onChanged.addListener((changes, area) => {
         if (area === "sync") readPrefsAndGate();
+        // #1027 Slice 2 / PR B2: the background pipeline (PR B1) may cache
+        // a fresh signed Tier2 payload at any time via chrome.storage.local
+        // — re-filter/merge and re-dispatch immediately, but ONLY while the
+        // reject gate is open (a closed gate must not react to this at all,
+        // same posture as every other Tier 2 dispatch entry point).
+        if (area === "local" && changes && changes.remoteTier2Rules && _tier2GateOpen) {
+          tier2ReadRemoteRulesAndMerge(() => runTier2RejectDispatcher());
+        }
       });
     }
   }

--- a/src/lib/cmp-tier2-veto.js
+++ b/src/lib/cmp-tier2-veto.js
@@ -52,12 +52,30 @@
  * "require a role word" gate degrades an uncovered locale to a coverage
  * gap (fail-closed no-op), never a wrong click.
  *
+ * ── openSettings ALSO vetoes on a save-family word (PR A review follow-up,
+ * folded into PR B2) ────────────────────────────────────────────────────
+ *
+ * Once remote rules make `openSettings` reachable in production (PR B2), a
+ * mis-curated or hostile remote rule could point `openSettings` at a
+ * control whose accessible name is something like "Save my preferences" —
+ * a settings-word match ("preferences") would otherwise let it pass the
+ * positive gate below, but clicking it PERSISTS whatever consent state is
+ * currently selected, which is not a neutral settings-opening action (the
+ * two-step hop is only safe because opening a panel grants nothing by
+ * itself — see the openSettings role's docblock in computeClickVeto).
+ * `VETO_WORDS.save` is therefore checked, role-scoped to `openSettings`
+ * only (it does not apply to `reject`), IN ADDITION TO the existing
+ * require-a-settings-word gate: a target must match a settings word AND
+ * must NOT match a save word to be clicked. Legit settings-openers like
+ * "Manage preferences" or "Cookie settings" contain no save word and are
+ * unaffected.
+ *
  * @typedef {object} ClickVetoResult
  * @property {boolean} allow - true only when the accessible name is
  *   non-empty, matches no accept/agree word, AND matches the role's
- *   required positive word.
+ *   required positive word (and, for openSettings, matches no save word).
  * @property {string} reason - one of "empty-name", "accept-word",
- *   "no-reject-word", "no-settings-word", "unknown-role", "ok".
+ *   "no-reject-word", "no-settings-word", "save-word", "unknown-role", "ok".
  */
 
 // @sync:cmp-tier2-veto:start
@@ -193,6 +211,43 @@ const SETTINGS_WORDS = Object.freeze([
   "環境設定",
 ]);
 
+// Save/persist words — checked ONLY for a `role: "openSettings"` candidate,
+// IN ADDITION TO the SETTINGS_WORDS positive gate (see the file docblock's
+// "openSettings ALSO vetoes on a save-family word" section). A
+// settings-OPENER must not double as a consent-committing "Save" action.
+// DISJOINT from DENY_WORDS and REJECT_WORDS by construction (asserted by
+// the teeth test) — it deliberately overlaps with SETTINGS_WORDS in
+// spirit (a "save preferences" phrase legitimately contains a settings
+// word too), which is expected: the save check runs as an ADDITIONAL veto
+// step, not a replacement for the settings gate.
+const SAVE_WORDS = Object.freeze([
+  // en
+  "save",
+  "save preferences",
+  "save settings",
+  "save my preferences",
+  "save choices",
+  // es
+  "guardar",
+  "guardar preferencias",
+  "guardar mis preferencias",
+  // de
+  "speichern",
+  "einstellungen speichern",
+  // fr
+  "enregistrer",
+  "enregistrer mes preferences",
+  // it
+  "salva",
+  "salva le preferenze",
+  // pt
+  "salvar",
+  "salvar preferencias",
+  // ja
+  "保存",
+  "保存する",
+]);
+
 /**
  * The veto's bundled word lists (see the file docblock's "Word-list
  * distribution" section — BUNDLED, never remote). Passed explicitly into
@@ -204,6 +259,7 @@ const VETO_WORDS = Object.freeze({
   deny: DENY_WORDS,
   reject: REJECT_WORDS,
   settings: SETTINGS_WORDS,
+  save: SAVE_WORDS,
 });
 
 /**
@@ -241,16 +297,23 @@ function matchesAny(name, folded, words) {
  *      - `role === "reject"` requires a `wordLists.reject` match, else
  *        VETO ("no-reject-word").
  *      - `role === "openSettings"` requires a `wordLists.settings` match,
- *        else VETO ("no-settings-word").
+ *        else VETO ("no-settings-word"); IN ADDITION, if `wordLists.save`
+ *        also matches -> VETO ("save-word") — a settings-OPENER must not
+ *        double as a consent-committing "Save" action (see the file
+ *        docblock's "openSettings ALSO vetoes on a save-family word"
+ *        section). Checked AFTER the settings-word gate passes, since a
+ *        save-labelled control (e.g. "Save my preferences") typically
+ *        also contains a settings word and would otherwise clear step 3.
  *      - any other role -> VETO ("unknown-role").
  *   4. Otherwise -> ALLOW ("ok").
  *
  * The only allow path is: non-empty name AND no accept word AND the role's
- * required positive word present. Absence of signal always resolves to "do
- * not click" — fail-closed by construction. Pure; never throws.
+ * required positive word present (AND, for openSettings, no save word
+ * present). Absence of signal always resolves to "do not click" —
+ * fail-closed by construction. Pure; never throws.
  * @param {*} accessibleName
  * @param {"reject"|"openSettings"} role
- * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string> }} wordLists
+ * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string>, save: ReadonlyArray<string> }} wordLists
  * @returns {ClickVetoResult}
  */
 function computeClickVeto(accessibleName, role, wordLists) {
@@ -266,6 +329,7 @@ function computeClickVeto(accessibleName, role, wordLists) {
   }
   if (role === "openSettings") {
     if (!matchesAny(name, folded, lists.settings)) return { allow: false, reason: "no-settings-word" };
+    if (matchesAny(name, folded, lists.save)) return { allow: false, reason: "save-word" };
     return { allow: true, reason: "ok" };
   }
   return { allow: false, reason: "unknown-role" };

--- a/tests/unit/cmp-tier2-veto.test.mjs
+++ b/tests/unit/cmp-tier2-veto.test.mjs
@@ -162,6 +162,43 @@ describe("computeClickVeto — openSettings role", () => {
   });
 });
 
+// ── openSettings — save-family word veto (PR A review follow-up / PR B2) ─
+//
+// Once remote rules make openSettings reachable in production, a
+// mis-curated or hostile remote rule could point openSettings at a "Save"
+// control that also happens to name a settings word (e.g. "Save my
+// preferences"). This must be vetoed even though it clears the existing
+// settings-word gate — see computeClickVeto's precedence docblock.
+
+describe("computeClickVeto — openSettings role: save-family word is vetoed (PR A review follow-up)", () => {
+  test("'Save my preferences' (contains both a settings word and a save word) -> VETO (save-word)", () => {
+    const result = computeClickVeto("Save my preferences", "openSettings", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "save-word");
+  });
+
+  test("'Manage preferences' (legit opener, no save word) -> allow", () => {
+    const result = computeClickVeto("Manage preferences", "openSettings", VETO_WORDS);
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("'Cookie settings' (legit opener, no save word) -> allow", () => {
+    const result = computeClickVeto("Cookie settings", "openSettings", VETO_WORDS);
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("the save-word veto does NOT apply to the reject role — a reject-labelled control containing 'save' text is judged solely on REJECT_WORDS/DENY_WORDS", () => {
+    // No real reject phrase contains a save word, but this proves the
+    // save check is role-scoped: a reject-role candidate is never vetoed
+    // via VETO_WORDS.save at all (only via deny or the reject-word gate).
+    const result = computeClickVeto("Reject all", "reject", VETO_WORDS);
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+});
+
 describe("computeClickVeto — multi-locale reject coverage (en/es/de/fr/it/ja/pt)", () => {
   const REJECT_ALLOWS = [
     ["en", "Reject all"],
@@ -285,8 +322,23 @@ describe("VETO_WORDS — teeth/shape guard (load-bearing)", () => {
     }
   });
 
+  test("save is non-empty and DISJOINT from deny", () => {
+    assert.ok(Array.isArray(VETO_WORDS.save) && VETO_WORDS.save.length > 0);
+    const denySet = new Set(VETO_WORDS.deny);
+    for (const word of VETO_WORDS.save) {
+      assert.ok(!denySet.has(word), `save word "${word}" must not also be a deny word`);
+    }
+  });
+
+  test("save is DISJOINT from reject (PR A review follow-up)", () => {
+    const rejectSet = new Set(VETO_WORDS.reject);
+    for (const word of VETO_WORDS.save) {
+      assert.ok(!rejectSet.has(word), `save word "${word}" must not also be a reject word`);
+    }
+  });
+
   test("every entry in every list is already lowercase", () => {
-    for (const list of [VETO_WORDS.deny, VETO_WORDS.reject, VETO_WORDS.settings]) {
+    for (const list of [VETO_WORDS.deny, VETO_WORDS.reject, VETO_WORDS.settings, VETO_WORDS.save]) {
       for (const word of list) {
         assert.equal(word, word.toLowerCase(), `"${word}" must be lowercase`);
       }
@@ -302,7 +354,7 @@ describe("VETO_WORDS — teeth/shape guard (load-bearing)", () => {
   // never decomposes CJK), so this is a test-scoping fix, not a veto bug.
   test("every Latin-script entry is already diacritic-normalized (folding is a no-op)", () => {
     const hasCJK = (s) => /[぀-ヿ㐀-鿿]/.test(s);
-    for (const list of [VETO_WORDS.deny, VETO_WORDS.reject, VETO_WORDS.settings]) {
+    for (const list of [VETO_WORDS.deny, VETO_WORDS.reject, VETO_WORDS.settings, VETO_WORDS.save]) {
       for (const word of list) {
         if (hasCJK(word)) continue;
         const folded = word.normalize("NFD").replace(/\p{Diacritic}/gu, "");
@@ -311,11 +363,12 @@ describe("VETO_WORDS — teeth/shape guard (load-bearing)", () => {
     }
   });
 
-  test("all three lists are frozen (immutable at the object and array level)", () => {
+  test("all four lists are frozen (immutable at the object and array level)", () => {
     assert.ok(Object.isFrozen(VETO_WORDS));
     assert.ok(Object.isFrozen(VETO_WORDS.deny));
     assert.ok(Object.isFrozen(VETO_WORDS.reject));
     assert.ok(Object.isFrozen(VETO_WORDS.settings));
+    assert.ok(Object.isFrozen(VETO_WORDS.save));
   });
 });
 

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -21,6 +21,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
+import { computeClickVeto, VETO_WORDS } from "../../src/lib/cmp-tier2-veto.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -473,6 +474,13 @@ describe("cookie-noise-sync — @sync:cmp-tier2-veto block matches src/lib/cmp-t
     assert.ok(/"aceptar"/.test(joined));
     assert.ok(/"akzeptieren"/.test(joined));
   });
+
+  test("the veto defines a save-family word list and the openSettings save-word veto reason (PR A review follow-up / PR B2)", () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/const SAVE_WORDS\s*=\s*Object\.freeze/.test(joined), "must define SAVE_WORDS");
+    assert.ok(/save:\s*SAVE_WORDS/.test(joined), "VETO_WORDS must expose the save list");
+    assert.ok(/"save-word"/.test(joined), "computeClickVeto must be able to return the save-word veto reason");
+  });
 });
 
 // ── Tier 2 dispatch — main-world exclusion (task 3.3) ───────────────────────
@@ -643,13 +651,201 @@ describe("cookie-noise.js — Tier 2 semantic click-veto wiring", () => {
   test("the veto applies identically regardless of rule origin — exactly one veto call site per role, no conditional skip", () => {
     // Spec scenario 5 / design ADR-1: the veto call sites take no
     // origin/source parameter and there is no per-rule conditional that
-    // skips computeClickVeto for any subset of TIER2_RULES — every rule in
-    // the single shared TIER2_RULES loop goes through the same two calls.
+    // skips computeClickVeto for any subset of rules — every rule in the
+    // single shared `mergedRules` loop (bundled + filtered remote, #1027
+    // Slice 2 / PR B2) goes through the same two calls.
     const body = tier2DispatcherBody();
     const rejectVetoCalls = body.split('computeClickVeto(result.target.fullText, "reject", VETO_WORDS)').length - 1;
     const openVetoCalls = body.split('computeClickVeto(openCandidates[0].fullText, "openSettings", VETO_WORDS)').length - 1;
     assert.equal(rejectVetoCalls, 1, "exactly one unconditional reject veto call site, shared by every rule");
     assert.equal(openVetoCalls, 1, "exactly one unconditional openSettings veto call site, shared by every rule");
+  });
+});
+
+// ── Tier 2 remote-rule content-side merge (#1027, Slice 2 / PR B2) ─────────
+//
+// cookie-noise.js cannot be imported in Node (top-level chrome.*/document
+// usage — see AGENTS.md), so the CSS-parse-filter + ADD-only merge logic is
+// exercised here via a PURE re-implementation that mirrors production
+// exactly (same pattern as makeMaybeFetchTier2Helper in
+// service-worker-patterns.test.mjs), with an INJECTABLE `canParse`
+// predicate standing in for the real `document.querySelector` try/catch —
+// this makes the filter/merge decision genuinely behaviorally testable
+// without a DOM, while the production file's own use of a real
+// document.querySelector is confirmed by a single minimal structural guard
+// below (#824 — one new source-string assertion, mirroring the existing
+// precedent in this file and in service-worker-patterns.test.mjs).
+
+function makeTier2RemoteMergeHelper(bundledIds, canParse) {
+  function filterSelectorArray(arr) {
+    if (!Array.isArray(arr)) return [];
+    return arr.filter((sel) => typeof sel === "string" && sel.length > 0 && canParse(sel));
+  }
+  function filterRemoteRule(rule) {
+    if (!rule || typeof rule !== "object") return null;
+    if (typeof rule.id !== "string" || bundledIds.has(rule.id)) return null;
+    const reject = filterSelectorArray(rule.reject);
+    if (reject.length === 0) return null;
+    const present = filterSelectorArray(rule.present);
+    const openSettings = filterSelectorArray(rule.openSettings);
+    return { id: rule.id, present, reject, openSettings };
+  }
+  return function recomputeMergedRules(bundledRules, rawRemoteRules) {
+    const list = Array.isArray(rawRemoteRules) ? rawRemoteRules : [];
+    const filtered = [];
+    for (const raw of list) {
+      const rule = filterRemoteRule(raw);
+      if (rule) filtered.push(rule);
+    }
+    return [...bundledRules, ...filtered];
+  };
+}
+
+describe("Tier 2 content-side remote-rule merge — pure re-implementation (mirrors cookie-noise.js)", () => {
+  const BUNDLED = [
+    { id: "complianz", present: ["#a"], reject: [".deny"], openSettings: [] },
+    { id: "cookie-notice", present: ["#b"], reject: ["#refuse"], openSettings: [] },
+  ];
+  const bundledIds = new Set(BUNDLED.map((r) => r.id));
+
+  test("a fresh-id remote rule with fully parseable selectors is merged (spec scenario: fresh id merged)", () => {
+    const canParse = () => true;
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      { id: "acme-cmp", present: ["#acme"], reject: [".acme-reject"], openSettings: [] },
+    ]);
+    assert.equal(merged.length, 3);
+    assert.ok(merged.some((r) => r.id === "acme-cmp"));
+  });
+
+  test("ADD-only: a remote rule id colliding with a bundled id is dropped entirely — bundled wins (defense-in-depth)", () => {
+    const canParse = () => true;
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      { id: "complianz", present: ["#hostile"], reject: [".hostile-reject"], openSettings: [] },
+    ]);
+    assert.equal(merged.length, 2, "the colliding remote rule must be dropped, not appended or merged");
+    const complianz = merged.find((r) => r.id === "complianz");
+    assert.deepEqual(complianz, BUNDLED[0], "the bundled rule's own selectors must be completely untouched");
+  });
+
+  test("an unparseable selector is dropped from its array (fail-closed), never used to match DOM elements", () => {
+    const canParse = (sel) => sel !== ":::not-css";
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      { id: "acme-cmp", present: ["#acme"], reject: [".good-reject", ":::not-css"], openSettings: [] },
+    ]);
+    const rule = merged.find((r) => r.id === "acme-cmp");
+    assert.deepEqual(rule.reject, [".good-reject"], "the unparseable selector must be filtered out");
+  });
+
+  test("a rule left with zero usable reject selectors after filtering is skipped entirely", () => {
+    const canParse = (sel) => sel !== ".only-reject";
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      { id: "acme-cmp", present: ["#acme"], reject: [".only-reject"], openSettings: [] },
+    ]);
+    assert.equal(merged.length, 2, "a rule with no usable reject selector must not be merged at all");
+  });
+
+  test("present/openSettings are allowed to end up empty after filtering (fails closed downstream, not here)", () => {
+    const canParse = (sel) => sel !== "#gone-present";
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      { id: "acme-cmp", present: ["#gone-present"], reject: [".good-reject"], openSettings: ["#gone-present"] },
+    ]);
+    const rule = merged.find((r) => r.id === "acme-cmp");
+    assert.deepEqual(rule.present, []);
+    assert.deepEqual(rule.openSettings, []);
+  });
+
+  test("a merged rule object carries no origin/source field distinguishing it from a bundled rule", () => {
+    const canParse = () => true;
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      { id: "acme-cmp", present: ["#acme"], reject: [".acme-reject"], openSettings: [] },
+    ]);
+    for (const rule of merged) {
+      assert.deepEqual(
+        Object.keys(rule).sort(),
+        ["id", "openSettings", "present", "reject"],
+        "a merged rule (bundled or remote-origin) must expose exactly id/present/reject/openSettings — no origin/source field a dispatcher could branch on",
+      );
+    }
+  });
+});
+
+// ── Spec scenario 5 integration test: veto applies identically to bundled ──
+// and remote-origin candidates (#1027, Slice 2 / PR B2, task 6.4) ─────────
+//
+// Uses the REAL computeClickVeto/VETO_WORDS exported from
+// src/lib/cmp-tier2-veto.js (a pure ES module, genuinely importable and
+// executable in Node — unlike cookie-noise.js itself) to prove there is no
+// origin-based exemption: a bundled-origin candidate and a merged
+// remote-origin candidate, both resolving to an accept-matching accessible
+// name, are vetoed identically. computeClickVeto's signature takes no
+// origin/source parameter at all (see its JSDoc), so this test also proves
+// there is structurally no way to plumb one through.
+
+describe("Tier 2 dispatch — spec scenario 5: veto applies identically to bundled and remote-origin candidates", () => {
+  const canParse = () => true;
+  const bundledIds = new Set(["complianz", "cookie-notice"]);
+  const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+  const merged = recompute(
+    [{ id: "complianz", present: ["#a"], reject: [".deny"], openSettings: [] }],
+    [{ id: "acme-cmp", present: ["#acme"], reject: [".acme-reject"], openSettings: [] }],
+  );
+  const bundledOriginRule = merged.find((r) => r.id === "complianz");
+  const remoteOriginRule = merged.find((r) => r.id === "acme-cmp");
+
+  test("both a bundled-origin and a remote-origin candidate with an accept-matching accessible name are vetoed", () => {
+    assert.ok(bundledOriginRule, "test setup: bundled-origin rule must be present in mergedRules");
+    assert.ok(remoteOriginRule, "test setup: remote-origin rule must be present in mergedRules");
+    const bundledVeto = computeClickVeto("Accept all", "reject", VETO_WORDS);
+    const remoteVeto = computeClickVeto("Accept all", "reject", VETO_WORDS);
+    assert.equal(bundledVeto.allow, false, "bundled-origin candidate must be vetoed");
+    assert.equal(remoteVeto.allow, false, "remote-origin candidate must be vetoed identically");
+    assert.equal(bundledVeto.reason, remoteVeto.reason, "the veto reason must be identical regardless of rule origin");
+  });
+
+  test("computeClickVeto's own signature has no origin/source parameter — there is no code path to plumb one through", () => {
+    assert.equal(computeClickVeto.length, 3, "computeClickVeto must take exactly (accessibleName, role, wordLists) — no 4th origin argument");
+  });
+});
+
+// ── Structural wiring guards (#824 — minimal, one assertion per guard) ────
+
+describe("cookie-noise.js — Tier 2 remote-rule merge wiring (structural, task 6.1-6.3)", () => {
+  const src = sources.isolated;
+
+  test("runTier2RejectDispatcher iterates mergedRules, not TIER2_RULES directly", () => {
+    const fnMatch = /function runTier2RejectDispatcher\(\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    assert.ok(/for \(const rule of mergedRules\)/.test(fnMatch[1]),
+      "runTier2RejectDispatcher must iterate mergedRules (bundled + filtered remote)");
+  });
+
+  test("tier2ArmGiveUp's drift check iterates mergedRules, not TIER2_RULES directly", () => {
+    const fnMatch = /function tier2ArmGiveUp\(\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    assert.ok(/for \(const rule of mergedRules\)/.test(fnMatch[1]),
+      "tier2ArmGiveUp must also check mergedRules so drift warnings cover remote rules too");
+  });
+
+  test("gate-open reads chrome.storage.local.remoteTier2Rules and merges BEFORE the initial dispatch sweep", () => {
+    const readIdx = src.indexOf("tier2ReadRemoteRulesAndMerge(() => {");
+    const gateIdx = src.indexOf("_tier2GateOpen = open;");
+    assert.ok(readIdx !== -1, "cookie-noise.js must call tier2ReadRemoteRulesAndMerge at gate-open");
+    assert.ok(gateIdx !== -1 && gateIdx < readIdx, "the merge-and-dispatch call must happen inside the gate-open branch");
+  });
+
+  test("chrome.storage.onChanged(area local, remoteTier2Rules) re-merges and re-dispatches, gated on _tier2GateOpen", () => {
+    const listenerMatch = /chrome\.storage\.onChanged\.addListener\(\(changes, area\) => \{([\s\S]*?)\n {6}\}\);/.exec(src);
+    assert.ok(listenerMatch, "cookie-noise.js must register a storage.onChanged listener taking (changes, area)");
+    const body = listenerMatch[1];
+    assert.ok(/area === "local"/.test(body), "must react to area \"local\"");
+    assert.ok(/changes\.remoteTier2Rules/.test(body), "must react specifically to a remoteTier2Rules change");
+    assert.ok(/_tier2GateOpen/.test(body), "must be gated on the same _tier2GateOpen the dispatcher itself checks");
   });
 });
 


### PR DESCRIPTION
## PR B2 of the cookie-consent-tier2-remote chain — remote rules become runtime-reachable (still fully veto-gated)

Gated behind PR A (semantic click-veto) + PR B1 (signed fetch/validate/cache), both on main. This slice reads B1's `remoteTier2Rules` cache in the isolated-world content script, filters + merges it with bundled rules, and dispatches.

### What's in this slice
- At gate-open, read `remoteTier2Rules` → **CSS-parse-filter** each selector (real `document.querySelector` try/catch; unparseable dropped; a rule left with zero `reject` selectors skipped) → **ADD-only merge** with bundled `TIER2_RULES` (bundled always first; a remote id colliding with a bundled id is dropped) → `mergedRules` that the dispatcher iterates. Re-merge + re-dispatch on `storage.onChanged(local, remoteTier2Rules)` while the gate is open (double-gated).
- **Never-accept absolute**: bundled and remote rules pass through the SAME `computeClickVeto` — merged rule objects carry NO origin/source field, and there is no provenance-keyed branch. Two `.click()` sites, both veto-preceded and fail-closed.
- **Save-word openSettings veto** (folded-in PR-A review follow-up): a remote "Save preferences"-style selector can't pass the openSettings gate; `reject` role + legit openers ("Manage preferences"/"Cookie settings") unaffected. `@sync:cmp-tier2-veto` byte-for-byte.

### Verification
- `npm test` 7719 pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0
- Fresh adversarial review: **AIRTIGHT** — no origin veto-bypass, remote can't shadow bundled, unparseable/accept selectors never reach a click, save-veto correct, onChanged hygiene sound, `mergedRules` migrated everywhere.

### Minor non-blocking (noted for follow-up)
- The spec-scenario-5 integration test asserts via a hardcoded literal rather than the merged remote rule's own candidate; the invariant is covered by the structural call-site guards (cookie-noise.js isn't Node-importable).
- No content-side length cap on `remoteTier2Rules` (B1 caps at fetch; only a already-compromised profile could bypass; perf-only, not click-safety).

### Not in this PR
- PR B3: CI signing (reuse the existing publish/validate workflow + one step to build+sign `tier2.json` with the shared key)

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9