### PR TITLE
ci(consent): publish Tier 2 rules via PR + go-live the endpoint

### DIFF
--- a/.github/workflows/publish-tier2-rules.yml
+++ b/.github/workflows/publish-tier2-rules.yml
@@ -26,16 +26,21 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Elevated to write so we can commit the signed artifact back to main.
+    # Elevated to write so we can push the publish branch; pull-requests:write
+    # so the PAT-driven `gh pr create/merge` can open + auto-merge the PR.
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          # Use the default GITHUB_TOKEN — this is sufficient for push to main.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Direct push to protected main is rejected (GH006) — same as params.
+          # Publish via a PR using MUGA_PR_TOKEN (the fine-grained PAT already
+          # used by auto-ingest-rules.yml): it triggers ci.yml and can auto-merge
+          # past branch protection. No new secret.
+          token: ${{ secrets.MUGA_PR_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -67,44 +72,34 @@ jobs:
         if: always()
         run: rm -f "$RUNNER_TEMP/key.pem"
 
-      - name: Commit and push signed artifact
+      - name: Open PR with the signed artifact
+        # Mirrors auto-ingest-rules.yml: a params/tier2 artifact reaches protected
+        # main via a PR (never a direct push). The signed docs/rules/v1/tier2.json
+        # is a deterministic function of the already-reviewed source, so auto-merge
+        # after ci.yml passes is safe. GitHub Pages (docs/CNAME = rules.muga.app)
+        # then serves it at https://rules.muga.app/rules/v1/tier2.json — no
+        # separate endpoint deploy exists or is needed.
+        env:
+          GH_TOKEN: ${{ secrets.MUGA_PR_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/rules/v1/tier2.json
-          # Only commit if the file actually changed
-          if ! git diff --cached --quiet; then
-            git commit -m "ci(rules): publish signed tier2.json [skip ci]"
-            git push
-          else
-            echo "No changes to docs/rules/v1/tier2.json — skipping commit"
+          if git diff --cached --quiet; then
+            echo "No changes to docs/rules/v1/tier2.json — nothing to publish."
+            exit 0
           fi
-
-  smoke-check:
-    runs-on: ubuntu-latest
-    needs: publish
-    # Allow some propagation delay — GitHub Pages can take a minute after push.
-    # NOTE: the https://rules.muga.app/rules/v1/tier2.json endpoint deploy is
-    # tracked separately (task 7.6, out-of-repo ops). Until that endpoint is
-    # deployed, this job is EXPECTED to fail on the first few runs after this
-    # workflow merges — it does not block the publish job above, which already
-    # committed the signed artifact to docs/rules/v1/tier2.json.
-    steps:
-      - name: Wait for GitHub Pages propagation
-        # Brief initial pause to let the push reach Pages CDN before retrying.
-        run: sleep 30
-
-      - name: Smoke-check published URL
-        # --fail exits non-zero on HTTP 4xx/5xx (including 404 during propagation).
-        # --retry-all-errors retries on transient HTTP errors (not just network errors).
-        # --retry 3 with --retry-delay 30 tolerates up to ~120s of propagation lag.
-        # --silent suppresses progress bar; --show-error still shows error messages.
-        run: |
-          curl --head \
-               --fail \
-               --silent \
-               --show-error \
-               --retry 3 \
-               --retry-delay 30 \
-               --retry-all-errors \
-               https://rules.muga.app/rules/v1/tier2.json
+          BRANCH="publish-tier2/${GITHUB_SHA::12}"
+          git checkout -B "$BRANCH"
+          # NO [skip ci]: the PR needs ci.yml's required checks to pass so branch
+          # protection is satisfied and `--auto` merge can complete.
+          git commit -m "ci(rules): publish signed tier2.json"
+          git push -u origin "$BRANCH" --force-with-lease
+          if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            echo "PR already open for $BRANCH — leaving it."
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "ci(rules): publish signed tier2.json" \
+              --body "Automated signed publish of \`docs/rules/v1/tier2.json\` from \`tools/rules-source/tier2.json\`, signed by publish-tier2-rules.yml with the shared MUGA_SIGNING_KEY. GitHub Pages serves it at https://rules.muga.app/rules/v1/tier2.json."
+            gh pr merge "$BRANCH" --squash --auto
+          fi

--- a/tools/rules-source/tier2.json
+++ b/tools/rules-source/tier2.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "version": 1,
-  "published": "2026-07-26T00:00:00.000Z",
+  "published": "2026-07-26T12:00:00.000Z",
   "rules": []
 }


### PR DESCRIPTION
## What + why

The `publish-tier2-rules.yml` job **failed on the PR #1170 merge** with `GH006: Protected branch update failed` — it tried to push the signed artifact **directly to protected main**. That's the same reason the params `publish-rules.yml` only ever "succeeds" by doing nothing: **direct push to main is blocked**; params actually publishes via **PRs** (`auto-ingest-rules.yml`, using the fine-grained `MUGA_PR_TOKEN`).

This fixes the tier2 publish to use that same PR-based flow:
- checkout + PR via `MUGA_PR_TOKEN` (existing secret, no new one) → triggers `ci.yml` and can auto-merge past branch protection
- branch + commit (no `[skip ci]`) + `gh pr create ... && gh pr merge --squash --auto`
- removed the in-job smoke-check (can't run synchronously when publish is a PR)

## Endpoint go-live (clarifies archived task 7.6)
There is **no separate endpoint to deploy**: `docs/CNAME = rules.muga.app` and GitHub Pages already serves `docs/` (params.json is live there, HTTP 200). Committing the signed `docs/rules/v1/tier2.json` **is** the deploy. Bumping the seed's `published` here makes merging this PR trigger the fixed workflow → it signs the empty seed → opens an auto-merge publish PR → `docs/rules/v1/tier2.json` lands → Pages serves it (200).

**The live payload has zero rules** — inert, fail-closed to bundled-only, until real reject-rules are curated (that step needs live-site selector verification, a maintainer task). This just proves the pipeline end-to-end in production and flips the endpoint 404 → 200.

Workflow YAML validated (js-yaml); seed passes `validate-tier2-source.mjs` (0 rules, valid).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9