### PR TITLE
fix(rules): enforce MIN_PARAM_LEN in promote, unblocking the weekly ingest

### DIFF
--- a/tests/unit/ingestion-promote-rules.test.mjs
+++ b/tests/unit/ingestion-promote-rules.test.mjs
@@ -1756,3 +1756,112 @@ describe("runPromote — writes the normalized store, not just the artifact", ()
     assert.strictEqual(readFileSync(sourcePath, "utf8"), sourceBefore, "params.json was written despite a bad signature");
   });
 });
+
+// ── The MIN_PARAM_LEN floor (#1218 gap, found by exercising auto-ingest) ──────
+
+describe("runPromote — short names never reach params.json", () => {
+  test("a param shorter than MIN_PARAM_LEN is skipped, not merged", async () => {
+    // #1218 put this floor on sign-rules.mjs and the runtime validator but NOT
+    // on promote. The 2026-08-21 auto-ingest dispatch proved the consequence:
+    // promote wrote "_d" into params.json, every gate passed, and the run died
+    // at `sign-rules.mjs`. The weekly job could only ever succeed when it was a
+    // no-op.
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const result = await runPromote({
+      promotePath: writeArtifact(
+        tmpDir,
+        buildArtifact({
+          version: 3,
+          published: "2026-05-01T00:00:00.000Z",
+          // "u" is ShareASale's affiliate id -- the exact param of #1212, and it
+          // is really in the current auto-merge candidate list.
+          params: ["_d", "u", "long_enough_param"],
+          privateKey: TEST_PRIV_KEY,
+        })
+      ),
+      sourcePath: writeParamsJson(tmpDir, {
+        version: 3,
+        published: "2026-04-01T00:00:00.000Z",
+        params: ["existing_param"],
+      }),
+      storePath: writeStore(tmpDir),
+      domainRulesPath: writeDomainRules(tmpDir, [
+        { domain: "example.com", preserveParams: ["safe_keep"] },
+      ]),
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    assert.ok(!result.merged.includes("_d"), '"_d" reached the merged list');
+    assert.ok(!result.merged.includes("u"), '"u" reached the merged list');
+    assert.ok(
+      result.merged.includes("long_enough_param"),
+      "a valid param was collateral damage"
+    );
+
+    assert.ok(
+      result.skipped.some(
+        (s) => s.param === "_d" && s.reason === "shorter than MIN_PARAM_LEN"
+      ),
+      '"_d" must be reported with the length reason, not silently dropped'
+    );
+
+    // "u" is stopped EARLIER, by the affiliate guard in step 4b, and keeps that
+    // more specific reason. The layering is the point: the length floor is the
+    // last net, not the first. Asserting the length reason here would have
+    // pinned the wrong contract -- an earlier draft of this test did exactly
+    // that and failed.
+    const uSkip = result.skipped.find((s) => s.param === "u");
+    assert.ok(uSkip, '"u" must be reported as skipped');
+    assert.notEqual(
+      uSkip.reason,
+      "shorter than MIN_PARAM_LEN",
+      '"u" should be caught by the affiliate guard, which is more specific'
+    );
+  });
+
+  test("a preserveParams collision outranks the length reason", async () => {
+    // Ordering matters: the more specific safety reason must survive, matching
+    // how the denylist and affiliate guard outrank this check upstream.
+    const { runPromote } = await import(
+      "../../tools/rule-ingestion/promote-rules.mjs"
+    );
+
+    const tmpDir = makeTmpDir();
+    const result = await runPromote({
+      promotePath: writeArtifact(
+        tmpDir,
+        buildArtifact({
+          version: 3,
+          published: "2026-05-01T00:00:00.000Z",
+          params: ["ab", "long_enough_param"],
+          privateKey: TEST_PRIV_KEY,
+        })
+      ),
+      sourcePath: writeParamsJson(tmpDir, {
+        version: 3,
+        published: "2026-04-01T00:00:00.000Z",
+        params: ["existing_param"],
+      }),
+      storePath: writeStore(tmpDir),
+      domainRulesPath: writeDomainRules(tmpDir, [
+        { domain: "example.com", preserveParams: ["ab"] },
+      ]),
+      trustedKeys: TEST_TRUSTED_KEYS,
+      subtle: globalThis.crypto.subtle,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    assert.ok(
+      result.skipped.some(
+        (s) => s.param === "ab" && s.reason === "collides with preserveParams"
+      ),
+      "the preserve reason was replaced by the length reason"
+    );
+  });
+});

--- a/tools/rule-ingestion/promote-rules.mjs
+++ b/tools/rule-ingestion/promote-rules.mjs
@@ -34,6 +34,7 @@ import {
   verifySignature,
   PARAM_FORMAT_RE,
   MAX_PARAM_LEN,
+  MIN_PARAM_LEN,
   REMOTE_PARAM_DENYLIST,
   AFFILIATE_PARAM_GUARD,
 } from "../../src/lib/remote-rules.js";
@@ -373,6 +374,24 @@ export async function runPromote({
         `[promote-rules] skip: ${param} collides with preserveParams — excluded from merge`
       );
       skipped.push({ param, reason: "collides with preserveParams" });
+    } else if (param.length < MIN_PARAM_LEN) {
+      // The floor #1218 put on signing and on the runtime validator, but not
+      // here. promote kept admitting these, so every non-noop weekly run wrote
+      // them into params.json and then died at `sign-rules.mjs` -- the job could
+      // only ever succeed when it had nothing to do.
+      //
+      // Checked AFTER the preserve collision so a short name that is also a
+      // preserveParams entry keeps reporting the more specific reason, matching
+      // how the denylist and affiliate guard outrank this check upstream.
+      //
+      // The names this catches are not harmless: the auto-merge list contains
+      // `u`, ShareASale's affiliate id and the exact param of #1212. A
+      // two-character name is host-scoped upstream; applied globally it is the
+      // bug this floor exists to prevent.
+      console.log(
+        `[promote-rules] skip: ${param} is shorter than ${MIN_PARAM_LEN} characters — excluded from merge`
+      );
+      skipped.push({ param, reason: "shorter than MIN_PARAM_LEN" });
     } else {
       cleanParams.push(param);
     }


### PR DESCRIPTION
Found by exercising `auto-ingest-rules.yml` from `main` — the last step of Slice 1, and the only place that workflow can be exercised safely.

## The weekly ingest job has been broken since #1218

The dispatch failed:

```
[sign-rules] ERROR: Source validation failed: Param "_d" is shorter than 3
characters. Names this short are host-scoped upstream and would apply globally
here; put it in src/rules/domain-rules.json instead (#1217)
```

#1218 put the 3-character floor on `tools/sign-rules.mjs` and on the runtime validator, and removed the nineteen short names already sitting in `params.json`. **It did not put the floor on `promote`**, which still validates:

```js
if (param.length < 1 || param.length > MAX_PARAM_LEN || !PARAM_FORMAT_RE.test(param))
```

A floor of one, not three. So promote kept re-admitting them, wrote them into `params.json`, every gate passed, and the run died at the signing step.

**The job could only ever succeed when it was a no-op** — which is exactly what it had been doing. The previous scheduled run took 26 seconds. That is the profile of a job that exits early, and it is why this stayed invisible for weeks.

## How much was behind that door

The current auto-merge candidate list holds **27 names shorter than three characters**:

```
_d _r _t af ct cv dp ei fm h l oq pc pl pp sa sc sh si sk sr t th ts u u1 v
```

`u` is ShareASale's affiliate id — **the exact param of #1212**. The affiliate guard stops that one first and keeps its more specific reason. Nothing structural stopped the other 26 from being published as global strip rules except a signing step that fails the entire job rather than filtering them.

`v` is YouTube's video id. `t` is a timestamp. `l`, `pp`, `si` are in `domain-rules.json` preserve or strip sets for named hosts. These are host-scoped facts upstream; applied globally they are the bug the floor exists to prevent.

## The fix

The floor moves to where admission is decided, mirroring `sign-rules.mjs` and importing the same `MIN_PARAM_LEN` rather than redeclaring it.

It sits **after** the `preserveParams` collision check, so a short name that is also a preserve entry keeps reporting the more specific reason — the same ordering the denylist and affiliate guard already have upstream. Skipped params are reported in `skipped[]`, never silently dropped.

## Tests

- a param shorter than `MIN_PARAM_LEN` is skipped with its own reason, and a valid param alongside it is not collateral damage
- `u` is skipped by the **affiliate guard**, not the length floor — the layering is the point, and an earlier draft of this test asserted the wrong reason and failed. The corrected test now pins that the length floor is the last net, not the first
- a `preserveParams` collision outranks the length reason

Mutation-tested, 2/2 caught: floor disabled → skip test fails; check order inverted → precedence test fails.

## Test plan

- [x] `npm test` — 6852 tests, 0 failures
- [x] `npm run check:rules-store` — no drift
- [x] `npx tsc -p jsconfig.json`, `npx eslint` — clean
- [x] Mutation testing — 2/2 caught

Once this lands, `auto-ingest-rules.yml` should be dispatched again from `main`: this is the first non-no-op run the pipeline has attempted in a while, and it should be watched through to the PR it opens rather than assumed green.
