### PR TITLE
fix(rules): drop 'email' from remote params source (denylist conflict, unblocks validate CI)

### DIFF
--- a/tools/rules-source/params.json
+++ b/tools/rules-source/params.json
@@ -43,7 +43,6 @@
     "dp",
     "dt_dapp",
     "ecid",
-    "email",
     "email_source",
     "email_token",
     "entrypoint",


### PR DESCRIPTION
Pre-existing breakage on `main`: `email` is in both the params strip-source (`tools/rules-source/params.json`) and `REMOTE_PARAM_DENYLIST` (which protects it — login/newsletter/contact values, #1105). `validate-rules-source.mjs` rejects it, so the required `validate` CI job fails on any PR touching rules-source. It went unnoticed because no rules-source PR ran since the conflict was introduced.

Also a real bug: `email` was compiled into the bundled DNR params, so MUGA was stripping `email=` globally, breaking login/newsletter/contact URLs.

Fix: remove `email` from the source + regenerate `rules-manifest.json`/`tracking-params.json`. The signed `docs/rules/v1/params.json` re-publishes on merge (`email` is already runtime-rejected there by the denylist gate, so no live behavior change). `npm test` 6955/6956, `validate` now passes (206 params OK).

Unblocks the cookie-consent removal chain (Slice B onward).