### PR TITLE
fix(rules): stop stripping ShareASale's affiliate id

### DIFF
--- a/docs/rules/v1/params.json
+++ b/docs/rules/v1/params.json
@@ -1,6 +1,6 @@
 {
-  "version": 8,
-  "published": "2026-08-09T05:07:46.311Z",
+  "version": 9,
+  "published": "2026-08-19T09:20:00.000Z",
   "params": [
     "__source",
     "__tn__",
@@ -181,7 +181,6 @@
     "trackingid",
     "trk",
     "ts",
-    "u",
     "u_code",
     "u1",
     "uclick_id",
@@ -212,5 +211,5 @@
     "xtor",
     "zrclid"
   ],
-  "sig": "VPj7mipd0gkeIfmEhk31LAm4oIeLj3ECBBRUa8CaIahycgOnd0CiNwLW04tipILREuRaPXNwBpmvT1hVNXqpAQ"
+  "sig": "Apk6ireViUnQwLfUJDEJQ2AsJ_b1V_b8JabXGYPQMsIxAOqMJ5ifO9w1q58ne3HPBXAXhqc2IB-aZhQMDdoFCg"
 }

--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -173,6 +173,19 @@ export const AFFILIATE_PARAM_GUARD = Object.freeze(new Set([
   "partnerizecampaignid",
   // Connexity (shopping affiliate, flagged separately from the AdGuard triage)
   "cnxclid",
+  // ShareASale — `u` is the affiliate id in an r.cfm click:
+  // r.cfm?b=<banner>&u=<affiliate>&m=<merchant>&urllink=<destination>.
+  // A signed payload carried it as a global strip target, and because
+  // shareasale.com is an AFFILIATE_REDIRECT_NETWORKS host whose whole contract
+  // is to pass through untouched, stripping it handed the network a click with
+  // nobody attached. It cannot ride REDIRECT_NETWORK_PATTERNS.landingParams:
+  // those are the params a merchant tag reads on the landing AFTER the 30x,
+  // whereas `u` lives on the redirector itself. The same token is also the
+  // destination holder of `l.facebook.com/l.php?u=` in src/rules/wrappers.json,
+  // so it is doubly unsafe to strip globally. Guarding it here also protects
+  // installs that already cached the bad payload, because this set is filtered
+  // at runtime, not only at signing time.
+  "u",
   // Redirect-network landing params (#695): the click IDs a merchant tag reads
   // on the FIRST post-redirect landing. Derived from REDIRECT_NETWORK_PATTERNS
   // so every declared network stays auto-guarded and a future or compromised

--- a/tests/unit/affiliate-guard.test.mjs
+++ b/tests/unit/affiliate-guard.test.mjs
@@ -417,3 +417,54 @@ describe("audit #1039 — AFFILIATE_PARAM_GUARD covers all redirect-network land
     assert.ok(!isValidCustomParam("cjdata"), "cjdata (Commission Junction) must be rejected");
   });
 });
+
+// ── #1212 regression: a guarded param reached the PUBLISHED list ─────────────
+//
+// ShareASale's affiliate id is `u`: r.cfm?b=<banner>&u=<affiliate>&m=<merchant>
+// &urllink=<destination>. It was auto-ingested into the signed remote list and
+// shipped live at v7/v8, so MUGA stripped it on shareasale.com — an
+// AFFILIATE_REDIRECT_NETWORKS host whose entire contract is to pass through
+// untouched — handing the network a click with nobody attached.
+//
+// Two things were missing. `u` was in no guard, so neither the ingestion gate
+// nor sign-rules.mjs objected; and nothing ever checked the published artifact
+// against the guards, so it stayed live. Both are covered below.
+describe("published-artifact guard (#1212)", () => {
+  it("u is rejected by the live gate with source static-guard", () => {
+    const result = checkAffiliateGuard({ param: "u" });
+    assert.equal(result.rejected, true, "u is ShareASale's affiliate id and must never auto-merge as a tracker");
+    assert.equal(result.collidingPrograms[0].source, "static-guard");
+  });
+
+  it("AFFILIATE_PARAM_GUARD still contains u (re-introduction defense)", async () => {
+    const { AFFILIATE_PARAM_GUARD } = await import("../../src/lib/remote-rules.js");
+    assert.ok(
+      AFFILIATE_PARAM_GUARD.has("u"),
+      "u shipped in the signed list at v7/v8 — the guard entry is what keeps ingestion from re-adding it, and it is also what makes already-installed clients ignore it at runtime"
+    );
+  });
+
+  it("the committed docs/rules/v1/params.json contains no guarded or denylisted param", async () => {
+    // The check that was missing. sign-rules.mjs validates the SOURCE at
+    // signing time, but nothing re-checked the artifact that actually ships,
+    // so a param that predated a guard entry stayed live indefinitely.
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const { AFFILIATE_PARAM_GUARD, REMOTE_PARAM_DENYLIST } = await import("../../src/lib/remote-rules.js");
+
+    const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+    const published = JSON.parse(readFileSync(join(root, "docs/rules/v1/params.json"), "utf8"));
+
+    const offenders = published.params.filter((p) => {
+      const lower = p.toLowerCase();
+      return AFFILIATE_PARAM_GUARD.has(lower) || REMOTE_PARAM_DENYLIST.has(lower);
+    });
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `the published rules list strips params the guards say are functional or carry attribution: ${offenders.join(", ")}. Remove them from tools/rules-source/params.json, bump the version and re-sign.`
+    );
+  });
+});

--- a/tools/rule-ingestion/gates/affiliate-guard.mjs
+++ b/tools/rule-ingestion/gates/affiliate-guard.mjs
@@ -35,6 +35,16 @@ export const STATIC_PRESERVE = Object.freeze(new Set([
   // gate would auto-merge it back into the strip list (ADR-0005's
   // catastrophic path).
   "ascsubtag",
+  // ShareASale affiliate id (#1212): r.cfm?b=<banner>&u=<affiliate>
+  // &m=<merchant>&urllink=<destination>. ShareASale lives in
+  // AFFILIATE_REDIRECT_NETWORKS, not REDIRECT_NETWORK_PATTERNS, so it
+  // contributes no landingParams and the two live arrays cannot express this
+  // name — the same shape as ascsubtag above. It reached the signed list
+  // through ingestion once already and shipped live at v7/v8, stripping the
+  // creator's id on the one host whose contract is to pass through untouched.
+  // This entry is what stops ingestion re-proposing it; the sibling entry in
+  // remote-rules' AFFILIATE_PARAM_GUARD is what stops signing and runtime.
+  "u",
 ]));
 
 // ── Preserve-index construction ─────────────────────────────────────────────

--- a/tools/rules-source/params.json
+++ b/tools/rules-source/params.json
@@ -1,6 +1,6 @@
 {
-  "version": 8,
-  "published": "2026-08-09T05:07:46.311Z",
+  "version": 9,
+  "published": "2026-08-19T09:20:00.000Z",
   "params": [
     "__source",
     "__tn__",
@@ -181,7 +181,6 @@
     "trackingid",
     "trk",
     "ts",
-    "u",
     "u_code",
     "u1",
     "uclick_id",


### PR DESCRIPTION
Closes #1212.

MUGA was stripping the affiliate id out of ShareASale clicks. `u` is the affiliate in `r.cfm?b=<banner>&u=<affiliate>&m=<merchant>&urllink=<destination>`, it rode into the signed list at v7, and it reached users when v8 published. `shareasale.com` is an `AFFILIATE_REDIRECT_NETWORKS` host, so the one thing MUGA must not do there is touch the query, and it was removing the part that says who recommended the link.

## The fix, and why it is in three places

Three separate paths could put `u` back, so each is closed.

| Where | Stops |
|---|---|
| `AFFILIATE_PARAM_GUARD` in `src/lib/remote-rules.js` | Signing a source that contains it, and applying it at runtime |
| `STATIC_PRESERVE` in `tools/rule-ingestion/gates/affiliate-guard.mjs` | Auto-ingest proposing it again |
| `tools/rules-source/params.json` → re-signed `docs/rules/v1/params.json` | It being served, v8 → v9 |

The runtime half is worth calling out: `AFFILIATE_PARAM_GUARD` is filtered when a payload is applied, not only when one is signed, so **installs that already cached v8 stop stripping `u` as soon as they get this build**, without waiting for the endpoint. That is verified rather than assumed — with only the guard change in the tree, `redirect-unwrap-merged.spec.mjs:74` passes against the still-unfixed live endpoint.

`STATIC_PRESERVE` needs its own entry because GATE 1 deliberately does not consume `AFFILIATE_PARAM_GUARD`: that set is broader than genuine attribution and would quarantine legitimate tracker candidates. A name of this shape therefore needs an entry in both, exactly as `ascsubtag` does since #794.

## The structural miss

`sign-rules.mjs` validates the **source** at signing time, but nothing ever re-checked the **artifact that ships**. So a param that predated a guard entry could stay live indefinitely, which is precisely what happened. The new test asserts the committed `docs/rules/v1/params.json` contains nothing from either guard set.

## Signing

Re-signed locally with the production key. The published artifact is verified through the shipped `verifySignature()` against the shipped `TRUSTED_PUBLIC_KEYS`, and a deliberately tampered message is rejected, so the check is not trivially true:

```
published v9 | 208 params | has "u": false
signature verifies : true
tampered rejected  : true
guard has u        : true
ingest gate has u  : true
```

`publish-rules.yml` re-signs on merge and will find the same bytes, so it should no-op.

## Test plan

- [x] `npm test` — 0 failures
- [x] `npm run lint:js` — clean
- [x] `redirect-unwrap-merged.spec.mjs` and `url-cleaning.spec.mjs` — 10 passed, including the shareasale case that has been red on `main` since #1210
- [x] Regenerated `compile:rules`, `build:dnr`, `build:content`, `build:web` and confirmed no drift (the three `src/rules/*.json` files churn on CRLF only, reverted)
- [x] Three regression tests added, mirroring the `#794` `ascsubtag` block

## Deliberately not in this PR

The live list still carries `_d, _r, _t, af, ct, cv, dp, fm, mc, oq, pc, pl, pp, sa, sh, si, sr, ts, u1`. One and two letter names collide with ordinary site parameters by construction, and `u` was simultaneously a strip target and the destination holder of `l.facebook.com/l.php?u=` in `wrappers.json`. Whether the ingest gate should refuse short unscoped names is a policy call that wants its own discussion, not a quiet change inside a P0 fix. Removing them blindly would degrade real cleaning.

This unblocks every branch cut from `main`, whose `e2e` has been inheriting the failure. #1211 documents the split in its body.
