### PR TITLE
feat(consent): toggle-reject safety core — invariant + save veto role (PR 1/3)

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1659,7 +1659,10 @@
    *   1. Empty/whitespace-only `accessibleName` -> VETO ("empty-name").
    *      Covers icon-only / no-text controls and detached/hostile elements.
    *   2. Any `wordLists.deny` entry matches -> VETO ("accept-word"). Absolute
-   *      and role-independent — wins over every allowlist match below.
+   *      and role-independent — wins over every allowlist match below,
+   *      INCLUDING a `role === "save"` candidate with a satisfied invariant
+   *      (design.md ADR-4: a mis-curated "Save" selector that actually
+   *      resolves to "Accept all" is still vetoed).
    *   3. Role-specific positive gate (the required word must be PRESENT):
    *      - `role === "reject"` requires a `wordLists.reject` match, else
    *        VETO ("no-reject-word").
@@ -1671,19 +1674,30 @@
    *        section). Checked AFTER the settings-word gate passes, since a
    *        save-labelled control (e.g. "Save my preferences") typically
    *        also contains a settings word and would otherwise clear step 3.
+   *      - `role === "save"` requires a `wordLists.save` match, else VETO
+   *        ("no-save-word"); IN ADDITION, requires
+   *        `context.saveInvariantSatisfied === true`, else VETO
+   *        ("save-invariant-unsatisfied") — see the file docblock's `"save"`
+   *        role section. Only `context.saveInvariantSatisfied` is ever read;
+   *        no other field of `context` (e.g. an origin/source marker)
+   *        affects the outcome.
    *      - any other role -> VETO ("unknown-role").
    *   4. Otherwise -> ALLOW ("ok").
    *
    * The only allow path is: non-empty name AND no accept word AND the role's
    * required positive word present (AND, for openSettings, no save word
-   * present). Absence of signal always resolves to "do not click" —
-   * fail-closed by construction. Pure; never throws.
+   * present; for save, ALSO the invariant flag). Absence of signal always
+   * resolves to "do not click" — fail-closed by construction. Pure; never
+   * throws.
    * @param {*} accessibleName
-   * @param {"reject"|"openSettings"} role
+   * @param {"reject"|"openSettings"|"save"} role
    * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string>, save: ReadonlyArray<string> }} wordLists
+   * @param {{ saveInvariantSatisfied?: boolean }} [context] - defaulted so
+   *   `computeClickVeto.length` stays `3`; only `saveInvariantSatisfied` is
+   *   ever honored (design.md ADR-4 — no origin/source exemption).
    * @returns {ClickVetoResult}
    */
-  function computeClickVeto(accessibleName, role, wordLists) {
+  function computeClickVeto(accessibleName, role, wordLists, context = {}) {
     const { name, folded } = normalizeAccessibleName(accessibleName);
     if (name.length === 0) return { allow: false, reason: "empty-name" };
 
@@ -1699,9 +1713,114 @@
       if (matchesAny(name, folded, lists.save)) return { allow: false, reason: "save-word" };
       return { allow: true, reason: "ok" };
     }
+    if (role === "save") {
+      if (!matchesAny(name, folded, lists.save)) return { allow: false, reason: "no-save-word" };
+      const ctx = context && typeof context === "object" ? context : {};
+      if (ctx.saveInvariantSatisfied !== true) return { allow: false, reason: "save-invariant-unsatisfied" };
+      return { allow: true, reason: "ok" };
+    }
     return { allow: false, reason: "unknown-role" };
   }
   // @sync:cmp-tier2-veto:end
+
+  // ── Tier 2 toggle-reject save invariant (cookie-consent-toggle-reject,
+  // PR 1 — safety core, INERT this PR) ──────────────────────────────────────
+  //
+  // Hand-copied, byte-for-byte modulo indentation, from
+  // src/lib/cmp-tier2-save-invariant.js. Kept in sync by
+  // tests/unit/cookie-noise-sync.test.mjs. NOT CALLED ANYWHERE in this PR —
+  // no dispatcher wiring, no rule uses a `toggleScope` field yet (PR 2).
+  // This block exists so the safety math is reviewable and adversarially
+  // unit-tested before any DOM actuation code exists to call it. See that
+  // file's docblock for the full contract.
+  // @sync:cmp-tier2-save-invariant:start
+
+  /**
+   * Fail-closed gate for the Save click: re-verifies the post-sweep state of
+   * every in-scope toggle PLUS a CMP-selector-independent backstop scan,
+   * instead of trusting the sweep's own actuation result. See the file
+   * docblock for the full contract. Pure; never throws.
+   *
+   * Evaluated strictly in this order — first failing check returns:
+   *   1. `toggleReadout` is not an array -> unsatisfied ("unreadable-toggle").
+   *   2. `toggleReadout` is an empty array -> unsatisfied ("empty-scope").
+   *   3. Any entry is not a well-formed object -> unsatisfied
+   *      ("unreadable-toggle").
+   *   4. Any non-locked entry has `readable !== true` -> unsatisfied
+   *      ("unreadable-toggle").
+   *   5. Any non-locked entry has `checked !== false` -> unsatisfied
+   *      ("toggle-still-on").
+   *   6. No entry in scope has `locked === true` -> unsatisfied ("no-locked").
+   *   7. `backstopCheckedCount` is not the exact numeric value `0` -> a
+   *      non-zero, non-numeric, or non-finite value all fail CLOSED
+   *      ("backstop-checked").
+   *   8. Otherwise -> satisfied ("ok").
+   * @param {Array<ToggleReadoutEntry>} toggleReadout
+   * @param {number} backstopCheckedCount
+   * @returns {SaveInvariantResult}
+   */
+  function computeSaveInvariant(toggleReadout, backstopCheckedCount) {
+    if (!Array.isArray(toggleReadout)) return { satisfied: false, reason: "unreadable-toggle" };
+    if (toggleReadout.length === 0) return { satisfied: false, reason: "empty-scope" };
+
+    let hasLocked = false;
+    for (const entry of toggleReadout) {
+      if (!entry || typeof entry !== "object") return { satisfied: false, reason: "unreadable-toggle" };
+      if (entry.locked === true) {
+        hasLocked = true;
+        continue;
+      }
+      if (entry.readable !== true) return { satisfied: false, reason: "unreadable-toggle" };
+      if (entry.checked !== false) return { satisfied: false, reason: "toggle-still-on" };
+    }
+    if (!hasLocked) return { satisfied: false, reason: "no-locked" };
+
+    const backstopIsZero = typeof backstopCheckedCount === "number"
+      && Number.isFinite(backstopCheckedCount)
+      && backstopCheckedCount === 0;
+    if (!backstopIsZero) return { satisfied: false, reason: "backstop-checked" };
+
+    return { satisfied: true, reason: "ok" };
+  }
+
+  /**
+   * Pure reject-only actuation planner: returns the indices of `toggleReadout`
+   * entries that must be forced OFF. NEVER returns an index for a locked entry
+   * and has NO representation for an "on"/enable action anywhere in its
+   * return shape — an index in the returned array means exactly one thing,
+   * "force this toggle off", so there is no code path here capable of
+   * planning a toggle-toward-ON write. An entry already reading off
+   * (`checked === false`) is omitted (no redundant write); an unreadable
+   * entry is omitted too (the impure actuation layer cannot safely act on a
+   * state it could not read — the unread toggle then surfaces as a
+   * `computeSaveInvariant` failure downstream, never as a guessed write
+   * here). Pure; never throws.
+   * @param {Array<ToggleReadoutEntry>} toggleReadout
+   * @returns {number[]} indices, within `toggleReadout`, to force OFF
+   */
+  function planToggleActuation(toggleReadout) {
+    const list = Array.isArray(toggleReadout) ? toggleReadout : [];
+    const plan = [];
+    for (let i = 0; i < list.length; i += 1) {
+      const entry = list[i];
+      if (!entry || typeof entry !== "object") continue;
+      if (entry.locked === true) continue;
+      if (entry.readable !== true) continue;
+      if (entry.checked === true) plan.push(i);
+    }
+    return plan;
+  }
+  // @sync:cmp-tier2-save-invariant:end
+
+  // Referenced here (outside the @sync-pinned block above, so this line is
+  // NOT part of the byte-identity comparison against src/lib/cmp-tier2-save-
+  // invariant.js) only to satisfy no-unused-vars while both functions are
+  // inert — this PR (PR 1) wires no dispatcher call site for either. Follows
+  // the same `void <expr>;` deliberate-no-op idiom AGENTS.md already uses
+  // for `void chrome.runtime.lastError;`. Removed once PR 2 adds the real
+  // dispatcher toggle-branch call sites.
+  void computeSaveInvariant;
+  void planToggleActuation;
 
   let _spRejectActed = false;
   let _spPmOpened = false;

--- a/src/lib/cmp-tier2-save-invariant.js
+++ b/src/lib/cmp-tier2-save-invariant.js
@@ -1,0 +1,135 @@
+/**
+ * MUGA: Cookie Consent Minimizer — Tier 2 toggle-reject save invariant
+ * (cookie-consent-toggle-reject, PR 1 — safety core, INERT this PR)
+ *
+ * Pure, DOM-free module. NOT loaded as a content script — see AGENTS.md
+ * (content scripts cannot use ES module imports). Hand-copied, byte-for-byte
+ * modulo indentation, into src/content/cookie-noise.js under a
+ * `@sync:cmp-tier2-save-invariant` block, kept in sync by
+ * tests/unit/cookie-noise-sync.test.mjs — same pattern as
+ * `@sync:cmp-tier2-veto`'s copy of src/lib/cmp-tier2-veto.js.
+ *
+ * ── PR 1 scope: ZERO CMP wiring ─────────────────────────────────────────────
+ *
+ * This file is created but NOT called anywhere yet — no dispatcher wiring,
+ * no rule uses a `toggleScope` field, so this PR is BEHAVIOR-INERT (see
+ * design.md's "PR 1 — safety core (inert)" migration entry). It exists so
+ * the safety math (the invariant that must hold before any Save click is
+ * ever permitted) is reviewable and adversarially unit-tested BEFORE any DOM
+ * actuation code exists to call it.
+ *
+ * ── The two exported primitives ─────────────────────────────────────────────
+ *
+ * `computeSaveInvariant` decides whether it is safe to click a neutral
+ * "Save"/"Speichern" control after a reject-only toggle sweep: satisfied
+ * IFF every non-locked toggle in scope is verified OFF, at least one
+ * locked/necessary toggle is present (the CMP's "essential" category),
+ * and a CMP-selector-INDEPENDENT backstop scan of the panel found zero
+ * still-checked standard controls outside the locked set. Any unreadable,
+ * empty, or malformed input fails CLOSED (unsatisfied) — this function
+ * NEVER throws.
+ *
+ * `planToggleActuation` is the pure decision half of the reject-only sweep:
+ * given a toggle readout, it returns ONLY the indices that must be forced
+ * OFF. There is no "on"/enable action this planner is capable of expressing
+ * — by construction, not by convention: the returned array is a list of
+ * force-off targets, full stop, so a future edit cannot smuggle in an
+ * enable path without changing this function's entire return contract (and
+ * every call site that consumes it). The locked/necessary toggle is never
+ * included in the plan.
+ *
+ * @typedef {object} ToggleReadoutEntry
+ * @property {boolean} [locked] - true for the CMP's necessary/locked
+ *   category (matched by the rule's `lockedOn` selector) — excluded from
+ *   both the off-check and the actuation plan.
+ * @property {boolean} [checked] - the toggle's current on/off state.
+ * @property {boolean} [readable] - false when the DOM read of this toggle's
+ *   state failed or was ambiguous; treated as unreadable regardless of
+ *   `checked`'s value.
+ *
+ * @typedef {object} SaveInvariantResult
+ * @property {boolean} satisfied
+ * @property {string} reason - one of "ok", "unreadable-toggle",
+ *   "toggle-still-on", "backstop-checked", "empty-scope", "no-locked".
+ */
+
+// @sync:cmp-tier2-save-invariant:start
+
+/**
+ * Fail-closed gate for the Save click: re-verifies the post-sweep state of
+ * every in-scope toggle PLUS a CMP-selector-independent backstop scan,
+ * instead of trusting the sweep's own actuation result. See the file
+ * docblock for the full contract. Pure; never throws.
+ *
+ * Evaluated strictly in this order — first failing check returns:
+ *   1. `toggleReadout` is not an array -> unsatisfied ("unreadable-toggle").
+ *   2. `toggleReadout` is an empty array -> unsatisfied ("empty-scope").
+ *   3. Any entry is not a well-formed object -> unsatisfied
+ *      ("unreadable-toggle").
+ *   4. Any non-locked entry has `readable !== true` -> unsatisfied
+ *      ("unreadable-toggle").
+ *   5. Any non-locked entry has `checked !== false` -> unsatisfied
+ *      ("toggle-still-on").
+ *   6. No entry in scope has `locked === true` -> unsatisfied ("no-locked").
+ *   7. `backstopCheckedCount` is not the exact numeric value `0` -> a
+ *      non-zero, non-numeric, or non-finite value all fail CLOSED
+ *      ("backstop-checked").
+ *   8. Otherwise -> satisfied ("ok").
+ * @param {Array<ToggleReadoutEntry>} toggleReadout
+ * @param {number} backstopCheckedCount
+ * @returns {SaveInvariantResult}
+ */
+function computeSaveInvariant(toggleReadout, backstopCheckedCount) {
+  if (!Array.isArray(toggleReadout)) return { satisfied: false, reason: "unreadable-toggle" };
+  if (toggleReadout.length === 0) return { satisfied: false, reason: "empty-scope" };
+
+  let hasLocked = false;
+  for (const entry of toggleReadout) {
+    if (!entry || typeof entry !== "object") return { satisfied: false, reason: "unreadable-toggle" };
+    if (entry.locked === true) {
+      hasLocked = true;
+      continue;
+    }
+    if (entry.readable !== true) return { satisfied: false, reason: "unreadable-toggle" };
+    if (entry.checked !== false) return { satisfied: false, reason: "toggle-still-on" };
+  }
+  if (!hasLocked) return { satisfied: false, reason: "no-locked" };
+
+  const backstopIsZero = typeof backstopCheckedCount === "number"
+    && Number.isFinite(backstopCheckedCount)
+    && backstopCheckedCount === 0;
+  if (!backstopIsZero) return { satisfied: false, reason: "backstop-checked" };
+
+  return { satisfied: true, reason: "ok" };
+}
+
+/**
+ * Pure reject-only actuation planner: returns the indices of `toggleReadout`
+ * entries that must be forced OFF. NEVER returns an index for a locked entry
+ * and has NO representation for an "on"/enable action anywhere in its
+ * return shape — an index in the returned array means exactly one thing,
+ * "force this toggle off", so there is no code path here capable of
+ * planning a toggle-toward-ON write. An entry already reading off
+ * (`checked === false`) is omitted (no redundant write); an unreadable
+ * entry is omitted too (the impure actuation layer cannot safely act on a
+ * state it could not read — the unread toggle then surfaces as a
+ * `computeSaveInvariant` failure downstream, never as a guessed write
+ * here). Pure; never throws.
+ * @param {Array<ToggleReadoutEntry>} toggleReadout
+ * @returns {number[]} indices, within `toggleReadout`, to force OFF
+ */
+function planToggleActuation(toggleReadout) {
+  const list = Array.isArray(toggleReadout) ? toggleReadout : [];
+  const plan = [];
+  for (let i = 0; i < list.length; i += 1) {
+    const entry = list[i];
+    if (!entry || typeof entry !== "object") continue;
+    if (entry.locked === true) continue;
+    if (entry.readable !== true) continue;
+    if (entry.checked === true) plan.push(i);
+  }
+  return plan;
+}
+// @sync:cmp-tier2-save-invariant:end
+
+export { computeSaveInvariant, planToggleActuation };

--- a/src/lib/cmp-tier2-veto.js
+++ b/src/lib/cmp-tier2-veto.js
@@ -70,12 +70,36 @@
  * "Manage preferences" or "Cookie settings" contain no save word and are
  * unaffected.
  *
+ * ── The `"save"` role — a narrow, invariant-gated veto exception
+ * (cookie-consent-toggle-reject, design.md ADR-4) ───────────────────────
+ *
+ * `role === "save"` is the ONLY role that can ever be allowed while also
+ * matching a word from `VETO_WORDS.save` — every other role treats a save
+ * word as irrelevant noise. It requires BOTH a `wordLists.save` match AND
+ * `context.saveInvariantSatisfied === true` (see
+ * src/lib/cmp-tier2-save-invariant.js's `computeSaveInvariant` — the
+ * fail-closed re-verification that every non-essential toggle is off
+ * before this flag can ever be true). The absolute accept-denylist check
+ * (step 2 below) still runs FIRST and unconditionally wins: an "Accept
+ * all"-labelled control passed in with `role: "save"` and
+ * `saveInvariantSatisfied: true` is STILL vetoed — the invariant only ever
+ * relaxes the save-word requirement, never the accept-word ban. `context`
+ * is a 4th, DEFAULTED parameter (`context = {}`) so `computeClickVeto.length`
+ * stays `3` — the existing structural guard (see
+ * tests/unit/cookie-noise-sync.test.mjs's "spec scenario 5" test) keeps
+ * passing unmodified. Only `context.saveInvariantSatisfied` is ever read;
+ * any other field (e.g. an `origin`/`source`/rule-provenance marker) is
+ * inert — there is no code path here that branches on it (see
+ * tests/unit/cmp-tier2-veto.test.mjs's dedicated no-origin-exemption test).
+ *
  * @typedef {object} ClickVetoResult
  * @property {boolean} allow - true only when the accessible name is
  *   non-empty, matches no accept/agree word, AND matches the role's
- *   required positive word (and, for openSettings, matches no save word).
+ *   required positive word (and, for openSettings, matches no save word;
+ *   for save, ALSO requires context.saveInvariantSatisfied === true).
  * @property {string} reason - one of "empty-name", "accept-word",
- *   "no-reject-word", "no-settings-word", "save-word", "unknown-role", "ok".
+ *   "no-reject-word", "no-settings-word", "save-word", "no-save-word",
+ *   "save-invariant-unsatisfied", "unknown-role", "ok".
  */
 
 // @sync:cmp-tier2-veto:start
@@ -296,7 +320,10 @@ function matchesAny(name, folded, words) {
  *   1. Empty/whitespace-only `accessibleName` -> VETO ("empty-name").
  *      Covers icon-only / no-text controls and detached/hostile elements.
  *   2. Any `wordLists.deny` entry matches -> VETO ("accept-word"). Absolute
- *      and role-independent — wins over every allowlist match below.
+ *      and role-independent — wins over every allowlist match below,
+ *      INCLUDING a `role === "save"` candidate with a satisfied invariant
+ *      (design.md ADR-4: a mis-curated "Save" selector that actually
+ *      resolves to "Accept all" is still vetoed).
  *   3. Role-specific positive gate (the required word must be PRESENT):
  *      - `role === "reject"` requires a `wordLists.reject` match, else
  *        VETO ("no-reject-word").
@@ -308,19 +335,30 @@ function matchesAny(name, folded, words) {
  *        section). Checked AFTER the settings-word gate passes, since a
  *        save-labelled control (e.g. "Save my preferences") typically
  *        also contains a settings word and would otherwise clear step 3.
+ *      - `role === "save"` requires a `wordLists.save` match, else VETO
+ *        ("no-save-word"); IN ADDITION, requires
+ *        `context.saveInvariantSatisfied === true`, else VETO
+ *        ("save-invariant-unsatisfied") — see the file docblock's `"save"`
+ *        role section. Only `context.saveInvariantSatisfied` is ever read;
+ *        no other field of `context` (e.g. an origin/source marker)
+ *        affects the outcome.
  *      - any other role -> VETO ("unknown-role").
  *   4. Otherwise -> ALLOW ("ok").
  *
  * The only allow path is: non-empty name AND no accept word AND the role's
  * required positive word present (AND, for openSettings, no save word
- * present). Absence of signal always resolves to "do not click" —
- * fail-closed by construction. Pure; never throws.
+ * present; for save, ALSO the invariant flag). Absence of signal always
+ * resolves to "do not click" — fail-closed by construction. Pure; never
+ * throws.
  * @param {*} accessibleName
- * @param {"reject"|"openSettings"} role
+ * @param {"reject"|"openSettings"|"save"} role
  * @param {{ deny: ReadonlyArray<string>, reject: ReadonlyArray<string>, settings: ReadonlyArray<string>, save: ReadonlyArray<string> }} wordLists
+ * @param {{ saveInvariantSatisfied?: boolean }} [context] - defaulted so
+ *   `computeClickVeto.length` stays `3`; only `saveInvariantSatisfied` is
+ *   ever honored (design.md ADR-4 — no origin/source exemption).
  * @returns {ClickVetoResult}
  */
-function computeClickVeto(accessibleName, role, wordLists) {
+function computeClickVeto(accessibleName, role, wordLists, context = {}) {
   const { name, folded } = normalizeAccessibleName(accessibleName);
   if (name.length === 0) return { allow: false, reason: "empty-name" };
 
@@ -334,6 +372,12 @@ function computeClickVeto(accessibleName, role, wordLists) {
   if (role === "openSettings") {
     if (!matchesAny(name, folded, lists.settings)) return { allow: false, reason: "no-settings-word" };
     if (matchesAny(name, folded, lists.save)) return { allow: false, reason: "save-word" };
+    return { allow: true, reason: "ok" };
+  }
+  if (role === "save") {
+    if (!matchesAny(name, folded, lists.save)) return { allow: false, reason: "no-save-word" };
+    const ctx = context && typeof context === "object" ? context : {};
+    if (ctx.saveInvariantSatisfied !== true) return { allow: false, reason: "save-invariant-unsatisfied" };
     return { allow: true, reason: "ok" };
   }
   return { allow: false, reason: "unknown-role" };

--- a/tests/unit/cmp-tier2-save-invariant.test.mjs
+++ b/tests/unit/cmp-tier2-save-invariant.test.mjs
@@ -1,0 +1,228 @@
+/**
+ * MUGA — Cookie Consent Minimizer: cmp-tier2-save-invariant.js
+ * (cookie-consent-toggle-reject, PR 1 — safety core)
+ *
+ * Pure-logic tests for the toggle-reject save invariant and the reject-only
+ * actuation planner — the load-bearing safety math described in design.md
+ * ADR-2/ADR-3. No DOM, no chrome.*, no globals; toggle state is injected as
+ * plain-object fixtures, matching the pure-module contract described in
+ * src/lib/cmp-tier2-save-invariant.js.
+ *
+ * This PR (PR 1) is BEHAVIOR-INERT: neither function is wired to any
+ * dispatcher yet (that is PR 2). This suite exists so the safety math is
+ * reviewable and adversarially proven before any DOM actuation exists.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { computeSaveInvariant, planToggleActuation } from "../../src/lib/cmp-tier2-save-invariant.js";
+
+// ── computeSaveInvariant — satisfied cases ───────────────────────────────
+
+describe("computeSaveInvariant — satisfied", () => {
+  test("every non-locked toggle off + a locked toggle present + zero backstop -> satisfied", () => {
+    const readout = [
+      { locked: false, checked: false, readable: true },
+      { locked: false, checked: false, readable: true },
+      { locked: true, checked: true, readable: true },
+    ];
+    const result = computeSaveInvariant(readout, 0);
+    assert.equal(result.satisfied, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("a single locked-only scope (no non-locked toggles at all) with zero backstop -> satisfied", () => {
+    const readout = [{ locked: true, checked: true, readable: true }];
+    const result = computeSaveInvariant(readout, 0);
+    assert.equal(result.satisfied, true);
+  });
+});
+
+// ── computeSaveInvariant — adversarial unsatisfied cases ─────────────────
+
+describe("computeSaveInvariant — adversarial fail-closed cases", () => {
+  test("one non-locked toggle still on -> unsatisfied (toggle-still-on)", () => {
+    const readout = [
+      { locked: false, checked: true, readable: true },
+      { locked: true, checked: true, readable: true },
+    ];
+    const result = computeSaveInvariant(readout, 0);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "toggle-still-on");
+  });
+
+  test("backstopCheckedCount > 0 (an unmapped checked control) -> unsatisfied (backstop-checked), even with all mapped toggles off", () => {
+    const readout = [
+      { locked: false, checked: false, readable: true },
+      { locked: true, checked: true, readable: true },
+    ];
+    const result = computeSaveInvariant(readout, 1);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "backstop-checked");
+  });
+
+  test("readout is not an array (unreadable) -> unsatisfied (unreadable-toggle), never throws", () => {
+    for (const garbage of [null, undefined, "x", 42, {}]) {
+      assert.doesNotThrow(() => computeSaveInvariant(garbage, 0));
+      const result = computeSaveInvariant(garbage, 0);
+      assert.equal(result.satisfied, false);
+      assert.equal(result.reason, "unreadable-toggle");
+    }
+  });
+
+  test("empty scope (empty array) -> unsatisfied (empty-scope)", () => {
+    const result = computeSaveInvariant([], 0);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "empty-scope");
+  });
+
+  test("no locked/necessary toggle present anywhere in scope -> unsatisfied (no-locked)", () => {
+    const readout = [
+      { locked: false, checked: false, readable: true },
+      { locked: false, checked: false, readable: true },
+    ];
+    const result = computeSaveInvariant(readout, 0);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "no-locked");
+  });
+
+  test("a non-locked entry with readable: false (DOM read failed) -> unsatisfied (unreadable-toggle), never guessed as off", () => {
+    const readout = [
+      { locked: false, checked: false, readable: false },
+      { locked: true, checked: true, readable: true },
+    ];
+    const result = computeSaveInvariant(readout, 0);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "unreadable-toggle");
+  });
+
+  test("a malformed entry (null / non-object) anywhere in the readout -> unsatisfied (unreadable-toggle), never throws", () => {
+    for (const garbageEntry of [null, undefined, "x", 42, []]) {
+      const readout = [garbageEntry, { locked: true, checked: true, readable: true }];
+      assert.doesNotThrow(() => computeSaveInvariant(readout, 0));
+      const result = computeSaveInvariant(readout, 0);
+      assert.equal(result.satisfied, false);
+      assert.equal(result.reason, "unreadable-toggle");
+    }
+  });
+
+  test("backstopCheckedCount is non-numeric / NaN / negative -> unsatisfied (backstop-checked), fails closed rather than coercing", () => {
+    const readout = [
+      { locked: false, checked: false, readable: true },
+      { locked: true, checked: true, readable: true },
+    ];
+    for (const garbage of [NaN, "0", null, undefined, -1, Infinity]) {
+      const result = computeSaveInvariant(readout, garbage);
+      assert.equal(result.satisfied, false, `backstopCheckedCount=${String(garbage)} must not be treated as zero`);
+      assert.equal(result.reason, "backstop-checked");
+    }
+  });
+
+  test("one missed/dynamic toggle still on among several otherwise-off toggles -> unsatisfied", () => {
+    const readout = [
+      { locked: false, checked: false, readable: true },
+      { locked: false, checked: false, readable: true },
+      { locked: false, checked: true, readable: true }, // the missed one
+      { locked: true, checked: true, readable: true },
+    ];
+    const result = computeSaveInvariant(readout, 0);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "toggle-still-on");
+  });
+});
+
+// ── planToggleActuation — never-turn-ON battery (task 1.3) ───────────────
+//
+// For every fixture below, the plan must never contain any representation
+// of an "on"/enable action — the function's entire return shape is a list
+// of force-off indices, so this is really proving "the output never
+// includes a locked index and never includes an already-off/unreadable
+// index", which together exhaust every way an "on" action could sneak in.
+
+describe("planToggleActuation — never emits an on-action, for any fixture", () => {
+  function assertNeverOn(readout, expectedIndices, label) {
+    const plan = planToggleActuation(readout);
+    assert.deepEqual(plan, expectedIndices, `${label}: unexpected plan`);
+    // Structural proof: every planned index must reference a non-locked,
+    // readable, currently-checked (i.e. force-OFF-eligible) entry — never a
+    // locked entry, and the function returns bare indices with no "action
+    // type" field at all, so there is no field a future edit could flip to
+    // express "on".
+    for (const idx of plan) {
+      const entry = readout[idx];
+      assert.notEqual(entry.locked, true, `${label}: plan must never include a locked index`);
+      assert.equal(entry.checked, true, `${label}: plan must only include entries that were actually on`);
+    }
+  }
+
+  test("already-off fixture -> empty plan (no redundant write)", () => {
+    const readout = [
+      { locked: false, checked: false, readable: true },
+      { locked: false, checked: false, readable: true },
+    ];
+    assertNeverOn(readout, [], "already-off");
+  });
+
+  test("pre-checked fixture -> plans only the pre-checked indices", () => {
+    const readout = [
+      { locked: false, checked: true, readable: true },
+      { locked: false, checked: true, readable: true },
+    ];
+    assertNeverOn(readout, [0, 1], "pre-checked");
+  });
+
+  test("mixed on/off fixture -> plans only the on indices", () => {
+    const readout = [
+      { locked: false, checked: true, readable: true },
+      { locked: false, checked: false, readable: true },
+      { locked: false, checked: true, readable: true },
+    ];
+    assertNeverOn(readout, [0, 2], "mixed");
+  });
+
+  test("locked-present fixture -> the locked index is never planned even though it reads checked:true", () => {
+    const readout = [
+      { locked: false, checked: true, readable: true },
+      { locked: true, checked: true, readable: true },
+    ];
+    assertNeverOn(readout, [0], "locked-present");
+  });
+
+  test("malformed/unreadable fixture -> unreadable and non-object entries are skipped, never guessed into the plan", () => {
+    const readout = [
+      { locked: false, checked: true, readable: false },
+      null,
+      undefined,
+      { locked: false, checked: true, readable: true },
+    ];
+    assertNeverOn(readout, [3], "malformed");
+  });
+
+  test("non-array input -> empty plan, never throws", () => {
+    for (const garbage of [null, undefined, "x", 42, {}]) {
+      assert.doesNotThrow(() => planToggleActuation(garbage));
+      assert.deepEqual(planToggleActuation(garbage), []);
+    }
+  });
+
+  test("empty readout -> empty plan", () => {
+    assert.deepEqual(planToggleActuation([]), []);
+  });
+
+  test("across every fixture in this battery, the plan is always a plain number[] — no object, no {action} field, nothing an 'on' branch could hide inside", () => {
+    const fixtures = [
+      [],
+      [{ locked: false, checked: true, readable: true }],
+      [{ locked: true, checked: true, readable: true }],
+      [{ locked: false, checked: false, readable: true }],
+      [{ locked: false, checked: true, readable: false }],
+    ];
+    for (const readout of fixtures) {
+      const plan = planToggleActuation(readout);
+      assert.ok(Array.isArray(plan));
+      for (const entry of plan) {
+        assert.equal(typeof entry, "number", "every plan entry must be a bare numeric index, not an object/action");
+      }
+    }
+  });
+});

--- a/tests/unit/cmp-tier2-veto.test.mjs
+++ b/tests/unit/cmp-tier2-veto.test.mjs
@@ -109,7 +109,11 @@ describe("computeClickVeto — the four required fail-closed cases", () => {
   });
 
   test("unknown role -> VETO (unknown-role), even with an otherwise-clean reject name", () => {
-    const result = computeClickVeto("Reject all", "save", VETO_WORDS);
+    // (cookie-consent-toggle-reject, PR 1) previously used "save" as the
+    // stand-in unknown role here — now that "save" is a real, gated role
+    // (see the dedicated `role === "save"` describe block below), a
+    // genuinely-unknown role name is required to keep testing this branch.
+    const result = computeClickVeto("Reject all", "commit", VETO_WORDS);
     assert.equal(result.allow, false);
     assert.equal(result.reason, "unknown-role");
   });
@@ -196,6 +200,122 @@ describe("computeClickVeto — openSettings role: save-family word is vetoed (PR
     const result = computeClickVeto("Reject all", "reject", VETO_WORDS);
     assert.equal(result.allow, true);
     assert.equal(result.reason, "ok");
+  });
+});
+
+// ── "save" role — narrow, invariant-gated veto exception ────────────────
+// (cookie-consent-toggle-reject, PR 1 — design.md ADR-4, spec's "Save is a
+// controlled veto exception, not a relaxation" requirement)
+//
+// role === "save" is allowed ONLY when (1) the absolute accept-denylist does
+// NOT match — checked first, wins regardless of anything else; AND (2) a
+// SAVE_WORDS match is present; AND (3) context.saveInvariantSatisfied is
+// exactly true. `context` is the new, DEFAULTED 4th argument — the
+// structural guard below re-confirms computeClickVeto.length stays 3 and
+// that context carries no exploitable field beyond saveInvariantSatisfied.
+
+describe('computeClickVeto — role "save": invariant-gated exception', () => {
+  test('invariant satisfied + "Save" -> allow', () => {
+    const result = computeClickVeto("Save", "save", VETO_WORDS, { saveInvariantSatisfied: true });
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test('invariant satisfied + "Speichern" (de) -> allow', () => {
+    const result = computeClickVeto("Speichern", "save", VETO_WORDS, { saveInvariantSatisfied: true });
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test('invariant satisfied + "Accept all" -> VETO (accept-word) — deny wins over a satisfied invariant', () => {
+    const result = computeClickVeto("Accept all", "save", VETO_WORDS, { saveInvariantSatisfied: true });
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test('invariant satisfied + "Alle akzeptieren" (de accept) -> VETO (accept-word) — deny wins, even in a non-English locale', () => {
+    const result = computeClickVeto("Alle akzeptieren", "save", VETO_WORDS, { saveInvariantSatisfied: true });
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test('invariant UNSATISFIED + "Save" -> VETO (save-invariant-unsatisfied) regardless of the label', () => {
+    const result = computeClickVeto("Save", "save", VETO_WORDS, { saveInvariantSatisfied: false });
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "save-invariant-unsatisfied");
+  });
+
+  test('context omitted entirely (default {}) + "Save" -> VETO (save-invariant-unsatisfied) — safe default, never implicitly true', () => {
+    const result = computeClickVeto("Save", "save", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "save-invariant-unsatisfied");
+  });
+
+  test('invariant satisfied + a name with no save word (e.g. "Continue") -> VETO (no-save-word)', () => {
+    const result = computeClickVeto("Continue", "save", VETO_WORDS, { saveInvariantSatisfied: true });
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "no-save-word");
+  });
+
+  test('an unknown role stays vetoed even with a save-word name and a satisfied invariant', () => {
+    const result = computeClickVeto("Save", "commit", VETO_WORDS, { saveInvariantSatisfied: true });
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "unknown-role");
+  });
+
+  test("garbage context (null/undefined/non-object/array) never throws and never allows", () => {
+    for (const garbage of [null, undefined, 42, "x", []]) {
+      assert.doesNotThrow(() => computeClickVeto("Save", "save", VETO_WORDS, garbage));
+      const result = computeClickVeto("Save", "save", VETO_WORDS, garbage);
+      assert.equal(result.allow, false);
+      assert.equal(result.reason, "save-invariant-unsatisfied");
+    }
+  });
+
+  test("a context carrying an origin/source/rule-provenance field alongside saveInvariantSatisfied does not change the outcome — only saveInvariantSatisfied is ever honored (no-origin-exemption guarantee)", () => {
+    const withOrigin = computeClickVeto("Save", "save", VETO_WORDS, {
+      saveInvariantSatisfied: true,
+      origin: "remote",
+      source: "trusted-signing-key",
+      ruleOrigin: "bundled",
+    });
+    const withoutOrigin = computeClickVeto("Save", "save", VETO_WORDS, { saveInvariantSatisfied: true });
+    assert.deepEqual(withOrigin, withoutOrigin, "an extra provenance field must not alter the veto outcome");
+    assert.equal(withOrigin.allow, true);
+  });
+
+  test("an origin/source field CANNOT substitute for or bypass saveInvariantSatisfied — a context with only provenance fields (no saveInvariantSatisfied) is vetoed identically to an empty context", () => {
+    const provenanceOnly = computeClickVeto("Save", "save", VETO_WORDS, {
+      origin: "remote",
+      source: "trusted-signing-key",
+      trusted: true,
+      verified: true,
+    });
+    assert.equal(provenanceOnly.allow, false);
+    assert.equal(provenanceOnly.reason, "save-invariant-unsatisfied");
+  });
+
+  // Strengthened structural guard (task 1.6): computeClickVeto.length must
+  // stay 3 even after adding the "save" role + context param, because
+  // `context` is a DEFAULTED 4th parameter — JS function.length only counts
+  // parameters up to (not including) the first one with a default value.
+  // Mirrors the pre-existing structural guard in
+  // tests/unit/cookie-noise-sync.test.mjs's "spec scenario 5" describe
+  // block, kept here too as direct unit-level coverage on the source module
+  // itself (not just the content-script sync copy).
+  test("computeClickVeto.length stays exactly 3 — context is a defaulted 4th parameter, not a required one", () => {
+    assert.equal(
+      computeClickVeto.length,
+      3,
+      "computeClickVeto must still report arity 3 — the 4th `context` argument must stay defaulted so no existing 3-arg call site is a breaking change",
+    );
+  });
+
+  test("computeClickVeto can still be called with exactly 3 arguments (no context) and defaults to a vetoed save — proves the 4th param is truly optional, not silently required", () => {
+    assert.doesNotThrow(() => computeClickVeto("Save", "save", VETO_WORDS));
+    const result = computeClickVeto("Save", "save", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "save-invariant-unsatisfied");
   });
 });
 

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -481,6 +481,111 @@ describe("cookie-noise-sync — @sync:cmp-tier2-veto block matches src/lib/cmp-t
     assert.ok(/save:\s*SAVE_WORDS/.test(joined), "VETO_WORDS must expose the save list");
     assert.ok(/"save-word"/.test(joined), "computeClickVeto must be able to return the save-word veto reason");
   });
+
+  test('the veto defines a "save" role branch, gated on a save-word match AND context.saveInvariantSatisfied === true (cookie-consent-toggle-reject, PR 1 / design.md ADR-4)', () => {
+    const joined = libBlock.join("\n");
+    assert.ok(/role === "save"/.test(joined), "computeClickVeto must branch on role === \"save\"");
+    assert.ok(/context\.saveInvariantSatisfied\s*!==\s*true|saveInvariantSatisfied\s*===\s*true/.test(joined),
+      "the save branch must gate on saveInvariantSatisfied === true");
+    assert.ok(/"no-save-word"/.test(joined), "must be able to return the no-save-word veto reason");
+    assert.ok(/"save-invariant-unsatisfied"/.test(joined), "must be able to return the save-invariant-unsatisfied veto reason");
+  });
+
+  test("computeClickVeto's 4th `context` parameter is defaulted so .length stays 3 (cookie-consent-toggle-reject, PR 1 — no breaking change to existing 3-arg call sites)", () => {
+    assert.ok(/function computeClickVeto\(accessibleName, role, wordLists, context = \{\}\)/.test(libBlock.join("\n")),
+      "computeClickVeto must declare context as a defaulted 4th parameter, exactly `context = {}`");
+    assert.equal(computeClickVeto.length, 3, "computeClickVeto.length must stay 3 after adding the save role");
+  });
+});
+
+// ── @sync:cmp-tier2-save-invariant block (toggle-reject save invariant) ────
+// (cookie-consent-toggle-reject, PR 1 — safety core, INERT this PR)
+//
+// computeSaveInvariant / planToggleActuation are pure exports in
+// src/lib/cmp-tier2-save-invariant.js (unit-tested there, including the
+// never-turn-ON battery) whose body is hand-inlined ONLY into
+// content/cookie-noise.js (isolated world) — mirrors the @sync:cmp-tier2-veto
+// precedent immediately above. NOT CALLED anywhere in cookie-noise.js this
+// PR (see the block's own comment there) — no dispatcher wiring exists yet
+// (PR 2). This test proves the block is present and byte-identical even
+// while inert, so the safety math itself can be reviewed before any DOM
+// actuation code is added to call it.
+
+const SAVE_INVARIANT_FILES = {
+  lib: join(__dirname, "../../src/lib/cmp-tier2-save-invariant.js"),
+  isolated: FILES.isolated,
+};
+
+const saveInvariantSources = {
+  lib: readFileSync(SAVE_INVARIANT_FILES.lib, "utf8"),
+  isolated: sources.isolated,
+};
+
+const SAVE_INVARIANT_START = "@sync:cmp-tier2-save-invariant:start";
+const SAVE_INVARIANT_END = "@sync:cmp-tier2-save-invariant:end";
+
+describe("cookie-noise-sync — @sync:cmp-tier2-save-invariant block matches src/lib/cmp-tier2-save-invariant.js", () => {
+  const libBlock = extractMarkedBlock(saveInvariantSources.lib, SAVE_INVARIANT_START, SAVE_INVARIANT_END, "cmp-tier2-save-invariant.js");
+  const isolatedBlock = extractMarkedBlock(saveInvariantSources.isolated, SAVE_INVARIANT_START, SAVE_INVARIANT_END, "cookie-noise.js");
+
+  test("save-invariant sync block is non-empty and defines computeSaveInvariant and planToggleActuation", () => {
+    assert.ok(libBlock.length > 0, "extracted @sync:cmp-tier2-save-invariant block must not be empty — check the markers");
+    const joined = libBlock.join("\n");
+    assert.ok(/function computeSaveInvariant/.test(joined));
+    assert.ok(/function planToggleActuation/.test(joined));
+  });
+
+  test("cookie-noise.js @sync:cmp-tier2-save-invariant block matches src/lib/cmp-tier2-save-invariant.js", () => {
+    assert.deepEqual(
+      isolatedBlock,
+      libBlock,
+      "content/cookie-noise.js's @sync:cmp-tier2-save-invariant block has drifted from src/lib/cmp-tier2-save-invariant.js",
+    );
+  });
+
+  test("the main-world caller does NOT carry the @sync:cmp-tier2-save-invariant block (Tier 2 is isolated-world only)", () => {
+    assert.equal(sources.mainworld.includes(SAVE_INVARIANT_START), false,
+      "cookie-noise-mainworld.js must not inline the save invariant — this mechanism is isolated-world only");
+  });
+
+  test("planToggleActuation never emits an on-action — no field in its return shape could carry one (bare number[] of force-off indices)", () => {
+    const joined = libBlock.join("\n");
+    assert.doesNotMatch(joined, /checked\s*=\s*true/, "the block must never write checked = true anywhere");
+    assert.doesNotMatch(joined, /aria-checked['"]\s*,\s*['"]true/, "the block must never set aria-checked to true anywhere");
+  });
+
+  test("this PR wires ZERO dispatcher call sites for computeSaveInvariant/planToggleActuation — behavior-inert (PR 1)", () => {
+    const src = sources.isolated;
+    for (const fnName of ["computeSaveInvariant", "planToggleActuation"]) {
+      // A deliberate `void NAME;` no-op reference (satisfying no-unused-vars
+      // while the block is inert) must exist, and it must be the ONLY
+      // reference outside the declaration/docblocks — i.e. no real call
+      // `NAME(` anywhere except the function's own declaration line.
+      assert.ok(src.includes(`void ${fnName};`), `${fnName} must have a deliberate void no-op reference, not a real call site`);
+    }
+    // Neither function is referenced at all inside the two known dispatcher
+    // bodies (runTier2RejectDispatcher today; the PR-2 toggle branch that
+    // would call them does not exist yet).
+    const dispatcherMatch = /function runTier2RejectDispatcher\(\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(dispatcherMatch, "cookie-noise.js must define runTier2RejectDispatcher()");
+    assert.doesNotMatch(dispatcherMatch[1], /computeSaveInvariant\(|planToggleActuation\(/,
+      "runTier2RejectDispatcher must not call computeSaveInvariant/planToggleActuation yet — that wiring is PR 2, out of scope for PR 1");
+  });
+
+  test("no rule instance (bundled TIER2_RULES) uses a toggleScope field yet — PR 1 adds zero CMP wiring", () => {
+    // Scoped to the actual rule-data sync block, not prose — this file's own
+    // comments legitimately MENTION "toggleScope" to explain what PR 2 will
+    // add (see the block comment above the @sync:cmp-tier2-save-invariant
+    // region). What must not exist yet is the field itself inside the rule
+    // data (both the bundled TIER2_RULES array and its content-script copy).
+    const rulesLibSrc = readFileSync(join(__dirname, "../../src/lib/cmp-tier2-rules.js"), "utf8");
+    const rulesLibBlock = extractMarkedBlock(rulesLibSrc, TIER2_RULES_START, TIER2_RULES_END, "cmp-tier2-rules.js");
+    const rulesIsolatedBlock = extractMarkedBlock(sources.isolated, TIER2_RULES_START, TIER2_RULES_END, "cookie-noise.js");
+    assert.equal(/toggleScope/.test(rulesLibBlock.join("\n")), false,
+      "src/lib/cmp-tier2-rules.js's TIER2_RULES data must not reference toggleScope at all in PR 1 — that field is introduced in PR 2");
+    assert.equal(/toggleScope/.test(rulesIsolatedBlock.join("\n")), false,
+      "cookie-noise.js's @sync:cmp-tier2-rules copy must not reference toggleScope at all in PR 1");
+  });
 });
 
 // ── Tier 2 dispatch — main-world exclusion (task 3.3) ───────────────────────


### PR DESCRIPTION
**PR 1/3** of `cookie-consent-toggle-reject` — reject cookies on CMPs with pre-checked category toggles (open settings → uncheck non-essential → verify state → click Save).

This slice is the **safety core** and lands first so the never-accept-preserving logic is reviewable in isolation. It is **behavior-inert**: no dispatcher wiring, no rule uses `toggleScope`, zero runtime change ships.

## Never-accept guarantee (absolute)
MUGA never turns a toggle ON, never clicks Accept-all, and never lets Save fire on an unverified state. Enforced structurally here:

- **`src/lib/cmp-tier2-save-invariant.js` (new)**
  - `computeSaveInvariant(toggleReadout, backstopCheckedCount)` — satisfied IFF every non-locked toggle is readable + off, at least one locked toggle is present, AND `backstopCheckedCount === 0`. Fail-closed on every malformed / still-on / no-locked / non-zero-backstop input; never throws.
  - `planToggleActuation(toggleReadout)` — returns a `number[]` of indices to force OFF. The return shape **cannot express an "on" action**; it never targets a locked toggle and skips unreadable entries.
- **`src/lib/cmp-tier2-veto.js`** — new `role: "save"` branch in `computeClickVeto` via a **defaulted 4th `context` arg** (keeps `computeClickVeto.length === 3`). Save is allowed ONLY when `context.saveInvariantSatisfied === true` AND a save-word matches, AFTER the absolute deny check — so "Accept all" + `saveInvariantSatisfied:true` still **VETOES** (deny wins). Only `saveInvariantSatisfied` is read; `origin`/`source` fields are inert.
- **`@sync`** — updated `cmp-tier2-veto` region + new inert `cmp-tier2-save-invariant` region in `cookie-noise.js`, byte-for-byte, enforced by `cookie-noise-sync.test.mjs`.

## Verification
- `npm test` 7801/7801 pass, typecheck clean, `lint:js` 0, `web-ext` 0.
- Fresh adversarial review (opus): **AIRTIGHT** — no path can turn a toggle ON, no bad input yields `satisfied:true`, no Save fires past the deny check, no origin field grants an exemption.

size:exception — mostly adversarial tests (764 ins / 13 del).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9