### PR TITLE
docs(affiliates): state what AFFILIATE_PARAM_GUARD guards, and what it does not

### DIFF
--- a/src/lib/remote-rules.js
+++ b/src/lib/remote-rules.js
@@ -146,6 +146,34 @@ export const REMOTE_PARAM_DENYLIST = Object.freeze(new Set([
 /**
  * Affiliate attribution params — protecting affiliate economics (REQ-VALIDATE-5).
  * A compromised endpoint must never add these to the strip list.
+ *
+ * ── What this set is, and what it is NOT ──────────────────────────────
+ *
+ * This is an INGESTION safety net. It bounds what the remote payload and the
+ * rule-ingestion pipeline may ADD to the strip list, and it is deliberately
+ * WIDER than the set of params that actually carry attribution: a name that
+ * merely looks affiliate-shaped belongs here, because the cost of wrongly
+ * admitting one is a creator's commission and the cost of wrongly blocking one
+ * is an un-stripped low-value param.
+ *
+ * It is NOT a claim that MUGA never strips these names anywhere. MUGA's own
+ * curated rules may strip one deliberately — `src/rules/tracking-params.json`
+ * rule 302 removes `linkcode`, `creativeasin`, `linkid` and `ref_` on amazon.*
+ * while keeping `tag`, which is the param that actually carries the associate
+ * id. That is a curation decision about a specific host, not a contradiction of
+ * this set.
+ *
+ * It is also NOT the runtime's affiliate model. That is `AFFILIATE_PATTERNS`
+ * (src/lib/affiliates.js), built from CAPS_DIRECT_INJECTION_PROGRAMS, which
+ * names the ONE param per program that carries attribution — `tag` for Amazon
+ * Associates. Only names in THAT model are identified at runtime, preserved by
+ * default, and stripped when the user turns `stripAllAffiliates` on.
+ *
+ * The distinction matters because DNR rules cannot read a preference. A param
+ * in a static strip rule is removed for every user, always; the user's choice
+ * about affiliate params can only be honoured by the runtime cleaner. Moving a
+ * genuine attribution param into an ingested strip list would not enable that
+ * choice, it would destroy it.
  */
 export const AFFILIATE_PARAM_GUARD = Object.freeze(new Set([
   // Amazon


### PR DESCRIPTION
Comment only. No behaviour change, no generated artifact changes, no version bump.

## Why

While measuring how much of AdGuard's coverage MUGA could safely import, I read `AFFILIATE_PARAM_GUARD` as *"MUGA never strips these names anywhere"* — and rule 302 immediately looked like a bug:

```
regla 302 (amazon.*)
  tag            kept      ← the associate id
  ascsubtag      kept
  associatetag   kept
  linkcode       STRIPPED  ← and it is in the guard
  creativeasin   STRIPPED  ← and it is in the guard
  linkid         STRIPPED
  ref_           STRIPPED
```

It is not a bug. But working that out took a real detour, and nothing in the file said so.

## What the two lists actually are

| | `AFFILIATE_PARAM_GUARD` | `AFFILIATE_PATTERNS` |
|---|---|---|
| Layer | ingestion | runtime |
| Job | bound what the remote payload and the pipeline may **add** to the strip list | name the param that actually **carries attribution** |
| Breadth | deliberately wide — a name that merely *looks* affiliate-shaped belongs in it | narrow: one param per program. Amazon Associates → `tag` |
| Honours `stripAllAffiliates`? | n/a | **yes** |

`tag` is in both. `linkcode`, `creativeasin`, `linkid` and `ref_` are only in the guard — the runtime has no attribution model for them, so MUGA has no basis for treating them as commission carriers. Rule 302 removing them is a curation decision about one host, not a contradiction.

**The commission is safe because `tag` is what carries it, and `tag` is kept.**

## The part that is load-bearing

**DNR rules cannot read a preference.** A param in a static strip rule is removed for every user, always.

So the user's choice about affiliate params can only be honoured by the runtime cleaner. Moving a genuine attribution param into an ingested strip list would not *enable* that choice — it would **destroy** it, by relocating the decision to a layer that cannot ask.

That is the reason the ingestion guard exists at all, and it is worth writing down before someone reads the guard as over-cautious and relaxes it.

## Verified

- `npm test` — 6852, 0 failures
- `npx tsc`, `npx eslint` — clean
- Regenerated `build:content`, `build:web`, `compile:rules`: `src/content/cleaner-bundle.js`, `web/engine/cleaner-bundle.js` and `src/rules/tracking-params.json` all byte-identical — `remote-rules.js` is not bundled into the content script
- `npm run check:rules-store` — no drift
