### PR TITLE
refactor(affiliate): remove dead own-tag scaffolding from web-tool adapters (2/4)

### DIFF
--- a/landing/clean/engine/adapter.js
+++ b/landing/clean/engine/adapter.js
@@ -64,9 +64,6 @@ function buildFailure(action, error, rawInput) {
     unwrapped: false,
     destinationHost: null,
     affiliatePreserved: false,
-    mugaReferralInjected: false,
-    mugaReferralPresent: false,
-    cleanUrlNoMugaReferral: null,
     action,
     error,
   };
@@ -78,14 +75,9 @@ function buildFailure(action, error, rawInput) {
  * REAL defaults (`engine.PREF_DEFAULTS`) so behavioural defaults never
  * hand-drift from `src/lib/prefs.js`.
  *
- * `injectOwnAffiliate` stays on (design D1, web-tool-naked-link-injection
- * slice 2, ADR-1): the web tool injects MUGA's own tag on naked Amazon/eBay
- * links so the tool can fund itself, while every other web-tool policy
- * override (no notify, no honor-creator, no lists) stays in place. The
- * tag-free variant is no longer produced by a second injection-off run; it
- * is derived by surgically stripping MUGA's own tag from the cleaned URL
- * (see detectOwnReferral), which also covers links that ALREADY carried our
- * referral before cleaning.
+ * drop-affiliate-injection (PR 2/4): `injectOwnAffiliate` is no longer
+ * forced on — the engine dropped injection support (PR 1a) and the pref
+ * itself was removed (PR 1b), so this adapter stops passing it.
  *
  * @param {object} prefDefaults
  * @returns {object}
@@ -95,7 +87,6 @@ function buildPureCleanerPrefs(prefDefaults) {
     ...prefDefaults,
     enabled: true,
     onboardingDone: true,
-    injectOwnAffiliate: true,
     notifyForeignAffiliate: false,
     honorCreatorMode: false,
     blacklist: [],
@@ -103,66 +94,6 @@ function buildPureCleanerPrefs(prefDefaults) {
     customParams: [],
     userCustomRules: [],
   };
-}
-
-/**
- * Resolves MUGA's own affiliate tag for an affiliate pattern + hostname.
- * Adapter-local mirror of src/lib/affiliates.js `resolveOurTag`: the engine
- * bundle exposes `AFFILIATE_PATTERNS` (each pattern carries its per-host
- * `ourTag` map) and `getPatternsForHost`, but not `resolveOurTag` itself.
- * Reading the already-exposed `ourTag` map keeps the tag VALUES single-
- * sourced in the engine, so this adapter never hard-codes them.
- *
- * @param {{ourTag?: Object}|null|undefined} pattern
- * @param {string} hostname
- * @returns {string} the tag configured for this host, or "" when none.
- */
-function resolveOurTag(pattern, hostname) {
-  if (!pattern || !pattern.ourTag || !hostname) return "";
-  const host = hostname.replace(/^www\./, "");
-  return pattern.ourTag[host] || pattern.ourTag[hostname] || "";
-}
-
-/**
- * Detects whether a cleaned URL carries MUGA's OWN affiliate referral and,
- * when it does, returns the URL with only that param removed.
- *
- * Matches our tag by VALUE against the engine's per-host affiliate patterns,
- * so a foreign/creator referral (a different value on the same param, e.g.
- * `tag=somecreator-20`) is never stripped: the preservation moat stays
- * intact. Covers BOTH the just-injected case and a link the user pasted that
- * already carried MUGA's tag (design "copy-without-referral parity"). Never
- * throws: any failure degrades to "no own referral".
- *
- * @param {string} cleanUrl            The cleaned URL returned by the engine.
- * @param {string|null} destinationHost  Its hostname (already parsed by the caller).
- * @param {object} engine              The resolved engine handle.
- * @returns {{ present: boolean, stripped: string|null }}
- */
-function detectOwnReferral(cleanUrl, destinationHost, engine) {
-  const none = { present: false, stripped: null };
-  if (typeof cleanUrl !== "string" || !destinationHost) return none;
-  if (!engine || typeof engine.getPatternsForHost !== "function") return none;
-
-  let url;
-  try {
-    url = new URL(cleanUrl);
-  } catch {
-    return none;
-  }
-
-  const host = destinationHost.replace(/^www\./, "");
-  const patterns = engine.getPatternsForHost(host) || [];
-  let present = false;
-  for (const pattern of patterns) {
-    const ourTag = resolveOurTag(pattern, host);
-    if (!ourTag) continue;
-    if (url.searchParams.get(pattern.param) === ourTag) {
-      url.searchParams.delete(pattern.param);
-      present = true;
-    }
-  }
-  return present ? { present: true, stripped: url.toString() } : none;
 }
 
 /**
@@ -183,9 +114,6 @@ function detectOwnReferral(cleanUrl, destinationHost, engine) {
  *   unwrapped: boolean,
  *   destinationHost: string|null,
  *   affiliatePreserved: boolean,
- *   mugaReferralInjected: boolean,
- *   mugaReferralPresent: boolean,
- *   cleanUrlNoMugaReferral: string|null,
  *   action: string,
  *   error?: string,
  * }}
@@ -234,21 +162,6 @@ export function cleanUrl(input, engine = resolveEngine()) {
 
   const unwrapped = destinationHost !== null && destinationHost !== inputUrl.hostname;
 
-  // mugaReferralInjected (design D2): keyed off action === "injected", NOT
-  // affiliatePreserved. "injected" means MUGA added its own tag THIS run; a
-  // preserved creator/foreign referral means nothing MUGA-owned was added.
-  // It drives the disclosure WORDING (added vs already present).
-  const mugaReferralInjected = result.action === "injected";
-
-  // mugaReferralPresent + cleanUrlNoMugaReferral: the "copy without referral"
-  // opt-out must appear whenever the cleaned URL carries MUGA's OWN referral,
-  // whether MUGA injected it this run OR the pasted link already carried it
-  // (a MUGA-tagged link the user re-cleans). Detect our tag by value against
-  // the engine's per-host affiliate patterns and surgically remove only that
-  // param, so a foreign/creator referral is never stripped. This replaces the
-  // old injection-off rerun, which missed the already-present case entirely.
-  const ownReferral = detectOwnReferral(result.cleanUrl, destinationHost, engine);
-
   return {
     ok: true,
     cleanUrl: result.cleanUrl,
@@ -256,9 +169,6 @@ export function cleanUrl(input, engine = resolveEngine()) {
     unwrapped,
     destinationHost,
     affiliatePreserved: !!(result.preservedAffiliate || result.creatorReferralPreserved),
-    mugaReferralInjected,
-    mugaReferralPresent: ownReferral.present,
-    cleanUrlNoMugaReferral: ownReferral.stripped,
     action: result.action,
   };
 }

--- a/tests/unit/web-adapter-contract.test.mjs
+++ b/tests/unit/web-adapter-contract.test.mjs
@@ -111,54 +111,39 @@ describe("web adapter contract — negative / invalid input handling", () => {
   });
 });
 
-// drop-affiliate-injection (PR 1a): src/lib/affiliates.js no longer carries
-// OUR_TAGS / a per-pattern `ourTag` map, and src/lib/cleaner.js no longer
-// has an injection step — so the bundled engine these tests load can never
-// again produce action:"injected" or a non-empty own-referral. The adapter
-// (web/engine/adapter.js) itself is UNCHANGED in this PR (it is hand-
-// maintained, PR 2 scope) — its `resolveOurTag`/`detectOwnReferral` helpers
-// degrade gracefully (pattern.ourTag is now undefined → treated as "no own
-// tag"), so `mugaReferralInjected`/`mugaReferralPresent`/
-// `cleanUrlNoMugaReferral` are now ALWAYS false/false/null. This is a real,
-// immediate behavior change for the web tool (its "MUGA referral opt-out"
-// disclosure UI can never trigger anymore) shipped by this bundle rebuild,
-// ahead of the adapter.js/UI-copy rewiring planned for PR 2 — flagged for
-// maintainer review.
-describe("web adapter contract — naked-link MUGA referral injection (REMOVED, web-tool-naked-link-injection superseded)", () => {
+// drop-affiliate-injection (PR 2/4): the adapter's own-tag injection
+// scaffolding (`resolveOurTag`, `detectOwnReferral`, the `injectOwnAffiliate`
+// pref override, and the mugaReferralInjected/mugaReferralPresent/
+// cleanUrlNoMugaReferral result fields) is now REMOVED from
+// web/engine/adapter.js and landing/clean/engine/adapter.js, not merely
+// degraded. PR 1a already stopped the engine from ever producing
+// action:"injected" or a non-empty own-referral; this PR deletes the
+// now-dead adapter code that used to read/report that state.
+describe("web adapter contract — own-tag injection scaffolding removed (drop-affiliate-injection PR 2/4)", () => {
   test("naked Amazon link: no MUGA tag is added, stays tagless", () => {
     const out = cleanUrl("https://www.amazon.com/dp/B000123456", engine);
     assert.equal(out.ok, true);
     assert.notEqual(out.action, "injected");
-    assert.equal(out.mugaReferralInjected, false);
-    assert.equal(out.mugaReferralPresent, false);
-    assert.equal(out.cleanUrlNoMugaReferral, null);
     assert.equal(new URL(out.cleanUrl).searchParams.has("tag"), false);
   });
 
   test("naked Amazon link WITH a product-name slug: slug is still stripped, no tag is added", () => {
     const out = cleanUrl("https://www.amazon.es/-/en/Sony-MDR-7506-Reduction-Closed-Headphones/dp/B000AJIF4E", engine);
     assert.equal(out.ok, true);
-    assert.equal(out.mugaReferralInjected, false);
     assert.ok(!out.cleanUrl.includes("Sony-MDR-7506"), "the Amazon path-strip rule still runs, independent of injection");
-    assert.equal(out.cleanUrlNoMugaReferral, null);
   });
 
   test("naked eBay link: no MUGA referral is added", () => {
     const out = cleanUrl("https://www.ebay.com/itm/123456789", engine);
     assert.equal(out.ok, true);
     assert.notEqual(out.action, "injected");
-    assert.equal(out.mugaReferralInjected, false);
     assert.equal(new URL(out.cleanUrl).searchParams.has("campid"), false);
-    assert.equal(out.cleanUrlNoMugaReferral, null);
   });
 
-  test("existing creator/foreign referral is preserved: no injection, no opt-out URL", () => {
+  test("existing creator/foreign referral is preserved: no injection", () => {
     const out = cleanUrl("https://www.amazon.com/dp/B000123456?tag=somecreator-20", engine);
     assert.equal(out.ok, true);
     assert.equal(out.affiliatePreserved, true);
-    assert.equal(out.mugaReferralInjected, false, "MUGA must not add anything when a referral already exists");
-    assert.equal(out.mugaReferralPresent, false, "a foreign referral is not MUGA's own — no opt-out");
-    assert.equal(out.cleanUrlNoMugaReferral, null, "nothing to opt out of when the referral is not MUGA's");
     assert.equal(new URL(out.cleanUrl).searchParams.get("tag"), "somecreator-20");
   });
 
@@ -169,21 +154,18 @@ describe("web adapter contract — naked-link MUGA referral injection (REMOVED, 
     const out = cleanUrl("https://www.amazon.com/dp/B000123456?tag=muga0b-20", engine);
     assert.equal(out.ok, true);
     assert.notEqual(out.action, "injected");
-    assert.equal(out.mugaReferralInjected, false);
-    assert.equal(out.mugaReferralPresent, false, "there is no more concept of MUGA's own tag to detect");
-    assert.equal(out.cleanUrlNoMugaReferral, null);
     assert.equal(new URL(out.cleanUrl).searchParams.get("tag"), "muga0b-20", "the value is preserved unmodified");
   });
 
-  test("non-supported program / plain link: no injection, no opt-out URL", () => {
+  test("non-supported program / plain link: nothing injection-related on the result", () => {
     const out = cleanUrl("https://example.com/already-clean?id=42", engine);
     assert.equal(out.ok, true);
-    assert.equal(out.mugaReferralInjected, false);
-    assert.equal(out.mugaReferralPresent, false);
-    assert.equal(out.cleanUrlNoMugaReferral, null);
+    assert.equal("mugaReferralInjected" in out, false);
+    assert.equal("mugaReferralPresent" in out, false);
+    assert.equal("cleanUrlNoMugaReferral" in out, false);
   });
 
-  test("existing fields (removed, unwrapped, affiliatePreserved, action) are unchanged by the new fields", () => {
+  test("existing fields (removed, unwrapped, affiliatePreserved, action) are unchanged", () => {
     const out = cleanUrl(
       "https://example.com/shop/item?utm_source=news&utm_medium=email&id=42",
       engine,
@@ -193,9 +175,22 @@ describe("web adapter contract — naked-link MUGA referral injection (REMOVED, 
     assert.equal(out.unwrapped, false);
     assert.equal(out.affiliatePreserved, false);
     assert.equal(out.action, "cleaned");
-    assert.equal(out.mugaReferralInjected, false);
-    assert.equal(out.mugaReferralPresent, false);
-    assert.equal(out.cleanUrlNoMugaReferral, null);
+  });
+
+  test("the ok:true result shape has exactly the stable keys — no injection scaffolding fields survive", () => {
+    const out = cleanUrl("https://example.com/already-clean?id=42", engine);
+    const EXPECTED_KEYS = new Set([
+      "ok",
+      "cleanUrl",
+      "removed",
+      "unwrapped",
+      "destinationHost",
+      "affiliatePreserved",
+      "action",
+    ]);
+    for (const key of Object.keys(out)) {
+      assert.ok(EXPECTED_KEYS.has(key), `unexpected key on result: ${key}`);
+    }
   });
 });
 

--- a/tests/unit/web-adapter.test.mjs
+++ b/tests/unit/web-adapter.test.mjs
@@ -17,7 +17,6 @@ import { PATH_STRIP_RULES } from "../../web/engine/path-strip-rules.gen.mjs";
 
 const FAKE_PREF_DEFAULTS = {
   enabled: true,
-  injectOwnAffiliate: true,
   notifyForeignAffiliate: true,
   stripAllAffiliates: false,
   honorCreatorMode: true,
@@ -107,10 +106,10 @@ describe("web adapter — pure-cleaner prefs", () => {
     assert.ok(captured, "processUrl must have been called");
     assert.equal(captured.prefs.enabled, true);
     assert.equal(captured.prefs.onboardingDone, true);
-    // injectOwnAffiliate defaults to true for the web tool (design D1,
-    // web-tool-naked-link-injection slice 2): MUGA injects its own referral
-    // on naked Amazon/eBay links by default, disclosed with an opt-out.
-    assert.equal(captured.prefs.injectOwnAffiliate, true);
+    // drop-affiliate-injection (PR 2/4): the adapter no longer forces
+    // injectOwnAffiliate — the engine no longer reads that pref (PR 1a/1b
+    // already dropped injection support), so the adapter stops passing it.
+    assert.equal("injectOwnAffiliate" in captured.prefs, false);
     assert.equal(captured.prefs.notifyForeignAffiliate, false);
     assert.equal(captured.prefs.honorCreatorMode, false);
     assert.deepEqual(captured.prefs.blacklist, []);
@@ -193,6 +192,12 @@ describe("web adapter — result mapping", () => {
     assert.equal(out.destinationHost, "example.com");
     assert.equal(out.affiliatePreserved, false);
     assert.equal(out.action, "cleaned");
+    // drop-affiliate-injection (PR 2/4): the own-tag injection scaffolding
+    // (mugaReferralInjected/mugaReferralPresent/cleanUrlNoMugaReferral) is
+    // gone from the result shape entirely — not just false/null.
+    assert.equal("mugaReferralInjected" in out, false);
+    assert.equal("mugaReferralPresent" in out, false);
+    assert.equal("cleanUrlNoMugaReferral" in out, false);
   });
 
   test("marks affiliatePreserved true when processUrl reports a preserved affiliate", () => {
@@ -249,6 +254,9 @@ describe("web adapter — degradation", () => {
     assert.equal(out.ok, false);
     assert.equal(out.action, "error");
     assert.equal(out.error, "engine-unavailable");
+    assert.equal("mugaReferralInjected" in out, false);
+    assert.equal("mugaReferralPresent" in out, false);
+    assert.equal("cleanUrlNoMugaReferral" in out, false);
   });
 
   test("returns engine-unavailable when the injected engine has no processUrl function", () => {

--- a/web/engine/adapter.js
+++ b/web/engine/adapter.js
@@ -64,9 +64,6 @@ function buildFailure(action, error, rawInput) {
     unwrapped: false,
     destinationHost: null,
     affiliatePreserved: false,
-    mugaReferralInjected: false,
-    mugaReferralPresent: false,
-    cleanUrlNoMugaReferral: null,
     action,
     error,
   };
@@ -78,14 +75,9 @@ function buildFailure(action, error, rawInput) {
  * REAL defaults (`engine.PREF_DEFAULTS`) so behavioural defaults never
  * hand-drift from `src/lib/prefs.js`.
  *
- * `injectOwnAffiliate` stays on (design D1, web-tool-naked-link-injection
- * slice 2, ADR-1): the web tool injects MUGA's own tag on naked Amazon/eBay
- * links so the tool can fund itself, while every other web-tool policy
- * override (no notify, no honor-creator, no lists) stays in place. The
- * tag-free variant is no longer produced by a second injection-off run; it
- * is derived by surgically stripping MUGA's own tag from the cleaned URL
- * (see detectOwnReferral), which also covers links that ALREADY carried our
- * referral before cleaning.
+ * drop-affiliate-injection (PR 2/4): `injectOwnAffiliate` is no longer
+ * forced on — the engine dropped injection support (PR 1a) and the pref
+ * itself was removed (PR 1b), so this adapter stops passing it.
  *
  * @param {object} prefDefaults
  * @returns {object}
@@ -95,7 +87,6 @@ function buildPureCleanerPrefs(prefDefaults) {
     ...prefDefaults,
     enabled: true,
     onboardingDone: true,
-    injectOwnAffiliate: true,
     notifyForeignAffiliate: false,
     honorCreatorMode: false,
     blacklist: [],
@@ -103,66 +94,6 @@ function buildPureCleanerPrefs(prefDefaults) {
     customParams: [],
     userCustomRules: [],
   };
-}
-
-/**
- * Resolves MUGA's own affiliate tag for an affiliate pattern + hostname.
- * Adapter-local mirror of src/lib/affiliates.js `resolveOurTag`: the engine
- * bundle exposes `AFFILIATE_PATTERNS` (each pattern carries its per-host
- * `ourTag` map) and `getPatternsForHost`, but not `resolveOurTag` itself.
- * Reading the already-exposed `ourTag` map keeps the tag VALUES single-
- * sourced in the engine, so this adapter never hard-codes them.
- *
- * @param {{ourTag?: Object}|null|undefined} pattern
- * @param {string} hostname
- * @returns {string} the tag configured for this host, or "" when none.
- */
-function resolveOurTag(pattern, hostname) {
-  if (!pattern || !pattern.ourTag || !hostname) return "";
-  const host = hostname.replace(/^www\./, "");
-  return pattern.ourTag[host] || pattern.ourTag[hostname] || "";
-}
-
-/**
- * Detects whether a cleaned URL carries MUGA's OWN affiliate referral and,
- * when it does, returns the URL with only that param removed.
- *
- * Matches our tag by VALUE against the engine's per-host affiliate patterns,
- * so a foreign/creator referral (a different value on the same param, e.g.
- * `tag=somecreator-20`) is never stripped: the preservation moat stays
- * intact. Covers BOTH the just-injected case and a link the user pasted that
- * already carried MUGA's tag (design "copy-without-referral parity"). Never
- * throws: any failure degrades to "no own referral".
- *
- * @param {string} cleanUrl            The cleaned URL returned by the engine.
- * @param {string|null} destinationHost  Its hostname (already parsed by the caller).
- * @param {object} engine              The resolved engine handle.
- * @returns {{ present: boolean, stripped: string|null }}
- */
-function detectOwnReferral(cleanUrl, destinationHost, engine) {
-  const none = { present: false, stripped: null };
-  if (typeof cleanUrl !== "string" || !destinationHost) return none;
-  if (!engine || typeof engine.getPatternsForHost !== "function") return none;
-
-  let url;
-  try {
-    url = new URL(cleanUrl);
-  } catch {
-    return none;
-  }
-
-  const host = destinationHost.replace(/^www\./, "");
-  const patterns = engine.getPatternsForHost(host) || [];
-  let present = false;
-  for (const pattern of patterns) {
-    const ourTag = resolveOurTag(pattern, host);
-    if (!ourTag) continue;
-    if (url.searchParams.get(pattern.param) === ourTag) {
-      url.searchParams.delete(pattern.param);
-      present = true;
-    }
-  }
-  return present ? { present: true, stripped: url.toString() } : none;
 }
 
 /**
@@ -183,9 +114,6 @@ function detectOwnReferral(cleanUrl, destinationHost, engine) {
  *   unwrapped: boolean,
  *   destinationHost: string|null,
  *   affiliatePreserved: boolean,
- *   mugaReferralInjected: boolean,
- *   mugaReferralPresent: boolean,
- *   cleanUrlNoMugaReferral: string|null,
  *   action: string,
  *   error?: string,
  * }}
@@ -234,21 +162,6 @@ export function cleanUrl(input, engine = resolveEngine()) {
 
   const unwrapped = destinationHost !== null && destinationHost !== inputUrl.hostname;
 
-  // mugaReferralInjected (design D2): keyed off action === "injected", NOT
-  // affiliatePreserved. "injected" means MUGA added its own tag THIS run; a
-  // preserved creator/foreign referral means nothing MUGA-owned was added.
-  // It drives the disclosure WORDING (added vs already present).
-  const mugaReferralInjected = result.action === "injected";
-
-  // mugaReferralPresent + cleanUrlNoMugaReferral: the "copy without referral"
-  // opt-out must appear whenever the cleaned URL carries MUGA's OWN referral,
-  // whether MUGA injected it this run OR the pasted link already carried it
-  // (a MUGA-tagged link the user re-cleans). Detect our tag by value against
-  // the engine's per-host affiliate patterns and surgically remove only that
-  // param, so a foreign/creator referral is never stripped. This replaces the
-  // old injection-off rerun, which missed the already-present case entirely.
-  const ownReferral = detectOwnReferral(result.cleanUrl, destinationHost, engine);
-
   return {
     ok: true,
     cleanUrl: result.cleanUrl,
@@ -256,9 +169,6 @@ export function cleanUrl(input, engine = resolveEngine()) {
     unwrapped,
     destinationHost,
     affiliatePreserved: !!(result.preservedAffiliate || result.creatorReferralPreserved),
-    mugaReferralInjected,
-    mugaReferralPresent: ownReferral.present,
-    cleanUrlNoMugaReferral: ownReferral.stripped,
     action: result.action,
   };
 }


### PR DESCRIPTION
**PR 2 of 4** — the web cleaner (muga.app/clean + landing morph) already stopped injecting when PR 1a rebuilt the shared bundle. This removes the now-DEAD injection scaffolding from the two hand-maintained adapters. **Code only — web/landing marketing copy + the disclosure UI are reworded/removed in PR 3 (the narrative PR, shown to the user first).**

## Removed (identically in `web/engine/adapter.js` + `landing/clean/engine/adapter.js` — confirmed byte-identical)
- local `resolveOurTag` mirror + `detectOwnReferral`
- the `injectOwnAffiliate: true` pass into the engine (no-op since 1a)
- result fields `mugaReferralInjected` / `mugaReferralPresent` / `cleanUrlNoMugaReferral`

## Kept intact
`affiliatePreserved` (creator-referral preservation) + all URL cleaning/unwrapping/slug-strip.

## Interim state (intended)
`web/ui.js`/`ui-view.js` still read the removed fields via `!!result.x` / `typeof … === "string"` → they resolve falsy safely (disclosure UI just doesn't render, no crash). Those consumers + the copy are removed in PR 3.

## Verification
- `npm test` 7768/7769 pass (1 pre-existing skip); typecheck / lint:js / web-ext clean. 40/40 adapter + 52/52 consumer UI tests green.
- Fresh adversarial review (opus): **CLEAN** — adapters identical, preservation intact, consumers degrade safely, tests real not gutted.

277 lines. Next: PR 3 — docs/legal + web/landing copy + disclosure UI removal + new CHANGELOG/ADR + the honest narrative (shown before merge).