### PR TITLE
ci(consent): retry auto-merge enable on tier2 publish (unstable-status race)

### DIFF
--- a/.github/workflows/publish-tier2-rules.yml
+++ b/.github/workflows/publish-tier2-rules.yml
@@ -101,5 +101,21 @@ jobs:
             gh pr create --base main --head "$BRANCH" \
               --title "ci(rules): publish signed tier2.json" \
               --body "Automated signed publish of \`docs/rules/v1/tier2.json\` from \`tools/rules-source/tier2.json\`, signed by publish-tier2-rules.yml with the shared MUGA_SIGNING_KEY. GitHub Pages serves it at https://rules.muga.app/rules/v1/tier2.json."
-            gh pr merge "$BRANCH" --squash --auto
+            # Enabling auto-merge immediately after create can hit a transient
+            # "Pull request is in unstable status" race while GitHub computes the
+            # mergeable state. Retry until it settles.
+            enabled=false
+            for attempt in $(seq 1 6); do
+              if gh pr merge "$BRANCH" --squash --auto; then
+                enabled=true
+                echo "auto-merge enabled on attempt $attempt"
+                break
+              fi
+              echo "auto-merge not ready (attempt $attempt) — retrying in 15s..."
+              sleep 15
+            done
+            if [ "$enabled" != true ]; then
+              echo "::error::Could not enable auto-merge on $BRANCH after retries; merge it manually."
+              exit 1
+            fi
           fi


### PR DESCRIPTION
Follow-up to #1171. The first tier2 publish (#1172) opened the PR but `gh pr merge --auto` hit a transient "Pull request is in unstable status" race (GitHub still computing mergeable state right after create), so it needed a manual merge. This adds a 6×15s retry around enabling auto-merge so future publishes are hands-off, failing loudly only if it never settles. YAML validated. The endpoint is already live (https://rules.muga.app/rules/v1/tier2.json → 200, signature verified against TRUSTED_PUBLIC_KEYS).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9