### PR TITLE
fix(consent): complete Italian settings words in the Tier 2 click-veto

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1567,6 +1567,10 @@
     // it
     "impostazioni",
     "personalizza",
+    "gestisci",
+    "gestione",
+    "opzioni",
+    "preferenze",
     // pt
     "gerenciar",
     // ja

--- a/src/lib/cmp-tier2-veto.js
+++ b/src/lib/cmp-tier2-veto.js
@@ -204,6 +204,10 @@ const SETTINGS_WORDS = Object.freeze([
   // it
   "impostazioni",
   "personalizza",
+  "gestisci",
+  "gestione",
+  "opzioni",
+  "preferenze",
   // pt
   "gerenciar",
   // ja


### PR DESCRIPTION
Found via **live browser validation** of the Tier 2 veto (this session): the `openSettings` role over-vetoed a legitimate Italian settings-opener ("Gestisci opzioni" → `no-settings-word`), and "Salva preferenze" vetoed via the wrong reason (it lacked a settings word so it never reached the save-word check). The Italian `SETTINGS_WORDS` had only `impostazioni`/`personalizza`.

Added the Italian settings terms `gestisci`/`gestione`/`opzioni`/`preferenze` to `SETTINGS_WORDS` + the byte-for-byte `@sync:cmp-tier2-veto` copy in `cookie-noise.js`. Now:
- "Gestisci opzioni" / "Gestione opzioni" (openSettings) → **ALLOW**
- "Salva preferenze" (openSettings) → **VETO(save-word)**
- "Accetta tutto" (both roles) → **VETO(accept-word)** — never-accept unaffected

**Safe-direction / dormant** gap: `openSettings` is unused by any rule today, and the prior failure was over-veto (fail-closed). Never-accept was never at risk — `deny` is checked first and all 7 locales veto accept in both roles (validated live: German "Akzeptieren" → VETO on real banners in Chromium AND Firefox).

`npm test` 7760 pass / 0 fail · sync + teeth tests green (@sync byte-for-byte holds, settings/reject/save stay disjoint from deny).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9