### PR TITLE
chore(consent): Tier 2 remote-rules curation + signing CI (PR B3/B, final)

### DIFF
--- a/.github/workflows/publish-tier2-rules.yml
+++ b/.github/workflows/publish-tier2-rules.yml
@@ -1,22 +1,23 @@
-name: publish-rules
+name: publish-tier2-rules
 
-# Triggered on push to main that changes the unsigned rules source.
-# Signs the source with the Ed25519 key stored in MUGA_SIGNING_KEY secret,
-# commits the signed docs/rules/v1/params.json back to main, and smoke-checks
-# the GitHub Pages URL after publication.
+# Triggered on push to main that changes the unsigned Tier2 rules source.
+# Signs the source with the Ed25519 key stored in the SAME MUGA_SIGNING_KEY
+# repository secret already used for params.json (REVISED ADR-6 — shared
+# key, no separate Tier2 secret), commits the signed
+# docs/rules/v1/tier2.json back to main, and smoke-checks the published URL.
 #
-# Action required before first run:
-#   Upload the Ed25519 private key as the MUGA_SIGNING_KEY repository secret.
-#   See the PR body for the exact command.
+# No new secret is required — MUGA_SIGNING_KEY already exists for
+# publish-rules.yml. This workflow adds ONE MORE signing step for the Tier2
+# payload, not a parallel key/pipeline.
+#
+# Scoped to tools/rules-source/tier2.json only (not the tools/rules-source/**
+# glob) so a params-only merge doesn't trigger a redundant Tier2 sign job.
 on:
   push:
     branches:
       - main
     paths:
-      - "tools/rules-source/**"
-      # Tier 2 has its own publish-tier2-rules.yml; don't cross-trigger the
-      # params signing job (which loads the shared key) on a tier2-only change.
-      - "!tools/rules-source/tier2.json"
+      - "tools/rules-source/tier2.json"
 
 # Default to least privilege. The publish job elevates to contents: write.
 permissions:
@@ -46,7 +47,8 @@ jobs:
         run: npm ci
 
       - name: Write signing key to temp file and mask it
-        # Writes the private key PEM to a temp file in RUNNER_TEMP (not the workspace).
+        # Writes the private key PEM to a temp file in RUNNER_TEMP (not the
+        # workspace) — the SAME key used by publish-rules.yml for params.json.
         # Immediately masks the value so any accidental echo is redacted in logs.
         # SECURITY: never echo $MUGA_SIGNING_KEY directly — use the file path only.
         env:
@@ -55,10 +57,10 @@ jobs:
           echo "$MUGA_SIGNING_KEY" > "$RUNNER_TEMP/key.pem"
           while IFS= read -r line; do echo "::add-mask::$line"; done < "$RUNNER_TEMP/key.pem"
 
-      - name: Sign rules source
+      - name: Sign Tier2 rules source
         env:
           MUGA_SIGNING_KEY_PATH: ${{ runner.temp }}/key.pem
-        run: node tools/sign-rules.mjs
+        run: node tools/sign-tier2-rules.mjs
 
       - name: Clean up signing key
         # Always runs — even if previous steps fail — so the key is never left on disk.
@@ -69,19 +71,24 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/rules/v1/params.json
+          git add docs/rules/v1/tier2.json
           # Only commit if the file actually changed
           if ! git diff --cached --quiet; then
-            git commit -m "ci(rules): publish signed params.json [skip ci]"
+            git commit -m "ci(rules): publish signed tier2.json [skip ci]"
             git push
           else
-            echo "No changes to docs/rules/v1/params.json — skipping commit"
+            echo "No changes to docs/rules/v1/tier2.json — skipping commit"
           fi
 
   smoke-check:
     runs-on: ubuntu-latest
     needs: publish
     # Allow some propagation delay — GitHub Pages can take a minute after push.
+    # NOTE: the https://rules.muga.app/rules/v1/tier2.json endpoint deploy is
+    # tracked separately (task 7.6, out-of-repo ops). Until that endpoint is
+    # deployed, this job is EXPECTED to fail on the first few runs after this
+    # workflow merges — it does not block the publish job above, which already
+    # committed the signed artifact to docs/rules/v1/tier2.json.
     steps:
       - name: Wait for GitHub Pages propagation
         # Brief initial pause to let the push reach Pages CDN before retrying.
@@ -100,4 +107,4 @@ jobs:
                --retry 3 \
                --retry-delay 30 \
                --retry-all-errors \
-               https://rules.muga.app/rules/v1/params.json
+               https://rules.muga.app/rules/v1/tier2.json

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths:
       - "tools/rules-source/**"
+      # Tier 2 sources are gated by validate-tier2-rules.yml instead.
+      - "!tools/rules-source/tier2.json"
 
 permissions:
   contents: read

--- a/.github/workflows/validate-tier2-rules.yml
+++ b/.github/workflows/validate-tier2-rules.yml
@@ -1,0 +1,34 @@
+name: validate-tier2-rules
+
+# Triggered on pull requests that touch the unsigned Tier2 rules source.
+# Ensures bad rules (accept-token hit, schema, caps, id-collision-with-bundled)
+# are caught at PR time. Mirrors validate-rules.yml, scoped to tier2.json only
+# (not the whole tools/rules-source/** glob) so a params-only PR doesn't
+# needlessly run the Tier2 gate and vice versa.
+on:
+  pull_request:
+    paths:
+      - "tools/rules-source/tier2.json"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate Tier2 rules source
+        run: node tools/validate-tier2-source.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to MUGA will be documented in this file.
 ### Features
 
 - **Cookie Consent Minimizer** (#1027). Opt-in, off by default: on supported cookie-consent banners (currently OneTrust), MUGA can click reject / necessary-only for you the same way it already strips tracking noise from URLs. It never clicks "accept" or grants broader tracking on your behalf; if no safe reject option exists, it leaves the banner alone. Disclosed via a consent-version bump, opt-in any time in Settings > Advanced.
+- **Cookie Consent Minimizer: verified click + remote-curated coverage** (#1027 Slice 2). Before clicking, MUGA now double-checks what a button actually says it does, not just where it sits on the page. This reduces, but does not eliminate, the chance of a wrong click: a button with unclear or unreadable wording (icon-only, or in a language MUGA doesn't recognize yet) is left alone rather than guessed at. Coverage for more cookie-consent banners can now also arrive as a small, signed weekly update instead of waiting for a full extension release, reviewed the same way MUGA's tracking-parameter list already is.
 
 ## [2.6.0] - 2026-07-13
 

--- a/src/lib/locales/de.mjs
+++ b/src/lib/locales/de.mjs
@@ -354,7 +354,7 @@ export default Object.freeze({
   aria_hover_preview: "Vorschau des echten Linkziels beim Hovern anzeigen",
   hover_preview_label: "Führt zu:",
   row_cookie_consent_mode_label: "Cookie-Consent-Minimierer",
-  row_cookie_consent_mode_hint: "Bei unterstützten Cookie-Consent-Bannern lehnt MUGA Tracking-Cookies automatisch für dich ab, genau wie es deine URLs bereits bereinigt. MUGA akzeptiert niemals Cookies in deinem Namen.",
+  row_cookie_consent_mode_hint: "Bei unterstützten Cookie-Consent-Bannern lehnt MUGA Tracking-Cookies automatisch für dich ab, genau wie es deine URLs bereits bereinigt. MUGA akzeptiert niemals Cookies in deinem Namen. MUGA prüft außerdem, was auf einer Schaltfläche steht, bevor sie angeklickt wird, was die Gefahr eines falschen Klicks verringert, aber nicht ausschließt; wenn die Beschriftung einer Schaltfläche unklar oder unlesbar ist, lässt MUGA sie unberührt.",
   aria_cookie_consent_mode: "Modus des Cookie-Consent-Minimierers",
   cookie_consent_mode_opt_reject_only: "Nur ablehnen (empfohlen)",
   cookie_consent_mode_opt_off: "Aus",

--- a/src/lib/locales/en.mjs
+++ b/src/lib/locales/en.mjs
@@ -354,7 +354,7 @@ export default Object.freeze({
   aria_hover_preview: "Show a hover preview of the real link destination",
   hover_preview_label: "Goes to:",
   row_cookie_consent_mode_label: "Cookie Consent Minimizer",
-  row_cookie_consent_mode_hint: "On supported cookie-consent banners, MUGA automatically rejects tracking cookies for you, the same way it already cleans your URLs. MUGA never accepts cookies on your behalf.",
+  row_cookie_consent_mode_hint: "On supported cookie-consent banners, MUGA automatically rejects tracking cookies for you, the same way it already cleans your URLs. MUGA never accepts cookies on your behalf. MUGA also checks what a button says before clicking it, which reduces but doesn't eliminate the chance of a wrong click; when a button's label is unclear or unreadable, MUGA leaves it alone.",
   aria_cookie_consent_mode: "Cookie consent minimizer mode",
   cookie_consent_mode_opt_reject_only: "Reject only (recommended)",
   cookie_consent_mode_opt_off: "Off",

--- a/src/lib/locales/es.mjs
+++ b/src/lib/locales/es.mjs
@@ -354,7 +354,7 @@ export default Object.freeze({
   aria_hover_preview: "Mostrar una vista previa del destino real del enlace al pasar el ratón",
   hover_preview_label: "Va a:",
   row_cookie_consent_mode_label: "Minimizador de avisos de cookies",
-  row_cookie_consent_mode_hint: "En avisos de cookies compatibles, MUGA rechaza automáticamente las cookies de rastreo por ti, igual que ya limpia tus URL. MUGA nunca acepta cookies en tu nombre.",
+  row_cookie_consent_mode_hint: "En avisos de cookies compatibles, MUGA rechaza automáticamente las cookies de rastreo por ti, igual que ya limpia tus URL. MUGA nunca acepta cookies en tu nombre. MUGA también comprueba lo que dice un botón antes de pulsarlo, lo que reduce pero no elimina la posibilidad de un clic equivocado; cuando la etiqueta de un botón no es clara o no se puede leer, MUGA lo deja tal cual.",
   aria_cookie_consent_mode: "Modo del minimizador de avisos de cookies",
   cookie_consent_mode_opt_reject_only: "Solo rechazar (recomendado)",
   cookie_consent_mode_opt_off: "Desactivado",

--- a/src/lib/locales/fr.mjs
+++ b/src/lib/locales/fr.mjs
@@ -354,7 +354,7 @@ export default Object.freeze({
   aria_hover_preview: "Afficher un aperçu de la vraie destination du lien au survol",
   hover_preview_label: "Mène à :",
   row_cookie_consent_mode_label: "Minimiseur de bandeaux de cookies",
-  row_cookie_consent_mode_hint: "Sur les bandeaux de consentement aux cookies pris en charge, MUGA refuse automatiquement les cookies de pistage à votre place, de la même façon qu'il nettoie déjà vos URL. MUGA n'accepte jamais de cookies en votre nom.",
+  row_cookie_consent_mode_hint: "Sur les bandeaux de consentement aux cookies pris en charge, MUGA refuse automatiquement les cookies de pistage à votre place, de la même façon qu'il nettoie déjà vos URL. MUGA n'accepte jamais de cookies en votre nom. MUGA vérifie aussi ce qu'indique un bouton avant de cliquer dessus, ce qui réduit sans l'éliminer le risque d'un clic erroné ; lorsque le libellé d'un bouton est ambigu ou illisible, MUGA n'y touche pas.",
   aria_cookie_consent_mode: "Mode du minimiseur de bandeaux de cookies",
   cookie_consent_mode_opt_reject_only: "Refuser uniquement (recommandé)",
   cookie_consent_mode_opt_off: "Désactivé",

--- a/src/lib/locales/it.mjs
+++ b/src/lib/locales/it.mjs
@@ -354,7 +354,7 @@ export default Object.freeze({
   aria_hover_preview: "Mostra un'anteprima della vera destinazione del link al passaggio del mouse",
   hover_preview_label: "Porta a:",
   row_cookie_consent_mode_label: "Minimizzatore di banner sui cookie",
-  row_cookie_consent_mode_hint: "Sui banner di consenso ai cookie supportati, MUGA rifiuta automaticamente i cookie di tracciamento al posto tuo, proprio come già ripulisce i tuoi URL. MUGA non accetta mai cookie a tuo nome.",
+  row_cookie_consent_mode_hint: "Sui banner di consenso ai cookie supportati, MUGA rifiuta automaticamente i cookie di tracciamento al posto tuo, proprio come già ripulisce i tuoi URL. MUGA non accetta mai cookie a tuo nome. MUGA controlla anche cosa dice un pulsante prima di premerlo, il che riduce ma non elimina la possibilità di un clic sbagliato; quando l'etichetta di un pulsante non è chiara o leggibile, MUGA lo lascia stare.",
   aria_cookie_consent_mode: "Modalità del minimizzatore di banner sui cookie",
   cookie_consent_mode_opt_reject_only: "Solo rifiuta (consigliato)",
   cookie_consent_mode_opt_off: "Disattivato",

--- a/src/lib/locales/ja.mjs
+++ b/src/lib/locales/ja.mjs
@@ -354,7 +354,7 @@ export default Object.freeze({
   aria_hover_preview: "ホバー時にリンクの実際の遷移先をプレビュー表示する",
   hover_preview_label: "遷移先:",
   row_cookie_consent_mode_label: "Cookie同意バナーの最小化",
-  row_cookie_consent_mode_hint: "対応するCookie同意バナーでは、MUGAがトラッキングCookieを自動的に拒否し、URLをきれいにする仕組みと同じようにあなたの代わりに処理します。MUGAがあなたの代わりにCookieに同意することは一切ありません。",
+  row_cookie_consent_mode_hint: "対応するCookie同意バナーでは、MUGAがトラッキングCookieを自動的に拒否し、URLをきれいにする仕組みと同じようにあなたの代わりに処理します。MUGAがあなたの代わりにCookieに同意することは一切ありません。MUGAはクリックする前にボタンの表示内容も確認します。これにより誤クリックの可能性は減りますが、なくなるわけではありません。ボタンのラベルが不明確または読み取れない場合、MUGAはそれに触れません。",
   aria_cookie_consent_mode: "Cookie同意バナー最小化のモード",
   cookie_consent_mode_opt_reject_only: "拒否のみ（推奨）",
   cookie_consent_mode_opt_off: "オフ",

--- a/src/lib/locales/pt.mjs
+++ b/src/lib/locales/pt.mjs
@@ -354,7 +354,7 @@ export default Object.freeze({
   aria_hover_preview: "Mostrar uma prévia do destino real do link ao passar o mouse",
   hover_preview_label: "Vai para:",
   row_cookie_consent_mode_label: "Minimizador de avisos de cookies",
-  row_cookie_consent_mode_hint: "Em avisos de cookies compatíveis, o MUGA rejeita automaticamente os cookies de rastreamento por você, da mesma forma que já limpa suas URLs. O MUGA nunca aceita cookies em seu nome.",
+  row_cookie_consent_mode_hint: "Em avisos de cookies compatíveis, o MUGA rejeita automaticamente os cookies de rastreamento por você, da mesma forma que já limpa suas URLs. O MUGA nunca aceita cookies em seu nome. O MUGA também verifica o que um botão diz antes de clicá-lo, o que reduz mas não elimina a chance de um clique errado; quando o rótulo de um botão não está claro ou legível, o MUGA não mexe nele.",
   aria_cookie_consent_mode: "Modo do minimizador de avisos de cookies",
   cookie_consent_mode_opt_reject_only: "Rejeitar apenas (recomendado)",
   cookie_consent_mode_opt_off: "Desativado",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -237,7 +237,7 @@
         <div class="row">
           <div class="row-label">
             <strong data-i18n="row_cookie_consent_mode_label">Cookie Consent Minimizer</strong>
-            <small data-i18n="row_cookie_consent_mode_hint">On supported cookie-consent banners, MUGA automatically rejects tracking cookies for you, the same way it already cleans your URLs. MUGA never accepts cookies on your behalf.</small>
+            <small data-i18n="row_cookie_consent_mode_hint">On supported cookie-consent banners, MUGA automatically rejects tracking cookies for you, the same way it already cleans your URLs. MUGA never accepts cookies on your behalf. MUGA also checks what a button says before clicking it, which reduces but doesn't eliminate the chance of a wrong click; when a button's label is unclear or unreadable, MUGA leaves it alone.</small>
           </div>
           <select class="lang-select" id="cookie-consent-mode-select" data-i18n-aria-label="aria_cookie_consent_mode">
             <option value="reject-only" data-i18n="cookie_consent_mode_opt_reject_only">Reject only (recommended)</option>

--- a/tests/unit/sign-tier2-rules.test.mjs
+++ b/tests/unit/sign-tier2-rules.test.mjs
@@ -1,0 +1,292 @@
+/**
+ * MUGA — Unit tests for tools/sign-tier2-rules.mjs
+ *
+ * Run with: npm test
+ *
+ * REVISED ADR-6 (shared key): this tool signs with the SAME
+ * `MUGA_SIGNING_KEY` / `MUGA_SIGNING_KEY_PATH` used by `tools/sign-rules.mjs`
+ * — there is no separate Tier2 key. The only new element is the domain-tagged
+ * canonical message, which this tool MUST import (not reimplement) from
+ * `src/lib/remote-tier2-rules.js` so the signed bytes are byte-identical to
+ * what the runtime verifier builds.
+ *
+ * Security invariants (mirrors tests/unit/sign-rules.test.mjs):
+ *   - All keypairs are generated at test runtime (throw-away). No fixture keys.
+ *   - Private key is written to os.tmpdir(), passed via MUGA_SIGNING_KEY_PATH.
+ *   - The script must NOT contain hard-coded private key file paths.
+ *
+ * Filesystem invariants:
+ *   - The test MUST NOT touch the canonical source
+ *     (tools/rules-source/tier2.json) or canonical output
+ *     (docs/rules/v1/tier2.json) — both are CI-owned. All invocations point
+ *     MUGA_TIER2_SOURCE_FILE / MUGA_TIER2_OUTPUT_FILE at a per-process tmp dir.
+ *
+ * Coverage:
+ *   - Import-equality: tool re-exports the SAME `canonicalTier2Message`
+ *     function reference as src/lib/remote-tier2-rules.js (no signing
+ *     needed — proves "do NOT re-implement it" by construction).
+ *   - Entry-guard: importing the module performs zero I/O.
+ *   - Happy path: valid seed + valid key → exit 0, signed output verifies.
+ *   - Exit 2: missing/unusable key.
+ *   - Exit 1: source validation failure (reused validateTier2SourceContent).
+ *   - Exit 3: source file not found.
+ */
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  generateKeyPairSync,
+  createPublicKey,
+  verify as cryptoVerify,
+} from "node:crypto";
+import {
+  writeFileSync,
+  mkdtempSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { canonicalTier2Message as toolCanonicalTier2Message } from "../../tools/sign-tier2-rules.mjs";
+import { canonicalTier2Message as libCanonicalTier2Message } from "../../src/lib/remote-tier2-rules.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, "../../tools/sign-tier2-rules.mjs");
+
+// ---------------------------------------------------------------------------
+// Import-equality: no signing, no I/O — proves sign-tier2-rules.mjs imports
+// (not reimplements) the runtime's canonical-message builder.
+// ---------------------------------------------------------------------------
+describe("sign-tier2-rules.mjs canonical message (import-equality, pure)", () => {
+  test("re-exports the SAME function reference as remote-tier2-rules.js", () => {
+    assert.strictEqual(
+      toolCanonicalTier2Message,
+      libCanonicalTier2Message,
+      "sign-tier2-rules.mjs must import (not reimplement) canonicalTier2Message"
+    );
+  });
+
+  test("produces byte-identical output to the runtime builder for the same input", () => {
+    const rules = [{ id: "x", present: ["a"], reject: ["b"], openSettings: [] }];
+    assert.strictEqual(
+      toolCanonicalTier2Message(1, "2026-01-01T00:00:00.000Z", rules),
+      libCanonicalTier2Message(1, "2026-01-01T00:00:00.000Z", rules)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard: script must NOT contain hard-coded private key paths
+// ---------------------------------------------------------------------------
+describe("security: no hard-coded private key paths", () => {
+  test("sign-tier2-rules.mjs does not contain the local muga-keys directory path", () => {
+    const content = readFileSync(SCRIPT, "utf8");
+    assert.ok(!content.includes(".muga-keys"));
+  });
+
+  test("sign-tier2-rules.mjs reads the key path from MUGA_SIGNING_KEY_PATH (shared key, no MUGA_TIER2_SIGNING_KEY)", () => {
+    const content = readFileSync(SCRIPT, "utf8");
+    assert.ok(content.includes("MUGA_SIGNING_KEY_PATH"));
+    assert.ok(
+      !content.includes("MUGA_TIER2_SIGNING_KEY"),
+      "REVISED ADR-6: no separate Tier2 signing key — must reuse MUGA_SIGNING_KEY"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI (subprocess) tests — per-process tmp dir, never touches canonical paths
+// ---------------------------------------------------------------------------
+let testPrivKeyPath;
+let testPubKeyBase64;
+let tmpTestDir;
+let tmpSourceFile;
+let tmpOutputFile;
+
+before(() => {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+
+  tmpTestDir = mkdtempSync(join(tmpdir(), "muga-tier2-sign-test-"));
+  testPrivKeyPath = join(tmpTestDir, "test-signing.key");
+  tmpSourceFile = join(tmpTestDir, "source-tier2.json");
+  tmpOutputFile = join(tmpTestDir, "output-tier2.json");
+
+  writeFileSync(testPrivKeyPath, privateKey.export({ type: "pkcs8", format: "pem" }), {
+    mode: 0o600,
+  });
+
+  const pubDer = publicKey.export({ type: "spki", format: "der" });
+  testPubKeyBase64 = pubDer.slice(12).toString("base64");
+});
+
+after(() => {
+  if (tmpTestDir && existsSync(tmpTestDir)) rmSync(tmpTestDir, { recursive: true, force: true });
+});
+
+function runScript({ envOverrides = {}, sourceContent, sourceFile } = {}) {
+  if (sourceContent !== undefined) writeFileSync(tmpSourceFile, sourceContent);
+  return spawnSync("node", [SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      MUGA_SIGNING_KEY_PATH: testPrivKeyPath,
+      MUGA_TIER2_SOURCE_FILE: sourceFile ?? tmpSourceFile,
+      MUGA_TIER2_OUTPUT_FILE: tmpOutputFile,
+      ...envOverrides,
+    },
+  });
+}
+
+describe("sign-tier2-rules.mjs happy path", () => {
+  test("exits 0 with a valid empty-seed source and key; output has all required fields", () => {
+    const fixture = JSON.stringify({
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [],
+    });
+
+    const result = runScript({ sourceContent: fixture });
+    assert.strictEqual(
+      result.status,
+      0,
+      `Expected exit 0, got ${result.status}. stderr: ${result.stderr}`
+    );
+
+    assert.ok(existsSync(tmpOutputFile));
+    const output = JSON.parse(readFileSync(tmpOutputFile, "utf8"));
+    assert.strictEqual(output.schemaVersion, 1);
+    assert.strictEqual(typeof output.version, "number");
+    assert.strictEqual(typeof output.published, "string");
+    assert.ok(Array.isArray(output.rules));
+    assert.strictEqual(typeof output.sig, "string");
+    assert.ok(output.sig.length > 0);
+  });
+
+  test("output signature verifies against the test public key over canonicalTier2Message", () => {
+    const rules = [{ id: "example-cmp", present: [".banner"], reject: [".reject-all"], openSettings: [] }];
+    const fixture = JSON.stringify({
+      schemaVersion: 1,
+      version: 2,
+      published: "2026-01-02T00:00:00.000Z",
+      rules,
+    });
+
+    const result = runScript({ sourceContent: fixture });
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+    const output = JSON.parse(readFileSync(tmpOutputFile, "utf8"));
+    const canonical = libCanonicalTier2Message(output.version, output.published, output.rules);
+
+    const stdB64 = output.sig.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = stdB64 + "=".repeat((4 - (stdB64.length % 4)) % 4);
+    const sigBuf = Buffer.from(padded, "base64");
+
+    const pubDer = Buffer.from(testPubKeyBase64, "base64");
+    const spkiPrefix = Buffer.from("302a300506032b6570032100", "hex");
+    const spkiDer = Buffer.concat([spkiPrefix, pubDer]);
+    const pubKey = createPublicKey({ key: spkiDer, type: "spki", format: "der" });
+
+    const ok = cryptoVerify(null, Buffer.from(canonical, "utf8"), pubKey, sigBuf);
+    assert.ok(ok, "Signature must verify against the test public key over canonicalTier2Message");
+  });
+
+  test("sig field is base64url encoded (no padding, URL-safe chars)", () => {
+    const fixture = JSON.stringify({
+      schemaVersion: 1,
+      version: 3,
+      published: "2026-01-03T00:00:00.000Z",
+      rules: [],
+    });
+    const result = runScript({ sourceContent: fixture });
+    assert.strictEqual(result.status, 0);
+    const output = JSON.parse(readFileSync(tmpOutputFile, "utf8"));
+    assert.ok(!/[+/=]/.test(output.sig));
+  });
+});
+
+describe("sign-tier2-rules.mjs exit code 2 (key setup error)", () => {
+  test("exits 2 when MUGA_SIGNING_KEY_PATH env var is not set", () => {
+    const fixture = JSON.stringify({ schemaVersion: 1, version: 1, published: "2026-01-01T00:00:00.000Z", rules: [] });
+    const result = runScript({ sourceContent: fixture, envOverrides: { MUGA_SIGNING_KEY_PATH: "" } });
+    assert.strictEqual(result.status, 2, `stderr: ${result.stderr}`);
+  });
+
+  test("exits 2 when the key file path does not exist", () => {
+    const fixture = JSON.stringify({ schemaVersion: 1, version: 1, published: "2026-01-01T00:00:00.000Z", rules: [] });
+    const result = runScript({
+      sourceContent: fixture,
+      envOverrides: { MUGA_SIGNING_KEY_PATH: "/nonexistent/path/to/key.pem" },
+    });
+    assert.strictEqual(result.status, 2, `stderr: ${result.stderr}`);
+  });
+});
+
+describe("sign-tier2-rules.mjs exit code 1 (source validation error)", () => {
+  test("exits 1 when a selector contains an accept token", () => {
+    const fixture = JSON.stringify({
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [{ id: "sneaky", present: [".x"], reject: [".AcceptAll"], openSettings: [] }],
+    });
+    const result = runScript({ sourceContent: fixture });
+    assert.strictEqual(result.status, 1, `stderr: ${result.stderr}`);
+  });
+
+  test("exits 1 when source JSON is malformed", () => {
+    const result = runScript({ sourceContent: "{ not valid json" });
+    assert.strictEqual(result.status, 1, `stderr: ${result.stderr}`);
+  });
+
+  test("exits 1 when source contains a 'sig' field (must be unsigned)", () => {
+    const fixture = JSON.stringify({
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [],
+      sig: "should_not_be_here",
+    });
+    const result = runScript({ sourceContent: fixture });
+    assert.strictEqual(result.status, 1, `stderr: ${result.stderr}`);
+  });
+});
+
+describe("sign-tier2-rules.mjs exit code 3 (IO error)", () => {
+  test("exits 3 when the source file cannot be read", () => {
+    const result = runScript({ sourceFile: "/nonexistent/path/tier2.json" });
+    assert.strictEqual(result.status, 3, `stderr: ${result.stderr}`);
+  });
+});
+
+describe("publish-tier2-rules.yml workflow file", () => {
+  const workflowFile = join(__dirname, "../../.github/workflows/publish-tier2-rules.yml");
+
+  test("publish-tier2-rules.yml exists in .github/workflows/", () => {
+    assert.ok(existsSync(workflowFile), "publish-tier2-rules.yml must exist");
+  });
+
+  test("publish-tier2-rules.yml references sign-tier2-rules.mjs and the shared MUGA_SIGNING_KEY secret", () => {
+    const content = readFileSync(workflowFile, "utf8");
+    assert.ok(content.includes("sign-tier2-rules.mjs"));
+    assert.ok(content.includes("secrets.MUGA_SIGNING_KEY"));
+    assert.ok(
+      !content.includes("MUGA_TIER2_SIGNING_KEY"),
+      "REVISED ADR-6: must not introduce a second secret"
+    );
+  });
+
+  test("publish-tier2-rules.yml is scoped to tools/rules-source/tier2.json only", () => {
+    const content = readFileSync(workflowFile, "utf8");
+    assert.ok(content.includes("tools/rules-source/tier2.json"));
+  });
+
+  test("publish-tier2-rules.yml cleans up the signing key (always-run step)", () => {
+    const content = readFileSync(workflowFile, "utf8");
+    assert.ok(/rm -f .*key\.pem/.test(content));
+  });
+});

--- a/tests/unit/validate-tier2-source.test.mjs
+++ b/tests/unit/validate-tier2-source.test.mjs
@@ -1,0 +1,233 @@
+/**
+ * MUGA — Unit tests for tools/validate-tier2-source.mjs
+ *
+ * Run with: npm test
+ *
+ * The validator reuses `validateTier2PayloadShape` + `validateTier2Rules` from
+ * `src/lib/remote-tier2-rules.js` — the SAME pure validators the runtime
+ * fetch pipeline uses (design ADR-7: "single source of truth ... imported by
+ * both"). Version/freshness checks are intentionally SKIPPED here (signing-
+ * time concerns — a source file may be dated during authoring), mirroring
+ * `validate-rules-source.mjs`'s `validateParamsForSource` precedent.
+ *
+ * Pure-core coverage (entry-guarded — importing this module runs zero I/O):
+ *   - `validateTier2SourceContent`: accept-token in source text → non-ok
+ *   - `validateTier2SourceContent`: shape-invalid source → non-ok
+ *   - `validateTier2SourceContent`: clean empty seed → ok
+ *   - `validateTier2SourceContent`: id colliding with a bundled id → non-ok
+ *   - `validateTier2SourceContent`: unparseable-looking selector → non-ok
+ *   - `selectorLooksSyntacticallyValid`: balanced vs unbalanced brackets/quotes
+ *
+ * CLI coverage (subprocess, mirrors validate-rules-source.test.mjs):
+ *   - Real seed file (tools/rules-source/tier2.json) → exit 0
+ *   - Malformed JSON → exit 1
+ *   - Missing source file → exit 3
+ *   - validate-tier2-rules.yml workflow file exists and wires this script
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { writeFileSync, readFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+import {
+  validateTier2SourceContent,
+  selectorLooksSyntacticallyValid,
+} from "../../tools/validate-tier2-source.mjs";
+import { BUNDLED_TIER2_IDS } from "../../src/lib/remote-tier2-rules.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, "../../tools/validate-tier2-source.mjs");
+const SEED_FILE = join(__dirname, "../../tools/rules-source/tier2.json");
+
+// ---------------------------------------------------------------------------
+// Pure-core tests — no I/O, no subprocess (entry-guard verification)
+// ---------------------------------------------------------------------------
+describe("validateTier2SourceContent (pure)", () => {
+  test("clean empty seed → ok", () => {
+    const source = { schemaVersion: 1, version: 1, published: "2026-01-01T00:00:00.000Z", rules: [] };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, true, `Expected ok, got: ${JSON.stringify(result)}`);
+  });
+
+  test("accept-token in a selector → non-ok", () => {
+    const source = {
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [{ id: "sneaky", present: [".banner"], reject: [".AcceptAll"], openSettings: [] }],
+    };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, false);
+  });
+
+  test("accept-token anywhere in the raw JSON text (not just a selector) → non-ok", () => {
+    const source = {
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [{ id: "allowall-vendor", present: [".x"], reject: [".y"], openSettings: [] }],
+    };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, false);
+  });
+
+  test("shape-invalid source (missing 'rules' field) → non-ok", () => {
+    const source = { schemaVersion: 1, version: 1, published: "2026-01-01T00:00:00.000Z" };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, false);
+  });
+
+  test("shape-invalid source (extra top-level key) → non-ok", () => {
+    const source = {
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [],
+      extra: "nope",
+    };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, false);
+  });
+
+  test("source containing a 'sig' field is rejected (source must be unsigned)", () => {
+    const source = {
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [],
+      sig: "should_not_be_here",
+    };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, false);
+  });
+
+  test("a rule id colliding with a bundled id → non-ok (ADD-only, mirrors runtime)", () => {
+    const [bundledId] = [...BUNDLED_TIER2_IDS];
+    assert.ok(bundledId, "expected at least one bundled Tier2 id to test against");
+    const source = {
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [{ id: bundledId, present: [".x"], reject: [".y"], openSettings: [] }],
+    };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, false);
+  });
+
+  test("a valid new rule (no collision, no accept token) → ok", () => {
+    const source = {
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [{ id: "example-cmp", present: [".consent-banner"], reject: [".reject-all"], openSettings: [] }],
+    };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, true, `Expected ok, got: ${JSON.stringify(result)}`);
+  });
+
+  test("a selector that fails the DOM-free syntax pre-check → non-ok", () => {
+    const source = {
+      schemaVersion: 1,
+      version: 1,
+      published: "2026-01-01T00:00:00.000Z",
+      rules: [{ id: "broken-selector", present: [".x"], reject: [".unclosed['bracket"], openSettings: [] }],
+    };
+    const result = validateTier2SourceContent(source, JSON.stringify(source));
+    assert.strictEqual(result.ok, false);
+  });
+});
+
+describe("selectorLooksSyntacticallyValid (pure)", () => {
+  test("a plain class selector is valid", () => {
+    assert.strictEqual(selectorLooksSyntacticallyValid(".reject-all"), true);
+  });
+
+  test("a well-formed attribute selector is valid", () => {
+    assert.strictEqual(selectorLooksSyntacticallyValid("button[data-role='reject']"), true);
+  });
+
+  test("an empty string is invalid", () => {
+    assert.strictEqual(selectorLooksSyntacticallyValid(""), false);
+  });
+
+  test("unbalanced brackets are invalid", () => {
+    assert.strictEqual(selectorLooksSyntacticallyValid(".unclosed["), false);
+  });
+
+  test("unbalanced quotes are invalid", () => {
+    assert.strictEqual(selectorLooksSyntacticallyValid("button[data-role='reject]"), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI (subprocess) tests
+// ---------------------------------------------------------------------------
+function runValidator({ sourceContent, envOverrides = {} } = {}) {
+  let tmpDir;
+  let tmpFile;
+
+  if (sourceContent !== undefined) {
+    tmpDir = mkdtempSync(join(tmpdir(), "muga-tier2-val-test-"));
+    tmpFile = join(tmpDir, "tier2.json");
+    writeFileSync(tmpFile, sourceContent);
+  }
+
+  try {
+    return spawnSync("node", [SCRIPT], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...(tmpFile ? { MUGA_TIER2_SOURCE_FILE: tmpFile } : {}),
+        ...envOverrides,
+      },
+    });
+  } finally {
+    if (tmpDir && existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe("validate-tier2-source.mjs CLI", () => {
+  test("exits 0 for the real committed seed (tools/rules-source/tier2.json)", () => {
+    const result = spawnSync("node", [SCRIPT], {
+      encoding: "utf8",
+      env: { ...process.env, MUGA_TIER2_SOURCE_FILE: SEED_FILE },
+    });
+    assert.strictEqual(
+      result.status,
+      0,
+      `Expected exit 0 for the committed seed, got ${result.status}. stderr: ${result.stderr}`
+    );
+  });
+
+  test("exits 1 for malformed JSON", () => {
+    const result = runValidator({ sourceContent: "{ not valid json" });
+    assert.strictEqual(result.status, 1);
+  });
+
+  test("exits 3 when the source file does not exist", () => {
+    const result = runValidator({ envOverrides: { MUGA_TIER2_SOURCE_FILE: "/nonexistent/tier2.json" } });
+    assert.strictEqual(result.status, 3);
+  });
+});
+
+describe("validate-tier2-rules.yml workflow file", () => {
+  const workflowFile = join(__dirname, "../../.github/workflows/validate-tier2-rules.yml");
+
+  test("validate-tier2-rules.yml exists in .github/workflows/", () => {
+    assert.ok(existsSync(workflowFile), "validate-tier2-rules.yml must exist");
+  });
+
+  test("validate-tier2-rules.yml references validate-tier2-source.mjs", () => {
+    const content = readFileSync(workflowFile, "utf8");
+    assert.ok(content.includes("validate-tier2-source.mjs"));
+  });
+
+  test("validate-tier2-rules.yml is scoped to tools/rules-source/tier2.json only", () => {
+    const content = readFileSync(workflowFile, "utf8");
+    assert.ok(content.includes("tools/rules-source/tier2.json"));
+  });
+});

--- a/tools/rules-source/tier2.json
+++ b/tools/rules-source/tier2.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "version": 1,
+  "published": "2026-07-26T00:00:00.000Z",
+  "rules": []
+}

--- a/tools/sign-tier2-rules.mjs
+++ b/tools/sign-tier2-rules.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * MUGA — sign-tier2-rules.mjs (#1027 Slice 2, PR B3)
+ *
+ * CLI tool to sign tools/rules-source/tier2.json and emit
+ * docs/rules/v1/tier2.json with an Ed25519 signature.
+ *
+ * REVISED ADR-6 (product-owner decision — shared key): this tool signs with
+ * the SAME `MUGA_SIGNING_KEY_PATH` / `MUGA_SIGNING_KEY` used by
+ * `tools/sign-rules.mjs` for params.json. There is NO separate Tier2-scoped
+ * signing secret and NO `remote-tier2-keys.js`. The runtime already verifies
+ * Tier2 signatures against the existing `TRUSTED_PUBLIC_KEYS` (see
+ * src/lib/remote-tier2-rules.js).
+ *
+ * Domain separation across the two payload types sharing one key comes
+ * entirely from `canonicalTier2Message`'s leading `tier2|` tag — which is why
+ * this tool IMPORTS that function from src/lib/remote-tier2-rules.js instead
+ * of reimplementing it (unlike tools/sign-rules.mjs's `canonicalMessage`,
+ * which is a local reimplementation for params). The signed bytes here MUST
+ * be byte-identical to what `runTier2RulesFetch` verifies at fetch time —
+ * importing the shared function is what guarantees that, structurally.
+ *
+ * Usage:
+ *   MUGA_SIGNING_KEY_PATH=/path/to/key.pem node tools/sign-tier2-rules.mjs
+ *
+ * Environment variables:
+ *   MUGA_SIGNING_KEY_PATH    (required) Path to the Ed25519 private key PEM
+ *                            file — the SAME key file used for params.json.
+ *                            Do NOT pass key material via CLI args.
+ *   MUGA_TIER2_SOURCE_FILE   (optional) Override source file path (tests).
+ *   MUGA_TIER2_OUTPUT_FILE   (optional) Override output file path (tests).
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — validation error in source (schema, token-scan, selector-syntax, rules)
+ *   2 — signing setup error (missing MUGA_SIGNING_KEY_PATH, unreadable key, bad PEM)
+ *   3 — I/O error (cannot read source file, cannot write output file)
+ *
+ * Security rules (identical to tools/sign-rules.mjs):
+ *   - Private key path is ONLY accepted via MUGA_SIGNING_KEY_PATH env var.
+ *   - Key material never logged, never on stdout.
+ *   - No npm dependencies — uses node:crypto and node:fs only.
+ *
+ * This module is entry-guarded (see bottom of file): importing it for unit
+ * tests (e.g. the canonicalTier2Message import-equality test) performs ZERO
+ * I/O and never calls main().
+ */
+
+import { sign as cryptoSign, createPrivateKey, createHash } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Reused verbatim (REVISED ADR-6) — the exact function the runtime verifier
+// builds its message with. Re-exported below for the import-equality test.
+import { canonicalTier2Message } from "../src/lib/remote-tier2-rules.js";
+import { validateTier2SourceContent } from "./validate-tier2-source.mjs";
+
+export { canonicalTier2Message };
+
+// ── Path resolution ──────────────────────────────────────────────────────────
+
+const DEFAULT_SOURCE = new URL("../tools/rules-source/tier2.json", import.meta.url).pathname;
+const DEFAULT_OUTPUT = new URL("../docs/rules/v1/tier2.json", import.meta.url).pathname;
+
+// On Windows, URL.pathname starts with /C:/ — normalize that
+function normalizePath(p) {
+  if (process.platform === "win32" && p.startsWith("/")) {
+    return p.slice(1);
+  }
+  return p;
+}
+
+const SOURCE_FILE = process.env.MUGA_TIER2_SOURCE_FILE || normalizePath(DEFAULT_SOURCE);
+const OUTPUT_FILE = process.env.MUGA_TIER2_OUTPUT_FILE || normalizePath(DEFAULT_OUTPUT);
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+function main() {
+  // 1. Load the private key from env var (exit 2 if missing or unreadable)
+  const keyPath = process.env.MUGA_SIGNING_KEY_PATH;
+  if (!keyPath) {
+    console.error("[sign-tier2-rules] ERROR: MUGA_SIGNING_KEY_PATH env var is not set.");
+    console.error("  Set it to the path of the SAME Ed25519 private key PEM file used for params.json.");
+    process.exit(2);
+  }
+
+  let privateKey;
+  try {
+    const keyPem = readFileSync(keyPath, "utf8");
+    privateKey = createPrivateKey({ key: keyPem, format: "pem" });
+  } catch (err) {
+    console.error(`[sign-tier2-rules] ERROR: Cannot read private key from "${keyPath}": ${err.message}`);
+    process.exit(2);
+  }
+
+  // 2. Read the source file (exit 3 on I/O error)
+  let rawSource;
+  try {
+    rawSource = readFileSync(SOURCE_FILE, "utf8");
+  } catch (err) {
+    console.error(`[sign-tier2-rules] ERROR: Cannot read source file "${SOURCE_FILE}": ${err.message}`);
+    process.exit(3);
+  }
+
+  // 3. Parse and validate the source (exit 1 on validation error). Reuses the
+  // SAME pure validator the PR-gate CI job runs (validate-tier2-source.mjs),
+  // so a payload that passed PR review can never fail signing for a
+  // different reason than what the reviewer already saw.
+  let source;
+  try {
+    source = JSON.parse(rawSource);
+  } catch (err) {
+    console.error(`[sign-tier2-rules] ERROR: Source file is not valid JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  const validation = validateTier2SourceContent(source, rawSource);
+  if (!validation.ok) {
+    console.error(`[sign-tier2-rules] ERROR: Source validation failed [${validation.code}]: ${validation.detail}`);
+    process.exit(1);
+  }
+
+  // 4. Sign the canonical message — imported, not reimplemented (see docblock).
+  const canonical = canonicalTier2Message(source.version, source.published, source.rules);
+  const msgBuf = Buffer.from(canonical, "utf8");
+
+  let sigBuf;
+  try {
+    sigBuf = cryptoSign(null, msgBuf, privateKey);
+  } catch (err) {
+    console.error(`[sign-tier2-rules] ERROR: Signing failed: ${err.message}`);
+    process.exit(2);
+  }
+
+  // Encode as base64url (URL-safe, no padding) — same encoding as sign-rules.mjs.
+  const sigBase64url = sigBuf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+  // 5. Write the signed output (exit 3 on I/O error)
+  const output = {
+    schemaVersion: source.schemaVersion,
+    version: source.version,
+    published: source.published,
+    rules: source.rules,
+    sig: sigBase64url,
+  };
+
+  try {
+    mkdirSync(dirname(OUTPUT_FILE), { recursive: true });
+    writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2) + "\n", "utf8");
+  } catch (err) {
+    console.error(`[sign-tier2-rules] ERROR: Cannot write output to "${OUTPUT_FILE}": ${err.message}`);
+    process.exit(3);
+  }
+
+  // 6. Emit a one-line summary (stdout only, no key material)
+  const sha256 = createHash("sha256")
+    .update(JSON.stringify(output))
+    .digest("hex");
+
+  console.log(JSON.stringify({
+    input: SOURCE_FILE,
+    output: OUTPUT_FILE,
+    version: source.version,
+    ruleCount: source.rules.length,
+    sha256,
+  }));
+
+  process.exit(0);
+}
+
+// Only run the filesystem/signing main() when invoked directly — importing
+// this module (e.g. for the canonicalTier2Message import-equality test)
+// performs zero I/O and never signs anything.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/tools/validate-tier2-source.mjs
+++ b/tools/validate-tier2-source.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * MUGA — validate-tier2-source.mjs (#1027 Slice 2, PR B3)
+ *
+ * Validates tools/rules-source/tier2.json against the SAME pure validators
+ * the runtime fetch pipeline uses — `validateTier2PayloadShape` and
+ * `validateTier2Rules` are imported from `src/lib/remote-tier2-rules.js`,
+ * NOT reimplemented, so the CI gate and the runtime can never drift apart
+ * (design ADR-7: "single source of truth ... imported by both").
+ *
+ * Additionally runs (design ADR-7/ADR-8):
+ *   - The extended `/allowall|accept/i` structural scan over the RAW JSON
+ *     SOURCE TEXT (not just selector strings) — the shipped build-time guard
+ *     (`cmp-adapters.test.mjs`) scans only `cmp-adapters.js` and
+ *     `cmp-tier2-rules.js`; without this extension the new remote-source
+ *     payload class would silently lose the accept-token net.
+ *   - A lightweight, DOM-free selector SYNTAX pre-check (charset/bracket/quote
+ *     balance). Best-effort only — there is no DOM in CI, so a full CSS parse
+ *     stays a runtime check (content script, gate-open).
+ *
+ * Version/freshness (VERSION_REGRESSION / STALE_PAYLOAD) are intentionally
+ * SKIPPED here — those are signing-time concerns, not source-authoring
+ * concerns (a source file may be dated during dev). This mirrors
+ * `validate-rules-source.mjs`'s `validateParamsForSource` precedent, which
+ * skips the same two checks for the identical reason. ADR-7 lists exactly
+ * what this validator covers: "shape, caps, id regex, id-collision-with-
+ * bundled, remote-vs-remote dup" — version/freshness are not in that list.
+ *
+ * Usage:
+ *   node tools/validate-tier2-source.mjs
+ *
+ * Environment variables:
+ *   MUGA_TIER2_SOURCE_FILE  (optional) Override source file path (tests).
+ *
+ * Exit codes:
+ *   0 — source is valid
+ *   1 — validation failure (schema, token-scan, selector-syntax, rules content)
+ *   3 — I/O error (cannot read source file)
+ *
+ * This module is entry-guarded (see bottom of file): importing it for unit
+ * tests performs ZERO I/O — `validateTier2SourceContent` and
+ * `selectorLooksSyntacticallyValid` are pure functions over already-parsed
+ * data. Only `main()` touches the filesystem, and only when this file is
+ * run directly (mirrors `tools/build-tier2-rules.mjs`'s entry-guard).
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import {
+  validateTier2PayloadShape,
+  validateTier2Rules,
+  BUNDLED_TIER2_IDS,
+  TIER2_TOKEN_SCAN_RE,
+} from "../src/lib/remote-tier2-rules.js";
+
+// ── Path resolution ──────────────────────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_SOURCE = join(__dirname, "rules-source", "tier2.json");
+
+function normalizePath(p) {
+  // On Windows, file:// URL.pathname starts with /C:/ — normalize.
+  if (process.platform === "win32" && p.startsWith("/")) return p.slice(1);
+  return p;
+}
+
+const SOURCE_FILE = process.env.MUGA_TIER2_SOURCE_FILE
+  ? normalizePath(process.env.MUGA_TIER2_SOURCE_FILE)
+  : DEFAULT_SOURCE;
+
+// ── DOM-free selector syntax pre-check ──────────────────────────────────────
+
+/**
+ * Best-effort, DOM-free CSS selector syntax sanity check: rejects empty
+ * strings and unbalanced brackets/parens/quotes. This is NOT a real CSS
+ * parse — the service worker and CI both lack a DOM. The authoritative
+ * parseability check runs content-side via a real `document.querySelector`
+ * try/catch at gate-open (PR B2, `tier2SelectorParses`). This pre-check only
+ * catches the most obviously broken shapes at PR-review time.
+ *
+ * @param {string} sel
+ * @returns {boolean}
+ */
+export function selectorLooksSyntacticallyValid(sel) {
+  if (typeof sel !== "string" || sel.trim() === "") return false;
+
+  const OPENERS_TO_CLOSERS = { "[": "]", "(": ")" };
+  const CLOSERS = new Set(Object.values(OPENERS_TO_CLOSERS));
+  const stack = [];
+  let quote = null;
+
+  for (const ch of sel) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (OPENERS_TO_CLOSERS[ch]) {
+      stack.push(OPENERS_TO_CLOSERS[ch]);
+      continue;
+    }
+    if (CLOSERS.has(ch)) {
+      if (stack.pop() !== ch) return false;
+    }
+  }
+
+  return stack.length === 0 && quote === null;
+}
+
+// ── Pure core ────────────────────────────────────────────────────────────────
+
+/**
+ * Validates the full content of an unsigned Tier2 source object: shape,
+ * the accept-token structural scan over the raw text, the DOM-free selector
+ * syntax pre-check, and rules content (caps/id/selector-bounds/token-scan/
+ * ADD-only collision) via the SAME validators the runtime uses. Pure — no I/O.
+ *
+ * @param {unknown} source  - The parsed JSON source object.
+ * @param {string}  rawText - The raw (unparsed) JSON source text, for the
+ *                            structural accept-token scan.
+ * @returns {{ ok: boolean, code?: string, detail?: string }}
+ */
+export function validateTier2SourceContent(source, rawText) {
+  if (source === null || typeof source !== "object" || Array.isArray(source)) {
+    return { ok: false, code: "SCHEMA_ERROR", detail: "Source must be a JSON object" };
+  }
+
+  /** @type {Record<string, unknown>} */
+  const o = /** @type {Record<string, unknown>} */ (source);
+
+  // Source is UNSIGNED — a 'sig' field here means someone accidentally
+  // committed a signed/partial output as the source. Reject explicitly,
+  // mirroring sign-rules.mjs's identical guard for params.json.
+  if (Object.prototype.hasOwnProperty.call(source, "sig")) {
+    return {
+      ok: false,
+      code: "SCHEMA_ERROR",
+      detail: "Source file must NOT contain a 'sig' field — sig is added by sign-tier2-rules.mjs",
+    };
+  }
+
+  // Shape check reuses the runtime's exact validator. The source lacks
+  // 'sig' by design, so a placeholder string is supplied only to satisfy the
+  // exact-5-key shape check — it never leaves this function.
+  const shapeResult = validateTier2PayloadShape({ ...source, sig: "" });
+  if (!shapeResult.ok) {
+    return {
+      ok: false,
+      code: shapeResult.code,
+      detail: "Top-level shape invalid — expected exactly {schemaVersion, version, published, rules}",
+    };
+  }
+
+  // Extended structural scan (ADR-7/ADR-8): scans the RAW JSON TEXT, not
+  // just selector strings, so an accept-family token hidden anywhere (e.g.
+  // in an `id`) is also caught — the runtime's own per-selector scan
+  // (inside validateTier2Rules below) only covers selector fields.
+  if (TIER2_TOKEN_SCAN_RE.test(rawText)) {
+    return {
+      ok: false,
+      code: "DENYLIST_HIT",
+      detail: "Source JSON text contains an accept/allowall token — not allowed in remote-delivered data",
+    };
+  }
+
+  // DOM-free selector syntax pre-check, every present/reject/openSettings entry.
+  const rules = Array.isArray(o.rules) ? /** @type {object[]} */ (o.rules) : [];
+  for (const rule of rules) {
+    const selectors = [
+      ...(Array.isArray(rule?.present) ? rule.present : []),
+      ...(Array.isArray(rule?.reject) ? rule.reject : []),
+      ...(Array.isArray(rule?.openSettings) ? rule.openSettings : []),
+    ];
+    for (const sel of selectors) {
+      if (typeof sel === "string" && !selectorLooksSyntacticallyValid(sel)) {
+        return {
+          ok: false,
+          code: "SELECTOR_SYNTAX",
+          detail: `Selector fails the DOM-free syntax pre-check: ${sel}`,
+        };
+      }
+    }
+  }
+
+  // Rules content: caps, id regex/length/uniqueness, selector array bounds,
+  // per-selector length + token-scan, ADD-only bundled-id collision. Version
+  // and freshness are deliberately bypassed here (signing-time concerns —
+  // see file docblock): version is set high and published is "now" so both
+  // checks trivially pass, isolating this call to the content checks ADR-7
+  // actually assigns to source validation.
+  const rulesResult = validateTier2Rules(o.rules, {
+    version: 999_999_999,
+    published: new Date().toISOString(),
+    versionFloor: 0,
+    bundledIds: BUNDLED_TIER2_IDS,
+    nowMs: Date.now(),
+  });
+  if (!rulesResult.ok) {
+    return { ok: false, code: rulesResult.code, detail: "Rules content validation failed" };
+  }
+
+  return { ok: true };
+}
+
+// ── I/O boundary (main) ──────────────────────────────────────────────────────
+
+function main() {
+  let rawText;
+  try {
+    rawText = readFileSync(SOURCE_FILE, "utf8");
+  } catch (err) {
+    console.error(`[validate-tier2-source] ERROR: Cannot read source file "${SOURCE_FILE}": ${err.message}`);
+    process.exit(3);
+  }
+
+  let source;
+  try {
+    source = JSON.parse(rawText);
+  } catch (err) {
+    console.error(`[validate-tier2-source] ERROR: Source file is not valid JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  const result = validateTier2SourceContent(source, rawText);
+  if (!result.ok) {
+    console.error(`[validate-tier2-source] ERROR: [${result.code}] ${result.detail}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `[validate-tier2-source] OK: ${source.rules.length} rule(s) validated successfully ` +
+      `(schemaVersion ${source.schemaVersion}, version ${source.version})`
+  );
+  process.exit(0);
+}
+
+// Only run the filesystem-reading main() when invoked directly, so the pure
+// functions above can be imported by unit tests without touching the
+// filesystem (mirrors tools/build-tier2-rules.mjs's entry-guard).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}


### PR DESCRIPTION
## PR B3 — final slice of the cookie-consent-tier2-remote chain. Completes the feature (only the ops endpoint deploy remains).

Maintainer curation source + CI signing pipeline, reusing the EXISTING signing key + workflow (REVISED ADR-6). No shipping runtime change.

### What's in this slice
- **`tools/rules-source/tier2.json`** — empty seed (`{schemaVersion,version,published,rules:[]}`); remote rules are additive to the bundled Complianz/Cookie-Notice.
- **`tools/validate-tier2-source.mjs`** — PR-gate validator that **imports the shared runtime validators** (`validateTier2PayloadShape`/`validateTier2Rules`/`BUNDLED_TIER2_IDS`/`TIER2_TOKEN_SCAN_RE`) from `src/lib/remote-tier2-rules.js`, so the CI gate and the runtime can never diverge; + accept-token scan + DOM-free selector syntax pre-check.
- **`tools/sign-tier2-rules.mjs`** — mirrors `sign-rules.mjs` but **imports `canonicalTier2Message`** (signed bytes == what the runtime verifies — proven by a reference-identity + end-to-end Ed25519 verify test); signs with the existing `MUGA_SIGNING_KEY`, emits `docs/rules/v1/tier2.json`.
- **`validate-tier2-rules.yml` / `publish-tier2-rules.yml`** — mirror the params workflows (key temp-file, mask, sign, always-run cleanup, commit), scoped to the exact tier2 source path, reusing `secrets.MUGA_SIGNING_KEY` (no new secret). Also narrowed the params workflows to exclude `tier2.json` so a tier2 change no longer cross-triggers the params job.
- **Residual-risk copy** — `CHANGELOG` + `row_cookie_consent_mode_hint` (all **7 locales**): the veto REDUCES not eliminates mis-click risk; unclear/unreadable labels are left alone. No absolute-safety claim, no em-dashes, peninsular es.

### Verification
- `npm test` 7761 pass / 0 fail · typecheck 0 · eslint 0 · web-ext 0 · all 4 workflows parse
- 37 tool tests (import-equality, real subprocess exit codes, end-to-end Ed25519 verify)
- Fresh adversarial review: CLEAN — signed bytes == verified bytes (no divergence), key handling byte-parity with the params precedent, tools pure-on-import + out of the bundle, copy honest across 7 locales.

### Remaining (ops, out of repo — task 7.6)
Deploy `https://rules.muga.app/rules/v1/tier2.json`. No new key (reuses `MUGA_SIGNING_KEY`). Until then the runtime fetch 404s harmlessly (inert, fail-closed).

Completes the `cookie-consent-tier2-remote` change (PRs #1167 veto, #1168 pipeline, #1169 transport, this).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9