### PR TITLE
feat(consent): Osano direct-reject Tier 2 rule + citation fix (PR 3/3)

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1366,8 +1366,8 @@
   const TIER2_RULES = Object.freeze([
     /**
      * Complianz (cmplz) — API-less, WordPress plugin. Real-site verification
-     * (doaj.org, 2026-07) confirmed a direct first-layer reject control:
-     * `.cmplz-deny` inside `#cmplz-cookiebanner-container`.
+     * (steuck-aachen.de, 2026-07) confirmed a direct first-layer reject
+     * control: `.cmplz-deny` inside `#cmplz-cookiebanner-container`.
      *
      * Complianz's "manage options" / "save preferences" panel was
      * DELIBERATELY NOT modeled as an `openSettings` two-step hop: that panel's
@@ -1399,6 +1399,36 @@
       id: "cookie-notice",
       present: Object.freeze(["#cookie-notice"]),
       reject: Object.freeze(["#cn-refuse-cookie"]),
+      openSettings: Object.freeze([]),
+    }),
+
+    /**
+     * Osano — API-less, self-hosted CMP widget. Live-probe-confirmed on
+     * osano.com (2026-07, EU vantage): a direct first-layer reject control,
+     * `.osano-cm-denyAll` ("Reject Non-Essential"), inside the bottom-bar
+     * banner anchor `.osano-cm-dialog--type_bar` (`role=dialog`,
+     * `aria-label="Cookie Consent Banner"`; the banner's own `id` is a random
+     * UUID per page load, so it is deliberately NOT used as a selector here).
+     * `.osano-cm-denyAll` is locale-independent (the full class also carries
+     * an equivalent `denyAll`-suffixed type modifier); its accessible name is
+     * localized (EN "Reject Non-Essential", DE "Nicht wesentliche Cookies
+     * ablehnen"), but every observed locale carries a reject-family word, and
+     * the structurally distinct opt-in control lives under its own,
+     * completely disjoint class name, so there is no selector collision risk.
+     *
+     * Deliberately NOT modeled with the multi-step toggle-sweep-and-save
+     * descriptor: Osano exposes a genuine one-click first-layer reject and,
+     * under GDPR, defaults its non-essential categories to OFF — there is no
+     * ambiguous currently-checked panel state to sweep or verify here, so
+     * that multi-step machinery is the wrong tool for this CMP.
+     * `openSettings` stays empty: the Manage drawer is never opened, this is
+     * a genuine single-hop reject (fail-closed no-op if `.osano-cm-denyAll`
+     * is absent on a given installation).
+     */
+    Object.freeze({
+      id: "osano",
+      present: Object.freeze([".osano-cm-dialog--type_bar"]),
+      reject: Object.freeze([".osano-cm-denyAll"]),
       openSettings: Object.freeze([]),
     }),
   ]);

--- a/src/lib/cmp-tier2-rules.js
+++ b/src/lib/cmp-tier2-rules.js
@@ -66,11 +66,14 @@
  *   post-sweep save invariant (src/lib/cmp-tier2-save-invariant.js) is
  *   satisfied AND the single resolved `save` candidate clears the `"save"`
  *   click-veto role (src/lib/cmp-tier2-veto.js) — clicks the confirmed Save
- *   control. Absent on both seed rules (Complianz, Cookie Notice); no
- *   bundled rule uses this field yet (introduced for the curated Osano
- *   pilot in a later PR). Carries NO field capable of expressing the
- *   broad-consent-granting path this project's structural guard forbids
- *   naming (see the file docblock above) — same closed-vocabulary
+ *   control. No bundled rule uses this field (Complianz, Cookie Notice, and
+ *   Osano all rely on a direct single-layer `reject` control instead — a
+ *   live probe found Osano exposes a genuine one-click reject and defaults
+ *   non-essential categories to OFF under GDPR, so the toggle-and-save
+ *   machinery this field describes was deliberately NOT used for it; see
+ *   the Osano rule's own comment below). Carries NO field capable of
+ *   expressing the broad-consent-granting path this project's structural
+ *   guard forbids naming (see the file docblock above) — same closed-vocabulary
  *   guarantee as the rest of this shape; the structural guard in
  *   tests/unit/cookie-noise-sync.test.mjs scans this field's values for the
  *   same forbidden pattern.
@@ -99,8 +102,8 @@
 export const TIER2_RULES = Object.freeze([
   /**
    * Complianz (cmplz) — API-less, WordPress plugin. Real-site verification
-   * (doaj.org, 2026-07) confirmed a direct first-layer reject control:
-   * `.cmplz-deny` inside `#cmplz-cookiebanner-container`.
+   * (steuck-aachen.de, 2026-07) confirmed a direct first-layer reject
+   * control: `.cmplz-deny` inside `#cmplz-cookiebanner-container`.
    *
    * Complianz's "manage options" / "save preferences" panel was
    * DELIBERATELY NOT modeled as an `openSettings` two-step hop: that panel's
@@ -132,6 +135,36 @@ export const TIER2_RULES = Object.freeze([
     id: "cookie-notice",
     present: Object.freeze(["#cookie-notice"]),
     reject: Object.freeze(["#cn-refuse-cookie"]),
+    openSettings: Object.freeze([]),
+  }),
+
+  /**
+   * Osano — API-less, self-hosted CMP widget. Live-probe-confirmed on
+   * osano.com (2026-07, EU vantage): a direct first-layer reject control,
+   * `.osano-cm-denyAll` ("Reject Non-Essential"), inside the bottom-bar
+   * banner anchor `.osano-cm-dialog--type_bar` (`role=dialog`,
+   * `aria-label="Cookie Consent Banner"`; the banner's own `id` is a random
+   * UUID per page load, so it is deliberately NOT used as a selector here).
+   * `.osano-cm-denyAll` is locale-independent (the full class also carries
+   * an equivalent `denyAll`-suffixed type modifier); its accessible name is
+   * localized (EN "Reject Non-Essential", DE "Nicht wesentliche Cookies
+   * ablehnen"), but every observed locale carries a reject-family word, and
+   * the structurally distinct opt-in control lives under its own,
+   * completely disjoint class name, so there is no selector collision risk.
+   *
+   * Deliberately NOT modeled with the multi-step toggle-sweep-and-save
+   * descriptor: Osano exposes a genuine one-click first-layer reject and,
+   * under GDPR, defaults its non-essential categories to OFF — there is no
+   * ambiguous currently-checked panel state to sweep or verify here, so
+   * that multi-step machinery is the wrong tool for this CMP.
+   * `openSettings` stays empty: the Manage drawer is never opened, this is
+   * a genuine single-hop reject (fail-closed no-op if `.osano-cm-denyAll`
+   * is absent on a given installation).
+   */
+  Object.freeze({
+    id: "osano",
+    present: Object.freeze([".osano-cm-dialog--type_bar"]),
+    reject: Object.freeze([".osano-cm-denyAll"]),
     openSettings: Object.freeze([]),
   }),
 ]);

--- a/tests/e2e/cookie-consent-minimizer-osano.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-osano.spec.mjs
@@ -1,0 +1,146 @@
+/**
+ * E2E: Cookie Consent Minimizer — Osano Tier 2 rule (cookie-consent-toggle-
+ * reject, PR 3 — PIVOTED from a `toggleScope` multi-step rule to a simple
+ * direct-reject rule after a live probe of osano.com found Osano exposes a
+ * genuine one-click "Reject Non-Essential" control and, under GDPR, defaults
+ * its non-essential categories to OFF — the toggle-sweep-and-save machinery
+ * (design.md ADR-1/ADR-5) is the wrong tool for this CMP).
+ *
+ * Verifies the BUNDLED `osano` entry in TIER2_RULES (src/lib/cmp-tier2-rules.js)
+ * against a real Chromium with the extension loaded, using a SYNTHETIC
+ * fixture that reproduces Osano's banner DOM shape:
+ * `.osano-cm-dialog--type_bar` (banner anchor) containing a
+ * `.osano-cm-denyAll` reject control and a structurally distinct opt-in
+ * control. Mirrors tests/e2e/cookie-consent-minimizer.spec.mjs's structure
+ * (the OneTrust Tier 1 spec) — this rule needs no remote-rule injection
+ * because, unlike the toggle-reject mechanism's PR 2 synthetic fixture, it
+ * is a real BUNDLED entry, not fixture-only data.
+ *
+ * HONEST LIMIT (same posture as the sibling Tier 2 e2e specs): a
+ * synthetic-fixture regression oracle only, Chromium-only. It does not
+ * prove compatibility with real osano.com markup beyond the 2026-07 EU-
+ * vantage live probe this rule's selectors are cited from — re-capture this
+ * fixture manually whenever Osano's markup changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-osano.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode: enableFeature ? "reject-only" : "off" },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture: reproduces Osano's bottom-bar banner DOM shape — the
+ * `.osano-cm-dialog--type_bar` anchor, a `.osano-cm-denyAll` reject
+ * button (localized text, EN here), and a structurally distinct opt-in
+ * control that must NEVER be clicked.
+ */
+async function stubOsanoPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div class="osano-cm-dialog--type_bar" role="dialog" aria-label="Cookie Consent Banner" id="osano-random-uuid-marker">
+          <button class="osano-cm-denyAll osano-cm-button--type_denyAll" id="osano-deny-btn">Reject Non-Essential</button>
+          <button class="osano-cm-accept-all osano-cm-button--type_accept" id="osano-accept-btn">Accept All</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__e2eClicks = [];
+          var banner = document.getElementById("osano-random-uuid-marker");
+          document.getElementById("osano-deny-btn").addEventListener("click", function () {
+            window.__e2eClicks.push("deny");
+            window.__consentState = "necessary-only";
+            banner.remove();
+          });
+          document.getElementById("osano-accept-btn").addEventListener("click", function () {
+            window.__e2eClicks.push("accept");
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — Osano (cookie-consent-toggle-reject, PR 3)", () => {
+  test("clicks the bundled Osano reject control, dismisses the banner, and never clicks the opt-in decoy", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubOsanoPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    expect(clicks).toEqual(["deny"]);
+    expect(clicks).not.toContain("accept");
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    const bannerGone = await page.evaluate(() => document.getElementById("osano-random-uuid-marker") === null);
+    expect(bannerGone).toBe(true);
+
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF) — the opt-in decoy is never clicked either", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubOsanoPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // REASON: negative assertion (feature OFF) — no positive signal to wait
+    // on; fixed settle window, the standard pattern for this suite's
+    // negatives (see cookie-consent-minimizer.spec.mjs).
+    await page.waitForTimeout(1500);
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    expect(clicks).toEqual([]);
+    const bannerStillThere = await page.evaluate(() => document.getElementById("osano-random-uuid-marker") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -61,10 +61,10 @@ describe("cmp-adapters — registry shape", () => {
     assert.strictEqual(TIER1[9], consentmanagerAdapter);
   });
 
-  test("TIER2 ships with the Slice 1 seed rules (Complianz, Cookie Notice)", () => {
+  test("TIER2 ships with the Slice 1 seed rules plus the Osano pilot (Complianz, Cookie Notice, Osano)", () => {
     assert.ok(Array.isArray(TIER2));
-    assert.equal(TIER2.length, 2);
-    assert.deepEqual(TIER2.map((a) => a.id), ["complianz", "cookie-notice"]);
+    assert.equal(TIER2.length, 3);
+    assert.deepEqual(TIER2.map((a) => a.id), ["complianz", "cookie-notice", "osano"]);
     for (const adapter of TIER2) {
       assert.equal(adapter.tier, 2);
       assert.equal(typeof adapter.detect, "function");
@@ -734,10 +734,11 @@ describe("decideAction — truth table", () => {
 // ── Tier 2 rule data (src/lib/cmp-tier2-rules.js) — shape ───────────────────
 
 describe("TIER2_RULES — closed reject-only shape (#1027 Slice 1)", () => {
-  test("TIER2_RULES contains exactly the Complianz and Cookie Notice seed rules, in order", () => {
-    assert.equal(TIER2_RULES.length, 2);
+  test("TIER2_RULES contains exactly the Complianz, Cookie Notice, and Osano rules, in order", () => {
+    assert.equal(TIER2_RULES.length, 3);
     assert.equal(TIER2_RULES[0].id, "complianz");
     assert.equal(TIER2_RULES[1].id, "cookie-notice");
+    assert.equal(TIER2_RULES[2].id, "osano");
   });
 
   test("TIER2_RULES and every rule entry are frozen", () => {
@@ -770,7 +771,7 @@ describe("TIER2_RULES — closed reject-only shape (#1027 Slice 1)", () => {
     }
   });
 
-  test("Slice 1 seed ships with no two-step openSettings path (both rules rely on a direct reject control)", () => {
+  test("every rule ships with no two-step openSettings path (all rely on a direct reject control)", () => {
     for (const rule of TIER2_RULES) {
       assert.deepEqual(rule.openSettings, [], `rule "${rule.id}".openSettings must be empty in Slice 1`);
     }
@@ -786,6 +787,15 @@ describe("TIER2_RULES — closed reject-only shape (#1027 Slice 1)", () => {
     const rule = TIER2_RULES.find((r) => r.id === "cookie-notice");
     assert.deepEqual([...rule.present], ["#cookie-notice"]);
     assert.deepEqual([...rule.reject], ["#cn-refuse-cookie"]);
+  });
+
+  test("Osano rule matches the live-probe-confirmed selectors and has no toggleScope field (simple direct-reject path)", () => {
+    const rule = TIER2_RULES.find((r) => r.id === "osano");
+    assert.ok(rule, "TIER2_RULES must contain an osano rule");
+    assert.deepEqual([...rule.present], [".osano-cm-dialog--type_bar"]);
+    assert.deepEqual([...rule.reject], [".osano-cm-denyAll"]);
+    assert.deepEqual([...rule.openSettings], []);
+    assert.equal("toggleScope" in rule, false, "the Osano pilot must NOT use toggleScope — it has a genuine one-click reject");
   });
 });
 

--- a/tests/unit/cmp-tier2-veto.test.mjs
+++ b/tests/unit/cmp-tier2-veto.test.mjs
@@ -146,6 +146,36 @@ describe("computeClickVeto — reject role: selector-wrongly-matches-accept-labe
   });
 });
 
+// ── Osano pilot rule coverage (cookie-consent-toggle-reject, PR 3 — pivoted
+// from a toggleScope rule to a simple direct-reject rule after a live probe
+// found `.osano-cm-denyAll` is a genuine first-layer reject control) ────────
+
+describe("computeClickVeto — Osano's .osano-cm-denyAll reject control accessible names", () => {
+  test("EN 'Reject Non-Essential' -> allow (reject-word)", () => {
+    const result = computeClickVeto("Reject Non-Essential", "reject", VETO_WORDS);
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("DE 'Nicht wesentliche Cookies ablehnen' -> allow (reject-word 'ablehnen')", () => {
+    const result = computeClickVeto("Nicht wesentliche Cookies ablehnen", "reject", VETO_WORDS);
+    assert.equal(result.allow, true);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("EN 'Accept All' (the structurally distinct opt-in control, must never be resolved as the reject target, but is vetoed regardless) -> VETO (accept-word)", () => {
+    const result = computeClickVeto("Accept All", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test("DE 'Alle akzeptieren' -> VETO (accept-word)", () => {
+    const result = computeClickVeto("Alle akzeptieren", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+});
+
 describe("computeClickVeto — openSettings role", () => {
   test("a settings-labelled opener -> allow", () => {
     const result = computeClickVeto("Manage options", "openSettings", VETO_WORDS);


### PR DESCRIPTION
**PR 3/3** of `cookie-consent-toggle-reject` — **pivoted** per a live probe.

A live-probe of osano.com (EU vantage) refuted the pre-checked-toggle premise for Osano under GDPR: its non-essential category toggles default **OFF**, and its banner exposes a direct one-click **"Reject Non-Essential"** button. So the `toggleScope` multi-step machinery (PR 1/2) is the wrong tool for Osano — a simple direct-reject Tier 2 rule (the proven Complianz/Cookie-Notice pattern) is correct here. The toggleScope machinery stays inert and ready for a CMP that genuinely needs it (none found with a clean GDPR profile yet).

## What lands
- **Osano rule** (`cmp-tier2-rules.js` + byte-mirrored `@sync` copy in `cookie-noise.js`):
  `{ id:"osano", present:[".osano-cm-dialog--type_bar"], reject:[".osano-cm-denyAll"], openSettings:[] }`
  Selectors live-probe-confirmed on osano.com. `.osano-cm-denyAll` is locale-independent and structurally disjoint from the accept button (`.osano-cm-accept-all`). No `toggleScope`, no accept path, no settings hop.
- **Citation fix**: the Complianz rule's verification reference `doaj.org` → `steuck-aachen.de` (doaj.org no longer serves the `cmplz` marker; steuck-aachen.de is a live-validated Complianz deployment). Comment-only; selectors byte-unchanged.
- **Tests**: rule-shape unit assertions (incl. `"toggleScope" in rule === false`); veto coverage for EN/DE reject names (allow) + accept names (veto) — no word-list gap; a real two-button e2e (`cookie-consent-minimizer-osano.spec.mjs`) asserting MUGA clicks reject, dismisses the banner, and never clicks accept.

## Never-accept
Structural (disjoint class), semantic (absolute deny-word veto gates the click), empirical (two-button e2e). Osano is the first bundled rule that actuates on real users' banners — reviewed accordingly.

## Verification
- `npm test` 7865/7866 pass (1 pre-existing skip); typecheck/lint:js/web-ext clean; e2e Osano 2/2 + regression re-run of the toggle + minimizer specs green; `build:content` zero drift.
- Fresh adversarial review (opus): **CLEAN** — all 7 vectors hold, ship it.

279 lines, under budget (no size:exception).

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9