### PR TITLE
fix(consent): share one consent migration between concurrent callers

### DIFF
--- a/src/lib/sync-migration.js
+++ b/src/lib/sync-migration.js
@@ -64,12 +64,45 @@ function syncHasLegacy(sync) {
 }
 
 /**
- * Performs the migration. Idempotent. Returns a small report describing
- * what happened, useful for tests and diagnostics.
+ * In-flight migration, shared by concurrent callers (#1216).
+ *
+ * The service worker calls migrateConsentToLocal() from module scope AND from
+ * its startup/install handlers, so on a fresh wake two or three calls overlap
+ * by design. The migration is idempotent in its EFFECT, but it was not atomic:
+ * read sync, read local, write local, remove sync. Two runs could interleave
+ * so that the second reads sync (still holding the legacy keys, because the
+ * first has not reached removeLegacySync yet) and local (already written by
+ * the first), and therefore reports `copiedToLocal: false` for a copy that did
+ * happen.
+ *
+ * The stored data was always correct; only the report lied, which is why this
+ * surfaced as a flaky e2e assertion rather than a user-visible bug. Sharing
+ * one promise makes concurrent callers observe the same, accurate report and
+ * removes the duplicate storage writes on every wake.
+ *
+ * Cleared once settled so a later wake can migrate again if it needs to.
+ */
+let _inFlight = null;
+
+/**
+ * Performs the migration. Idempotent, and safe to call concurrently: callers
+ * that arrive while a migration is running share its result. Returns a small
+ * report describing what happened, useful for tests and diagnostics.
  *
  * @returns {Promise<{ ranWork: boolean, copiedToLocal: boolean, cleanedSync: boolean }>}
  */
 export async function migrateConsentToLocal() {
+  if (_inFlight) return _inFlight;
+  _inFlight = _migrateConsentToLocal();
+  try {
+    return await _inFlight;
+  } finally {
+    _inFlight = null;
+  }
+}
+
+/** @returns {Promise<{ ranWork: boolean, copiedToLocal: boolean, cleanedSync: boolean }>} */
+async function _migrateConsentToLocal() {
   try {
     const sync = await readLegacySync();
     if (!syncHasLegacy(sync)) {

--- a/tests/e2e/consent-migration.spec.mjs
+++ b/tests/e2e/consent-migration.spec.mjs
@@ -16,6 +16,17 @@
  *
  * Each test seeds storage from a known clean slate, runs the migration
  * via the test-mode handler, and asserts on storage afterwards.
+ *
+ * Flake hazard, if you are reading this after a red run (#1216): the service
+ * worker ALSO calls migrateConsentToLocal() from module scope and from its
+ * startup handler, so a wake between seedStorage() and runMigration() puts two
+ * migrations in flight over the same data. The report below is per-call, so an
+ * overlap used to produce `ranWork: true, copiedToLocal: false` for a copy that
+ * had in fact happened — the storage assertions stayed correct throughout,
+ * only the report lied. #1216 made concurrent callers share one migration and
+ * one report; tests/unit/sync-migration.test.mjs pins that. If a report
+ * assertion here fails again, check whether the worker completed a migration
+ * on its own before the explicit call rather than alongside it.
  */
 
 import { test, expect } from "./fixtures.mjs";

--- a/tests/unit/sync-migration.test.mjs
+++ b/tests/unit/sync-migration.test.mjs
@@ -175,4 +175,55 @@ describe("sync-migration", () => {
     const second = await mod.migrateConsentToLocal();
     assert.deepEqual(second, { ranWork: false, copiedToLocal: false, cleanedSync: false });
   });
+
+  // ── #1216: overlapping calls are the normal case ──────────────────────────
+  //
+  // The service worker calls migrateConsentToLocal() from module scope AND
+  // from its startup/install handlers, so two or three calls overlap on every
+  // wake. The migration is idempotent in effect but was not atomic: read sync,
+  // read local, write local, remove sync. A second call landing mid-sequence
+  // read sync (still holding the legacy keys, because the first had not
+  // reached removeLegacySync) and local (already written by the first), so it
+  // reported copiedToLocal:false for a copy that did happen. The data was
+  // always right; the report was not, which is how this surfaced as a flaky
+  // e2e assertion instead of a user-visible bug.
+  test("concurrent calls share one migration and report it identically", async () => {
+    stores.syncStore.set("onboardingDone", true);
+    stores.syncStore.set("consentVersion", "1.0");
+    stores.syncStore.set("consentDate", 100);
+
+    const area = globalThis.chrome.storage.local;
+    const realSet = area.set.bind(area);
+    let localWrites = 0;
+    area.set = (data, cb) => {
+      localWrites += 1;
+      return realSet(data, cb);
+    };
+
+    const [a, b, c] = await Promise.all([
+      mod.migrateConsentToLocal(),
+      mod.migrateConsentToLocal(),
+      mod.migrateConsentToLocal(),
+    ]);
+
+    const expected = { ranWork: true, copiedToLocal: true, cleanedSync: true };
+    assert.deepEqual(a, expected, "the winning call must report the copy it performed");
+    assert.deepEqual(b, expected, "a caller that arrived mid-migration must see the same report");
+    assert.deepEqual(c, expected, "and so must a third");
+    assert.equal(localWrites, 1, "one migration means one write to local, not one per caller");
+
+    assert.equal(stores.localStore.get("mugaConsent").onboardingDone, true);
+    assert.equal(stores.syncStore.has("onboardingDone"), false);
+  });
+
+  test("a later call still migrates — the in-flight guard is not a latch", async () => {
+    // Clearing the shared promise once settled matters: a service worker that
+    // wakes again must be able to migrate data that appeared in the meantime.
+    const first = await mod.migrateConsentToLocal();
+    assert.deepEqual(first, { ranWork: false, copiedToLocal: false, cleanedSync: false });
+
+    stores.syncStore.set("onboardingDone", true);
+    const second = await mod.migrateConsentToLocal();
+    assert.deepEqual(second, { ranWork: true, copiedToLocal: true, cleanedSync: true });
+  });
 });


### PR DESCRIPTION
Closes #1216.

The service worker calls `migrateConsentToLocal()` from **module scope** and from its **startup** and **install** handlers, so two or three calls overlap on every wake. That is by design and the migration is idempotent in its *effect*, but it was not atomic:

```
read sync → read local → write local → remove sync
```

A second call landing mid-sequence read sync (still holding the legacy keys, because the first had not reached `removeLegacySync` yet) and local (already written by the first). So it took the *"local already has consent"* branch and reported `copiedToLocal: false` for a copy that had just happened.

**The stored data was correct throughout.** Only the report was wrong, which is why this never surfaced as a user-visible bug and instead showed up as a flaky assertion on `main`:

```
expect(report.copiedToLocal).toBe(true)   // received: false
```

## The fix

`migrateConsentToLocal()` now shares a single in-flight promise, so concurrent callers observe the same accurate report and the extension performs **one migration per wake instead of one per call site**.

The promise is cleared once settled, so a later wake can still migrate data that appeared in the meantime. It is a dedupe, not a latch, and there is a test for that distinction.

## Tests

Two unit tests: three concurrent calls must return identical reports and write local **exactly once**; and a call after the first has settled must still migrate. Both mutation-checked — reverting the dedupe fails the concurrency test on the write count:

```
ok    removing the dedupe fails the concurrency test
        -> AssertionError: one migration means one write to local, not one per caller
```

The e2e spec **keeps** its report assertions rather than being weakened: they are the documented contract for a single run, and the interleaving they tripped over is now fixed. What it gains is a header note describing the hazard, so the next person to see a red run there knows to check whether the worker completed a migration *before* the explicit call rather than alongside it.

## Honest limit

The flake never reproduced locally — 5 consecutive clean runs before the fix, 3 after. So the evidence is that **the mechanism matches the observed report exactly**, not that CI has been seen to stop flaking. The scenario this does *not* address is a worker that finishes a migration entirely before the explicit call, which would report `ranWork: false`; that has not been observed and is noted in the spec header.

## Test plan

- [x] `npm test` — 6818, 0 failures
- [x] `npm run lint:js` — clean
- [x] `consent-migration` e2e green 3 runs in a row with `--retries=0`
- [x] Dedupe mutation-checked