### PR TITLE
ci(release): tag/manifest guard, and align the repo identity with the store name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,19 +103,31 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Chrome extension
-        run: npm run build:chrome
-
-      - name: Build Firefox extension
-        run: npm run build:firefox
-
       - name: Get version from tag
         id: version
         run: |
           # For push events, GITHUB_REF_NAME is the tag (v1.2.3); for
           # workflow_dispatch, read from the input.
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
           echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the tag matches what would be published
+        # The stores validate the MANIFEST version, not the tag name. Tagging
+        # v3.0.1 with manifests still at 3.0.0 publishes 3.0.0 under a tag that
+        # says otherwise, and nothing about that is loud: the store accepts it
+        # and the GitHub Release is named after the tag. The cost lands later,
+        # when a version number has been silently burned and cannot be reused.
+        #
+        # Runs BEFORE the builds so a mistyped tag costs seconds, not a full
+        # build-and-publish cycle, and long before anything is uploaded.
+        run: node tools/verify-release-version.mjs "${{ steps.version.outputs.TAG }}"
+
+      - name: Build Chrome extension
+        run: npm run build:chrome
+
+      - name: Build Firefox extension
+        run: npm run build:firefox
 
       - name: Rename build artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@
 [![Version](https://img.shields.io/badge/version-3.0.0-blue)](#)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen)](#development)
 [![CAPS](https://img.shields.io/badge/CAPS-Basic%20%2B%20Contextual-2ea44f)](CONFORMANCE.md)
-# MUGA: The URL denoise extension for the web
+# MUGA: URL Cleaner. Remove tracking
 
 ### Install now
 
 [![Firefox](https://img.shields.io/badge/Firefox-Install_from_AMO-FF7139?logo=firefox-browser&logoColor=white)](https://addons.mozilla.org/firefox/addon/muga/)
-[![Chrome](https://img.shields.io/badge/Chrome-Install_from_CWS-4285F4?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh)
+[![Chrome](https://img.shields.io/badge/Chrome-Install_from_CWS-4285F4?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/pjdpeamhcjdhfijpmgamjdoplbnbajoh)
 
 ---
 
-**MUGA turns the noise down on every URL while trying not to strip the credit of whoever recommended you.** Every other URL cleaner removes `utm_source`, `fbclid`, `gclid`, and the rest. So does MUGA. But every other URL cleaner also strips the affiliate tag of the YouTuber whose video you came from, the newsletter that shared the link, the reviewer who took the time to write the comparison. That tag is how independent creators get paid for the recommendation. By default MUGA tries to leave it alone, and when it does, the popup shows a "Creator referral preserved" badge so you can see it. It is best-effort rather than a guarantee, and you stay in control. No other URL cleaner we know of even attempts this.
+**MUGA removes the tracking from every URL while trying not to strip the credit of whoever recommended you.** Every other URL cleaner removes `utm_source`, `fbclid`, `gclid`, and the rest. So does MUGA. But every other URL cleaner also strips the affiliate tag of the YouTuber whose video you came from, the newsletter that shared the link, the reviewer who took the time to write the comparison. That tag is how independent creators get paid for the recommendation. By default MUGA tries to leave it alone, and when it does, the popup shows a "Creator referral preserved" badge so you can see it. It is best-effort rather than a guarantee, and you stay in control. No other URL cleaner we know of even attempts this.
 
-> **MUGA?** Maximally Unannoying Garbage Auditor. **MUGA.** Make URLs Quiet Again. **MUGA!** The web, with the noise turned down.
+> **MUGA?** Maximally Unannoying Garbage Auditor. **MUGA.** Make URLs Quiet Again. **MUGA!** Clean URLs, tracking removed.
 
 > **3.0.0 shipped.** MUGA no longer adds an affiliate tag of its own: no hidden tag, no commission from your clicks, and the original creator's referral is still preserved by default. It also stops interrupting you about its own Terms, which are now permanently available and linked instead of announced. New in this release: `Referer` suppression and `<a ping>` beacon blocking enforced at the network layer, and short-link resolution split so that resolving on click stays on while resolving on hover is opt-in. Presigned download links (GitHub artifacts, S3, Azure) are now left untouched instead of broken. See [CHANGELOG](CHANGELOG.md) for the full release notes.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ![Before and after URL cleaning](docs/assets/screenshot-ss1-before-after.png)
 
-MUGA intercepts URLs as you browse and removes noise patterns before the page loads. The result is a shorter, quieter URL: your browsing stays the same, minus the surveillance.
+MUGA intercepts URLs as you browse and removes the tracking before the page loads. The result is a shorter, cleaner URL: your browsing stays the same, minus the surveillance.
 
 <details>
 <summary><strong>More examples</strong></summary>
@@ -59,7 +59,7 @@ After:  https://www.ebay.es/itm/123456789
 
 ---
 
-## What it quiets
+## What it removes
 
 **447 tracking params + 12 prefix patterns** across 6 categories, on every site:
 
@@ -69,10 +69,10 @@ After:  https://www.ebay.es/itm/123456789
 | Paid Ads | `fbclid`, `gclid`, `msclkid`, `ttclid`, `li_fat_id` + 30 more |
 | Email Marketing | `mc_cid`, `_hsenc`, `mkt_tok`, `_mkto_trk`, `_kx` + 20 more |
 | Social Media | `igshid`, `igsh`, `epik`, `sc_channel`, `pin_unauth` + 5 more |
-| Platform Noise | E-commerce session IDs, click params, marketplace tokens + 25 more |
+| Platform tracking | E-commerce session IDs, click params, marketplace tokens + 25 more |
 | Generic | `s_cid`, `wickedid`, and catch-all click IDs |
 
-Domain-specific rules for **188 domains** preserve functional query params (search queries, pagination, filters) while removing the noise.
+Domain-specific rules for **188 domains** preserve functional query params (search queries, pagination, filters) while removing the tracking.
 
 ---
 
@@ -92,8 +92,8 @@ Settings give you full control: affiliate behavior, per-domain rules, blacklists
 
 ### Always on, no configuration needed
 
-- Quiet 447 tracking params and 12 prefix patterns on every navigation (UTMs, fbclid, gclid, share tokens, click IDs, and more)
-- Strip e-commerce path noise (`/ref=nav_logo`, session IDs after product ID, product slug, locale params)
+- Remove 447 tracking params and 12 prefix patterns on every navigation (UTMs, fbclid, gclid, share tokens, click IDs, and more)
+- Strip e-commerce path clutter (`/ref=nav_logo`, session IDs after product ID, product slug, locale params)
 - Right-click any link → **Copy clean link**
 - **Alt+Shift+C**: copy clean URL of current tab to clipboard
 - Badge counter showing params stripped on current tab
@@ -101,7 +101,7 @@ Settings give you full control: affiliate behavior, per-domain rules, blacklists
 
 ### Optional, configured during first setup
 
-- **Pre-navigation cleaning**: browser-native DNR rules quiet noise patterns *before* the page loads, covering address-bar navigation, bookmarks, and external apps
+- **Pre-navigation cleaning**: browser-native DNR rules remove tracking patterns *before* the page loads, covering address-bar navigation, bookmarks, and external apps
 - **Block `<a ping>` beacons**: prevents background ping requests on click
 - **AMP redirect**: silently redirects AMP pages to the canonical article URL
 - **Redirect-wrapper unwrapping**: detects and bypasses intermediary redirect wrappers so you land on the real URL
@@ -111,7 +111,7 @@ Settings give you full control: affiliate behavior, per-domain rules, blacklists
 - Per-domain blacklist: strip everything on a specific site, a single param value (`domain::param::value`), or a param regardless of its value (`domain::param::*`)
 - Per-domain disable (`domain::disabled`): opt entire domains out of MUGA
 - Whitelist: protect specific creator affiliate tags from detection. Supports `domain::param::value` (one exact value) and `domain::param::*` (any value of that param). A Whitelist match always wins over a Blacklist match for the same parameter
-- Custom noise params: add your own parameter names
+- Custom tracking params: add your own parameter names
 - Strip all affiliate parameters (opt-in)
 - Strip all third-party affiliate tags (opt-in; off by default, the original referral is respected until you turn this on; MUGA never adds a tag of its own in their place)
 - Toast notification when a third-party affiliate is detected (opt-in)
@@ -140,7 +140,7 @@ By default, MUGA respects the original referral: if a link already carries a cre
 
 If you prefer, "Strip all third-party affiliate tags" in Settings removes those tags instead, leaving none behind. This is an optional extra, off by default, and MUGA never adds a tag of its own in their place.
 
-On stores where attribution is redirect-based (an external server sets the referral via a 30x redirect), MUGA also strips the affiliate noise parameters (`awc`, `wt_mc`, `lgw_code`, and others) those networks leave on the landing URL, and unwraps affiliate redirect URLs where possible so you land directly on the store, without changing who gets credit for the referral.
+On stores where attribution is redirect-based (an external server sets the referral via a 30x redirect), MUGA also strips the affiliate tracking parameters (`awc`, `wt_mc`, `lgw_code`, and others) those networks leave on the landing URL, and unwraps affiliate redirect URLs where possible so you land directly on the store, without changing who gets credit for the referral.
 
 This is explained during onboarding, disclosed in the extension description, documented in the [privacy policy](https://rules.muga.app/privacy-page.html), and verifiable in the source code.
 
@@ -172,7 +172,7 @@ MUGA does not hold an affiliate account of its own on any store and does not add
 
 **Firefox.** [Install from AMO](https://addons.mozilla.org/firefox/addon/muga/)
 
-**Chrome.** [Install from Chrome Web Store](https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh)
+**Chrome.** [Install from Chrome Web Store](https://chromewebstore.google.com/detail/pjdpeamhcjdhfijpmgamjdoplbnbajoh)
 
 Or install from source:
 
@@ -201,7 +201,7 @@ New release: tag `vX.Y.Z` → push → GitHub Actions builds and publishes autom
 
 ## Contributing
 
-PRs welcome for new noise patterns, new stores, or additional languages. Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, workflow, and conventions.
+PRs welcome for new tracking patterns, new stores, or additional languages. Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, workflow, and conventions.
 
 Key contribution points:
 

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MUGA FAQ: The denoise extension for the web</title>
+  <title>MUGA FAQ: URL Cleaner. Remove tracking</title>
   <meta name="description" content="A direct, evidence-cited FAQ for skeptics. Every factual claim is backed by a line in MUGA's open source. No analytics, no telemetry. GPL v3.">
   <meta name="color-scheme" content="dark">
   <link rel="icon" href="/assets/muga-mark.svg">
@@ -33,10 +33,10 @@
   <div class="wrap">
 
   <h1>Frequently Asked Questions</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Version 2.6.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, tracking removed &nbsp;·&nbsp; Version 3.0.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
-    A direct, evidence-cited FAQ for skeptics. MUGA is the denoise extension for the web, it quiets the noise on every URL so the web feels clean and fast again. Every factual claim below is backed by a line in the source tree of this repository. If you find a discrepancy between what is written here and the code, the code wins, please open an issue.
+    A direct, evidence-cited FAQ for skeptics. MUGA is a URL cleaner: it removes the tracking parameters from every URL, unwraps redirects, and reveals where a shortened link really goes. Every factual claim below is backed by a line in the source tree of this repository. If you find a discrepancy between what is written here and the code, the code wins, please open an issue.
   </div>
 
   <p>This document is intentionally written for a technical audience that has already read the <a href="/privacy-page.html">Privacy policy</a> and the <a href="/tos.html">Terms of service</a> and wants to verify the claims.</p>
@@ -59,7 +59,7 @@
 
   <p>If you only want noise removed and don't care about creator attribution, a generic cleaner is fine. If you want the YouTuber who recommended you that USB-C dock to actually get paid for the recommendation, you need a tool that knows the difference between a noise param and an affiliate tag.</p>
 
-  <h3>Q: Doesn't preserving affiliate parameters defeat the denoise goal?</h3>
+  <h3>Q: Doesn't preserving affiliate parameters defeat the point of a URL cleaner?</h3>
 
   <p>No, and the distinction matters. An affiliate tag like <code>?tag=somecreator-21</code> identifies <strong>the recommender</strong>, not you. A tracking parameter like <code>?fbclid=IwAR3...</code> identifies <strong>you</strong>, across sessions, across sites. MUGA strips the second and preserves the first.</p>
 
@@ -175,7 +175,7 @@
       <a href="/faq.html">FAQ</a>
       <a href="https://github.com/yocreoquesi/muga">GitHub</a>
     </div>
-    <div class="colophon">MUGA · GPL v3 · The web, with the noise turned down.</div>
+    <div class="colophon">MUGA · GPL v3 · Clean URLs, tracking removed.</div>
   </div>
 </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,19 +3,19 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MUGA: The denoise extension for the web</title>
+  <title>MUGA: URL Cleaner. Remove tracking</title>
   <meta name="description" content="MUGA cleans the tracking noise from your URLs without breaking them. No analytics, no telemetry. Open source, GPL v3.">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="MUGA: The denoise extension for the web">
+  <meta property="og:title" content="MUGA: URL Cleaner. Remove tracking">
   <meta property="og:description" content="450+ noise patterns removed automatically. Creator affiliate referrals preserved. Open source.">
   <meta property="og:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
   <meta property="og:url" content="https://rules.muga.app/">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="MUGA: The denoise extension for the web">
+  <meta name="twitter:title" content="MUGA: URL Cleaner. Remove tracking">
   <meta name="twitter:description" content="450+ noise patterns removed automatically. Creator affiliate referrals preserved. Open source.">
   <meta name="twitter:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
 
@@ -150,7 +150,7 @@
         <path d="M 80 37 L 98 50 L 80 63 Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
       </svg>
       <h1>MUGA</h1>
-      <div class="tagline">The denoise extension for the web.</div>
+      <div class="tagline">Removes the tracking from your URLs.</div>
       <p class="intro">Every URL arrives loaded with noise: tracking parameters, click IDs, share tokens. MUGA removes it automatically, before the page loads. One install, zero clicks. The web, quieter.</p>
       <div class="backronym" id="backronym"></div>
       <div class="cta-row">
@@ -250,7 +250,7 @@
       <a href="/faq.html">FAQ</a>
       <a href="https://github.com/yocreoquesi/muga">GitHub</a>
     </div>
-    <div class="colophon">MUGA · GPL v3 · The web, with the noise turned down.</div>
+    <div class="colophon">MUGA · GPL v3 · Clean URLs, tracking removed.</div>
   </div>
 </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,19 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MUGA: URL Cleaner. Remove tracking</title>
-  <meta name="description" content="MUGA cleans the tracking noise from your URLs without breaking them. No analytics, no telemetry. Open source, GPL v3.">
+  <meta name="description" content="MUGA removes the tracking from your URLs without breaking them. No analytics, no telemetry. Open source, GPL v3.">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="MUGA: URL Cleaner. Remove tracking">
-  <meta property="og:description" content="450+ noise patterns removed automatically. Creator affiliate referrals preserved. Open source.">
+  <meta property="og:description" content="450+ tracking patterns removed automatically. Creator affiliate referrals preserved. Open source.">
   <meta property="og:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
   <meta property="og:url" content="https://rules.muga.app/">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="MUGA: URL Cleaner. Remove tracking">
-  <meta name="twitter:description" content="450+ noise patterns removed automatically. Creator affiliate referrals preserved. Open source.">
+  <meta name="twitter:description" content="450+ tracking patterns removed automatically. Creator affiliate referrals preserved. Open source.">
   <meta name="twitter:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
 
   <!-- JSON-LD -->
@@ -27,7 +27,7 @@
     "name": "MUGA",
     "applicationCategory": "BrowserApplication",
     "operatingSystem": "Chrome, Firefox",
-    "description": "Browser extension that quiets 450+ noise patterns from every URL automatically. Creator affiliate referrals preserved.",
+    "description": "Browser extension that removes 450+ tracking patterns from every URL automatically. Creator affiliate referrals preserved.",
     "url": "https://rules.muga.app/",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -151,10 +151,10 @@
       </svg>
       <h1>MUGA</h1>
       <div class="tagline">Removes the tracking from your URLs.</div>
-      <p class="intro">Every URL arrives loaded with noise: tracking parameters, click IDs, share tokens. MUGA removes it automatically, before the page loads. One install, zero clicks. The web, quieter.</p>
+      <p class="intro">Every URL arrives loaded with tracking: campaign parameters, click IDs, share tokens. MUGA removes it automatically, before the page loads. One install, zero clicks. Links, clean again.</p>
       <div class="backronym" id="backronym"></div>
       <div class="cta-row">
-        <a class="cta cta-primary" href="https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh">Install for Chrome</a>
+        <a class="cta cta-primary" href="https://chromewebstore.google.com/detail/pjdpeamhcjdhfijpmgamjdoplbnbajoh">Install for Chrome</a>
         <a class="cta cta-secondary" href="https://addons.mozilla.org/firefox/addon/muga/">Install for Firefox</a>
       </div>
     </div>
@@ -163,7 +163,7 @@
   <section>
     <div class="wrap">
       <div class="stats">
-        <div class="stat-item"><div class="num">450<span class="u">+</span></div><div class="desc">bits of noise removed</div></div>
+        <div class="stat-item"><div class="num">450<span class="u">+</span></div><div class="desc">tracking patterns removed</div></div>
         <div class="stat-item"><div class="num">150<span class="u">+</span></div><div class="desc">domain-specific rules</div></div>
         <div class="stat-item"><div class="num">0</div><div class="desc">data collected</div></div>
       </div>
@@ -189,8 +189,8 @@
       <h2>What it does</h2>
       <div class="feature-grid">
         <div class="feature-card">
-          <h3>450+ bits of noise, gone</h3>
-          <p>UTMs, fbclid, gclid, e-commerce noise, share tokens, click IDs, email beacons. All removed before the page loads.</p>
+          <h3>450+ tracking patterns, gone</h3>
+          <p>UTMs, fbclid, gclid, e-commerce session params, share tokens, click IDs, email beacons. All removed before the page loads.</p>
         </div>
         <div class="feature-card">
           <h3>Never acts behind your back</h3>

--- a/docs/privacy-page.html
+++ b/docs/privacy-page.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MUGA Privacy Policy: The denoise extension for the web</title>
+  <title>MUGA Privacy Policy: URL Cleaner. Remove tracking</title>
   <meta name="color-scheme" content="dark">
   <link rel="icon" href="/assets/muga-mark.svg">
   <link rel="stylesheet" href="muga-docs.css">
@@ -32,7 +32,7 @@
   <div class="wrap">
 
   <h1>Privacy Policy</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 3.0.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, tracking removed &nbsp;·&nbsp; Effective date: 2026-05-25 &nbsp;·&nbsp; Version 3.0.0 &nbsp;·&nbsp; <a href="https://github.com/yocreoquesi/muga">Source code</a></p>
 
   <div class="highlight">
     <strong>Short version:</strong> You control what MUGA does. Every feature is transparent and configurable.
@@ -133,7 +133,7 @@
       <a href="/faq.html">FAQ</a>
       <a href="https://github.com/yocreoquesi/muga">GitHub</a>
     </div>
-    <div class="colophon">MUGA · GPL v3 · The web, with the noise turned down.</div>
+    <div class="colophon">MUGA · GPL v3 · Clean URLs, tracking removed.</div>
   </div>
 </footer>
 

--- a/docs/transparency.html
+++ b/docs/transparency.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MUGA: Transparency Report: The denoise extension for the web</title>
+  <title>MUGA Transparency Report: URL Cleaner. Remove tracking</title>
   <meta name="color-scheme" content="dark">
   <link rel="icon" href="/assets/muga-mark.svg">
   <link rel="stylesheet" href="muga-docs.css">
@@ -32,7 +32,7 @@
   <div class="wrap">
 
   <h1>Transparency Report</h1>
-  <p class="meta">MUGA: The web, with the noise turned down &nbsp;&middot;&nbsp; Version 3.0.0 &nbsp;&middot;&nbsp; 2026-08-08 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
+  <p class="meta">MUGA: Clean URLs, tracking removed &nbsp;&middot;&nbsp; Version 3.0.0 &nbsp;&middot;&nbsp; 2026-08-08 &nbsp;&middot;&nbsp; <a href="https://github.com/yocreoquesi/muga" target="_blank" rel="noopener noreferrer">Source code</a></p>
 
   <div class="highlight">
     Privacy policies say "we don't collect your data." This page shows the evidence behind that claim: what MUGA actually does, which permissions it uses and why, and how you can verify every statement yourself.
@@ -191,7 +191,7 @@
       <a href="/faq.html">FAQ</a>
       <a href="https://github.com/yocreoquesi/muga">GitHub</a>
     </div>
-    <div class="colophon">MUGA · GPL v3 · The web, with the noise turned down.</div>
+    <div class="colophon">MUGA · GPL v3 · Clean URLs, tracking removed.</div>
   </div>
 </footer>
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -4,17 +4,17 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>MUGA: URL Cleaner. Remove tracking</title>
-<meta name="description" content="MUGA cleans the tracking noise from your URLs without breaking them. No analytics, no telemetry. Open source, GPL v3.">
+<meta name="description" content="MUGA removes the tracking from your URLs without breaking them. No analytics, no telemetry. Open source, GPL v3.">
 <meta name="color-scheme" content="dark">
 
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://muga.app/">
 <meta property="og:title" content="MUGA: URL Cleaner. Remove tracking">
-<meta property="og:description" content="Clean the tracking noise from your URLs without breaking the pages. No analytics, no telemetry. Open source.">
+<meta property="og:description" content="Remove the tracking from your URLs without breaking the pages. No analytics, no telemetry. Open source.">
 <meta property="og:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="MUGA: URL Cleaner. Remove tracking">
-<meta name="twitter:description" content="Clean the tracking noise from your URLs without breaking the pages. No analytics, no telemetry. Open source.">
+<meta name="twitter:description" content="Remove the tracking from your URLs without breaking the pages. No analytics, no telemetry. Open source.">
 <meta name="twitter:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
 
 <link rel="icon" href="https://rules.muga.app/assets/muga-mark.svg">
@@ -26,7 +26,7 @@
   "name": "MUGA",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Chrome, Firefox",
-  "description": "Open-source browser extension that cleans the tracking noise from your URLs without breaking pages, with no analytics and no telemetry.",
+  "description": "Open-source browser extension that removes the tracking from your URLs without breaking pages, with no analytics and no telemetry.",
   "offers": { "@type": "Offer", "price": "0" },
   "softwareVersion": "3.0.0",
   "license": "https://www.gnu.org/licenses/gpl-3.0.html"
@@ -529,16 +529,16 @@
   <section class="hero">
     <div class="hero-glow"></div>
     <div class="wrap hero-inner">
-      <h1>The web, <span class="mark">with the noise turned&nbsp;down.</span></h1>
+      <h1>Every link, <span class="mark">with the tracking&nbsp;removed.</span></h1>
 
       <p class="lede">
-        MUGA quiets the tracking noise from every link you open, without breaking pages.
+        MUGA removes the tracking from every link you open, without breaking pages.
         And unlike most URL cleaners, it tries to keep the referral of whoever recommended
         you the link, and leaves you in control.
       </p>
 
       <div class="install" id="hero-install">
-        <a class="btn" id="cta-chrome" href="https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh">
+        <a class="btn" id="cta-chrome" href="https://chromewebstore.google.com/detail/pjdpeamhcjdhfijpmgamjdoplbnbajoh">
           <svg class="ico" width="18" height="18" aria-hidden="true"><use href="#logo-chrome"/></svg>
           Add to Chrome
         </a>
@@ -620,8 +620,8 @@
     <div class="stats">
       <div class="stat">
         <div class="num">450<span class="unit">+</span></div>
-        <div class="label">Noise patterns</div>
-        <div class="desc">utm_*, fbclid, gclid, mc_cid, igshid and 446 more, quieted at request time.</div>
+        <div class="label">Tracking patterns</div>
+        <div class="desc">utm_*, fbclid, gclid, mc_cid, igshid and 446 more, removed at request time.</div>
       </div>
       <div class="stat">
         <div class="num">100<span class="unit">%</span></div>
@@ -644,7 +644,7 @@
         <p>
           When a reviewer, a creator or a newsletter shares a link, their referral is often how they get
           credited for the recommendation, at no extra cost to you. Most cleaners strip it along with the
-          noise. MUGA tries not to.
+          tracking. MUGA tries not to.
         </p>
         <p>
           When MUGA recognizes a referral like that, it tries to leave it alone and shows a small
@@ -665,7 +665,7 @@
         <div class="row"><span class="k">path</span><span class="v">/p/AZ12345</span></div>
         <div class="row"><span class="k">strip</span><span class="v strip">utm_source, utm_campaign, fbclid, gclid, ref_</span></div>
         <div class="row"><span class="k">keep</span><span class="v keep-v">ref=creator</span></div>
-        <div class="row"><span class="k">action</span><span class="v action">strip the noise, keep the referral, show a toast</span></div>
+        <div class="row"><span class="k">action</span><span class="v action">strip the tracking, keep the referral, show a toast</span></div>
       </div>
     </div>
   </section>
@@ -754,10 +754,10 @@
             <path d="M 12 56 C 12 8, 46 8, 52 46 L 62 22 L 72 50 L 84 50" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M 80 37 L 98 50 L 80 63 Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
           </svg>
-          <h2>Turn the noise down today.</h2>
+          <h2>Clean your links today.</h2>
           <p>Free and open source. Pick whichever way fits how you browse.</p>
           <div class="ways">
-            <a class="way" data-plat="chrome" href="https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh">
+            <a class="way" data-plat="chrome" href="https://chromewebstore.google.com/detail/pjdpeamhcjdhfijpmgamjdoplbnbajoh">
               <svg class="way-ico" width="26" height="26" aria-hidden="true"><use href="#logo-chrome"/></svg>
               <span class="way-title">Chrome &amp; Chromium</span>
               <span class="way-desc">The full extension for Chrome, Edge, Brave and Opera. Cleans every link as you browse.</span>
@@ -802,7 +802,7 @@
       <div class="footer-col">
         <h4>Install</h4>
         <ul>
-          <li><a href="https://chromewebstore.google.com/detail/muga-clean-urls-fair-to-e/pjdpeamhcjdhfijpmgamjdoplbnbajoh">Chrome Web Store</a></li>
+          <li><a href="https://chromewebstore.google.com/detail/pjdpeamhcjdhfijpmgamjdoplbnbajoh">Chrome Web Store</a></li>
           <li><a href="https://addons.mozilla.org/firefox/addon/muga/">Firefox Add-ons</a></li>
           <li><a href="https://muga.app/clean">MUGA URL Cleaner</a></li>
         </ul>

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,17 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>MUGA: The denoise extension for the web</title>
+<title>MUGA: URL Cleaner. Remove tracking</title>
 <meta name="description" content="MUGA cleans the tracking noise from your URLs without breaking them. No analytics, no telemetry. Open source, GPL v3.">
 <meta name="color-scheme" content="dark">
 
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://muga.app/">
-<meta property="og:title" content="MUGA: The denoise extension for the web">
+<meta property="og:title" content="MUGA: URL Cleaner. Remove tracking">
 <meta property="og:description" content="Clean the tracking noise from your URLs without breaking the pages. No analytics, no telemetry. Open source.">
 <meta property="og:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="MUGA: The denoise extension for the web">
+<meta name="twitter:title" content="MUGA: URL Cleaner. Remove tracking">
 <meta name="twitter:description" content="Clean the tracking noise from your URLs without breaking the pages. No analytics, no telemetry. Open source.">
 <meta name="twitter:image" content="https://rules.muga.app/assets/promo-marquee-1400x560.png">
 
@@ -797,7 +797,7 @@
           </svg>
           <span class="name">muga.app</span>
         </a>
-        <p>The denoise extension for the web. Tries to keep the referral of whoever recommended you the link. Built by an independent developer. Free and open source.</p>
+        <p>Removes the tracking from your URLs. Tries to keep the referral of whoever recommended you the link. Built by an independent developer. Free and open source.</p>
       </div>
       <div class="footer-col">
         <h4>Install</h4>

--- a/tests/unit/docs-version-consistency.test.mjs
+++ b/tests/unit/docs-version-consistency.test.mjs
@@ -67,6 +67,22 @@ describe("Docs version stamps must match manifest version", () => {
     );
   });
 
+  test(`docs/faq.html — Version stamp matches manifest (${MANIFEST_VERSION})`, () => {
+    // Added after the FAQ sat at 2.6.0 through the whole 3.0 cycle: it was the
+    // one public doc carrying a version stamp that nothing asserted, so it
+    // drifted in silence while its neighbours were kept honest.
+    const html = read("docs/faq.html");
+    const matches = [...html.matchAll(/Version\s+(\d+\.\d+\.\d+)/g)];
+    assert.ok(matches.length > 0, "docs/faq.html must contain a Version X.Y.Z stamp");
+    for (const m of matches) {
+      assert.equal(
+        m[1],
+        MANIFEST_VERSION,
+        `docs/faq.html has stale version stamp "${m[1]}", expected "${MANIFEST_VERSION}"`
+      );
+    }
+  });
+
   test(`src/privacy/privacy.html — Version stamp matches manifest (${MANIFEST_VERSION})`, () => {
     const html = read("src/privacy/privacy.html");
     const match = html.match(/Version\s+(\d+\.\d+\.\d+)/);

--- a/tests/unit/verify-release-version.test.mjs
+++ b/tests/unit/verify-release-version.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * MUGA — release version pre-flight
+ *
+ * The stores validate the manifest version, not the git tag. Until now
+ * nothing compared them, so a mistyped tag would publish a different version
+ * than the tag claims — quietly, since the store accepts it and the GitHub
+ * Release is named after the tag. The damage shows up later, when the next
+ * release cannot reuse a number that was already burned.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+import {
+  versionFromTag,
+  findReleaseVersionProblems,
+} from "../../tools/verify-release-version.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+const PKG = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+
+/** A coherent set of sources, so each test can break exactly one thing. */
+function sources(overrides = {}) {
+  return {
+    pkg: { version: "3.0.1" },
+    mv3: { version: "3.0.1", version_name: "3.0.1" },
+    mv2: { version: "3.0.1" },
+    changelog: "# Changelog\n\n## [3.0.1] - 2026-08-10\n\n- something\n",
+    ...overrides,
+  };
+}
+
+describe("versionFromTag", () => {
+  it("strips the leading v", () => {
+    assert.equal(versionFromTag("v3.0.1"), "3.0.1");
+  });
+
+  it("accepts a bare version", () => {
+    assert.equal(versionFromTag("3.0.1"), "3.0.1");
+  });
+
+  it("strips only ONE leading v, so a typo cannot be normalised away", () => {
+    assert.equal(versionFromTag("vv3.0.1"), "v3.0.1");
+  });
+
+  it("rejects an empty or non-string tag rather than comparing against nothing", () => {
+    for (const bad of ["", "   ", null, undefined, 3]) {
+      assert.throws(() => versionFromTag(/** @type {any} */ (bad)), /tag is required/);
+    }
+  });
+});
+
+describe("findReleaseVersionProblems — the coherent case", () => {
+  it("reports nothing when every source agrees", () => {
+    assert.deepEqual(findReleaseVersionProblems("v3.0.1", sources()), []);
+  });
+
+  it("accepts a manifest with no version_name at all", () => {
+    const s = sources({ mv3: { version: "3.0.1" } });
+    assert.deepEqual(findReleaseVersionProblems("v3.0.1", s), []);
+  });
+});
+
+describe("findReleaseVersionProblems — each drift is caught", () => {
+  it("catches a stale package.json", () => {
+    const problems = findReleaseVersionProblems("v3.0.1", sources({ pkg: { version: "3.0.0" } }));
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /package\.json is 3\.0\.0/);
+  });
+
+  it("catches a stale MV3 manifest — the one Chrome validates", () => {
+    const s = sources({ mv3: { version: "3.0.0", version_name: "3.0.0" } });
+    const problems = findReleaseVersionProblems("v3.0.1", s);
+    assert.ok(problems.some((p) => /src\/manifest\.json is 3\.0\.0/.test(p)));
+  });
+
+  it("catches a stale MV2 manifest — the one AMO validates", () => {
+    const problems = findReleaseVersionProblems("v3.0.1", sources({ mv2: { version: "3.0.0" } }));
+    assert.ok(problems.some((p) => /manifest\.v2\.json is 3\.0\.0/.test(p)));
+  });
+
+  it("catches a version_name that contradicts the version users are shipped", () => {
+    const s = sources({ mv3: { version: "3.0.1", version_name: "3.0.0" } });
+    const problems = findReleaseVersionProblems("v3.0.1", s);
+    assert.ok(problems.some((p) => /version_name is 3\.0\.0/.test(p)));
+  });
+
+  it("catches a missing CHANGELOG section, which would ship placeholder notes", () => {
+    const s = sources({ changelog: "# Changelog\n\n## [3.0.0] - 2026-08-08\n\n- older\n" });
+    const problems = findReleaseVersionProblems("v3.0.1", s);
+    assert.ok(problems.some((p) => /no "## \[3\.0\.1\]" section/.test(p)));
+  });
+
+  it("does not accept a link reference at the bottom as a CHANGELOG section", () => {
+    // "[3.0.1]: https://..." is a link definition, not a release entry.
+    const s = sources({ changelog: "# Changelog\n\n[3.0.1]: https://example.com/compare\n" });
+    const problems = findReleaseVersionProblems("v3.0.1", s);
+    assert.ok(problems.some((p) => /no "## \[3\.0\.1\]" section/.test(p)));
+  });
+
+  it("reports EVERY problem at once instead of stopping at the first", () => {
+    const s = sources({
+      pkg: { version: "3.0.0" },
+      mv3: { version: "3.0.0", version_name: "3.0.0" },
+      mv2: { version: "3.0.0" },
+      changelog: "# Changelog\n",
+    });
+    // package + mv3 + mv2 + version_name + changelog
+    assert.equal(findReleaseVersionProblems("v3.0.1", s).length, 5);
+  });
+
+  it("treats a version that is a prefix of another as a mismatch", () => {
+    // "3.0.1" must not be satisfied by "3.0.10".
+    const s = sources({ pkg: { version: "3.0.10" } });
+    assert.ok(findReleaseVersionProblems("v3.0.1", s).some((p) => /package\.json is 3\.0\.10/.test(p)));
+  });
+});
+
+describe("findReleaseVersionProblems — against the real repository", () => {
+  it("the current tree is coherent with its own package.json version", () => {
+    // Guards the guard: if this fails, the repo itself is mid-drift and the
+    // next release would have shipped it.
+    assert.deepEqual(findReleaseVersionProblems(`v${PKG.version}`), []);
+  });
+});

--- a/tools/verify-release-version.mjs
+++ b/tools/verify-release-version.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Release pre-flight: does the tag actually describe what is about to ship?
+ *
+ * The stores validate the MANIFEST version, not the git tag. Nothing in the
+ * release pipeline compared the two, so tagging `v3.0.1` with manifests still
+ * at 3.0.0 would publish 3.0.0 under a tag that says otherwise — and the
+ * failure is not loud. The store accepts it, the GitHub Release is named after
+ * the tag, and the mismatch only surfaces later when the next release cannot
+ * reuse a version number that was silently already burned. MUGA has been here
+ * before (the 2.6.0 version-drift incident).
+ *
+ * Three things are checked, all of them silent failures otherwise:
+ *
+ *   1. The tag matches package.json and BOTH manifests.
+ *   2. manifest.json's `version_name` matches too, since that is the string
+ *      users actually see in chrome://extensions.
+ *   3. CHANGELOG.md has a section for this version. scripts/prepare-amo-
+ *      metadata.sh greps for `## [x.y.z]` and falls back to generic
+ *      "Bug fixes and improvements" notes with only a warning if it is
+ *      missing, so a forgotten changelog entry ships as real release notes.
+ *
+ * Usage: node tools/verify-release-version.mjs v3.0.1
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+/**
+ * Strips a single leading "v" from a git tag. Tags are `vX.Y.Z`; every
+ * version field in the repo is bare `X.Y.Z`.
+ *
+ * @param {string} tag
+ * @returns {string}
+ */
+export function versionFromTag(tag) {
+  if (typeof tag !== "string" || tag.trim() === "") {
+    throw new Error("A tag is required, e.g. v3.0.1");
+  }
+  return tag.trim().replace(/^v/, "");
+}
+
+/**
+ * Collects every mismatch rather than throwing on the first one: a release
+ * engineer fixing one field at a time, re-tagging, and failing again on the
+ * next is a worse loop than seeing all of them at once.
+ *
+ * @param {string} tag - the git tag being released, e.g. "v3.0.1"
+ * @param {{ pkg?: object, mv3?: object, mv2?: object, changelog?: string }} [sources]
+ * @returns {string[]} human-readable problems; empty means the release is coherent
+ */
+export function findReleaseVersionProblems(tag, sources = {}) {
+  const version = versionFromTag(tag);
+  const problems = [];
+
+  const read = (rel) => JSON.parse(fs.readFileSync(path.join(ROOT, rel), "utf8"));
+  const pkg = sources.pkg ?? read("package.json");
+  const mv3 = sources.mv3 ?? read("src/manifest.json");
+  const mv2 = sources.mv2 ?? read("src/manifest.v2.json");
+  const changelog =
+    sources.changelog ?? fs.readFileSync(path.join(ROOT, "CHANGELOG.md"), "utf8");
+
+  if (pkg.version !== version) {
+    problems.push(`package.json is ${pkg.version}, tag says ${version}`);
+  }
+  if (mv3.version !== version) {
+    problems.push(`src/manifest.json is ${mv3.version}, tag says ${version}`);
+  }
+  if (mv2.version !== version) {
+    problems.push(`src/manifest.v2.json is ${mv2.version}, tag says ${version}`);
+  }
+  // version_name is what chrome://extensions displays. It is allowed to be
+  // absent, but if present it must not contradict the shipped version.
+  if (mv3.version_name !== undefined && mv3.version_name !== version) {
+    problems.push(`src/manifest.json version_name is ${mv3.version_name}, tag says ${version}`);
+  }
+
+  // Anchored to line start so a link reference like "[3.0.0]: https://..."
+  // at the bottom of the file cannot satisfy the check.
+  const heading = new RegExp(`^## \\[${version.replace(/\./g, "\\.")}\\]`, "m");
+  if (!heading.test(changelog)) {
+    problems.push(
+      `CHANGELOG.md has no "## [${version}]" section — ` +
+      "AMO would receive generic placeholder release notes"
+    );
+  }
+
+  return problems;
+}
+
+function isMain() {
+  const entry = process.argv[1] ? path.resolve(process.argv[1]) : "";
+  return entry === fileURLToPath(import.meta.url);
+}
+
+if (isMain()) {
+  const tag = process.argv[2];
+  let problems;
+  try {
+    problems = findReleaseVersionProblems(tag);
+  } catch (err) {
+    console.error(`FATAL: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (problems.length > 0) {
+    console.error(`FATAL: tag ${tag} does not match what would be published:\n`);
+    for (const p of problems) console.error(`  - ${p}`);
+    console.error(
+      "\nThe stores validate the manifest version, not the tag name. Publishing " +
+      "now would burn a version number under a tag that describes a different one."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Release pre-flight OK: ${tag} matches both manifests, package.json and CHANGELOG.md`);
+}


### PR DESCRIPTION
Two release-hygiene items for 3.0.1, in three commits.

## 1. The release can no longer publish a version the tag does not describe

The stores validate the **manifest** version, not the git tag, and nothing compared them. Tagging `v3.0.1` with manifests still at 3.0.0 publishes 3.0.0 under a tag saying otherwise — and none of it is loud: the store accepts the upload, the GitHub Release is named after the tag. The cost lands later, when a version number has been silently burned and cannot be reused. MUGA already paid that on 2.6.0.

`tools/verify-release-version.mjs` checks three things that all fail silently today:

| Check | What it prevents |
|---|---|
| tag == `package.json` == **both** manifests | publishing a different version than the tag claims |
| tag == `manifest.json` `version_name` | `chrome://extensions` showing a version nobody shipped |
| `CHANGELOG.md` has `## [x.y.z]` | AMO receiving *"Bug fixes and improvements"* as real release notes |

That last one is the sneakiest: `prepare-amo-metadata.sh` greps for exactly that heading and falls back to generic notes with only a `Warning:` on stdout.

It reports **every** mismatch at once. Fixing one field, re-tagging, and failing again on the next is a worse loop than seeing all five:

```
FATAL: tag v3.0.1 does not match what would be published:

  - package.json is 3.0.0, tag says 3.0.1
  - src/manifest.json is 3.0.0, tag says 3.0.1
  - src/manifest.v2.json is 3.0.0, tag says 3.0.1
  - src/manifest.json version_name is 3.0.0, tag says 3.0.1
  - CHANGELOG.md has no "## [3.0.1]" section — AMO would receive generic placeholder release notes
```

The workflow now extracts the tag **first** and verifies **before** the builds, so a mistyped tag costs seconds rather than a full build-and-publish cycle, and long before anything is uploaded.

15 unit tests, including one that runs the check against the real repository so a mid-drift tree fails here instead of at release time.

## 2. The repo said it was a different product than the stores do

The listing says **"MUGA: URL Cleaner. Remove tracking"**. The README's first line said *"The URL denoise extension for the web"*, muga.app's hero said *"The web, with the noise turned down"*, and every docs page signed off the same way. Someone arriving from a store listing met a different product name immediately.

The denoise framing is also less true than it was. It came from ADR-0002, when the pitch was broader; 3.0 removed the cookie-consent work and the affiliate injection, leaving a URL cleaner. The copy now says that.

Updated across `README.md`, `docs/index.html`, `docs/faq.html`, `docs/privacy-page.html`, `docs/transparency.html` and `landing/index.html`: page titles, og/twitter titles, meta descriptions, JSON-LD, hero, lede, stat labels, section headings, feature bullets and colophons.

**Left alone deliberately**: the FAQ's uses of "noise". There it is descriptive prose contrasting a *noise-detector* with an *affiliate-tag detector*, which is the actual argument of that page rather than a product name.

The MUGA backronym stays. *"Make URLs Quiet Again"* was never the part that drifted.

## Two things found while doing it

- **`docs/faq.html` still stamped Version 2.6.0.** It was the one public doc carrying a version stamp that no test asserted, so it drifted through the entire 3.0 cycle while its neighbours were kept honest. `docs-version-consistency` now covers it.
- **The Chrome install link still carried the v1.x store slug** (`muga-clean-urls-fair-to-e`) in three places. Only the extension ID resolves, so those now link by ID alone and cannot go stale on the next rename.

## Verification

6807 tests, 0 failures, plus `typecheck` and `lint:js`. The version-guard CLI was exercised in both directions against the real tree before wiring it in.
