### PR TITLE
feat(consent): toggle-reject mechanism — sweep, backstop, dispatcher wiring (PR 2/3)

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -2156,6 +2156,17 @@
   // activates via a direct chrome.storage.local.remoteTier2Rules write,
   // e.g. tests/e2e/cookie-consent-toggle-reject.spec.mjs's synthetic
   // fixture rule).
+  // NEVER-ACCEPT TRIPWIRE (do NOT widen the remote schema without re-review):
+  // this filter is LIVE and will promote a remote rule's `toggleScope` into
+  // the reject-only Save/toggle/lockedOn click surface — BUT it is currently
+  // UNREACHABLE via a signed payload, because the background validator
+  // (src/lib/remote-tier2-rules.js) enforces an EXACT 4-key rule shape
+  // (TIER2_RULE_KEYS) that rejects any rule carrying a `toggleScope` (or any
+  // other unknown) key. That strict allowlist is the sole barrier between
+  // signed remote data and a remote Save-click path; it is guarded by the
+  // TIER2_RULE_KEYS tripwire test in tests/unit/remote-tier2-rules.test.mjs.
+  // Do NOT add `toggleScope` (or any key) to the remote schema without
+  // re-reviewing this remote Save-click surface end-to-end.
   function tier2FilterRemoteToggleScope(scope) {
     if (!scope || typeof scope !== "object") return null;
     if (typeof scope.container !== "string" || !tier2SelectorParses(scope.container)) return null;
@@ -2278,8 +2289,47 @@
   }
 
   /**
+   * PROVABLY-INERT gate (cookie-consent-toggle-reject, PR 2 hardening —
+   * partial-accept safety hole #2). A toggle counts as locked/necessary ONLY
+   * when the REAL DOM proves it inert, NEVER on a curated `lockedOn` selector
+   * match alone. A non-essential, defaulted-ON control that merely MATCHES the
+   * hint would otherwise be excluded from BOTH actuation AND the backstop
+   * count, letting computeSaveInvariant pass `satisfied:true` with a tracking
+   * category still ON — a PARTIAL ACCEPT. Inert markers:
+   *   - native input[type=checkbox]        -> `disabled === true`
+   *   - ARIA role=switch / role=checkbox   -> `aria-disabled="true"` OR a
+   *     matching `[disabled]`
+   * An unknown widget kind is NEVER treated as inert (fail-closed: it must be
+   * actuated off / counted by the backstop). This matches the design's real
+   * Osano `lockedOn` (`[disabled],[aria-disabled='true']`) — the genuine
+   * markers — so genuine necessary toggles still read locked, while a
+   * non-inert over-match is correctly treated as a live category. Mis-reading
+   * a genuinely-necessary-but-not-disabled toggle as non-locked is
+   * fail-closed-safe (we try to turn it off; if it will not flip, the
+   * invariant fails -> NOOP, never an accept). Never throws.
+   * @param {Element} el
+   * @returns {boolean}
+   */
+  function tier2ToggleProvablyInert(el) {
+    try {
+      const kind = tier2ToggleKind(el);
+      if (kind === "checkbox") {
+        return el.disabled === true;
+      }
+      if (kind === "aria") {
+        if (el.getAttribute("aria-disabled") === "true") return true;
+        return typeof el.matches === "function" && el.matches("[disabled]");
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Enumerates every toggle matching `toggleSel` inside `container`,
-   * classifying each as locked (matches `lockedOnSel`) or not and reading
+   * classifying each as locked (provably inert — see tier2ToggleProvablyInert)
+   * or not and reading
    * its current on/off state — see
    * src/lib/cmp-tier2-save-invariant.js's ToggleReadoutEntry typedef for the
    * shape this produces. A LOCKED entry is still INCLUDED in the readout
@@ -2291,10 +2341,12 @@
    * a totally failed container/toggle query returns `[]`. Never throws.
    * @param {Element} container
    * @param {string} toggleSel
-   * @param {string} lockedOnSel
+   * @param {string} lockedOnSel - retained curated hint (kept for signature
+   *   stability); the `locked` GATE is provably-inert DOM state, not this.
    * @returns {Array<{ref: Element, kind: string, checked: boolean, locked: boolean, readable: boolean}>}
    */
   function collectToggleStates(container, toggleSel, lockedOnSel) {
+    void lockedOnSel; // retained curated hint; the `locked` GATE is provably-inert DOM state (hole #2)
     const readout = [];
     if (!container || typeof container.querySelectorAll !== "function") return readout;
     let nodes = [];
@@ -2304,13 +2356,12 @@
       return readout;
     }
     for (const el of nodes) {
-      let locked = false;
-      try {
-        locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0
-          && typeof el.matches === "function" && el.matches(lockedOnSel);
-      } catch {
-        locked = false;
-      }
+      // `lockedOnSel` is a curated HINT only — the GATE is provably-inert DOM
+      // state (see tier2ToggleProvablyInert). A control that merely MATCHES
+      // the hint but is not actually disabled is treated as NON-locked, so it
+      // is actuated off and counted by the backstop (closes partial-accept
+      // hole #2). `lockedOnSel` is intentionally not consulted here.
+      const locked = tier2ToggleProvablyInert(el);
       const kind = tier2ToggleKind(el);
       const checked = tier2ReadToggleChecked(el, kind);
       readout.push({
@@ -2332,18 +2383,23 @@
     'input[type="checkbox"]:checked, [role="switch"][aria-checked="true"], [role="checkbox"][aria-checked="true"]';
 
   /**
-   * Counts every standard checked control inside `container` MINUS
-   * anything matching `lockedOnSel` — independent of the curated `toggle`
-   * selector (see TIER2_STANDARD_CHECKED_SELECTOR above). On any query
-   * failure, returns a non-zero, non-finite sentinel
-   * (Number.POSITIVE_INFINITY) so computeSaveInvariant's exact-zero check
-   * fails CLOSED rather than silently passing on a broken read. Never
+   * Counts every standard checked control inside `container` MINUS anything
+   * that is PROVABLY INERT (see tier2ToggleProvablyInert) — NOT anything that
+   * merely matches `lockedOnSel`. Excluding by a bare `lockedOn` match alone
+   * would let a non-essential, defaulted-ON control that over-matches the hint
+   * slip past the backstop (partial-accept hole #2); excluding only genuinely
+   * disabled/necessary controls keeps the backstop selector-independent per
+   * design ADR-3. On any query failure, returns a non-zero, non-finite
+   * sentinel (Number.POSITIVE_INFINITY) so computeSaveInvariant's exact-zero
+   * check fails CLOSED rather than silently passing on a broken read. Never
    * throws.
    * @param {Element} container
-   * @param {string} lockedOnSel
+   * @param {string} lockedOnSel - retained curated hint (kept for signature
+   *   stability); exclusion is gated on provably-inert DOM state, not this.
    * @returns {number}
    */
   function countCheckedControls(container, lockedOnSel) {
+    void lockedOnSel; // retained curated hint; exclusion is gated on provably-inert DOM state (hole #2)
     if (!container || typeof container.querySelectorAll !== "function") return Number.POSITIVE_INFINITY;
     let nodes = [];
     try {
@@ -2353,14 +2409,9 @@
     }
     let count = 0;
     for (const el of nodes) {
-      let locked = false;
-      try {
-        locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0
-          && typeof el.matches === "function" && el.matches(lockedOnSel);
-      } catch {
-        locked = false;
-      }
-      if (!locked) count += 1;
+      // Exclude ONLY provably-inert (disabled/aria-disabled) controls — a bare
+      // `lockedOnSel` match is NOT sufficient (closes partial-accept hole #2).
+      if (!tier2ToggleProvablyInert(el)) count += 1;
     }
     return count;
   }

--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1724,15 +1724,15 @@
   // @sync:cmp-tier2-veto:end
 
   // ── Tier 2 toggle-reject save invariant (cookie-consent-toggle-reject,
-  // PR 1 — safety core, INERT this PR) ──────────────────────────────────────
+  // PR 2 — wired into the toggle-sweep dispatcher branch below) ─────────────
   //
   // Hand-copied, byte-for-byte modulo indentation, from
   // src/lib/cmp-tier2-save-invariant.js. Kept in sync by
-  // tests/unit/cookie-noise-sync.test.mjs. NOT CALLED ANYWHERE in this PR —
-  // no dispatcher wiring, no rule uses a `toggleScope` field yet (PR 2).
-  // This block exists so the safety math is reviewable and adversarially
-  // unit-tested before any DOM actuation code exists to call it. See that
-  // file's docblock for the full contract.
+  // tests/unit/cookie-noise-sync.test.mjs. Called from tier2RunToggleSweep
+  // (further below): the safety math shipped inert in PR 1 so it could be
+  // reviewed and adversarially unit-tested before any DOM actuation code
+  // existed to call it — this PR adds that call site. See that file's
+  // docblock for the full contract.
   // @sync:cmp-tier2-save-invariant:start
 
   /**
@@ -1811,16 +1811,6 @@
     return plan;
   }
   // @sync:cmp-tier2-save-invariant:end
-
-  // Referenced here (outside the @sync-pinned block above, so this line is
-  // NOT part of the byte-identity comparison against src/lib/cmp-tier2-save-
-  // invariant.js) only to satisfy no-unused-vars while both functions are
-  // inert — this PR (PR 1) wires no dispatcher call site for either. Follows
-  // the same `void <expr>;` deliberate-no-op idiom AGENTS.md already uses
-  // for `void chrome.runtime.lastError;`. Removed once PR 2 adds the real
-  // dispatcher toggle-branch call sites.
-  void computeSaveInvariant;
-  void planToggleActuation;
 
   let _spRejectActed = false;
   let _spPmOpened = false;
@@ -1980,6 +1970,12 @@
 
   const _tier2Acted = {};
   const _tier2PmOpened = {};
+  // One-shot guard for the toggle-reject sweep (cookie-consent-toggle-reject,
+  // PR 2 / design.md ADR-2/ADR-5): a toggleScope rule's sweep runs AT MOST
+  // once per rule id, win or lose — never re-fights a page that re-flips a
+  // toggle, never re-clicks Save. Keyed by rule.id, same shape as
+  // _tier2Acted/_tier2PmOpened.
+  const _tier2ToggleSwept = {};
   const _tier2Warned = {};
   let _tier2GateOpen = false;
   let _tier2Observer = null;
@@ -2139,6 +2135,42 @@
   // runTier2RejectDispatcher below (an empty join(",") throws a syntax
   // error -> present=false -> the rule is skipped for that pass, exactly
   // like an absent anchor). Never throws.
+  //
+  // toggleScope (cookie-consent-toggle-reject, PR 2): passed through ONLY
+  // when every one of its selector fields is a non-empty, CSS-parseable
+  // string/array — same fail-closed filtering as present/reject/
+  // openSettings above, applied field-by-field. A malformed or partially
+  // missing toggleScope (any field absent, wrong type, or left with zero
+  // parseable selectors after filtering) drops the WHOLE field — the rule
+  // still merges as a plain reject/openSettings rule, it just never enters
+  // the toggle-sweep branch (design.md's "Open Questions" flags remote-
+  // origin toggleScope as unresolved for a signed/capped schema; this
+  // content-side filter is deliberately narrow scaffolding, safety-neutral
+  // because the actual click DECISION stays entirely bundled and
+  // non-remote — computeSaveInvariant/planToggleActuation (@sync block
+  // above) and computeClickVeto/VETO_WORDS (@sync:cmp-tier2-veto above) are
+  // never influenced by remote data, only WHERE to look is. The signed
+  // background fetch pipeline, src/lib/remote-tier2-rules.js, still
+  // enforces an EXACT 4-key rule shape with no toggleScope field at all, so
+  // this path is unreachable via a real signed payload today — it only
+  // activates via a direct chrome.storage.local.remoteTier2Rules write,
+  // e.g. tests/e2e/cookie-consent-toggle-reject.spec.mjs's synthetic
+  // fixture rule).
+  function tier2FilterRemoteToggleScope(scope) {
+    if (!scope || typeof scope !== "object") return null;
+    if (typeof scope.container !== "string" || !tier2SelectorParses(scope.container)) return null;
+    if (typeof scope.toggle !== "string" || !tier2SelectorParses(scope.toggle)) return null;
+    if (typeof scope.lockedOn !== "string" || !tier2SelectorParses(scope.lockedOn)) return null;
+    const save = tier2FilterSelectorArray(scope.save);
+    if (save.length === 0) return null;
+    return Object.freeze({
+      container: scope.container,
+      toggle: scope.toggle,
+      lockedOn: scope.lockedOn,
+      save: Object.freeze(save),
+    });
+  }
+
   function tier2FilterRemoteRule(rule) {
     if (!rule || typeof rule !== "object") return null;
     if (typeof rule.id !== "string" || BUNDLED_TIER2_IDS.has(rule.id)) return null;
@@ -2146,12 +2178,15 @@
     if (reject.length === 0) return null;
     const present = tier2FilterSelectorArray(rule.present);
     const openSettings = tier2FilterSelectorArray(rule.openSettings);
-    return Object.freeze({
+    const toggleScope = tier2FilterRemoteToggleScope(rule.toggleScope);
+    const filtered = {
       id: rule.id,
       present: Object.freeze(present),
       reject: Object.freeze(reject),
       openSettings: Object.freeze(openSettings),
-    });
+    };
+    if (toggleScope) filtered.toggleScope = toggleScope;
+    return Object.freeze(filtered);
   }
 
   function tier2RecomputeMergedRules(rawRemoteRules) {
@@ -2186,6 +2221,258 @@
       tier2RecomputeMergedRules([]);
       if (callback) callback();
     }
+  }
+
+  // ── Tier 2 toggle-reject sweep (cookie-consent-toggle-reject, PR 2) ───────
+  //
+  // Impure DOM-only helpers — deliberately NOT hand-copied into
+  // src/lib/* (design.md ADR-2/ADR-5): they read/write real DOM nodes, so
+  // they cannot be pure/Node-importable like computeSaveInvariant/
+  // planToggleActuation above. Pinned by STRUCTURAL guards in
+  // tests/unit/cookie-noise-sync.test.mjs, same pattern already used for
+  // collectAcceptCandidates/runTier2RejectDispatcher. Called only from
+  // tier2RunToggleSweep, further below — never from anywhere else.
+
+  /**
+   * Classifies a single toggle control's widget kind. "checkbox" for a
+   * native input[type=checkbox]; "aria" for anything exposing
+   * role=switch/role=checkbox via aria-checked; "unknown" otherwise — an
+   * "unknown" kind always reads back unreadable downstream (fail-closed),
+   * never guessed. Never throws.
+   */
+  function tier2ToggleKind(el) {
+    try {
+      const tag = typeof el.tagName === "string" ? el.tagName.toLowerCase() : "";
+      const type = typeof el.getAttribute === "function" ? el.getAttribute("type") : null;
+      if (tag === "input" && typeof type === "string" && type.toLowerCase() === "checkbox") return "checkbox";
+      const role = typeof el.getAttribute === "function" ? el.getAttribute("role") : null;
+      if (role === "switch" || role === "checkbox") return "aria";
+      return "unknown";
+    } catch {
+      return "unknown";
+    }
+  }
+
+  /**
+   * Reads a single toggle's current on/off state given its `kind`.
+   * Returns `true`/`false` on a confident read, `null` when unreadable
+   * (unknown kind, missing/invalid attribute, or any thrown error) — the
+   * caller degrades a `null` read to `readable: false`, never guesses a
+   * boolean. Never throws.
+   */
+  function tier2ReadToggleChecked(el, kind) {
+    try {
+      if (kind === "checkbox") {
+        return typeof el.checked === "boolean" ? el.checked : null;
+      }
+      if (kind === "aria") {
+        const v = el.getAttribute("aria-checked");
+        if (v === "true") return true;
+        if (v === "false") return false;
+        return null;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Enumerates every toggle matching `toggleSel` inside `container`,
+   * classifying each as locked (matches `lockedOnSel`) or not and reading
+   * its current on/off state — see
+   * src/lib/cmp-tier2-save-invariant.js's ToggleReadoutEntry typedef for the
+   * shape this produces. A LOCKED entry is still INCLUDED in the readout
+   * (never excluded here — only excluded from actuation/the off-check
+   * downstream, by computeSaveInvariant/planToggleActuation themselves), so
+   * the invariant can confirm at least one locked entry is present. Any
+   * single-entry DOM read failure degrades that entry to
+   * `readable: false, checked: false` (never dropped, never guessed);
+   * a totally failed container/toggle query returns `[]`. Never throws.
+   * @param {Element} container
+   * @param {string} toggleSel
+   * @param {string} lockedOnSel
+   * @returns {Array<{ref: Element, kind: string, checked: boolean, locked: boolean, readable: boolean}>}
+   */
+  function collectToggleStates(container, toggleSel, lockedOnSel) {
+    const readout = [];
+    if (!container || typeof container.querySelectorAll !== "function") return readout;
+    let nodes = [];
+    try {
+      nodes = Array.from(container.querySelectorAll(toggleSel));
+    } catch {
+      return readout;
+    }
+    for (const el of nodes) {
+      let locked = false;
+      try {
+        locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0
+          && typeof el.matches === "function" && el.matches(lockedOnSel);
+      } catch {
+        locked = false;
+      }
+      const kind = tier2ToggleKind(el);
+      const checked = tier2ReadToggleChecked(el, kind);
+      readout.push({
+        ref: el,
+        kind,
+        checked: checked === true,
+        locked,
+        readable: checked !== null,
+      });
+    }
+    return readout;
+  }
+
+  // CMP-selector-INDEPENDENT backstop scan (design.md ADR-3): every
+  // "standard" checked control shape, deliberately NOT keyed off any rule's
+  // own `toggle` selector — this is what catches a defaulted-ON category
+  // the curated selector missed.
+  const TIER2_STANDARD_CHECKED_SELECTOR =
+    'input[type="checkbox"]:checked, [role="switch"][aria-checked="true"], [role="checkbox"][aria-checked="true"]';
+
+  /**
+   * Counts every standard checked control inside `container` MINUS
+   * anything matching `lockedOnSel` — independent of the curated `toggle`
+   * selector (see TIER2_STANDARD_CHECKED_SELECTOR above). On any query
+   * failure, returns a non-zero, non-finite sentinel
+   * (Number.POSITIVE_INFINITY) so computeSaveInvariant's exact-zero check
+   * fails CLOSED rather than silently passing on a broken read. Never
+   * throws.
+   * @param {Element} container
+   * @param {string} lockedOnSel
+   * @returns {number}
+   */
+  function countCheckedControls(container, lockedOnSel) {
+    if (!container || typeof container.querySelectorAll !== "function") return Number.POSITIVE_INFINITY;
+    let nodes = [];
+    try {
+      nodes = Array.from(container.querySelectorAll(TIER2_STANDARD_CHECKED_SELECTOR));
+    } catch {
+      return Number.POSITIVE_INFINITY;
+    }
+    let count = 0;
+    for (const el of nodes) {
+      let locked = false;
+      try {
+        locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0
+          && typeof el.matches === "function" && el.matches(lockedOnSel);
+      } catch {
+        locked = false;
+      }
+      if (!locked) count += 1;
+    }
+    return count;
+  }
+
+  /**
+   * Reject-only actuation (design.md ADR-2): forces OFF every index
+   * planToggleActuation names (never a locked/unreadable/already-off entry
+   * — that planner's own contract), per the entry's widget kind, then
+   * RE-READS the result into the SAME readout array entry (mutated in
+   * place) — the invariant downstream re-verifies from this fresh read,
+   * never from the plan's own assumption. Native checkbox: set
+   * `.checked = false` (only ever reached when the plan says the entry
+   * currently reads true) and dispatch `input`+`change` so any page-side
+   * listener observes the change, mirroring how a real user interaction
+   * would fire. ARIA switch/checkbox: `.click()` ONCE — never re-clicked,
+   * never forced via a direct attribute write — then re-read; if it did
+   * NOT flip to false, that entry is simply left as its (still-on or
+   * unreadable) re-read state, which surfaces as a computeSaveInvariant
+   * failure downstream, never as a second click attempt. NEVER touches a
+   * locked entry (defense-in-depth: planToggleActuation already excludes
+   * them by construction). Never throws.
+   * @param {Array<object>} readout - collectToggleStates' output, mutated
+   *   in place for every actuated index.
+   */
+  function tier2ActuateToggleOff(readout) {
+    const plan = planToggleActuation(readout);
+    for (const idx of plan) {
+      const entry = readout[idx];
+      if (!entry || entry.locked === true) continue; // defense-in-depth only
+      try {
+        if (entry.kind === "checkbox") {
+          if (entry.ref.checked === true) {
+            entry.ref.checked = false;
+            try {
+              entry.ref.dispatchEvent(new Event("input", { bubbles: true }));
+            } catch {
+              // A throwing/hostile page listener must never break the page.
+            }
+            try {
+              entry.ref.dispatchEvent(new Event("change", { bubbles: true }));
+            } catch {
+              // A throwing/hostile page listener must never break the page.
+            }
+          }
+        } else if (entry.kind === "aria") {
+          if (typeof entry.ref.click === "function") entry.ref.click();
+        }
+      } catch {
+        // A throwing/hostile page element must never break the page.
+      }
+      const checked = tier2ReadToggleChecked(entry.ref, entry.kind);
+      entry.checked = checked === true;
+      entry.readable = checked !== null;
+    }
+  }
+
+  /**
+   * The reject-only multi-step toggle sweep (design.md ADR-5): scopes to
+   * `rule.toggleScope.container`, actuates every in-scope toggle
+   * reject-only, re-verifies via the SAME fail-closed computeSaveInvariant
+   * gate PR 1 shipped inert, and — ONLY when the invariant is satisfied AND
+   * exactly one confirmed Save target clears the `"save"` veto role —
+   * clicks Save. Every failure path is a silent NOOP that leaves the
+   * banner exactly as-is and warns at most once (tier2WarnDrift /
+   * tier2WarnVeto, both console-only). `_tier2Acted[rule.id]` is set in
+   * exactly ONE place in this whole file for the toggle path: at the very
+   * end of the allow branch here, strictly AFTER the veto has already
+   * passed — mirrors the existing reject-branch invariant in
+   * runTier2RejectDispatcher above. Never throws.
+   * @param {object} rule - a mergedRules entry carrying a toggleScope.
+   */
+  function tier2RunToggleSweep(rule) {
+    const scope = rule.toggleScope;
+    if (!scope || typeof scope !== "object") return;
+    let container = null;
+    try {
+      container = document.querySelector(scope.container);
+    } catch {
+      container = null;
+    }
+    if (!container) {
+      tier2WarnDrift(rule.id);
+      return;
+    }
+    const readout = collectToggleStates(container, scope.toggle, scope.lockedOn);
+    tier2ActuateToggleOff(readout);
+    const backstop = countCheckedControls(container, scope.lockedOn);
+    const invariant = computeSaveInvariant(readout, backstop);
+    if (!invariant.satisfied) {
+      // Fail-closed NOOP — leave the banner exactly as-is. Reuses
+      // tier2WarnVeto's console-only, warn-at-most-once-per-role shape
+      // (role "save") rather than adding a third warn helper.
+      tier2WarnVeto(rule.id, "save", invariant.reason);
+      return;
+    }
+    const saveCandidates = tier2FilterCandidates(collectAcceptCandidates(), scope.save);
+    if (saveCandidates.length !== 1) {
+      tier2WarnDrift(rule.id);
+      return;
+    }
+    const veto = computeClickVeto(saveCandidates[0].fullText, "save", VETO_WORDS, { saveInvariantSatisfied: true });
+    if (!veto.allow) {
+      tier2WarnVeto(rule.id, "save", veto.reason);
+      return;
+    }
+    _tier2Acted[rule.id] = true;
+    try {
+      saveCandidates[0].ref.click();
+    } catch {
+      // A throwing/hostile page element must never break the page.
+    }
+    confirmTier2RejectDismissal(rule.id, tier2BannerGoneBy(rule));
   }
 
   function runTier2RejectDispatcher() {
@@ -2229,7 +2516,21 @@
       // (opening a settings panel grants nothing), NOT marked acted — the
       // revealed reject control is re-resolved on the observer's next pass.
       // Dormant for both Slice-1 seed rules (openSettings: []).
-      if (_tier2PmOpened[rule.id]) continue;
+      if (_tier2PmOpened[rule.id]) {
+        // Toggle-reject multi-step sweep (cookie-consent-toggle-reject,
+        // PR 2 / design.md ADR-5): once the settings panel is confirmed
+        // open, a toggleScope-bearing rule runs the reject-only toggle
+        // sweep here INSTEAD of doing nothing. One-shot per rule
+        // (_tier2ToggleSwept) so the observer never re-runs the sweep on a
+        // later mutation pass. Dormant for every rule without a
+        // toggleScope (both bundled seed rules, and any remote rule whose
+        // toggleScope failed the content-side filter).
+        if (rule.toggleScope && !_tier2ToggleSwept[rule.id]) {
+          _tier2ToggleSwept[rule.id] = true;
+          tier2RunToggleSweep(rule);
+        }
+        continue;
+      }
       const openCandidates = tier2FilterCandidates(candidates, rule.openSettings);
       if (openCandidates.length !== 1) continue;
       // Same semantic click-veto, role "openSettings" — its OWN positive

--- a/src/lib/cmp-tier2-rules.js
+++ b/src/lib/cmp-tier2-rules.js
@@ -58,6 +58,41 @@
  * @property {ReadonlyArray<string>} openSettings - Optional single hop to
  *   open a settings panel before re-resolving `reject` in the revealed
  *   panel. `[]` when no two-step path is used.
+ * @property {ToggleScopeConfig} [toggleScope] - Optional multi-step
+ *   reject-and-save descriptor (cookie-consent-toggle-reject, PR 2 —
+ *   design.md ADR-1/ADR-5). When present AND the panel opened by
+ *   `openSettings` is confirmed open, the dispatcher enumerates every
+ *   toggle inside `container`, sweeps it reject-only, and — ONLY when the
+ *   post-sweep save invariant (src/lib/cmp-tier2-save-invariant.js) is
+ *   satisfied AND the single resolved `save` candidate clears the `"save"`
+ *   click-veto role (src/lib/cmp-tier2-veto.js) — clicks the confirmed Save
+ *   control. Absent on both seed rules (Complianz, Cookie Notice); no
+ *   bundled rule uses this field yet (introduced for the curated Osano
+ *   pilot in a later PR). Carries NO field capable of expressing the
+ *   broad-consent-granting path this project's structural guard forbids
+ *   naming (see the file docblock above) — same closed-vocabulary
+ *   guarantee as the rest of this shape; the structural guard in
+ *   tests/unit/cookie-noise-sync.test.mjs scans this field's values for the
+ *   same forbidden pattern.
+ *
+ * @typedef {object} ToggleScopeConfig
+ * @property {string} container - CSS selector scoping the settings-panel
+ *   root that toggle enumeration and the CMP-selector-independent backstop
+ *   scan (`countCheckedControls`) both operate within.
+ * @property {string} toggle - CSS selector enumerating EVERY category
+ *   toggle control inside `container` — native `input[type=checkbox]` or an
+ *   ARIA `role=switch`/`role=checkbox` control. Every match is included in
+ *   the readout (locked or not); only non-locked, readable entries are ever
+ *   planned for actuation (see `planToggleActuation`).
+ * @property {string} lockedOn - CSS selector identifying the
+ *   necessary/locked category control(s) inside `container`. A locked entry
+ *   is excluded from actuation and from the off-check, but at least one
+ *   locked entry must be present in the readout for the save invariant to
+ *   ever be satisfied.
+ * @property {ReadonlyArray<string>} save - Curated Save/confirm control
+ *   selector(s) inside `container`, OR-matched exactly like `reject`. Fail-
+ *   closed: 0 or more than 1 actionable match is a NOOP; exactly 1 is the
+ *   confirmed Save target, still gated by the `"save"` click-veto role.
  */
 
 // @sync:cmp-tier2-rules:start

--- a/src/lib/remote-tier2-rules.js
+++ b/src/lib/remote-tier2-rules.js
@@ -92,8 +92,14 @@ export const BUNDLED_TIER2_IDS = new Set(TIER2_RULES.map((r) => r.id));
 const TIER2_PAYLOAD_KEYS = new Set(["schemaVersion", "version", "published", "rules", "sig"]);
 
 /** Exact keys a single Tier2 rule must have — no more, no fewer. This is the
- * structural never-accept guarantee: no field can express an accept action. */
-const TIER2_RULE_KEYS = new Set(["id", "present", "reject", "openSettings"]);
+ * structural never-accept guarantee: no field can express an accept action,
+ * and — critically — no `toggleScope` field can reach the LIVE content-side
+ * `tier2FilterRemoteToggleScope` (src/content/cookie-noise.js), which would
+ * otherwise activate a remote Save/toggle/lockedOn click surface. Exported so
+ * the never-accept tripwire test (tests/unit/remote-tier2-rules.test.mjs)
+ * can pin the exact 4-key set: widening it must fail RED and force a
+ * deliberate re-review of the remote Save-click surface. */
+export const TIER2_RULE_KEYS = new Set(["id", "present", "reject", "openSettings"]);
 
 // ── Error codes ───────────────────────────────────────────────────────────────
 

--- a/tests/e2e/cookie-consent-toggle-reject.spec.mjs
+++ b/tests/e2e/cookie-consent-toggle-reject.spec.mjs
@@ -1,0 +1,313 @@
+/**
+ * E2E: Cookie Consent Toggle-Reject sweep (cookie-consent-toggle-reject,
+ * PR 2 — design.md ADR-2/ADR-3/ADR-5)
+ *
+ * Verifies the reject-only multi-step toggle sweep (open settings -> sweep
+ * every category toggle reject-only -> verify the fail-closed save
+ * invariant -> click Save only when safe) against a real Chromium with the
+ * extension loaded, using a SYNTHETIC fixture rule — NOT Osano, no live
+ * site (that curated pilot rule ships in PR 3). The fixture rule is
+ * injected directly into `chrome.storage.local.remoteTier2Rules`, exactly
+ * the same content-side extension point PR B2 (#1027 Slice 2) already
+ * ships for reject/openSettings selectors — see
+ * `tier2FilterRemoteToggleScope` in src/content/cookie-noise.js. This is
+ * deliberately NOT routed through the signed background fetch pipeline
+ * (src/lib/remote-tier2-rules.js), which still enforces an EXACT 4-key
+ * rule shape with no toggleScope field at all — a real signed payload
+ * cannot carry a toggleScope today; only a direct storage write (what this
+ * spec does, mirroring how other e2e specs seed chrome.storage.sync/local
+ * directly) can reach this code path.
+ *
+ * Every negative scenario proves the SAME thing from a different angle:
+ * the "save" click-veto role only ever fires after
+ * computeSaveInvariant is satisfied, and any failure to reach that state
+ * is a silent NOOP that leaves the banner exactly as-is — Save is never
+ * clicked, and a decoy Accept-All control (present on every fixture
+ * variant) is NEVER clicked either.
+ *
+ * HONEST LIMIT (same posture as the sibling Tier 2 e2e specs): a
+ * synthetic-fixture regression oracle only, Chromium-only. It does not
+ * prove compatibility with any real CMP's markup — that is exactly what
+ * PR 3's curated, probe-gated Osano rule is for.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-toggle-reject.invalid";
+
+const TOGGLE_RULE = Object.freeze({
+  id: "e2e-toggle-fixture",
+  present: ["#e2e-toggle-cmp"],
+  reject: [".e2e-toggle-noop-reject"], // never present on this fixture — always noop, harmless
+  openSettings: ["#e2e-open-settings"],
+  toggleScope: {
+    container: "#e2e-panel",
+    toggle: "[role='switch']",
+    lockedOn: "[aria-disabled='true']",
+    save: ["#e2e-save"],
+  },
+});
+
+async function completeOnboardingAndSeedRule(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature, rule }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode: enableFeature ? "reject-only" : "off" },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+                // Synthetic fixture rule, injected the SAME way the real
+                // background pipeline would eventually cache a signed
+                // Tier2 payload's rules — see this file's docblock.
+                remoteTier2Rules: [rule],
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature, rule: TOGGLE_RULE }
+  );
+  await page.close();
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture: a banner exposing only a "Manage preferences" settings-opener.
+ * Clicking it reveals (asynchronously, mirroring the real Sourcepoint
+ * multi-layer fixture's timing) a panel with a locked/necessary switch, one
+ * or more category switches whose click behavior is scenario-controlled,
+ * a decoy "Accept All" control (must NEVER be clicked), and a "Save
+ * preferences" control.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {{
+ *   toggleStartsOn?: boolean,
+ *   toggleFlipsOnClick?: boolean,
+ *   extraUncuratedCheckedBox?: boolean,
+ * }} opts
+ */
+async function stubToggleFixturePage(page, {
+  toggleStartsOn = true,
+  toggleFlipsOnClick = true,
+  extraUncuratedCheckedBox = false,
+} = {}) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div id="e2e-toggle-cmp">
+          <button id="e2e-open-settings">Manage preferences</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__e2eClicks = [];
+          var cmp = document.getElementById("e2e-toggle-cmp");
+          var openBtn = document.getElementById("e2e-open-settings");
+          openBtn.addEventListener("click", function () {
+            window.__e2eClicks.push("open-settings");
+            if (document.getElementById("e2e-panel")) return;
+            // Asynchronous panel render — same deliberate timing as the
+            // Sourcepoint multi-layer fixture: the extension's
+            // MutationObserver must react to a later mutation task, not a
+            // mutation fired synchronously inside its own click call.
+            setTimeout(function () {
+              var panel = document.createElement("div");
+              panel.id = "e2e-panel";
+
+              var locked = document.createElement("div");
+              locked.setAttribute("role", "switch");
+              locked.setAttribute("aria-checked", "true");
+              locked.setAttribute("aria-disabled", "true");
+              locked.textContent = "Strictly necessary";
+              panel.appendChild(locked);
+
+              var category = document.createElement("div");
+              category.setAttribute("role", "switch");
+              category.setAttribute("aria-checked", ${toggleStartsOn ? "\"true\"" : "\"false\""});
+              category.textContent = "Analytics";
+              category.addEventListener("click", function () {
+                window.__e2eClicks.push("category-click");
+                ${toggleFlipsOnClick ? 'category.setAttribute("aria-checked", "false");' : "/* stuck — deliberately does NOT flip */"}
+              });
+              panel.appendChild(category);
+
+              ${
+                extraUncuratedCheckedBox
+                  ? `var rogue = document.createElement("input");
+                     rogue.type = "checkbox";
+                     rogue.checked = true;
+                     rogue.id = "e2e-rogue-checkbox";
+                     // Deliberately NO role="switch" — the curated toggle
+                     // selector ([role='switch']) never enumerates this,
+                     // only the CMP-selector-independent backstop can.
+                     panel.appendChild(rogue);`
+                  : ""
+              }
+
+              var accept = document.createElement("button");
+              accept.id = "e2e-accept";
+              accept.textContent = "Accept All";
+              accept.addEventListener("click", function () { window.__e2eClicks.push("accept"); });
+              panel.appendChild(accept);
+
+              var save = document.createElement("button");
+              save.id = "e2e-save";
+              save.textContent = "Save preferences";
+              save.addEventListener("click", function () {
+                window.__e2eClicks.push("save");
+                window.__e2eConsentState = "necessary-only";
+                cmp.remove();
+              });
+              panel.appendChild(save);
+
+              cmp.appendChild(panel);
+            }, 50);
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Toggle-Reject sweep (cookie-consent-toggle-reject, PR 2)", () => {
+  test("(a) all non-locked toggles read OFF after the sweep -> the save invariant is satisfied -> Save is clicked, banner dismissed", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboardingAndSeedRule(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubToggleFixturePage(page, { toggleStartsOn: true, toggleFlipsOnClick: true });
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__e2eConsentState === "necessary-only", { timeout: 10000 });
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    // Exact sequence: open settings -> sweep clicks the category toggle
+    // once -> Save. The decoy Accept control is NEVER clicked.
+    expect(clicks).toEqual(["open-settings", "category-click", "save"]);
+    expect(clicks).not.toContain("accept");
+
+    const bannerGone = await page.evaluate(() => document.getElementById("e2e-toggle-cmp") === null);
+    expect(bannerGone).toBe(true);
+
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("(b) a defaulted-ON standard toggle the curated selector never enumerated -> the CMP-selector-independent backstop catches it -> Save is VETOED (NOOP), banner stays", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboardingAndSeedRule(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubToggleFixturePage(page, {
+      toggleStartsOn: true,
+      toggleFlipsOnClick: true,
+      extraUncuratedCheckedBox: true,
+    });
+    await page.goto(`https://${HOST}/index.html`);
+
+    // The sweep still runs (the curated toggle gets clicked off) — wait for
+    // that positive signal, then give the extension ample time to
+    // (wrongly, if it regressed) click Save anyway.
+    await page.waitForFunction(() => window.__e2eClicks.includes("category-click"), { timeout: 10000 });
+    // REASON: adversarial negative (mirrors the Sourcepoint multi-layer
+    // spec) — settle, then assert a regressed Save click never fired.
+    await page.waitForTimeout(1500);
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    expect(clicks).not.toContain("save");
+    expect(clicks).not.toContain("accept");
+
+    const consentState = await page.evaluate(() => window.__e2eConsentState);
+    expect(consentState).toBeUndefined();
+    const bannerStillThere = await page.evaluate(() => document.getElementById("e2e-toggle-cmp") !== null);
+    expect(bannerStillThere).toBe(true);
+    // The rogue, uncurated checkbox is untouched — this dispatcher only
+    // ever writes to entries it actually enumerated.
+    const rogueStillChecked = await page.evaluate(() => document.getElementById("e2e-rogue-checkbox")?.checked);
+    expect(rogueStillChecked).toBe(true);
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("(c) a toggle that reads back ON after .click() (stuck) -> the save invariant is unsatisfied -> Save is VETOED (NOOP), no second click attempt", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboardingAndSeedRule(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubToggleFixturePage(page, { toggleStartsOn: true, toggleFlipsOnClick: false });
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__e2eClicks.includes("category-click"), { timeout: 10000 });
+    // REASON: adversarial negative — same settle-then-assert-nothing-more
+    // pattern as scenario (b) above; a correct run never resolves a save
+    // candidate once the invariant is unsatisfied.
+    await page.waitForTimeout(1500);
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    // The toggle was clicked exactly once — never retried, never forced.
+    expect(clicks.filter((c) => c === "category-click")).toHaveLength(1);
+    expect(clicks).not.toContain("save");
+    expect(clicks).not.toContain("accept");
+
+    const consentState = await page.evaluate(() => window.__e2eConsentState);
+    expect(consentState).toBeUndefined();
+    const bannerStillThere = await page.evaluate(() => document.getElementById("e2e-toggle-cmp") !== null);
+    expect(bannerStillThere).toBe(true);
+    const stillOn = await page.evaluate(() => document.querySelector("#e2e-panel [role='switch']:not([aria-disabled])")?.getAttribute("aria-checked"));
+    expect(stillOn).toBe("true");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF) — never opens the settings panel", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboardingAndSeedRule(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubToggleFixturePage(page, { toggleStartsOn: true, toggleFlipsOnClick: true });
+    await page.goto(`https://${HOST}/index.html`);
+
+    // REASON: negative assertion (feature OFF) — no positive signal to wait
+    // on; fixed settle window, the standard pattern for this suite's
+    // negatives (see cookie-consent-minimizer-sourcepoint-multilayer.spec.mjs).
+    await page.waitForTimeout(1500);
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    expect(clicks).toEqual([]);
+    const bannerStillThere = await page.evaluate(() => document.getElementById("e2e-toggle-cmp") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -717,6 +717,31 @@ describe("cookie-noise.js — Tier 2 toggle-reject sweep structural guards (PR 2
     assert.ok(/Number\.POSITIVE_INFINITY/.test(body), "must return Number.POSITIVE_INFINITY on failure — never 0");
   });
 
+  test("tier2ToggleProvablyInert defines the real inert markers (disabled / aria-disabled / [disabled]) — partial-accept hole #2 gate", () => {
+    const fnMatch = /function tier2ToggleProvablyInert\(el\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define tier2ToggleProvablyInert(el)");
+    const body = fnMatch[1];
+    assert.ok(/el\.disabled === true/.test(body), "native checkbox inert marker is `el.disabled === true`");
+    assert.ok(/getAttribute\("aria-disabled"\) === "true"/.test(body), "ARIA inert marker is aria-disabled=\"true\"");
+    assert.ok(/el\.matches\("\[disabled\]"\)/.test(body), "ARIA inert marker also accepts a matching [disabled]");
+  });
+
+  test("collectToggleStates gates `locked` on provably-inert DOM state, NEVER on a bare lockedOnSel match (partial-accept hole #2)", () => {
+    const fnMatch = /function collectToggleStates\(container, toggleSel, lockedOnSel\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    const body = fnMatch[1];
+    assert.ok(/const locked = tier2ToggleProvablyInert\(el\)/.test(body), "locked must be tier2ToggleProvablyInert(el)");
+    assert.doesNotMatch(body, /el\.matches\(lockedOnSel\)/, "a bare lockedOnSel match must NEVER decide `locked` (over-match hole)");
+  });
+
+  test("countCheckedControls excludes ONLY provably-inert controls, NEVER a bare lockedOnSel match (partial-accept hole #2)", () => {
+    const fnMatch = /function countCheckedControls\(container, lockedOnSel\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    const body = fnMatch[1];
+    assert.ok(/!tier2ToggleProvablyInert\(el\)/.test(body), "backstop exclusion must be gated on tier2ToggleProvablyInert");
+    assert.doesNotMatch(body, /el\.matches\(lockedOnSel\)/, "a bare lockedOnSel match must NEVER exclude a control from the backstop");
+  });
+
   test("neither the toggle-sweep field names (container/toggle/lockedOn/save) nor tier2RunToggleSweep's source contain an accept/allowall identifier", () => {
     const FORBIDDEN = /allowall|accept/i;
     const fnMatch = /function tier2RunToggleSweep\(rule\)\s*\{([\s\S]*?)\n  \}/.exec(src);

--- a/tests/unit/cookie-noise-sync.test.mjs
+++ b/tests/unit/cookie-noise-sync.test.mjs
@@ -554,37 +554,183 @@ describe("cookie-noise-sync — @sync:cmp-tier2-save-invariant block matches src
     assert.doesNotMatch(joined, /aria-checked['"]\s*,\s*['"]true/, "the block must never set aria-checked to true anywhere");
   });
 
-  test("this PR wires ZERO dispatcher call sites for computeSaveInvariant/planToggleActuation — behavior-inert (PR 1)", () => {
+  test("computeSaveInvariant and planToggleActuation are wired for real — no more void no-op references (PR 2)", () => {
     const src = sources.isolated;
     for (const fnName of ["computeSaveInvariant", "planToggleActuation"]) {
-      // A deliberate `void NAME;` no-op reference (satisfying no-unused-vars
-      // while the block is inert) must exist, and it must be the ONLY
-      // reference outside the declaration/docblocks — i.e. no real call
-      // `NAME(` anywhere except the function's own declaration line.
-      assert.ok(src.includes(`void ${fnName};`), `${fnName} must have a deliberate void no-op reference, not a real call site`);
+      assert.equal(src.includes(`void ${fnName};`), false,
+        `${fnName} must no longer have a deliberate void no-op reference — PR 2 adds a real call site`);
     }
-    // Neither function is referenced at all inside the two known dispatcher
-    // bodies (runTier2RejectDispatcher today; the PR-2 toggle branch that
-    // would call them does not exist yet).
-    const dispatcherMatch = /function runTier2RejectDispatcher\(\)\s*\{([\s\S]*?)\n  \}/.exec(src);
-    assert.ok(dispatcherMatch, "cookie-noise.js must define runTier2RejectDispatcher()");
-    assert.doesNotMatch(dispatcherMatch[1], /computeSaveInvariant\(|planToggleActuation\(/,
-      "runTier2RejectDispatcher must not call computeSaveInvariant/planToggleActuation yet — that wiring is PR 2, out of scope for PR 1");
+    assert.ok(/computeSaveInvariant\(readout, backstop\)/.test(src),
+      "tier2RunToggleSweep must call computeSaveInvariant(readout, backstop)");
+    assert.ok(/planToggleActuation\(readout\)/.test(src),
+      "tier2ActuateToggleOff must call planToggleActuation(readout)");
   });
 
-  test("no rule instance (bundled TIER2_RULES) uses a toggleScope field yet — PR 1 adds zero CMP wiring", () => {
+  test("no BUNDLED rule instance (TIER2_RULES) uses a toggleScope field — the mechanism (PR 2) ships with zero curated CMP rules; a curated rule is PR 3's Osano pilot", () => {
     // Scoped to the actual rule-data sync block, not prose — this file's own
-    // comments legitimately MENTION "toggleScope" to explain what PR 2 will
-    // add (see the block comment above the @sync:cmp-tier2-save-invariant
-    // region). What must not exist yet is the field itself inside the rule
-    // data (both the bundled TIER2_RULES array and its content-script copy).
+    // comments legitimately MENTION "toggleScope" to explain the mechanism
+    // (see the block comment above the @sync:cmp-tier2-save-invariant
+    // region and the toggle-sweep helpers below it). What must not exist is
+    // the field itself inside the BUNDLED rule data (both TIER2_RULES and
+    // its content-script copy) — task 2.1: "Add NO rule instance that uses
+    // it yet."
     const rulesLibSrc = readFileSync(join(__dirname, "../../src/lib/cmp-tier2-rules.js"), "utf8");
     const rulesLibBlock = extractMarkedBlock(rulesLibSrc, TIER2_RULES_START, TIER2_RULES_END, "cmp-tier2-rules.js");
     const rulesIsolatedBlock = extractMarkedBlock(sources.isolated, TIER2_RULES_START, TIER2_RULES_END, "cookie-noise.js");
     assert.equal(/toggleScope/.test(rulesLibBlock.join("\n")), false,
-      "src/lib/cmp-tier2-rules.js's TIER2_RULES data must not reference toggleScope at all in PR 1 — that field is introduced in PR 2");
+      "src/lib/cmp-tier2-rules.js's TIER2_RULES data must not reference toggleScope at all in PR 2 — no bundled rule uses it yet");
     assert.equal(/toggleScope/.test(rulesIsolatedBlock.join("\n")), false,
-      "cookie-noise.js's @sync:cmp-tier2-rules copy must not reference toggleScope at all in PR 1");
+      "cookie-noise.js's @sync:cmp-tier2-rules copy must not reference toggleScope at all in PR 2");
+  });
+});
+
+// ── Tier 2 toggle-reject sweep wiring (cookie-consent-toggle-reject, PR 2 /
+// design.md ADR-2/ADR-5) — structural guards ────────────────────────────────
+//
+// Mirrors the existing reject/openSettings structural guards above:
+// computeSaveInvariant/planToggleActuation/computeClickVeto("save", ...)
+// are called before ANY write toward Save; _tier2Acted is set in exactly
+// one place inside tier2RunToggleSweep, strictly AFTER the veto passes;
+// there is no code path anywhere in this file that writes a toggle TOWARD
+// on (monotone-toward-denial); and the one-shot guard is wired into the
+// dispatcher's toggle branch.
+
+describe("cookie-noise.js — Tier 2 toggle-reject sweep structural guards (PR 2)", () => {
+  const src = sources.isolated;
+
+  function toggleSweepBody() {
+    const fnMatch = /function tier2RunToggleSweep\(rule\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define tier2RunToggleSweep(rule)");
+    return fnMatch[1];
+  }
+
+  test("tier2RunToggleSweep resolves computeSaveInvariant BEFORE ever resolving/clicking a save candidate", () => {
+    const body = toggleSweepBody();
+    const invariantIdx = body.indexOf("computeSaveInvariant(readout, backstop)");
+    const clickIdx = body.indexOf("saveCandidates[0].ref.click(");
+    assert.ok(invariantIdx !== -1, "must call computeSaveInvariant(readout, backstop)");
+    assert.ok(clickIdx !== -1, "must call saveCandidates[0].ref.click()");
+    assert.ok(invariantIdx < clickIdx, "the save invariant must be evaluated before the Save click");
+  });
+
+  test('tier2RunToggleSweep calls computeClickVeto with role "save" and { saveInvariantSatisfied: true } BEFORE the Save click', () => {
+    const body = toggleSweepBody();
+    const vetoIdx = body.indexOf('computeClickVeto(saveCandidates[0].fullText, "save", VETO_WORDS, { saveInvariantSatisfied: true })');
+    const clickIdx = body.indexOf("saveCandidates[0].ref.click(");
+    assert.ok(vetoIdx !== -1, 'must call computeClickVeto(..., "save", VETO_WORDS, { saveInvariantSatisfied: true })');
+    assert.ok(clickIdx !== -1);
+    assert.ok(vetoIdx < clickIdx, "the save veto must be evaluated before the Save click");
+  });
+
+  test("on an unsatisfied invariant, tier2RunToggleSweep returns without resolving a save candidate or setting _tier2Acted (NOOP, banner untouched)", () => {
+    const body = toggleSweepBody();
+    const invariantCheckIdx = body.indexOf("if (!invariant.satisfied) {");
+    const actedIdx = body.indexOf("_tier2Acted[rule.id] = true;");
+    assert.ok(invariantCheckIdx !== -1, "must branch on !invariant.satisfied");
+    assert.ok(actedIdx !== -1, "must set _tier2Acted[rule.id] = true somewhere in the allow path");
+    assert.ok(invariantCheckIdx < actedIdx, "the invariant check must come before _tier2Acted is ever set");
+    // The unsatisfied branch itself must return, not fall through.
+    const unsatisfiedBlock = /if \(!invariant\.satisfied\) \{([\s\S]*?)\n {4}\}/.exec(body);
+    assert.ok(unsatisfiedBlock, "must find the !invariant.satisfied block");
+    assert.ok(/return;/.test(unsatisfiedBlock[1]), "the unsatisfied branch must return (NOOP), never fall through toward a click");
+  });
+
+  test("on a save veto, tier2RunToggleSweep returns without setting _tier2Acted", () => {
+    const body = toggleSweepBody();
+    const vetoCheckIdx = body.indexOf("if (!veto.allow) {");
+    const actedIdx = body.indexOf("_tier2Acted[rule.id] = true;");
+    assert.ok(vetoCheckIdx !== -1 && actedIdx !== -1);
+    assert.ok(vetoCheckIdx < actedIdx, "the veto check must come before _tier2Acted is ever set");
+    const vetoBlock = /if \(!veto\.allow\) \{([\s\S]*?)\n {4}\}/.exec(body);
+    assert.ok(vetoBlock, "must find the !veto.allow block");
+    assert.ok(/return;/.test(vetoBlock[1]), "a save veto must return (NOOP), never fall through toward a click");
+  });
+
+  test("_tier2Acted is set in exactly ONE place inside tier2RunToggleSweep, strictly AFTER both the invariant and veto checks", () => {
+    const body = toggleSweepBody();
+    assert.equal(body.split("_tier2Acted[rule.id] = true;").length - 1, 1,
+      "tier2RunToggleSweep must set _tier2Acted in exactly one place");
+    const invariantIdx = body.indexOf("if (!invariant.satisfied) {");
+    const vetoIdx = body.indexOf("if (!veto.allow) {");
+    const actedIdx = body.indexOf("_tier2Acted[rule.id] = true;");
+    assert.ok(invariantIdx < actedIdx && vetoIdx < actedIdx,
+      "_tier2Acted must be set after both the invariant and veto gates");
+  });
+
+  test("the dispatcher's toggle branch is one-shot per rule (_tier2ToggleSwept) and only runs for a toggleScope-bearing rule, inside the panel-open branch", () => {
+    const fnMatch = /function runTier2RejectDispatcher\(\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define runTier2RejectDispatcher()");
+    const body = fnMatch[1];
+    const pmOpenedIdx = body.indexOf("if (_tier2PmOpened[rule.id]) {");
+    const toggleGuardIdx = body.indexOf("if (rule.toggleScope && !_tier2ToggleSwept[rule.id]) {");
+    const sweepCallIdx = body.indexOf("tier2RunToggleSweep(rule);");
+    assert.ok(pmOpenedIdx !== -1, "the toggle branch must live inside the panel-open ( _tier2PmOpened[rule.id] ) branch");
+    assert.ok(toggleGuardIdx !== -1 && sweepCallIdx !== -1);
+    assert.ok(pmOpenedIdx < toggleGuardIdx && toggleGuardIdx < sweepCallIdx,
+      "the toggleScope + one-shot guard must be checked, in order, before tier2RunToggleSweep is ever called");
+    assert.ok(/_tier2ToggleSwept\[rule\.id\]\s*=\s*true;/.test(body),
+      "the dispatcher must mark _tier2ToggleSwept[rule.id] = true before calling tier2RunToggleSweep — one-shot");
+  });
+
+  test("NO code path in this file ever writes checked = true or aria-checked to \"true\" — monotone-toward-denial by construction (never turn a toggle ON)", () => {
+    assert.doesNotMatch(src, /\.checked\s*=\s*true/, "must never write .checked = true anywhere in cookie-noise.js");
+    assert.doesNotMatch(src, /setAttribute\(\s*["']aria-checked["']\s*,\s*["']true["']\s*\)/,
+      "must never setAttribute('aria-checked', 'true') anywhere in cookie-noise.js");
+  });
+
+  test("tier2ActuateToggleOff only ever writes .checked = false, never true, and only inside the checkbox branch", () => {
+    const fnMatch = /function tier2ActuateToggleOff\(readout\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define tier2ActuateToggleOff(readout)");
+    const body = fnMatch[1];
+    assert.ok(/entry\.ref\.checked\s*=\s*false;/.test(body), "must write entry.ref.checked = false");
+    assert.doesNotMatch(body, /entry\.ref\.checked\s*=\s*true/, "must never write entry.ref.checked = true");
+  });
+
+  test("tier2ActuateToggleOff's ARIA branch clicks at most once and never re-clicks on a failed flip (no retry loop)", () => {
+    const fnMatch = /function tier2ActuateToggleOff\(readout\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    const body = fnMatch[1];
+    const clickCalls = body.split("entry.ref.click()").length - 1;
+    assert.equal(clickCalls, 1, "tier2ActuateToggleOff must call .click() in exactly one place — never a retry/second attempt");
+  });
+
+  test("collectToggleStates includes locked entries in the readout (never excludes them) — only actuation/off-check exclude locked entries", () => {
+    const fnMatch = /function collectToggleStates\(container, toggleSel, lockedOnSel\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define collectToggleStates(container, toggleSel, lockedOnSel)");
+    const body = fnMatch[1];
+    assert.doesNotMatch(body, /if\s*\(\s*locked\s*\)\s*continue;/, "collectToggleStates must not skip/exclude locked entries from the readout");
+    assert.ok(/readout\.push\(/.test(body), "every enumerated toggle (locked or not) must be pushed onto the readout");
+  });
+
+  test("countCheckedControls is CMP-selector-independent — its query does not reference the rule's own `toggle` field, only the fixed TIER2_STANDARD_CHECKED_SELECTOR", () => {
+    const fnMatch = /function countCheckedControls\(container, lockedOnSel\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch, "cookie-noise.js must define countCheckedControls(container, lockedOnSel)");
+    const body = fnMatch[1];
+    assert.ok(/TIER2_STANDARD_CHECKED_SELECTOR/.test(body), "must query TIER2_STANDARD_CHECKED_SELECTOR");
+    assert.doesNotMatch(body, /scope\.toggle|rule\.toggleScope\.toggle/, "must never reference a rule's own curated toggle selector — the backstop is selector-independent");
+  });
+
+  test("countCheckedControls fails CLOSED (non-zero, non-finite sentinel) on any query error, never a silent 0", () => {
+    const fnMatch = /function countCheckedControls\(container, lockedOnSel\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    const body = fnMatch[1];
+    assert.ok(/Number\.POSITIVE_INFINITY/.test(body), "must return Number.POSITIVE_INFINITY on failure — never 0");
+  });
+
+  test("neither the toggle-sweep field names (container/toggle/lockedOn/save) nor tier2RunToggleSweep's source contain an accept/allowall identifier", () => {
+    const FORBIDDEN = /allowall|accept/i;
+    const fnMatch = /function tier2RunToggleSweep\(rule\)\s*\{([\s\S]*?)\n  \}/.exec(src);
+    assert.ok(fnMatch);
+    // collectAcceptCandidates() is a DELIBERATE, retained exception (see
+    // this file's own docblock, "the accept-click mechanism has no
+    // MAIN-world copy" section) — a neutral DOM candidate scanner reused
+    // unmodified from the retired accept-click feature; runTier2RejectDispatcher
+    // already calls it too. Strip that one known-legitimate call before
+    // scanning for a REAL accept-family identifier.
+    const stripped = fnMatch[1].replace(/collectAcceptCandidates/g, "");
+    assert.doesNotMatch(stripped, FORBIDDEN, "tier2RunToggleSweep must contain no accept/allowall identifier");
+    const rulesLibSrc = readFileSync(join(__dirname, "../../src/lib/cmp-tier2-rules.js"), "utf8");
+    assert.doesNotMatch(rulesLibSrc, FORBIDDEN, "cmp-tier2-rules.js (including the new toggleScope typedef) must contain no accept/allowall identifier");
   });
 });
 
@@ -781,10 +927,25 @@ describe("cookie-noise.js — Tier 2 semantic click-veto wiring", () => {
 // below (#824 — one new source-string assertion, mirroring the existing
 // precedent in this file and in service-worker-patterns.test.mjs).
 
+// toggleScope pass-through mirrors production's tier2FilterRemoteToggleScope
+// (cookie-consent-toggle-reject, PR 2): every field must be present and
+// CSS-parseable (via the SAME injected `canParse` predicate), `save` must
+// keep at least one parseable selector after filtering, and a malformed/
+// missing toggleScope drops ONLY that field — the rule still merges as a
+// plain reject/openSettings rule.
 function makeTier2RemoteMergeHelper(bundledIds, canParse) {
   function filterSelectorArray(arr) {
     if (!Array.isArray(arr)) return [];
     return arr.filter((sel) => typeof sel === "string" && sel.length > 0 && canParse(sel));
+  }
+  function filterToggleScope(scope) {
+    if (!scope || typeof scope !== "object") return null;
+    if (typeof scope.container !== "string" || !canParse(scope.container)) return null;
+    if (typeof scope.toggle !== "string" || !canParse(scope.toggle)) return null;
+    if (typeof scope.lockedOn !== "string" || !canParse(scope.lockedOn)) return null;
+    const save = filterSelectorArray(scope.save);
+    if (save.length === 0) return null;
+    return { container: scope.container, toggle: scope.toggle, lockedOn: scope.lockedOn, save };
   }
   function filterRemoteRule(rule) {
     if (!rule || typeof rule !== "object") return null;
@@ -793,7 +954,10 @@ function makeTier2RemoteMergeHelper(bundledIds, canParse) {
     if (reject.length === 0) return null;
     const present = filterSelectorArray(rule.present);
     const openSettings = filterSelectorArray(rule.openSettings);
-    return { id: rule.id, present, reject, openSettings };
+    const toggleScope = filterToggleScope(rule.toggleScope);
+    const filtered = { id: rule.id, present, reject, openSettings };
+    if (toggleScope) filtered.toggleScope = toggleScope;
+    return filtered;
   }
   return function recomputeMergedRules(bundledRules, rawRemoteRules) {
     const list = Array.isArray(rawRemoteRules) ? rawRemoteRules : [];
@@ -864,7 +1028,7 @@ describe("Tier 2 content-side remote-rule merge — pure re-implementation (mirr
     assert.deepEqual(rule.openSettings, []);
   });
 
-  test("a merged rule object carries no origin/source field distinguishing it from a bundled rule", () => {
+  test("a merged rule object carries no origin/source field distinguishing it from a bundled rule (toggleScope-less case)", () => {
     const canParse = () => true;
     const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
     const merged = recompute(BUNDLED, [
@@ -874,9 +1038,98 @@ describe("Tier 2 content-side remote-rule merge — pure re-implementation (mirr
       assert.deepEqual(
         Object.keys(rule).sort(),
         ["id", "openSettings", "present", "reject"],
-        "a merged rule (bundled or remote-origin) must expose exactly id/present/reject/openSettings — no origin/source field a dispatcher could branch on",
+        "a merged rule (bundled or remote-origin) without toggleScope must expose exactly id/present/reject/openSettings — no origin/source field a dispatcher could branch on",
       );
     }
+  });
+
+  // ── toggleScope pass-through (cookie-consent-toggle-reject, PR 2) ────────
+
+  test("a remote rule with a non-empty reject AND a fully parseable toggleScope carries both through", () => {
+    const canParse = () => true;
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      {
+        id: "acme-cmp",
+        present: ["#acme"],
+        reject: [".acme-reject"],
+        openSettings: ["#acme-open"],
+        toggleScope: { container: "#acme-panel", toggle: "[role='switch']", lockedOn: "[disabled]", save: ["#acme-save"] },
+      },
+    ]);
+    const rule = merged.find((r) => r.id === "acme-cmp");
+    assert.ok(rule, "the rule must merge");
+    assert.deepEqual(
+      Object.keys(rule).sort(),
+      ["id", "openSettings", "present", "reject", "toggleScope"],
+      "a merged rule WITH a valid toggleScope must expose exactly these 5 keys — still no origin/source field",
+    );
+    assert.deepEqual(rule.toggleScope, {
+      container: "#acme-panel",
+      toggle: "[role='switch']",
+      lockedOn: "[disabled]",
+      save: ["#acme-save"],
+    });
+  });
+
+  test("a toggleScope missing any required field is dropped entirely — the rule still merges without it (fail-closed, not a rejected rule)", () => {
+    const canParse = () => true;
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      {
+        id: "acme-cmp",
+        present: ["#acme"],
+        reject: [".acme-reject"],
+        openSettings: [],
+        toggleScope: { container: "#acme-panel", toggle: "[role='switch']", save: ["#acme-save"] }, // missing lockedOn
+      },
+    ]);
+    const rule = merged.find((r) => r.id === "acme-cmp");
+    assert.ok(rule, "the rule must still merge as a plain reject rule");
+    assert.equal("toggleScope" in rule, false, "a malformed toggleScope must be dropped, not merged partially");
+  });
+
+  test("a toggleScope whose selectors are all unparseable is dropped entirely (fail-closed)", () => {
+    const canParse = (sel) => sel !== ":::not-css";
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      {
+        id: "acme-cmp",
+        present: ["#acme"],
+        reject: [".acme-reject"],
+        openSettings: [],
+        toggleScope: { container: ":::not-css", toggle: "[role='switch']", lockedOn: "[disabled]", save: ["#acme-save"] },
+      },
+    ]);
+    const rule = merged.find((r) => r.id === "acme-cmp");
+    assert.ok(rule);
+    assert.equal("toggleScope" in rule, false, "an unparseable container selector must drop the whole toggleScope field");
+  });
+
+  test("a toggleScope whose save array has zero parseable selectors after filtering is dropped entirely", () => {
+    const canParse = (sel) => sel !== "#gone-save";
+    const recompute = makeTier2RemoteMergeHelper(bundledIds, canParse);
+    const merged = recompute(BUNDLED, [
+      {
+        id: "acme-cmp",
+        present: ["#acme"],
+        reject: [".acme-reject"],
+        openSettings: [],
+        toggleScope: { container: "#acme-panel", toggle: "[role='switch']", lockedOn: "[disabled]", save: ["#gone-save"] },
+      },
+    ]);
+    const rule = merged.find((r) => r.id === "acme-cmp");
+    assert.ok(rule);
+    assert.equal("toggleScope" in rule, false, "a toggleScope with zero parseable save selectors must be dropped entirely");
+  });
+
+  test("production's tier2FilterRemoteToggleScope and tier2FilterRemoteRule use a real document.querySelector try/catch (structural companion to the pure mirror above)", () => {
+    const fnMatch = /function tier2FilterRemoteToggleScope\(scope\)\s*\{([\s\S]*?)\n  \}/.exec(sources.isolated);
+    assert.ok(fnMatch, "cookie-noise.js must define tier2FilterRemoteToggleScope(scope)");
+    assert.ok(/tier2SelectorParses\(scope\.container\)/.test(fnMatch[1]));
+    assert.ok(/tier2SelectorParses\(scope\.toggle\)/.test(fnMatch[1]));
+    assert.ok(/tier2SelectorParses\(scope\.lockedOn\)/.test(fnMatch[1]));
+    assert.ok(/tier2FilterSelectorArray\(scope\.save\)/.test(fnMatch[1]));
   });
 });
 

--- a/tests/unit/cookie-noise-toggle-sweep.test.mjs
+++ b/tests/unit/cookie-noise-toggle-sweep.test.mjs
@@ -1,0 +1,335 @@
+/**
+ * MUGA — Cookie Consent Minimizer: toggle-reject sweep shaping logic
+ * (cookie-consent-toggle-reject, PR 2 / design.md ADR-2/ADR-3)
+ *
+ * content/cookie-noise.js cannot be imported as an ES module (content
+ * scripts — see AGENTS.md), so `collectToggleStates` / `countCheckedControls`
+ * / `tier2ActuateToggleOff` are exercised here via a PURE re-implementation
+ * that mirrors production exactly, run against a small fake DOM (see
+ * tests/unit/helpers/fake-dom.mjs) — same "pure re-implementation mirrors
+ * cookie-noise.js" pattern already used by `makeTier2RemoteMergeHelper` in
+ * tests/unit/cookie-noise-sync.test.mjs. Production is pinned to the SAME
+ * shape by the structural guards in that file's "Tier 2 toggle-reject sweep
+ * structural guards (PR 2)" describe block (source-text regex assertions:
+ * exact write patterns, call ordering, one-shot guard).
+ *
+ * computeSaveInvariant/planToggleActuation themselves are the REAL, pure,
+ * genuinely-importable exports from src/lib/cmp-tier2-save-invariant.js —
+ * no mirror needed for those (already adversarially unit-tested in
+ * tests/unit/cmp-tier2-save-invariant.test.mjs, PR 1).
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { FakeElement, FakeDocument } from "./helpers/fake-dom.mjs";
+import { computeSaveInvariant, planToggleActuation } from "../../src/lib/cmp-tier2-save-invariant.js";
+
+// ── Pure re-implementations mirroring cookie-noise.js's impure DOM helpers ──
+
+function toggleKind(el) {
+  const tag = typeof el.tagName === "string" ? el.tagName.toLowerCase() : "";
+  const type = typeof el.getAttribute === "function" ? el.getAttribute("type") : null;
+  if (tag === "input" && typeof type === "string" && type.toLowerCase() === "checkbox") return "checkbox";
+  const role = typeof el.getAttribute === "function" ? el.getAttribute("role") : null;
+  if (role === "switch" || role === "checkbox") return "aria";
+  return "unknown";
+}
+
+function readToggleChecked(el, kind) {
+  if (kind === "checkbox") return typeof el.checked === "boolean" ? el.checked : null;
+  if (kind === "aria") {
+    const v = el.getAttribute("aria-checked");
+    if (v === "true") return true;
+    if (v === "false") return false;
+    return null;
+  }
+  return null;
+}
+
+function collectToggleStates(container, toggleSel, lockedOnSel) {
+  const readout = [];
+  if (!container) return readout;
+  const nodes = container.querySelectorAll(toggleSel);
+  for (const el of nodes) {
+    const locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0 && el.matches(lockedOnSel);
+    const kind = toggleKind(el);
+    const checked = readToggleChecked(el, kind);
+    readout.push({ ref: el, kind, checked: checked === true, locked, readable: checked !== null });
+  }
+  return readout;
+}
+
+const STANDARD_CHECKED_SELECTOR =
+  'input[type="checkbox"]:checked, [role="switch"][aria-checked="true"], [role="checkbox"][aria-checked="true"]';
+
+function countCheckedControls(container, lockedOnSel) {
+  if (!container) return Number.POSITIVE_INFINITY;
+  const nodes = container.querySelectorAll(STANDARD_CHECKED_SELECTOR);
+  let count = 0;
+  for (const el of nodes) {
+    const locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0 && el.matches(lockedOnSel);
+    if (!locked) count += 1;
+  }
+  return count;
+}
+
+/** ARIA click handler injection point: `onAriaClick(el)` simulates the
+ * page's own JS reacting to a `.click()` call — the test controls whether
+ * (and how) a toggle flips. */
+function actuateToggleOff(readout, { onAriaClick } = {}) {
+  const plan = planToggleActuation(readout);
+  for (const idx of plan) {
+    const entry = readout[idx];
+    if (!entry || entry.locked === true) continue;
+    if (entry.kind === "checkbox") {
+      if (entry.ref.checked === true) entry.ref.checked = false;
+    } else if (entry.kind === "aria") {
+      if (typeof onAriaClick === "function") onAriaClick(entry.ref);
+      else entry.ref.click();
+    }
+    const checked = readToggleChecked(entry.ref, entry.kind);
+    entry.checked = checked === true;
+    entry.readable = checked !== null;
+  }
+  return readout;
+}
+
+// ── Fixture builder ──────────────────────────────────────────────────────
+
+function buildPanel({ toggles = [], includeLocked = true } = {}) {
+  const doc = new FakeDocument();
+  const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+  doc.body.appendChild(panel);
+
+  if (includeLocked) {
+    const locked = new FakeElement("input", { type: "checkbox", checked: true, disabled: true, class: "toggle" });
+    panel.appendChild(locked);
+  }
+  const els = toggles.map((t) => {
+    const el = t.kind === "checkbox"
+      ? new FakeElement("input", { type: "checkbox", checked: t.checked === true, class: "toggle" })
+      : new FakeElement("div", { role: "switch", "aria-checked": t.checked === true ? "true" : "false", class: "toggle" });
+    panel.appendChild(el);
+    return el;
+  });
+  return { doc, panel, toggles: els };
+}
+
+const TOGGLE_SEL = ".toggle";
+const LOCKED_SEL = "[disabled]";
+
+// ── collectToggleStates ──────────────────────────────────────────────────
+
+describe("collectToggleStates — readout shaping (mirrors cookie-noise.js)", () => {
+  test("includes the locked entry in the readout (never excludes it)", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "checkbox", checked: true }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    assert.equal(readout.length, 2, "locked entry + one non-locked toggle");
+    assert.equal(readout.filter((e) => e.locked).length, 1);
+  });
+
+  test("classifies native input[type=checkbox] as kind 'checkbox' and reads .checked", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "checkbox", checked: true }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(entry.kind, "checkbox");
+    assert.equal(entry.checked, true);
+    assert.equal(entry.readable, true);
+  });
+
+  test("classifies role=switch as kind 'aria' and reads aria-checked", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "aria", checked: true }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(entry.kind, "aria");
+    assert.equal(entry.checked, true);
+    assert.equal(entry.readable, true);
+  });
+
+  test("an unknown widget kind (no type=checkbox, no role) reads back unreadable, never guessed", () => {
+    const { panel } = buildPanel({ toggles: [] });
+    const mystery = new FakeElement("div", { class: "toggle" }); // no role, not an input
+    panel.appendChild(mystery);
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(entry.readable, false);
+    assert.equal(entry.checked, false, "unreadable entries default checked to false, never true");
+  });
+
+  test("a malformed aria-checked value (not the literal string 'true'/'false') reads back unreadable", () => {
+    const { panel } = buildPanel({ toggles: [] });
+    const weird = new FakeElement("div", { role: "switch", "aria-checked": "mixed", class: "toggle" });
+    panel.appendChild(weird);
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(entry.readable, false);
+  });
+
+  test("an absent/null container returns an empty readout, never throws", () => {
+    assert.deepEqual(collectToggleStates(null, TOGGLE_SEL, LOCKED_SEL), []);
+  });
+});
+
+// ── countCheckedControls (backstop) ──────────────────────────────────────
+
+describe("countCheckedControls — CMP-selector-independent backstop (mirrors cookie-noise.js)", () => {
+  test("returns 0 when every standard control is off (excluding locked)", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "checkbox", checked: false }, { kind: "aria", checked: false }] });
+    assert.equal(countCheckedControls(panel, LOCKED_SEL), 0);
+  });
+
+  test("counts a standard checked control the curated `toggle` selector never enumerated (defaulted-ON category the rule missed)", () => {
+    const { panel } = buildPanel({ toggles: [] });
+    // A checkbox WITHOUT the ".toggle" class — the curated toggle selector
+    // (".toggle") would never see it, but the backstop's fixed selector
+    // (independent of any rule field) still counts it.
+    const missed = new FakeElement("input", { type: "checkbox", checked: true });
+    panel.appendChild(missed);
+    assert.equal(countCheckedControls(panel, LOCKED_SEL), 1);
+  });
+
+  test("excludes a checked control matching the lockedOn selector", () => {
+    const { panel } = buildPanel({ toggles: [] }); // includeLocked default true, locked checkbox is checked:true
+    assert.equal(countCheckedControls(panel, LOCKED_SEL), 0, "the locked/necessary control must not count toward the backstop");
+  });
+
+  test("counts a checked ARIA role=checkbox control too, not just role=switch", () => {
+    const { panel } = buildPanel({ toggles: [] });
+    const el = new FakeElement("div", { role: "checkbox", "aria-checked": "true" });
+    panel.appendChild(el);
+    assert.equal(countCheckedControls(panel, LOCKED_SEL), 1);
+  });
+
+  test("an absent/null container fails CLOSED (non-zero, non-finite sentinel), never a silent 0", () => {
+    const count = countCheckedControls(null, LOCKED_SEL);
+    assert.equal(Number.isFinite(count), false);
+    assert.notEqual(count, 0);
+  });
+});
+
+// ── tier2ActuateToggleOff (reject-only actuation) ────────────────────────
+
+describe("actuateToggleOff — reject-only, monotone-toward-denial (mirrors cookie-noise.js)", () => {
+  test("a native checkbox that reads ON is forced to .checked = false", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "checkbox", checked: true }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    actuateToggleOff(readout);
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(entry.ref.checked, false);
+    assert.equal(entry.checked, false);
+    assert.equal(entry.readable, true);
+  });
+
+  test("a native checkbox already OFF is left untouched (no redundant write, not planned for actuation)", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "checkbox", checked: false }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    const nonLockedIdx = readout.findIndex((e) => !e.locked);
+    assert.equal(planToggleActuation(readout).includes(nonLockedIdx), false,
+      "an already-off entry must not be in the actuation plan at all");
+    actuateToggleOff(readout);
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(entry.ref.checked, false);
+  });
+
+  test("an ARIA toggle that flips to false on .click() reads back off and readable", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "aria", checked: true }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    actuateToggleOff(readout, {
+      onAriaClick: (el) => el.setAttribute("aria-checked", "false"), // simulates the page's own JS flipping it
+    });
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(entry.checked, false);
+    assert.equal(entry.readable, true);
+  });
+
+  test("an ARIA toggle that does NOT flip on .click() (stuck/hostile page) is left as still-on — no second click, no forced write", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "aria", checked: true }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    let clickCount = 0;
+    actuateToggleOff(readout, {
+      onAriaClick: () => { clickCount += 1; /* deliberately does NOT flip aria-checked */ },
+    });
+    const entry = readout.find((e) => !e.locked);
+    assert.equal(clickCount, 1, "must click at most once — never retry");
+    assert.equal(entry.checked, true, "a stuck toggle must surface as still-on, never forced to false via a direct write");
+  });
+
+  test("a locked entry is NEVER included in the actuation plan (defense-in-depth, matches planToggleActuation's own contract)", () => {
+    const { panel } = buildPanel({ toggles: [] }); // only the locked, checked:true checkbox exists
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    const plan = planToggleActuation(readout);
+    assert.deepEqual(plan, [], "the locked entry must never be planned for actuation, even though it reads checked:true");
+    actuateToggleOff(readout);
+    const locked = readout.find((e) => e.locked);
+    assert.equal(locked.ref.checked, true, "the locked control's real DOM state must be completely untouched");
+  });
+
+  test("NEVER writes toward on: no fixture in this suite results in a checked:true / aria-checked:true write by actuateToggleOff", () => {
+    const { panel } = buildPanel({
+      toggles: [
+        { kind: "checkbox", checked: true },
+        { kind: "aria", checked: true },
+        { kind: "checkbox", checked: false },
+        { kind: "aria", checked: false },
+      ],
+    });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    actuateToggleOff(readout, { onAriaClick: (el) => el.setAttribute("aria-checked", "false") });
+    for (const entry of readout.filter((e) => !e.locked)) {
+      assert.equal(entry.checked, false, `entry (kind=${entry.kind}) must never end up checked:true after actuation`);
+    }
+  });
+});
+
+// ── End-to-end shaping: readout + backstop -> computeSaveInvariant ───────
+//
+// Exercises the REAL, imported computeSaveInvariant against readouts
+// produced by the mirror helpers above — proves the shaping logic feeds
+// the real safety oracle correctly for the scenarios task 2.7's e2e also
+// covers (all-off satisfied; backstop-catches-missed-toggle; reads-back-on
+// unsatisfied), at the unit level, before the Playwright e2e re-proves it
+// against a real browser.
+
+describe("collectToggleStates + countCheckedControls + actuateToggleOff -> computeSaveInvariant (integration of the mirrors)", () => {
+  test("all toggles off, locked present, backstop 0 -> invariant satisfied", () => {
+    const { panel } = buildPanel({
+      toggles: [{ kind: "checkbox", checked: true }, { kind: "aria", checked: true }],
+    });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    actuateToggleOff(readout, { onAriaClick: (el) => el.setAttribute("aria-checked", "false") });
+    const backstop = countCheckedControls(panel, LOCKED_SEL);
+    const result = computeSaveInvariant(readout, backstop);
+    assert.equal(result.satisfied, true, result.reason);
+  });
+
+  test("a defaulted-ON standard toggle the curated selector missed -> backstop catches it -> invariant unsatisfied", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "checkbox", checked: true }] });
+    const missed = new FakeElement("input", { type: "checkbox", checked: true }); // no ".toggle" class
+    panel.appendChild(missed);
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL); // never sees `missed`
+    actuateToggleOff(readout);
+    const backstop = countCheckedControls(panel, LOCKED_SEL); // DOES see `missed`
+    const result = computeSaveInvariant(readout, backstop);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "backstop-checked");
+  });
+
+  test("an ARIA toggle that reads back ON after .click() -> invariant unsatisfied (toggle-still-on)", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "aria", checked: true }] });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    actuateToggleOff(readout, { onAriaClick: () => {} }); // stuck — never flips
+    const backstop = countCheckedControls(panel, LOCKED_SEL);
+    const result = computeSaveInvariant(readout, backstop);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "toggle-still-on");
+  });
+
+  test("no locked/necessary entry present at all -> invariant unsatisfied (no-locked), even if every toggle reads off", () => {
+    const { panel } = buildPanel({ toggles: [{ kind: "checkbox", checked: false }], includeLocked: false });
+    const readout = collectToggleStates(panel, TOGGLE_SEL, LOCKED_SEL);
+    const backstop = countCheckedControls(panel, LOCKED_SEL);
+    const result = computeSaveInvariant(readout, backstop);
+    assert.equal(result.satisfied, false);
+    assert.equal(result.reason, "no-locked");
+  });
+});

--- a/tests/unit/cookie-noise-toggle-sweep.test.mjs
+++ b/tests/unit/cookie-noise-toggle-sweep.test.mjs
@@ -46,12 +46,28 @@ function readToggleChecked(el, kind) {
   return null;
 }
 
+// PROVABLY-INERT gate (mirrors cookie-noise.js's tier2ToggleProvablyInert):
+// `locked`/backstop-exclusion is earned by real disabled/aria-disabled DOM
+// state, NEVER by a bare `lockedOn` selector match (partial-accept hole #2).
+function toggleProvablyInert(el) {
+  const kind = toggleKind(el);
+  if (kind === "checkbox") return el.disabled === true;
+  if (kind === "aria") {
+    if (el.getAttribute("aria-disabled") === "true") return true;
+    return typeof el.matches === "function" && el.matches("[disabled]");
+  }
+  return false;
+}
+
+// lockedOnSel retained for signature parity with production; the GATE is
+// provably-inert DOM state, so lockedOnSel is intentionally not consulted.
 function collectToggleStates(container, toggleSel, lockedOnSel) {
+  void lockedOnSel; // retained hint; the GATE is provably-inert DOM state
   const readout = [];
   if (!container) return readout;
   const nodes = container.querySelectorAll(toggleSel);
   for (const el of nodes) {
-    const locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0 && el.matches(lockedOnSel);
+    const locked = toggleProvablyInert(el);
     const kind = toggleKind(el);
     const checked = readToggleChecked(el, kind);
     readout.push({ ref: el, kind, checked: checked === true, locked, readable: checked !== null });
@@ -62,13 +78,15 @@ function collectToggleStates(container, toggleSel, lockedOnSel) {
 const STANDARD_CHECKED_SELECTOR =
   'input[type="checkbox"]:checked, [role="switch"][aria-checked="true"], [role="checkbox"][aria-checked="true"]';
 
+// lockedOnSel retained for signature parity with production; exclusion is
+// gated on provably-inert DOM state, so lockedOnSel is intentionally unused.
 function countCheckedControls(container, lockedOnSel) {
+  void lockedOnSel; // retained hint; exclusion is gated on provably-inert DOM state
   if (!container) return Number.POSITIVE_INFINITY;
   const nodes = container.querySelectorAll(STANDARD_CHECKED_SELECTOR);
   let count = 0;
   for (const el of nodes) {
-    const locked = typeof lockedOnSel === "string" && lockedOnSel.length > 0 && el.matches(lockedOnSel);
-    if (!locked) count += 1;
+    if (!toggleProvablyInert(el)) count += 1;
   }
   return count;
 }
@@ -331,5 +349,151 @@ describe("collectToggleStates + countCheckedControls + actuateToggleOff -> compu
     const result = computeSaveInvariant(readout, backstop);
     assert.equal(result.satisfied, false);
     assert.equal(result.reason, "no-locked");
+  });
+});
+
+// ── FIX A: lockedOn requires PROVABLY-INERT DOM state, never a bare selector
+// match (partial-accept safety hole #2) ──────────────────────────────────────
+//
+// A NON-essential, defaulted-ON toggle that ALSO matches the curated
+// `lockedOn` hint must NOT be treated as locked: a bare selector match would
+// exclude it from BOTH actuation AND the backstop count, letting
+// computeSaveInvariant pass `satisfied:true` with a tracking category still
+// ON — a PARTIAL ACCEPT. The never-accept guarantee is ABSOLUTE: `locked` is
+// earned only by provably-inert DOM state (disabled / aria-disabled), never by
+// matching a decorative selector.
+
+describe("collectToggleStates — lockedOn requires provably-inert DOM state (FIX A, partial-accept hole #2)", () => {
+  test("a checked toggle that MATCHES lockedOnSel but is NOT disabled reads locked:false (never locked on a selector match alone)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    // A non-essential category checkbox, defaulted ON, that ALSO matches the
+    // curated lockedOn hint (over-match) but is NOT actually disabled.
+    const overMatch = new FakeElement("input", { type: "checkbox", checked: true, class: "toggle necessary-hint" });
+    panel.appendChild(overMatch);
+    const readout = collectToggleStates(panel, ".toggle", ".necessary-hint");
+    const entry = readout[0];
+    assert.equal(entry.locked, false, "a non-disabled control must NEVER be locked, even if it matches the curated lockedOn hint");
+    assert.equal(entry.checked, true);
+  });
+
+  test("an ARIA switch that MATCHES lockedOnSel but has no aria-disabled/disabled reads locked:false", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    const overMatch = new FakeElement("div", { role: "switch", "aria-checked": "true", class: "toggle necessary-hint" });
+    panel.appendChild(overMatch);
+    const readout = collectToggleStates(panel, ".toggle", ".necessary-hint");
+    assert.equal(readout[0].locked, false, "an ARIA switch without aria-disabled/[disabled] is not provably inert -> not locked");
+  });
+
+  test("a genuinely disabled checkbox reads locked:true (provably inert — existing behavior preserved)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    const necessary = new FakeElement("input", { type: "checkbox", checked: true, disabled: true, class: "toggle" });
+    panel.appendChild(necessary);
+    const readout = collectToggleStates(panel, ".toggle", LOCKED_SEL);
+    assert.equal(readout[0].locked, true, "a disabled checkbox is provably inert -> locked");
+  });
+
+  test("an aria-disabled='true' switch reads locked:true (provably inert — matches the real Osano lockedOn markers)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    const necessary = new FakeElement("div", { role: "switch", "aria-checked": "true", "aria-disabled": "true", class: "toggle" });
+    panel.appendChild(necessary);
+    const readout = collectToggleStates(panel, ".toggle", "[aria-disabled='true']");
+    assert.equal(readout[0].locked, true, "aria-disabled='true' is provably inert -> locked");
+  });
+});
+
+describe("countCheckedControls — excludes ONLY provably-inert controls, never a bare lockedOn match (FIX A backstop)", () => {
+  test("a checked control that MATCHES lockedOnSel but is NOT provably inert is STILL counted (no over-match exclusion)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    // Checked, matches the lockedOn hint, but not disabled -> must be counted.
+    const rogue = new FakeElement("input", { type: "checkbox", checked: true, class: "necessary-hint" });
+    panel.appendChild(rogue);
+    assert.equal(countCheckedControls(panel, ".necessary-hint"), 1, "a non-inert checked control must count toward the backstop even if it matches the lockedOn hint");
+  });
+
+  test("a genuinely disabled checked control is excluded (provably inert)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    const necessary = new FakeElement("input", { type: "checkbox", checked: true, disabled: true });
+    panel.appendChild(necessary);
+    assert.equal(countCheckedControls(panel, LOCKED_SEL), 0, "a disabled/inert checked control does not count toward the backstop");
+  });
+
+  test("a checked aria-disabled='true' switch is excluded (provably inert)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    const necessary = new FakeElement("div", { role: "switch", "aria-checked": "true", "aria-disabled": "true" });
+    panel.appendChild(necessary);
+    assert.equal(countCheckedControls(panel, "[aria-disabled='true']"), 0);
+  });
+});
+
+// ── FIX C: adversarial end-to-end — a non-disabled toggle matching lockedOnSel
+// that stays ON must VETO the Save (never a partial accept) ───────────────────
+//
+// This is the coverage gap the review flagged: prove that the over-matched,
+// still-ON toggle propagates all the way to an UNSATISFIED invariant (VETO /
+// NOOP), not a silent partial accept. A unit guard via the fake-dom mirror is
+// used (rather than a 5th Playwright scenario) because demonstrating the hole
+// in the shared e2e fixture would require a NEW rule variant with a
+// class-based (non-inert-marker) lockedOn selector plus a stuck toggle that
+// matches it — materially complicating the shared fixture. The mirror proves
+// the exact readout+backstop -> computeSaveInvariant logic that production is
+// structurally pinned to.
+
+describe("FIX C — over-matched non-inert toggle left ON -> Save invariant UNSATISFIED (adversarial, never a partial accept)", () => {
+  test("a non-disabled aria toggle matching lockedOnSel that will NOT flip -> invariant unsatisfied (VETO/NOOP)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    // A genuine locked/necessary control (provably inert).
+    const necessary = new FakeElement("input", { type: "checkbox", checked: true, disabled: true, class: "toggle" });
+    panel.appendChild(necessary);
+    // A NON-essential, defaulted-ON aria switch that ALSO matches the lockedOn
+    // hint (over-match) and refuses to flip on .click() (stuck/hostile page).
+    const rogue = new FakeElement("div", { role: "switch", "aria-checked": "true", class: "toggle necessary-hint" });
+    panel.appendChild(rogue);
+
+    // lockedOn is a curated hint whose class-part over-matches the rogue.
+    const lockedSel = "[disabled], .necessary-hint";
+    const readout = collectToggleStates(panel, ".toggle", lockedSel);
+    actuateToggleOff(readout, { onAriaClick: () => { /* stuck — never flips */ } });
+    const backstop = countCheckedControls(panel, lockedSel);
+    const result = computeSaveInvariant(readout, backstop);
+
+    assert.equal(result.satisfied, false, "a tracking category left ON must NEVER satisfy the Save invariant (never a partial accept)");
+    assert.ok(
+      ["toggle-still-on", "backstop-checked"].includes(result.reason),
+      `expected toggle-still-on or backstop-checked, got ${result.reason}`,
+    );
+  });
+
+  test("the same scope with the rogue toggle actually turned OFF -> invariant satisfied (control: the gate is state, not selector)", () => {
+    const doc = new FakeDocument();
+    const panel = new FakeElement("div", { id: "panel", class: "cmp-panel" });
+    doc.body.appendChild(panel);
+    const necessary = new FakeElement("input", { type: "checkbox", checked: true, disabled: true, class: "toggle" });
+    panel.appendChild(necessary);
+    const rogue = new FakeElement("div", { role: "switch", "aria-checked": "true", class: "toggle necessary-hint" });
+    panel.appendChild(rogue);
+
+    const lockedSel = "[disabled], .necessary-hint";
+    const readout = collectToggleStates(panel, ".toggle", lockedSel);
+    actuateToggleOff(readout, { onAriaClick: (el) => el.setAttribute("aria-checked", "false") });
+    const backstop = countCheckedControls(panel, lockedSel);
+    const result = computeSaveInvariant(readout, backstop);
+
+    assert.equal(result.satisfied, true, result.reason);
   });
 });

--- a/tests/unit/helpers/fake-dom.mjs
+++ b/tests/unit/helpers/fake-dom.mjs
@@ -1,0 +1,169 @@
+/**
+ * Minimal fake DOM for exercising cookie-noise.js's toggle-sweep helpers
+ * (cookie-consent-toggle-reject, PR 2) via `vm.runInContext` — mirrors the
+ * existing `vm.runInContext` precedent in
+ * tests/unit/cookie-noise-frame-exemption.test.mjs, extended with just
+ * enough of a CSS selector engine to support the small set of selector
+ * shapes this feature actually uses: tag names, `#id`, `.class`,
+ * `[attr]` / `[attr="value"]` / `[attr='value']`, the `:checked` pseudo,
+ * and comma-separated OR groups. Deliberately NOT a general CSS engine —
+ * no descendant/child combinators, no other pseudo-classes.
+ *
+ * Usage:
+ *   import { FakeElement, FakeDocument } from "./helpers/fake-dom.mjs";
+ *   const doc = new FakeDocument();
+ *   const panel = doc.createElement("div", { id: "panel" });
+ *   doc.documentElement.appendChild(panel);
+ */
+
+/**
+ * Parses a single compound selector (no combinators) into its parts.
+ * @param {string} sel
+ * @returns {{ tag: string|null, id: string|null, classes: string[], attrs: Array<{name: string, value: string|null}>, pseudos: string[] }}
+ */
+function parseCompoundSelector(sel) {
+  const tokenRe = /(#[\w-]+)|(\.[\w-]+)|(:[\w-]+)|(\[[^\]]+\])|([a-zA-Z][\w-]*)/g;
+  const result = { tag: null, id: null, classes: [], attrs: [], pseudos: [] };
+  let m;
+  while ((m = tokenRe.exec(sel)) !== null) {
+    const tok = m[0];
+    if (tok.startsWith("#")) {
+      result.id = tok.slice(1);
+    } else if (tok.startsWith(".")) {
+      result.classes.push(tok.slice(1));
+    } else if (tok.startsWith(":")) {
+      result.pseudos.push(tok.slice(1));
+    } else if (tok.startsWith("[")) {
+      const inner = tok.slice(1, -1);
+      const eq = inner.indexOf("=");
+      if (eq === -1) {
+        result.attrs.push({ name: inner.trim(), value: null });
+      } else {
+        const name = inner.slice(0, eq).trim();
+        let value = inner.slice(eq + 1).trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+        result.attrs.push({ name, value });
+      }
+    } else {
+      result.tag = tok;
+    }
+  }
+  return result;
+}
+
+function elementMatchesCompound(el, compound) {
+  if (compound.tag && el.tagName.toLowerCase() !== compound.tag.toLowerCase()) return false;
+  if (compound.id && el.getAttribute("id") !== compound.id) return false;
+  if (compound.classes.length > 0) {
+    const cls = (el.getAttribute("class") || "").split(/\s+/).filter(Boolean);
+    for (const c of compound.classes) {
+      if (!cls.includes(c)) return false;
+    }
+  }
+  for (const a of compound.attrs) {
+    const val = el.getAttribute(a.name);
+    if (val === null) return false;
+    if (a.value !== null && val !== a.value) return false;
+  }
+  for (const p of compound.pseudos) {
+    if (p === "checked") {
+      if (el.checked !== true) return false;
+    }
+  }
+  return true;
+}
+
+function matchesSelectorGroup(el, selector) {
+  if (typeof selector !== "string" || selector.length === 0) return false;
+  const groups = selector.split(",").map((s) => s.trim()).filter(Boolean);
+  return groups.some((g) => elementMatchesCompound(el, parseCompoundSelector(g)));
+}
+
+export class FakeElement extends EventTarget {
+  constructor(tag, attrs = {}) {
+    super();
+    this.tagName = tag;
+    this._attrs = new Map();
+    for (const [k, v] of Object.entries(attrs)) this._attrs.set(k, String(v));
+    this.children = [];
+    this.parentNode = null;
+    this.checked = tag.toLowerCase() === "input" && attrs.checked === true;
+    this.value = "";
+    this.disabled = attrs.disabled === true;
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  getAttribute(name) {
+    return this._attrs.has(name) ? this._attrs.get(name) : null;
+  }
+
+  setAttribute(name, value) {
+    this._attrs.set(name, String(value));
+  }
+
+  hasAttribute(name) {
+    return this._attrs.has(name);
+  }
+
+  matches(selector) {
+    return matchesSelectorGroup(this, selector);
+  }
+
+  querySelectorAll(selector) {
+    const results = [];
+    const walk = (node) => {
+      for (const child of node.children) {
+        if (matchesSelectorGroup(child, selector)) results.push(child);
+        walk(child);
+      }
+    };
+    walk(this);
+    return results;
+  }
+
+  querySelector(selector) {
+    const all = this.querySelectorAll(selector);
+    return all.length > 0 ? all[0] : null;
+  }
+
+  getClientRects() {
+    return [{ width: 10, height: 10 }];
+  }
+
+  click() {
+    this.dispatchEvent(new Event("click", { bubbles: true }));
+  }
+}
+
+export class FakeDocument extends EventTarget {
+  constructor() {
+    super();
+    this.documentElement = new FakeElement("html");
+    this.body = new FakeElement("body");
+    this.documentElement.appendChild(this.body);
+    this.readyState = "complete";
+  }
+
+  createElement(tag, attrs = {}) {
+    return new FakeElement(tag, attrs);
+  }
+
+  getElementById(id) {
+    return this.documentElement.querySelector(`#${id}`);
+  }
+
+  querySelector(selector) {
+    return this.documentElement.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.documentElement.querySelectorAll(selector);
+  }
+}

--- a/tests/unit/remote-tier2-rules.test.mjs
+++ b/tests/unit/remote-tier2-rules.test.mjs
@@ -54,6 +54,7 @@ import {
   MAX_TIER2_ID_LEN,
   STALE_DAYS_TIER2,
   TIER2_ID_FORMAT_RE,
+  TIER2_RULE_KEYS,
   BUNDLED_TIER2_IDS,
   ERR,
 } from "../../src/lib/remote-tier2-rules.js";
@@ -754,5 +755,29 @@ describe("runTier2RulesFetch — orchestrator (fail-closed matrix)", () => {
     await Promise.all([promise1, promise2]);
 
     assert.ok(fetchCount >= 1, "at least one fetch occurred");
+  });
+});
+
+// ── TIER2_RULE_KEYS never-accept tripwire ────────────────────────────────────
+//
+// The content-side `tier2FilterRemoteToggleScope` (src/content/cookie-noise.js)
+// is LIVE: it will happily promote a remote rule carrying a `toggleScope`
+// field into the reject-only Save/toggle/lockedOn click surface. It is
+// currently UNREACHABLE via a signed payload ONLY because this strict 4-key
+// allowlist rejects any rule with an extra key (`toggleScope` included). That
+// is the sole structural barrier between "signed remote data" and "a remote
+// Save-click selector path". This test pins the allowlist so that relaxing it
+// (e.g. adding `toggleScope` to the remote schema) trips RED and forces a
+// deliberate re-review of the remote Save-click surface — the never-accept
+// guarantee must never regress silently through a schema widening.
+describe("TIER2_RULE_KEYS — strict 4-key allowlist tripwire (never-accept)", () => {
+  test("equals EXACTLY {id, present, reject, openSettings} — widening it must force a remote toggleScope re-review", () => {
+    assert.equal(TIER2_RULE_KEYS instanceof Set, true, "TIER2_RULE_KEYS must be a Set");
+    assert.equal(TIER2_RULE_KEYS.size, 4, "exactly 4 keys — no field may express an accept/toggle action");
+    assert.deepEqual(
+      [...TIER2_RULE_KEYS].sort(),
+      ["id", "openSettings", "present", "reject"],
+      "adding any key (e.g. toggleScope) reaches the live tier2FilterRemoteToggleScope path — re-review the remote Save-click surface before widening",
+    );
   });
 });


### PR DESCRIPTION
**PR 2/3** of `cookie-consent-toggle-reject`. Builds the runtime MECHANISM that, on CMPs with pre-checked category toggles, opens the settings panel, sweeps non-essential toggles OFF, verifies necessary-only, then clicks Save — reusing PR 1's safety core (`computeSaveInvariant` / `planToggleActuation` / the `"save"` veto role). **Synthetic-fixture only — no bundled CMP rule ships** (Osano is PR 3).

**Never-accept stays ABSOLUTE**: the sweep only ever writes toggles toward OFF, `_tier2Acted` is set ONLY after the veto passes, one-shot per rule, isolated-world only, locked toggles are never actuated, and any unsatisfied-invariant or vetoed-Save path NOOPs (banner left visible, nothing clicked).

## What lands
- `src/lib/cmp-tier2-rules.js` — optional `toggleScope { container, toggle, lockedOn, save }` JSDoc typedef only; existing Complianz/Cookie-Notice rules byte-unchanged.
- `src/content/cookie-noise.js` — impure DOM helpers `collectToggleStates` / `countCheckedControls` (the CMP-selector-independent backstop), reject-only actuation (`tier2ActuateToggleOff`: native `.checked=false` only-if-true; ARIA `.click()` once then re-read, abort on non-flip), dispatcher toggle branch (`tier2RunToggleSweep`: enumerate → actuate → re-read + backstop → `computeSaveInvariant` → veto-gated Save).
- Unit: 21 pure-logic mirror tests (`cookie-noise-toggle-sweep.test.mjs`) + a reusable CSS-capable fake DOM + 12 structural safety guards in `cookie-noise-sync.test.mjs`.
- E2e: 4 adversarial Playwright scenarios (all-off→save; defaulted-ON missed by selector→backstop VETO; reads-back-ON→VETO; feature-off→noop).

## Safety hardening folded in (from fresh adversarial review of the first cut)
Two latent findings were confirmed and CLOSED before this PR (commit `e4ee2ae`):
- **lockedOn = provably-inert only**: a toggle counts as locked ONLY when the real DOM is `disabled` / `aria-disabled` — a bare `lockedOn` selector match no longer grants locked status. Closes a partial-accept hole where an over-matching `lockedOn` could exclude a still-ON tracking toggle from BOTH actuation and the backstop, yielding a false-satisfied invariant. `tier2ToggleProvablyInert` gates BOTH consumers consistently; fail-closed on unknown kind.
- **Remote-schema tripwire**: `TIER2_RULE_KEYS` is exported and pinned by a test asserting exactly `{id,present,reject,openSettings}`, so remote-origin `toggleScope` can't silently become deliverable without a deliberate re-review of the remote Save-click surface.

## Verification
- `npm test` → 7857/7858 pass (1 pre-existing unrelated skip); `typecheck` clean; `lint:js` clean; `web-ext` 0 errors; `test:e2e` toggle spec 4/4; `build:content` zero drift.
- Two fresh adversarial reviews (opus): the wired mechanism AIRTIGHT; the hardening fix AIRTIGHT AND COMPLETE (both findings closed consistently, no fail-open, no regression).

size:exception — dominated by adversarial unit/e2e volume for safety-critical logic.

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9