### PR TITLE
feat(release): ship the AMO listing copy with the release, not by hand

### DIFF
--- a/docs/amo-release-guide.md
+++ b/docs/amo-release-guide.md
@@ -1,131 +1,143 @@
-# Firefox AMO: Release Guide
+# Release Guide: what ships automatically, and what does not
 
-> Manual process for now. CI/CD automation planned for when cadence justifies it.
+> Releases are automated. Pushing a `vX.Y.Z` tag runs
+> [`.github/workflows/release.yml`](../.github/workflows/release.yml), which
+> gates on the full test and e2e suites and then submits to **both** stores.
+>
+> This document exists for the parts that are still manual, and to say exactly
+> which ones those are. It previously described AMO as a manual process with
+> automation "planned for when cadence justifies it"; that automation shipped,
+> and the guide had not caught up.
 
 ---
 
-## Manual release process
-
-### 1. Build
+## Releasing
 
 ```bash
-npm test                          # must pass all 730+ tests
-npm run build:firefox             # generates dist/firefox/
+git checkout main && git pull
+git tag v3.0.0
+git push --tags
 ```
 
-### 2. Package
+If the tagged commit carries `[skip ci]` in its message (the `publish-rules.yml`
+auto-commit does), GitHub suppresses the tag-push trigger. Use the manual
+dispatch instead, which takes the tag name as an input:
 
 ```bash
-# Extension zip (what AMO installs)
-cd dist/firefox && zip -r ../../muga-firefox.zip . && cd ../..
-
-# Source code zip (AMO requires it because we have a build step)
-git archive --format=zip --prefix=muga-source/ HEAD -o muga-source.zip
+gh workflow run release.yml -f tag=v3.0.0
 ```
 
-### 3. Upload to AMO
-
-1. Go to https://addons.mozilla.org/developers/addon/muga/versions/submit/
-2. Upload `muga-firefox.zip`
-3. Attach `muga-source.zip` when prompted for source code
-4. Fill "Notes to Reviewer" (see template below)
-5. Submit
-
-### 4. Notes to Reviewer template
-
-```
-Version X.Y.Z
-
-Changes in this version:
-- [summary of changes]
-
-No permission changes from previous version.
-
-Build instructions:
-1. Unzip source code
-2. npm install
-3. npm run build:firefox
-4. Output in dist/firefox/
-
-Open source: https://github.com/yocreoquesi/muga
-License: GPL v3
-```
-
-### 5. Post-submission
-
-- Auto-review: minutes to hours (most common for updates)
-- Manual review: 1-5 days (if permissions or code patterns are flagged)
-- Check dashboard daily for 2 days after submission
-- If reviewer asks questions, respond within 24 hours
+The workflow will not publish unless `npm test`, the live-Worker integration
+tests and the Playwright e2e suite all pass first.
 
 ---
 
-## Tips to minimize review time
+## What the tag push does for you
 
-- Do not change permissions unless absolutely necessary
-- Do not minify or obfuscate code
-- Always attach source code with clear build instructions
-- Keep a clean history -- each approved version builds trust
-- Use "Notes to Reviewer" on every submission
+| | Chrome Web Store | Firefox AMO |
+|---|---|---|
+| Upload the built package | automatic | automatic |
+| Publish / submit for review | automatic | automatic |
+| Extension **name** | automatic | automatic |
+| **Short description** / summary | automatic | automatic |
+| **Detailed description** | **manual** | automatic |
+| Release notes | not supported by the API | automatic |
+| Source archive for reviewers | n/a | automatic |
+| Keywords / tags | **manual** | **manual** |
+| Category | **manual** | **manual** |
+| Screenshots | **manual** | **manual** |
+
+### How the copy actually travels
+
+**Chrome** derives the store title from the manifest `name` and the summary
+from the manifest `description`. MUGA ships no `default_locale` or `_locales/`,
+so those two fields are simply whatever `src/manifest.json` says. Changing the
+name is a code change, not a dashboard change.
+
+**AMO** gets its listing fields from `amo-metadata.json`, which
+`scripts/prepare-amo-metadata.sh` regenerates during the release:
+
+- `version.release_notes` from the matching `CHANGELOG.md` section
+- `name` from `src/manifest.json`
+- `summary` and `description` from the **Firefox Add-ons (AMO)** section of
+  [`docs/store-listing.md`](./store-listing.md)
+
+`web-ext sign --amo-metadata` spreads that whole object into the
+`PUT /addon/{id}/` request, so editing `docs/store-listing.md` is what updates
+the public AMO listing. The dashboard is the mirror; the file is the source.
+
+The committed `amo-metadata.json` is a template holding only `version` — the
+listing fields are injected at release time and are deliberately not committed,
+so they cannot go stale against `docs/store-listing.md`.
 
 ---
 
-## Future: CI/CD automation plan
+## What you still have to do by hand
 
-When release cadence justifies it, automate with GitHub Actions:
+### Chrome Web Store, every time the marketing copy changes
 
-### Workflow trigger
+The CWS API (v1.1) supports `upload` and `publish` and nothing else. There is no
+endpoint for listing metadata, so this cannot be automated:
 
-Tag `vX.Y.Z` push triggers the workflow.
+1. Open the [Developer Dashboard](https://chrome.google.com/webstore/devconsole)
+2. **Store listing** tab → paste the **Detailed description** from the
+   *Chrome Web Store* section of `docs/store-listing.md`
+3. Update the 5 keywords from the same document
+4. Confirm category and screenshots
+5. Submit for review
 
-### Required secrets (GitHub Settings > Secrets > Actions)
+Copy rule that has already cost one rejection: **never enumerate retailer or
+brand names** in the listing body. That triggered a keyword-spam rejection
+(routing ID FZSL, 2026-05).
 
-- `AMO_JWT_ISSUER` -- API key from https://addons.mozilla.org/developers/addon/api/key/
-- `AMO_JWT_SECRET` -- API secret from same page
+### Both stores, when it applies
 
-### Security notes
+- Keywords / tags, category and screenshots
+- Permission justifications, which live in the CWS *Privacy practices* tab
 
-- Secrets are encrypted at rest by GitHub
-- Never appear in logs (auto-masked)
-- Not accessible from fork PRs (GitHub default protection)
-- Only injected into ephemeral runner during workflow execution
-- Runner is destroyed after workflow completes
-- No credentials touch the repository
+---
 
-### Workflow outline
+## If a submission fails
 
-```yaml
-# .github/workflows/amo-release.yml (DO NOT COMMIT UNTIL READY)
-name: Firefox AMO Release
-on:
-  push:
-    tags: ['v*']
+Both store steps use `continue-on-error` and report `success | noop | failure`
+in the job summary, so a partial failure on one store does not mask the other.
+Re-running the same tag is safe: a store reporting "version already submitted"
+is treated as a no-op, not an error.
 
-jobs:
-  release-firefox:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+Two failure modes worth recognising:
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
+- **CWS returns HTTP 200 with an `itemError` array in the body.** Checking only
+  the status code hides this; `scripts/cws-check-response.mjs` parses the body.
+  This masked five consecutive silently failed releases (#616, v1.13.4 through
+  v1.16.0).
+- **AMO caps release notes at 3000 characters.** v1.13.0's notes were 4938 and
+  broke the upload with no obvious cause. `tools/amo-build-metadata.mjs`
+  truncates at a safe budget and links to the GitHub Release for the rest.
 
-      - run: npm ci
-      - run: npm test
-      - run: npm run build:firefox
+---
 
-      - name: Sign and upload to AMO
-        run: npx web-ext sign --source-dir=dist/firefox/ --api-key=${{ secrets.AMO_JWT_ISSUER }} --api-secret=${{ secrets.AMO_JWT_SECRET }}
+## Keeping review time short
 
-      - name: Attach .xpi to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: web-ext-artifacts/*.xpi
-```
+- Do not change permissions unless necessary. A permission change moves AMO from
+  auto-review (minutes) to manual review (1 to 5 days).
+- Do not minify or obfuscate. The one build step is the content-script bundle,
+  and its output is committed so a reviewer can diff it against its source.
+- The reviewer notes in `amo-metadata.json` already explain that build step and
+  how to verify it. Keep them accurate if the build changes.
+- After submitting, check the dashboard for two days. Answer reviewer questions
+  within 24 hours.
 
-### What NOT to do
+---
 
-- Never commit API keys in the repo (not in .env, not in workflow plaintext)
-- Never expose secrets in workflows triggered by fork PRs
-- Never give write permissions to the workflow unless strictly needed
+## Secrets the workflow needs
+
+Set in **Settings → Secrets → Actions**. They are encrypted at rest, masked in
+logs, unavailable to fork PRs, and only injected into the ephemeral runner.
+
+| Secret | Source |
+|---|---|
+| `AMO_JWT_ISSUER`, `AMO_JWT_SECRET` | https://addons.mozilla.org/developers/addon/api/key/ |
+| `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` | Google Cloud OAuth client |
+| `CWS_EXTENSION_ID` | the item ID in the Developer Dashboard URL |
+
+Never commit these anywhere, including `.env` files and workflow plaintext.

--- a/tests/unit/amo-listing-metadata.test.mjs
+++ b/tests/unit/amo-listing-metadata.test.mjs
@@ -1,0 +1,171 @@
+/**
+ * MUGA — AMO listing metadata builder
+ *
+ * `web-ext sign --amo-metadata=<file>` spreads the whole JSON object into the
+ * `PUT /addon/{id}/` body, so whatever this builder emits is what the public
+ * AMO listing becomes on the next release. That makes it worth pinning
+ * tightly: a parsing slip here does not fail loudly in CI, it quietly
+ * republishes the wrong marketing copy, or the right copy with a stray `---`
+ * or an editor's `*(234 chars)*` annotation in the middle of it.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import {
+  buildAmoListing,
+  amoSection,
+  sectionBody,
+  AMO_NAME_MAX,
+  AMO_SUMMARY_MAX,
+} from "../../tools/amo-listing-metadata.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+
+const MANIFEST = JSON.parse(readFileSync(join(ROOT, "src", "manifest.json"), "utf8"));
+const STORE_LISTING = readFileSync(join(ROOT, "docs", "store-listing.md"), "utf8");
+
+describe("AMO listing — built from the real store-listing document", () => {
+  const listing = buildAmoListing();
+
+  it("takes the name from the manifest, not from a second copy in the markdown", () => {
+    assert.equal(listing.name["en-US"], MANIFEST.name);
+  });
+
+  it("stays inside AMO's name and summary limits", () => {
+    assert.ok(listing.name["en-US"].length <= AMO_NAME_MAX);
+    assert.ok(listing.summary["en-US"].length <= AMO_SUMMARY_MAX);
+  });
+
+  it("reads the AMO summary, not the Chrome Web Store short description", () => {
+    // The two sections carry different copy. The CWS one is the manifest
+    // description; the AMO one is longer and mentions "without breaking pages".
+    assert.match(listing.summary["en-US"], /without breaking pages/);
+    assert.notEqual(listing.summary["en-US"], MANIFEST.description);
+  });
+
+  it("captures the whole detailed description, opening to closing line", () => {
+    const description = listing.description["en-US"];
+    assert.match(description, /^Remember when a link was just a link\?/);
+    assert.match(description, /https:\/\/github\.com\/yocreoquesi\/muga$/);
+  });
+
+  it("carries none of the document's editing scaffolding", () => {
+    for (const [field, value] of Object.entries(listing)) {
+      const text = value["en-US"];
+      assert.ok(!/^---$/m.test(text), `${field} contains a horizontal rule`);
+      assert.ok(!/\*\(\d+\s+chars?\)\*/.test(text), `${field} contains a char-count annotation`);
+      assert.ok(!/^### /m.test(text), `${field} contains a markdown heading`);
+    }
+  });
+
+  it("emits exactly the three add-on fields, and no categories or tags", () => {
+    // categories/tags are slug-typed on the AMO API and a wrong slug fails the
+    // entire PUT, taking the version submission down with it. They stay manual
+    // on purpose — see the note in tools/amo-listing-metadata.mjs.
+    assert.deepEqual(Object.keys(listing).sort(), ["description", "name", "summary"]);
+  });
+
+  it("emits every field as an en-US localized object, the shape AMO expects", () => {
+    for (const [field, value] of Object.entries(listing)) {
+      assert.deepEqual(Object.keys(value), ["en-US"], `${field} is not a localized object`);
+      assert.equal(typeof value["en-US"], "string");
+    }
+  });
+});
+
+describe("AMO listing — section parsing", () => {
+  it("slices the AMO section, not the Chrome one, when both use the same headings", () => {
+    const section = amoSection(STORE_LISTING);
+    assert.ok(section.includes("Firefox Add-ons (AMO)"));
+    assert.ok(!section.includes("## Chrome Web Store"));
+    assert.ok(!section.includes("Keywords (Chrome Web Store"));
+  });
+
+  it("stops a body at the next ### heading", () => {
+    const section = [
+      "## Firefox Add-ons (AMO)",
+      "",
+      "### Summary (250 chars max)",
+      "",
+      "The summary.",
+      "",
+      "### Detailed description",
+      "",
+      "The description.",
+    ].join("\n");
+
+    assert.equal(sectionBody(section, /^Summary\b/), "The summary.");
+    assert.equal(sectionBody(section, /^Detailed description$/), "The description.");
+  });
+
+  it("keeps blank lines inside a body, since paragraphs are the copy's structure", () => {
+    const section = [
+      "## Firefox Add-ons (AMO)",
+      "",
+      "### Detailed description",
+      "",
+      "First paragraph.",
+      "",
+      "Second paragraph.",
+    ].join("\n");
+
+    assert.equal(sectionBody(section, /^Detailed description$/), "First paragraph.\n\nSecond paragraph.");
+  });
+
+  it("throws a named error when the AMO section is missing entirely", () => {
+    assert.throws(() => amoSection("# Store Listings\n\n## Chrome Web Store\n"), /Firefox Add-ons \(AMO\)/);
+  });
+
+  it("throws when a required heading is missing rather than emitting an empty field", () => {
+    assert.throws(
+      () => sectionBody("## Firefox Add-ons (AMO)\n\n### Summary\n\nx\n", /^Detailed description$/),
+      /no heading matching/
+    );
+  });
+});
+
+describe("AMO listing — limits fail the build instead of truncating", () => {
+  const validMarkdown = [
+    "## Firefox Add-ons (AMO)",
+    "",
+    "### Summary (250 chars max)",
+    "",
+    "A short summary.",
+    "",
+    "### Detailed description",
+    "",
+    "A description.",
+  ].join("\n");
+
+  it("rejects a name over the AMO limit", () => {
+    assert.throws(
+      () =>
+        buildAmoListing({
+          manifest: { name: "M".repeat(AMO_NAME_MAX + 1) },
+          storeListing: validMarkdown,
+        }),
+      /AMO name is \d+ chars/
+    );
+  });
+
+  it("rejects a summary over the AMO limit", () => {
+    const longSummary = validMarkdown.replace("A short summary.", "S".repeat(AMO_SUMMARY_MAX + 1));
+    assert.throws(
+      () => buildAmoListing({ manifest: { name: "MUGA" }, storeListing: longSummary }),
+      /AMO summary is \d+ chars/
+    );
+  });
+
+  it("rejects an empty description rather than blanking the live listing", () => {
+    const emptyDescription = validMarkdown.replace("A description.", "");
+    assert.throws(
+      () => buildAmoListing({ manifest: { name: "MUGA" }, storeListing: emptyDescription }),
+      /detailed description is empty/
+    );
+  });
+});

--- a/tools/amo-build-metadata.mjs
+++ b/tools/amo-build-metadata.mjs
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
-// Builds amo-metadata.json release_notes from CHANGELOG content piped on stdin.
-// Truncates to stay under AMO's 3000-char hard cap with a link back to the
-// GitHub Release for the full notes.
+// Builds amo-metadata.json from two sources:
+//   - version.release_notes  <- CHANGELOG content piped on stdin, truncated to
+//     stay under AMO's 3000-char hard cap with a link back to the GitHub Release.
+//   - name / summary / description <- the AMO section of docs/store-listing.md
+//     (see tools/amo-listing-metadata.mjs). web-ext spreads this whole object
+//     into the PUT /addon/{id}/ body, so the listing copy ships with the
+//     release instead of being hand-edited in the dashboard afterwards.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { buildAmoListing } from "./amo-listing-metadata.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -45,8 +51,22 @@ if (isMain()) {
   const metaPath = path.join(ROOT, "amo-metadata.json");
   const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
   meta.version.release_notes = { "en-US": notes };
+
+  // Listing copy is rebuilt from docs/store-listing.md on every release, so
+  // the file is the source of truth and the dashboard is the mirror, not the
+  // other way round. buildAmoListing throws on an over-limit name or summary
+  // rather than truncating: failing here is cheaper than publishing marketing
+  // copy that was silently cut.
+  const listing = buildAmoListing();
+  Object.assign(meta, listing);
+
   fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2) + "\n");
   console.log(
     `amo-metadata.json updated with release notes for v${version} (${notes.length}/${AMO_RELEASE_NOTES_HARD_LIMIT} chars)`,
+  );
+  console.log(
+    `  listing: name ${listing.name["en-US"].length} chars, ` +
+      `summary ${listing.summary["en-US"].length} chars, ` +
+      `description ${listing.description["en-US"].length} chars`,
   );
 }

--- a/tools/amo-listing-metadata.mjs
+++ b/tools/amo-listing-metadata.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Builds the add-on-level AMO listing fields (name, summary, description)
+ * from the single source they already live in: docs/store-listing.md.
+ *
+ * Why this exists: `web-ext sign --amo-metadata=<file>` spreads the WHOLE
+ * JSON object into the `PUT /addon/{id}/` body (see web-ext's
+ * lib/util/submit-addon.js#doNewAddonOrVersionSubmit), so anything the AMO
+ * add-on API accepts at the top level can be shipped from that file. MUGA's
+ * amo-metadata.json only ever carried `version`, so the listing name and
+ * copy on AMO were never updated by a release. Editing them meant
+ * remembering to do it by hand in the dashboard, which is exactly the kind
+ * of step that gets skipped.
+ *
+ * Deliberately NOT sent: `categories` and `tags`. The AMO API takes those as
+ * slugs, and a wrong slug fails the entire PUT, which would take the version
+ * submission down with it. A cosmetic field is not worth risking the release
+ * on a guess; those two stay manual in the dashboard.
+ *
+ * Source of truth, split on purpose:
+ *   - name        <- src/manifest.json, the same string the extension ships
+ *                    under. Sourcing it from the markdown too would create a
+ *                    third place for it to drift.
+ *   - summary     <- docs/store-listing.md, AMO "Summary" section
+ *   - description <- docs/store-listing.md, AMO "Detailed description"
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+/** AMO caps the listing name at 50 characters. */
+export const AMO_NAME_MAX = 50;
+
+/** AMO caps the summary at 250 characters. */
+export const AMO_SUMMARY_MAX = 250;
+
+/**
+ * Returns the "## Firefox Add-ons (AMO)" section of the listing document.
+ * The file also holds a Chrome Web Store section whose headings have the
+ * same names, so slicing to the AMO section first is what keeps the two
+ * from being confused.
+ *
+ * @param {string} markdown - full docs/store-listing.md contents
+ * @returns {string}
+ */
+export function amoSection(markdown) {
+  const start = markdown.indexOf("## Firefox Add-ons (AMO)");
+  if (start === -1) {
+    throw new Error('docs/store-listing.md has no "## Firefox Add-ons (AMO)" section');
+  }
+  const rest = markdown.slice(start + 1);
+  const nextTop = rest.indexOf("\n## ");
+  return nextTop === -1 ? rest : rest.slice(0, nextTop);
+}
+
+/**
+ * Extracts the body under an `### <heading>` up to the next `###`.
+ *
+ * Drops horizontal rules and the italic character-count annotations the
+ * document carries for human editors (e.g. `*(234 chars)*`), neither of
+ * which belongs in what gets sent to AMO.
+ *
+ * @param {string} section - output of amoSection()
+ * @param {RegExp} headingPattern - matches the heading text after "### "
+ * @returns {string}
+ */
+export function sectionBody(section, headingPattern) {
+  const lines = section.split(/\r?\n/);
+  const startIdx = lines.findIndex(
+    (l) => l.startsWith("### ") && headingPattern.test(l.slice(4).trim())
+  );
+  if (startIdx === -1) {
+    throw new Error(`docs/store-listing.md AMO section has no heading matching ${headingPattern}`);
+  }
+
+  const body = [];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith("### ")) break;
+    if (line.trim() === "---") continue;
+    if (/^\*\(\d+\s+chars?\)\*$/.test(line.trim())) continue;
+    body.push(line);
+  }
+
+  return body.join("\n").replace(/^\s+|\s+$/g, "");
+}
+
+/**
+ * Builds the add-on-level metadata block for amo-metadata.json.
+ *
+ * Throws rather than truncating when a field is over its AMO limit: unlike
+ * release notes, which are informational and safe to cut short, a truncated
+ * name or summary is public marketing copy nobody proofread. Failing the
+ * release is the cheaper outcome.
+ *
+ * @param {{ manifest?: object, storeListing?: string }} [sources]
+ * @returns {{ name: object, summary: object, description: object }}
+ */
+export function buildAmoListing(sources = {}) {
+  const manifest =
+    sources.manifest ??
+    JSON.parse(fs.readFileSync(path.join(ROOT, "src", "manifest.json"), "utf8"));
+  const markdown =
+    sources.storeListing ??
+    fs.readFileSync(path.join(ROOT, "docs", "store-listing.md"), "utf8");
+
+  const section = amoSection(markdown);
+  const name = manifest.name;
+  const summary = sectionBody(section, /^Summary\b/);
+  const description = sectionBody(section, /^Detailed description$/);
+
+  if (!name) throw new Error("src/manifest.json has no name");
+  if (name.length > AMO_NAME_MAX) {
+    throw new Error(`AMO name is ${name.length} chars, limit is ${AMO_NAME_MAX}: "${name}"`);
+  }
+  if (!summary) throw new Error("AMO summary is empty");
+  if (summary.length > AMO_SUMMARY_MAX) {
+    throw new Error(`AMO summary is ${summary.length} chars, limit is ${AMO_SUMMARY_MAX}`);
+  }
+  if (!description) throw new Error("AMO detailed description is empty");
+
+  // AMO takes localized fields as { locale: value }. MUGA's store copy is
+  // authored in English only; the in-extension UI localization is separate
+  // and does not translate the listing.
+  return {
+    name: { "en-US": name },
+    summary: { "en-US": summary },
+    description: { "en-US": description },
+  };
+}


### PR DESCRIPTION
Answers the question "does the new name and the descriptions ship with the release, or do I update them by hand afterwards?" — for AMO, they now ship.

## What was wrong

`web-ext sign --amo-metadata=<file>` spreads the **whole** JSON object into the `PUT /addon/{id}/` body — see web-ext's `lib/util/submit-addon.js#doNewAddonOrVersionSubmit`:

```js
const jsonData = { ...metaDataJson, version: { upload: uuid, ...metaDataJson.version } };
```

So any add-on-level field the AMO API accepts can travel with a release. `amo-metadata.json` only ever carried `version`, so the AMO listing name and copy were never updated by one. Changing them meant remembering to edit the dashboard afterwards.

## What now ships

`scripts/prepare-amo-metadata.sh` regenerates, alongside the release notes:

| Field | Source |
|---|---|
| `name` | `src/manifest.json` |
| `summary` | `docs/store-listing.md`, AMO **Summary** |
| `description` | `docs/store-listing.md`, AMO **Detailed description** |

Verified against the real documents:

```
listing: name 34 chars, summary 234 chars, description 3463 chars
```

Three deliberate decisions:

- **Name comes from the manifest, not the markdown's copy of it.** The document repeats the name, and sourcing it there would create a third place for it to drift. There are already enough of those in this repo.
- **The AMO section is sliced before parsing.** The Chrome section reuses the same `### Summary` / `### Detailed description` headings, so parsing the file as a whole would silently pick the wrong copy.
- **`categories` and `tags` are NOT sent.** The AMO API takes them as slugs, and a wrong slug fails the entire PUT — which takes the version submission down with it. A cosmetic field is not worth risking a release on a guess. They stay manual, and the guide says so.

Over-limit name or summary **throws** rather than truncating. Release notes are informational and safe to cut short; a silently truncated listing name is public marketing copy nobody proofread. Failing the release is the cheaper outcome.

The committed `amo-metadata.json` stays a template holding only `version`, so injected copy cannot go stale against `docs/store-listing.md`.

## Chrome stays manual, and that is not fixable

The CWS API v1.1 exposes `upload` and `publish` and nothing else. There is no listing-metadata endpoint. The manifest `name` and `description` do travel in the package (no `default_locale`/`_locales`, so Chrome derives title and summary straight from the manifest), but the **detailed description**, keywords, category and screenshots have to be pasted into the dashboard.

## The release guide was lying

`docs/amo-release-guide.md` still opened with *"Manual process for now. CI/CD automation planned for when cadence justifies it"* and carried a `DO NOT COMMIT UNTIL READY` workflow sketch — while `release.yml` had been submitting to both stores for many versions. Rewritten to state, per store and per field, what is automatic and what is not, plus the two failure modes already paid for in production: CWS returning HTTP 200 with `itemError` in the body (#616, five silent failures), and AMO's 3000-char release-notes cap (v1.13.0).

## Verification

15 new assertions in `tests/unit/amo-listing-metadata.test.mjs`: the real document parses to the right fields, the AMO section is not confused with the Chrome one, blank lines inside the copy survive while `---` rules and `*(234 chars)*` annotations do not, every field is an `en-US` object, no `categories`/`tags` leak in, and each limit throws.

Full suite: **6787 tests, 0 failures**, plus `typecheck` and `lint:js`.
