### PR TITLE
ci(discovery): move the untriaged-backlog PR workflows to a monthly cadence

### DIFF
--- a/.github/workflows/firefox-smoke.yml
+++ b/.github/workflows/firefox-smoke.yml
@@ -1,9 +1,12 @@
 name: Firefox Smoke
 
-# Real headless-Firefox smoke coverage for the Cookie Consent Minimizer's
-# Firefox-only wrappedJSObject reject path (#1128). Deterministic: every
-# fixture is a local HTTP page served by tests/e2e-firefox/helpers/local-server.mjs,
-# not a live site, so this CAN be a real merge gate.
+# Real headless-Firefox smoke coverage for the Firefox-only privacy paths that
+# a Chromium run cannot exercise: referer suppression and beacon blocking.
+# (Originally added for the cookie-consent minimizer's wrappedJSObject reject
+# path in #1128; that subsystem was removed, and these specs replaced it.)
+# Deterministic: every fixture is a local HTTP page served by
+# tests/e2e-firefox/helpers/local-server.mjs, not a live site, so this CAN be a
+# real merge gate.
 on:
   pull_request:
     branches: [develop, main]
@@ -45,5 +48,5 @@ jobs:
       # add a browser-actions/setup-geckodriver step here (SHA-pinned) as a
       # fallback before this step.
 
-      - name: Run Firefox smoke tests (#1128)
+      - name: Run Firefox smoke tests (referer + beacon privacy)
         run: npm run test:firefox-smoke

--- a/.github/workflows/import-upstream.yml
+++ b/.github/workflows/import-upstream.yml
@@ -2,9 +2,10 @@ name: Import upstream tracking params
 
 on:
   schedule:
-    # Sunday 04:00 UTC. Off-peak so the PR notification arrives at the start
-    # of the maintainer's week without competing with weekday CI traffic.
-    - cron: "0 4 * * 0"
+    # 1st of the month, 04:00 UTC. Monthly rather than weekly: upstream
+    # candidates are only useful once triaged, and a weekly cadence re-reported
+    # the same untriaged backlog every run instead of surfacing new signal.
+    - cron: "0 4 1 * *"
   workflow_dispatch:
 
 permissions:
@@ -46,7 +47,7 @@ jobs:
 
       - name: Exit early if no new candidates
         if: steps.diff.outputs.count == '0'
-        run: echo "No new candidates from upstream this week. Exiting cleanly."
+        run: echo "No new candidates from upstream this month. Exiting cleanly."
 
       - name: Configure git for the bot commit
         if: steps.diff.outputs.count != '0'
@@ -90,7 +91,7 @@ jobs:
           CANDIDATES=$(jq -r '.new_candidates[] | "- `" + . + "`"' "$REPORT")
 
           BODY=$(cat <<EOF
-          Weekly automated diff against [AdGuard URL Tracking Protection (Filter 17)](https://filters.adtidy.org/extension/safari/filters/17.txt).
+          Monthly automated diff against [AdGuard URL Tracking Protection (Filter 17)](https://filters.adtidy.org/extension/safari/filters/17.txt).
 
           **Source:** AdGuard Filter 17
           **Fetched at:** $(jq -r '.fetched_at' "$REPORT")

--- a/.github/workflows/moat-expansion.yml
+++ b/.github/workflows/moat-expansion.yml
@@ -1,11 +1,12 @@
-name: Moat expansion — weekly affiliate-param discovery
+name: Moat expansion — monthly affiliate-param discovery
 
 on:
   schedule:
-    # Sunday 06:00 UTC — 2 h after import-upstream (0 4 * * 0) so the two
-    # weekly jobs do not collide.  Off-peak arrival at the start of the
-    # maintainer's week.
-    - cron: "0 6 * * 0"
+    # 1st of the month, 06:00 UTC — 2 h after import-upstream (0 4 1 * *) so the
+    # two monthly jobs do not collide. Monthly rather than weekly: gap entries
+    # are only useful once triaged, and a weekly cadence re-reported the same
+    # untriaged backlog every run instead of surfacing new signal.
+    - cron: "0 6 1 * *"
   workflow_dispatch:
 
 permissions:
@@ -48,7 +49,7 @@ jobs:
 
       - name: Exit early if no new gaps
         if: steps.report.outputs.gap_count == '0'
-        run: echo "No new gaps found this week — moat is current. Exiting cleanly."
+        run: echo "No new gaps found this month — moat is current. Exiting cleanly."
 
       - name: Configure git for the bot commit
         if: steps.report.outputs.gap_count != '0'
@@ -88,7 +89,7 @@ jobs:
           REPORT_BODY=$(cat "$REPORT")
 
           BODY=$(cat <<EOF
-          Weekly automated moat-expansion diff against [ClearURLs data.min.json](https://gitlab.com/ClearURLs/Rules/-/raw/master/data.min.json) (LGPL-3.0, signals-not-copies).
+          Monthly automated moat-expansion diff against [ClearURLs data.min.json](https://gitlab.com/ClearURLs/Rules/-/raw/master/data.min.json) (LGPL-3.0, signals-not-copies).
 
           **Fetched at:** $DATE
           **Raw file:** quarantined in \`tools/moat-expansion/quarantine/\` (gitignored — not committed)

--- a/tests/unit/moat-expansion-workflow.test.mjs
+++ b/tests/unit/moat-expansion-workflow.test.mjs
@@ -1,8 +1,8 @@
 /**
  * MUGA — Structural tests for .github/workflows/moat-expansion.yml
  *
- * Covers spec requirements (Weekly GitHub Actions Workflow):
- *   - Weekly cron "0 6 * * 0" (Sunday 06:00 UTC) + workflow_dispatch
+ * Covers spec requirements (Scheduled GitHub Actions Workflow):
+ *   - Monthly cron "0 6 1 * *" (1st of the month, 06:00 UTC) + workflow_dispatch
  *   - permissions: contents: write + pull-requests: write (before jobs:)
  *   - Node 20 runtime
  *   - Pinned action SHAs byte-identical to import-upstream.yml
@@ -61,11 +61,11 @@ function readImportUpstream() {
 // Triggers: schedule cron + workflow_dispatch
 // ---------------------------------------------------------------------------
 describe("triggers", () => {
-  test("has schedule trigger with cron '0 6 * * 0' (weekly Sun 06:00 UTC)", () => {
+  test("has schedule trigger with cron '0 6 1 * *' (monthly, 1st at 06:00 UTC)", () => {
     const content = readWorkflow();
     assert.ok(
-      /cron:\s*["']0 6 \* \* 0["']/.test(content),
-      "moat-expansion.yml must have a weekly cron schedule '0 6 * * 0'"
+      /cron:\s*["']0 6 1 \* \*["']/.test(content),
+      "moat-expansion.yml must have a monthly cron schedule '0 6 1 * *'"
     );
   });
 


### PR DESCRIPTION
`import-upstream` and `moat-expansion` both open PRs labelled **DO NOT auto-merge**, so their output piles up until someone triages it. At a weekly cadence that meant re-reporting the same untriaged backlog every run rather than surfacing new signal: PRs #1174 (2026-07-26) and #1195 (2026-08-02) both reported an identical **1410 candidates**.

| Workflow | Before | After |
|---|---|---|
| `import-upstream` | `0 4 * * 0` | `0 4 1 * *` |
| `moat-expansion` | `0 6 * * 0` | `0 6 1 * *` (keeps the 2 h offset) |
| `auto-ingest-rules` | `0 4 * * 0` | unchanged |

`auto-ingest-rules` stays weekly on purpose: it auto-merges via `--squash --auto`, so it creates no maintainer workload, and slowing it would only delay real tracking-param coverage reaching users.

### Note on the cron shape

GitHub cron cannot express "first Sunday of the month" - when day-of-month and day-of-week are both restricted, cron ORs them. Monthly therefore lands on day 1 regardless of weekday, losing the off-peak-Sunday property the previous comments were written around. The workflow comments now say so.

### Also here

`firefox-smoke.yml` still described the removed cookie-consent minimizer's `wrappedJSObject` reject path (#1128), but the specs it runs are now `beacon-block` and `referer-suppression`. The six-slice cookie-consent removal replaced the specs and missed the prose.

### Verification

`moat-expansion-workflow.test.mjs` pinned the old weekly cron and is retargeted in a separate commit here. Full suite green: **6730 pass / 0 fail**.