### PR TITLE
ci(rules): publish signed tier2.json

### DIFF
--- a/docs/rules/v1/tier2.json
+++ b/docs/rules/v1/tier2.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "version": 1,
+  "published": "2026-07-26T12:00:00.000Z",
+  "rules": [],
+  "sig": "zs9JBZlwXdETFCj8Q7p6Byn_uYFQaOlJcHdH64I50zVkuQ23Nc6n9-wpc2tcIlpD202cepgT6rk7Z0I5A01bAQ"
+}


### PR DESCRIPTION
Automated signed publish of `docs/rules/v1/tier2.json` from `tools/rules-source/tier2.json`, signed by publish-tier2-rules.yml with the shared MUGA_SIGNING_KEY. GitHub Pages serves it at https://rules.muga.app/rules/v1/tier2.json.