### PR TITLE
feat(consent): cookieconsent.js Tier 2 reject rule + German reject-veto fix

### DIFF
--- a/src/content/cookie-noise.js
+++ b/src/content/cookie-noise.js
@@ -1431,6 +1431,30 @@
       reject: Object.freeze([".osano-cm-denyAll"]),
       openSettings: Object.freeze([]),
     }),
+
+    /**
+     * cookieconsent.js (Osano/Insites) — API-less, self-hosted widget.
+     * Live-probe-confirmed across 11+ real deployments (2026-07, EU vantage):
+     * `.cc-window` is the stable banner root; `.cc-deny` is the confirmed
+     * reject control, present only in the opt-in/opt-out variants (roughly
+     * 18% of probed deployments). The library's common "info" variant ships
+     * only a `.cc-dismiss` ("Got it") acknowledgement button and NO `.cc-deny`
+     * at all — `present` still matches, but the fail-closed 0-match branch in
+     * `resolveTier2Reject` already no-ops gracefully, exactly like every
+     * other rule here whose reject control is admin-optional. The
+     * structurally distinct opt-in control (`.cc-allow`) lives under its own,
+     * completely disjoint class name, so there is no selector collision risk.
+     * No shadow DOM or iframe was observed in any probed deployment. A clone
+     * library, "DPCookieConsent", reuses the same `.cc-*` class names and is
+     * covered for free by this rule. `openSettings` stays empty: this is a
+     * genuine single-hop reject, no settings panel is ever opened.
+     */
+    Object.freeze({
+      id: "cookieconsent",
+      present: Object.freeze([".cc-window"]),
+      reject: Object.freeze([".cc-deny"]),
+      openSettings: Object.freeze([]),
+    }),
   ]);
   // @sync:cmp-tier2-rules:end
 
@@ -1558,6 +1582,7 @@
     // de
     "ablehnen",
     "alle ablehnen",
+    "abgelehnt",
     "nur notwendige",
     // fr
     "refuser",

--- a/src/lib/cmp-tier2-rules.js
+++ b/src/lib/cmp-tier2-rules.js
@@ -167,5 +167,29 @@ export const TIER2_RULES = Object.freeze([
     reject: Object.freeze([".osano-cm-denyAll"]),
     openSettings: Object.freeze([]),
   }),
+
+  /**
+   * cookieconsent.js (Osano/Insites) — API-less, self-hosted widget.
+   * Live-probe-confirmed across 11+ real deployments (2026-07, EU vantage):
+   * `.cc-window` is the stable banner root; `.cc-deny` is the confirmed
+   * reject control, present only in the opt-in/opt-out variants (roughly
+   * 18% of probed deployments). The library's common "info" variant ships
+   * only a `.cc-dismiss` ("Got it") acknowledgement button and NO `.cc-deny`
+   * at all — `present` still matches, but the fail-closed 0-match branch in
+   * `resolveTier2Reject` already no-ops gracefully, exactly like every
+   * other rule here whose reject control is admin-optional. The
+   * structurally distinct opt-in control (`.cc-allow`) lives under its own,
+   * completely disjoint class name, so there is no selector collision risk.
+   * No shadow DOM or iframe was observed in any probed deployment. A clone
+   * library, "DPCookieConsent", reuses the same `.cc-*` class names and is
+   * covered for free by this rule. `openSettings` stays empty: this is a
+   * genuine single-hop reject, no settings panel is ever opened.
+   */
+  Object.freeze({
+    id: "cookieconsent",
+    present: Object.freeze([".cc-window"]),
+    reject: Object.freeze([".cc-deny"]),
+    openSettings: Object.freeze([]),
+  }),
 ]);
 // @sync:cmp-tier2-rules:end

--- a/src/lib/cmp-tier2-veto.js
+++ b/src/lib/cmp-tier2-veto.js
@@ -189,6 +189,7 @@ const REJECT_WORDS = Object.freeze([
   // de
   "ablehnen",
   "alle ablehnen",
+  "abgelehnt",
   "nur notwendige",
   // fr
   "refuser",

--- a/tests/e2e/cookie-consent-minimizer-cookieconsent.spec.mjs
+++ b/tests/e2e/cookie-consent-minimizer-cookieconsent.spec.mjs
@@ -1,0 +1,200 @@
+/**
+ * E2E: Cookie Consent Minimizer — cookieconsent.js (Osano/Insites) Tier 2
+ * rule (standalone follow-up to cookie-consent-toggle-reject PR 3, live
+ * probe 2026-07).
+ *
+ * Verifies the BUNDLED `cookieconsent` entry in TIER2_RULES
+ * (src/lib/cmp-tier2-rules.js) against a real Chromium with the extension
+ * loaded, using a SYNTHETIC fixture that reproduces cookieconsent.js's
+ * banner DOM shape: `.cc-window` (banner anchor) containing a `.cc-deny`
+ * reject control and a structurally distinct opt-in control (`.cc-allow`).
+ * Mirrors tests/e2e/cookie-consent-minimizer-osano.spec.mjs's structure —
+ * this rule needs no remote-rule injection because it is a real BUNDLED
+ * entry, not fixture-only data.
+ *
+ * Also covers the library's common "info" variant, which ships only a
+ * `.cc-dismiss` ("Got it") acknowledgement button and NO `.cc-deny` at
+ * all: `present` still matches (`.cc-window` is there), but the fail-closed
+ * 0-match branch in `resolveTier2Reject` must NOOP — the banner stays and
+ * nothing is clicked.
+ *
+ * HONEST LIMIT (same posture as the sibling Tier 2 e2e specs): a
+ * synthetic-fixture regression oracle only, Chromium-only. It does not
+ * prove compatibility with real cookieconsent.js markup beyond the 2026-07
+ * EU-vantage live probe (11+ deployments) this rule's selectors are cited
+ * from — re-capture this fixture manually whenever the library's markup
+ * changes upstream.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+import { waitForDnrPropagation } from "./helpers/index.mjs";
+
+const HOST = "muga-test-cookie-consent-cookieconsent.invalid";
+const INFO_HOST = "muga-test-cookie-consent-cookieconsent-info.invalid";
+
+async function completeOnboarding(context, extensionId, { enableFeature = true } = {}) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await page.evaluate(
+    ({ enableFeature }) =>
+      new Promise((resolve) => {
+        chrome.storage.sync.set(
+          { enabled: true, cookieConsentMode: enableFeature ? "reject-only" : "off" },
+          () => {
+            chrome.storage.local.set(
+              {
+                mugaConsent: { onboardingDone: true, consentVersion: "1.2", consentDate: Date.now() },
+              },
+              () => {
+                chrome.storage.sync.set({ onboardingDone: true }, resolve);
+              }
+            );
+          }
+        );
+      }),
+    { enableFeature }
+  );
+  await page.close();
+  await waitForDnrPropagation(page);
+}
+
+/**
+ * Fixture: reproduces cookieconsent.js's opt-in/opt-out banner DOM shape —
+ * the `.cc-window` anchor, a `.cc-deny` reject button (EN "Decline"), and
+ * a structurally distinct opt-in control (`.cc-allow`) that must NEVER be
+ * clicked.
+ */
+async function stubCookieconsentPage(page) {
+  await page.route(`**://${HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div class="cc-window cc-banner cc-type-opt-out" id="cc-window-marker">
+          <button class="cc-deny cc-btn" id="cc-deny-btn">Decline</button>
+          <button class="cc-allow cc-btn" id="cc-allow-btn">Allow cookies</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__e2eClicks = [];
+          var banner = document.getElementById("cc-window-marker");
+          document.getElementById("cc-deny-btn").addEventListener("click", function () {
+            window.__e2eClicks.push("deny");
+            window.__consentState = "necessary-only";
+            banner.remove();
+          });
+          document.getElementById("cc-allow-btn").addEventListener("click", function () {
+            window.__e2eClicks.push("accept");
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+/**
+ * Fixture: reproduces cookieconsent.js's "info" variant DOM shape — a
+ * `.cc-window` anchor with ONLY a `.cc-dismiss` ("Got it") acknowledgement
+ * button, no `.cc-deny` at all. `resolveTier2Reject` must fail-closed NOOP
+ * here (0 reject candidates), leaving the banner untouched.
+ */
+async function stubCookieconsentInfoPage(page) {
+  await page.route(`**://${INFO_HOST}/**`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html><html><body>
+        <div class="cc-window cc-banner cc-type-info" id="cc-window-info-marker">
+          <button class="cc-dismiss cc-btn" id="cc-dismiss-btn">Got it</button>
+        </div>
+        <p id="page-content">Real page content</p>
+        <script>
+          window.__e2eClicks = [];
+          document.getElementById("cc-dismiss-btn").addEventListener("click", function () {
+            window.__e2eClicks.push("dismiss");
+          });
+        </script>
+      </body></html>`,
+    })
+  );
+}
+
+test.describe("Cookie Consent Minimizer — cookieconsent.js (Osano/Insites)", () => {
+  test("clicks the bundled .cc-deny reject control, dismisses the banner, and never clicks the .cc-allow decoy", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    await stubCookieconsentPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    await page.waitForFunction(() => window.__consentState === "necessary-only", { timeout: 10000 });
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    expect(clicks).toEqual(["deny"]);
+    expect(clicks).not.toContain("accept");
+
+    const consentState = await page.evaluate(() => window.__consentState);
+    expect(consentState).toBe("necessary-only");
+
+    const bannerGone = await page.evaluate(() => document.getElementById("cc-window-marker") === null);
+    expect(bannerGone).toBe(true);
+
+    const pageContent = await page.evaluate(() => document.getElementById("page-content")?.textContent);
+    expect(pageContent).toBe("Real page content");
+
+    expect(pageErrors).toHaveLength(0);
+
+    await page.close();
+  });
+
+  test("takes no action when the feature is disabled (default OFF) — the .cc-allow decoy is never clicked either", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: false });
+
+    const page = await context.newPage();
+    await stubCookieconsentPage(page);
+    await page.goto(`https://${HOST}/index.html`);
+
+    // REASON: negative assertion (feature OFF) — no positive signal to wait
+    // on; fixed settle window, the standard pattern for this suite's
+    // negatives (see cookie-consent-minimizer.spec.mjs).
+    await page.waitForTimeout(1500);
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    expect(clicks).toEqual([]);
+    const bannerStillThere = await page.evaluate(() => document.getElementById("cc-window-marker") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+
+  test("the dismiss-only 'info' variant (no .cc-deny) is a fail-closed NOOP — banner stays, nothing is clicked", async ({
+    context,
+    extensionId,
+  }) => {
+    await completeOnboarding(context, extensionId, { enableFeature: true });
+
+    const page = await context.newPage();
+    await stubCookieconsentInfoPage(page);
+    await page.goto(`https://${INFO_HOST}/index.html`);
+
+    // REASON: negative assertion (fail-closed NOOP, no `.cc-deny` present) —
+    // no positive signal to wait on; fixed settle window, mirroring the
+    // disabled-feature negative above.
+    await page.waitForTimeout(1500);
+
+    const clicks = await page.evaluate(() => window.__e2eClicks);
+    expect(clicks).toEqual([]);
+    const bannerStillThere = await page.evaluate(() => document.getElementById("cc-window-info-marker") !== null);
+    expect(bannerStillThere).toBe(true);
+
+    await page.close();
+  });
+});

--- a/tests/unit/cmp-adapters.test.mjs
+++ b/tests/unit/cmp-adapters.test.mjs
@@ -61,10 +61,10 @@ describe("cmp-adapters — registry shape", () => {
     assert.strictEqual(TIER1[9], consentmanagerAdapter);
   });
 
-  test("TIER2 ships with the Slice 1 seed rules plus the Osano pilot (Complianz, Cookie Notice, Osano)", () => {
+  test("TIER2 ships with the Slice 1 seed rules plus the Osano pilot and the cookieconsent rule (Complianz, Cookie Notice, Osano, cookieconsent)", () => {
     assert.ok(Array.isArray(TIER2));
-    assert.equal(TIER2.length, 3);
-    assert.deepEqual(TIER2.map((a) => a.id), ["complianz", "cookie-notice", "osano"]);
+    assert.equal(TIER2.length, 4);
+    assert.deepEqual(TIER2.map((a) => a.id), ["complianz", "cookie-notice", "osano", "cookieconsent"]);
     for (const adapter of TIER2) {
       assert.equal(adapter.tier, 2);
       assert.equal(typeof adapter.detect, "function");
@@ -734,11 +734,12 @@ describe("decideAction — truth table", () => {
 // ── Tier 2 rule data (src/lib/cmp-tier2-rules.js) — shape ───────────────────
 
 describe("TIER2_RULES — closed reject-only shape (#1027 Slice 1)", () => {
-  test("TIER2_RULES contains exactly the Complianz, Cookie Notice, and Osano rules, in order", () => {
-    assert.equal(TIER2_RULES.length, 3);
+  test("TIER2_RULES contains exactly the Complianz, Cookie Notice, Osano, and cookieconsent rules, in order", () => {
+    assert.equal(TIER2_RULES.length, 4);
     assert.equal(TIER2_RULES[0].id, "complianz");
     assert.equal(TIER2_RULES[1].id, "cookie-notice");
     assert.equal(TIER2_RULES[2].id, "osano");
+    assert.equal(TIER2_RULES[3].id, "cookieconsent");
   });
 
   test("TIER2_RULES and every rule entry are frozen", () => {
@@ -796,6 +797,15 @@ describe("TIER2_RULES — closed reject-only shape (#1027 Slice 1)", () => {
     assert.deepEqual([...rule.reject], [".osano-cm-denyAll"]);
     assert.deepEqual([...rule.openSettings], []);
     assert.equal("toggleScope" in rule, false, "the Osano pilot must NOT use toggleScope — it has a genuine one-click reject");
+  });
+
+  test("cookieconsent (Osano/Insites) rule matches the live-probe-confirmed selectors and has no toggleScope field", () => {
+    const rule = TIER2_RULES.find((r) => r.id === "cookieconsent");
+    assert.ok(rule, "TIER2_RULES must contain a cookieconsent rule");
+    assert.deepEqual([...rule.present], [".cc-window"]);
+    assert.deepEqual([...rule.reject], [".cc-deny"]);
+    assert.deepEqual([...rule.openSettings], []);
+    assert.equal("toggleScope" in rule, false, "the cookieconsent rule must NOT use toggleScope — it has a genuine one-click reject");
   });
 });
 

--- a/tests/unit/cmp-tier2-veto.test.mjs
+++ b/tests/unit/cmp-tier2-veto.test.mjs
@@ -349,6 +349,54 @@ describe('computeClickVeto — role "save": invariant-gated exception', () => {
   });
 });
 
+// ── cookieconsent.js (Osano/Insites) `.cc-deny` accessible names + the
+// German "abgelehnt" reject-word gap (live probe, adsimple.at, 2026-07) ────
+//
+// The live probe found a real cookieconsent.js deployment (adsimple.at)
+// whose `.cc-deny` accessible name reads "abgelehnt" — NOT a substring of
+// the pre-existing German REJECT_WORDS ("ablehnen" / "alle ablehnen") — so
+// computeClickVeto used to VETO ("no-reject-word") a legitimate reject
+// button. This RED->GREEN test proves the fix.
+
+describe("computeClickVeto — cookieconsent.js .cc-deny accessible names, including the German 'abgelehnt' gap", () => {
+  test("EN 'Decline' -> allow (reject role)", () => {
+    const result = computeClickVeto("Decline", "reject", VETO_WORDS);
+    assert.equal(result.allow, true, `expected allow, got reason "${result.reason}"`);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("EN 'Reject All' -> allow (reject role)", () => {
+    const result = computeClickVeto("Reject All", "reject", VETO_WORDS);
+    assert.equal(result.allow, true, `expected allow, got reason "${result.reason}"`);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("DE 'abgelehnt' -> allow (reject role) — the adsimple.at gap fix; FAILS before REJECT_WORDS gains 'abgelehnt'", () => {
+    const result = computeClickVeto("abgelehnt", "reject", VETO_WORDS);
+    assert.equal(result.allow, true, `expected allow, got reason "${result.reason}"`);
+    assert.equal(result.reason, "ok");
+  });
+
+  test("EN accept button 'Allow' -> VETO (accept-word), never let through by the 'abgelehnt' addition", () => {
+    const result = computeClickVeto("Allow", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test("DE accept button 'Alle akzeptieren' -> VETO (accept-word), never let through by the 'abgelehnt' addition", () => {
+    const result = computeClickVeto("Alle akzeptieren", "reject", VETO_WORDS);
+    assert.equal(result.allow, false);
+    assert.equal(result.reason, "accept-word");
+  });
+
+  test("'abgelehnt' is not a substring of any DENY_WORDS entry, and no DENY_WORDS entry is a substring of it (safety check — the absolute deny check still runs first and always wins)", () => {
+    for (const denyWord of VETO_WORDS.deny) {
+      assert.equal(denyWord.indexOf("abgelehnt"), -1, `DENY_WORDS entry "${denyWord}" must not contain "abgelehnt"`);
+      assert.equal("abgelehnt".indexOf(denyWord), -1, `"abgelehnt" must not contain DENY_WORDS entry "${denyWord}"`);
+    }
+  });
+});
+
 describe("computeClickVeto — multi-locale reject coverage (en/es/de/fr/it/ja/pt)", () => {
   const REJECT_ALLOWS = [
     ["en", "Reject all"],


### PR DESCRIPTION
Adds a bundled Tier 2 direct-reject rule for the Osano/Insites **cookieconsent.js** (`.cc-*`) library, plus a German click-veto reject-word fix — both surfaced by a live probe of 11 real cookieconsent.js deployments (EU vantage).

## What lands
- **Rule** (`cmp-tier2-rules.js` + byte-mirrored `@sync` copy in `cookie-noise.js`):
  `{ id:"cookieconsent", present:[".cc-window"], reject:[".cc-deny"], openSettings:[] }`
  `.cc-window` detects the banner; `.cc-deny` is the "Decline" button of the opt-in/opt-out variants; `.cc-allow` (accept) is a structurally disjoint token, never matched. The common dismiss-only "info" variant (`.cc-dismiss` "Got it", no `.cc-deny`) makes `resolveTier2Reject`'s exactly-1-match contract a **fail-closed NOOP** — verified. Covers the ~18% reject-capable deployments + the DPCookieConsent clone (same `.cc-*` scheme) for free; no shadow DOM / iframe in any probed site.
- **German veto fix**: the probe found a real reject button reading **"abgelehnt"**, which was not a substring of the existing German `REJECT_WORDS` (`ablehnen`), so the veto silently NOOP'd a working reject. Added `"abgelehnt"` to `REJECT_WORDS` (+ `@sync` copy). Safety-verified: `"abgelehnt"` is neither substring nor superstring of any accept-family `DENY_WORDS` term in any locale, and the absolute deny-word check still runs first — an accept button can never be classified reject.

## Never-accept
No accept path in the rule; the reject click stays veto-gated; the German word addition cannot let an accept through (deny check absolute + first, proven by a dedicated disjointness test).

## Verification
- `npm test` 7875 pass (1 pre-existing skip); typecheck/lint:js/web-ext clean; `build:content` zero drift (cookie-noise.js hand-synced, not bundled).
- New e2e `cookie-consent-minimizer-cookieconsent.spec.mjs` 3/3: opt-in → clicks `.cc-deny` + dismiss + never `.cc-allow`; info-variant → fail-closed NOOP; feature-off → no clicks.
- Fresh adversarial review (opus): **CLEAN** — all 7 vectors hold, including the veto-word safety check.

~313 lines, under budget.

https://claude.ai/code/session_01CVAo7pVAeb1zDcqP6dFym9