### PR TITLE
test(e2e): pin what a fresh install actually does with the remote-rules fetch

### DIFF
--- a/src/lib/remote-rules-status.js
+++ b/src/lib/remote-rules-status.js
@@ -11,9 +11,16 @@
  * (the onboarding accept path relies on `PREF_DEFAULTS.remoteRulesEnabled =
  * true`), so a hardcoded `false` default would report the toggle as OFF even
  * though the pref DEFAULTS to enabled. The toggle must reflect that default.
- * (The weekly signed fetch itself only begins once the user grants the
- * `rules.muga.app` optional host permission via the Settings toggle — it is
- * not running pre-grant.) Routing through `getPrefs()` keeps the Settings
+ * (The weekly signed fetch is opt-OUT and already running by the time this
+ * status is first read: `onInstalled` calls `maybeFetchRemoteRules()`
+ * directly, `runRemoteRulesFetch()` carries no permission check, and the
+ * `rules.muga.app` optional host permission reads as already granted because
+ * the manifest's `<all_urls>` host permission covers it — `permissions
+ * .contains()` reports coverage, not exact declaration. An earlier version of
+ * this note claimed the fetch "is not running pre-grant", which was wrong and
+ * is the sort of thing a privacy policy gets written from; see
+ * tests/e2e/remote-rules-fresh-install.spec.mjs, which pins both facts in a
+ * real browser.) Routing through `getPrefs()` keeps the Settings
  * toggle in lockstep with the effective preference, including any per-device
  * override written when a user declines a sync-inherited prompt.
  *

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -272,6 +272,14 @@ async function hasShortenerPermissions() {
  * gesture survives the async file read), so import may only restore
  * remoteRulesEnabled:true when this grant already exists — otherwise the pref
  * would say ON while the weekly signed fetch stays blocked.
+ *
+ * As long as the manifest declares `<all_urls>` in host_permissions, this
+ * returns true on a fresh install with nothing granted, because
+ * `permissions.contains()` reports coverage rather than exact declaration
+ * (pinned by tests/e2e/remote-rules-fresh-install.spec.mjs). The check is kept
+ * because it becomes load-bearing the moment `<all_urls>` is narrowed, which
+ * is the direction Chrome Web Store best practices push. It is a safety net
+ * that currently happens to be subsumed, not dead code.
  * @returns {Promise<boolean>}
  */
 async function hasRemoteRulesPermission() {

--- a/tests/e2e/remote-rules-fresh-install.spec.mjs
+++ b/tests/e2e/remote-rules-fresh-install.spec.mjs
@@ -1,0 +1,132 @@
+/**
+ * E2E: Remote rules — what a fresh install actually does, with no user action
+ *
+ * `remote-rules.spec.mjs` covers the enable / disable / dedup pipeline, but it
+ * always pre-grants `https://rules.muga.app/*` before triggering a fetch, so it
+ * never answers the question these tests exist for: on a brand new install,
+ * where the user has granted nothing and opened no settings, does the signed
+ * GET to rules.muga.app happen?
+ *
+ * It matters because two places in the codebase disagreed about the answer.
+ * `remote-rules-status.js` stated the fetch "is not running pre-grant", while
+ * the #888 comment in `service-worker.js` described exactly the opposite. Only
+ * one of those can be true, and a privacy policy is written from whichever the
+ * author happens to read.
+ *
+ * The mechanism these tests pin down: `rules.muga.app` is declared in
+ * `optional_host_permissions`, but `host_permissions` already declares
+ * `<all_urls>`, which COVERS it. `chrome.permissions.contains()` reports
+ * coverage, not exact declaration, so the "optional" grant is satisfied the
+ * moment the extension installs. Combined with `runRemoteRulesFetch()` carrying
+ * no permission check of its own and `onInstalled` calling
+ * `maybeFetchRemoteRules()` directly, the fetch is opt-OUT, not opt-in.
+ *
+ * These tests deliberately use the raw `context` fixture rather than
+ * `optionsPage` / `popupPage`, because those complete onboarding first and a
+ * completed onboarding is exactly the user action we must not perform.
+ *
+ * Network isolation: the endpoint is routed so no run reaches the real host.
+ * See the note on the install race in the second test.
+ */
+
+import { test, expect } from "./fixtures.mjs";
+
+const RULES_GLOB = "**/rules.muga.app/**";
+
+test.describe("Remote rules — fresh install, no user action", () => {
+  test("the optional rules.muga.app grant is already satisfied by <all_urls>", async ({
+    context,
+    extensionId,
+  }) => {
+    // Nothing is granted here. No onboarding, no Settings visit, no
+    // permissions.request(). This is the state a user is in the instant the
+    // extension finishes installing.
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const granted = await page.evaluate(() =>
+      chrome.permissions.contains({ origins: ["https://rules.muga.app/*"] }),
+    );
+
+    expect(
+      granted,
+      "rules.muga.app reads as granted on a fresh install because <all_urls> " +
+        "covers it, so listing it in optional_host_permissions gates nothing",
+    ).toBe(true);
+
+    // The same is true of the shortener hosts, which is why the click-time
+    // resolver works out of the box on Chrome. Asserted here so the two
+    // "optional" lists are documented as behaving identically.
+    const shortenerGranted = await page.evaluate(() =>
+      chrome.permissions.contains({ origins: ["https://bit.ly/*"] }),
+    );
+    expect(
+      shortenerGranted,
+      "shortener hosts are likewise covered by <all_urls> on Chrome",
+    ).toBe(true);
+
+    await page.close();
+  });
+
+  test("the signed GET fires without the user granting or enabling anything", async ({
+    context,
+    extensionId,
+  }) => {
+    // Route as early as the test body allows. There is an unavoidable race:
+    // the service worker starts with the browser and onInstalled calls
+    // maybeFetchRemoteRules() immediately, so that very first attempt may fire
+    // before this route is registered. That is precisely the behaviour under
+    // test, and it is why the assertion below reads persisted state rather
+    // than counting intercepted requests: whichever attempt wins the race, the
+    // evidence lands in remoteRulesMeta either way.
+    const seen = [];
+    await context.route(RULES_GLOB, (route) => {
+      seen.push(route.request().url());
+      // An unsigned body is rejected by verification, which is fine: a
+      // recorded lastError still proves an attempt was made, and it keeps this
+      // test independent of the signing fixtures.
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ version: 1, params: [] }),
+      });
+    });
+
+    // The only thing the user does is browse. No extension UI is touched.
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+    await page.waitForLoadState("domcontentloaded");
+
+    // maybeFetchRemoteRules is fire-and-forget, so poll for the persisted
+    // outcome instead of racing it. Note: waitForFunction is the wrong tool
+    // here — an async predicate returns a Promise, which it treats as truthy
+    // and resolves on the first tick.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async () => {
+            const { remoteRulesMeta } = await chrome.storage.local.get({
+              remoteRulesMeta: { fetchedAt: null, lastError: null },
+            });
+            return (
+              remoteRulesMeta?.fetchedAt !== null ||
+              remoteRulesMeta?.lastError !== null
+            );
+          }),
+        {
+          timeout: 20_000,
+          message:
+            "a fresh install with zero user action must have attempted the " +
+            "fetch: the attempt writes either fetchedAt or lastError",
+        },
+      )
+      .toBe(true);
+
+    // Whether or not this run's route caught the request (see the race note
+    // above), the attempt itself is what the assertion above proves.
+    console.log(`[fresh-install] intercepted rules requests: ${seen.length}`);
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
Two places in the codebase disagreed about whether the signed GET to `rules.muga.app` runs before the user grants anything:

| Source | Claim |
|---|---|
| `remote-rules-status.js:15` | *"the weekly signed fetch... is not running pre-grant"* |
| `service-worker.js` (#888) | a user *"who never touched the toggle would otherwise leak the GET on the very next SW wake"* |

Only one can be true, and a privacy policy gets written from whichever the author happens to read first.

## Settled in real Chromium, not by reading

```
✓ the optional rules.muga.app grant is already satisfied by <all_urls>
✓ the signed GET fires without the user granting or enabling anything
  [fresh-install] intercepted rules requests: 1
```

**The fetch is opt-OUT.** `remote-rules-status.js` was wrong, and is corrected here.

### Why

`rules.muga.app` sits in `optional_host_permissions`, but `host_permissions` already declares `<all_urls>`, which **covers** it. `permissions.contains()` reports *coverage*, not exact declaration, so the "optional" grant is satisfied the instant the extension installs. Combined with `runRemoteRulesFetch()` carrying no permission check and `onInstalled` calling `maybeFetchRemoteRules()` directly, nothing gates the request but `remoteRulesEnabled` (default `true`) and `onboardingDone` (written on install since #1193).

This is the intended behaviour and `docs/tos.html` already describes it correctly (*"Fetches weekly rule updates **by default**... You can turn it off at any time in Settings"*). The bug was the code claiming a protection that does not exist.

### Why the existing spec could not catch it

`remote-rules.spec.mjs` pre-grants the permission in every test, which is the one user action that had to be skipped to answer the question. These tests use the raw `context` fixture rather than `optionsPage` / `popupPage` for the same reason, since those complete onboarding first.

### On the install race

The second test asserts persisted state rather than counting intercepted requests. The service worker starts with the browser and `onInstalled` fires before any route can be registered, so whichever attempt wins that race the evidence lands in `remoteRulesMeta` either way. The endpoint is routed so no run reaches the real host.

## Not done, deliberately

Removing `rules.muga.app` from `optional_host_permissions`. It is currently subsumed by `<all_urls>`, but `permissions.request()` rejects any origin not declared as optional, so dropping it would break the Settings enable path and require deleting that `request()` call too. More importantly it becomes load-bearing the moment `<all_urls>` is narrowed, which is the direction Chrome Web Store best practices push. It is a safety net that happens to be subsumed, not dead code, and the comments now say so instead of implying a gate that does not exist.

## Verification

Unit suite **6837 pass / 0 fail**, typecheck clean, both new e2e green in real Chromium.